### PR TITLE
Protect user lookup route

### DIFF
--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -90,16 +90,21 @@ routes.get('/users/:username/:password', authenticateToken, (req, res) => {
 });
 
 // Get user by username (protected route)
-routes.get('/users/:username', (req, res) => {
+// Clients must include a valid JWT in the Authorization header: "Bearer <token>"
+routes.get('/users/:username', authenticateToken, (req, res) => {
   let db_connect = dbo.getDb();
   let myquery = { username: req.params.username };
   db_connect
     .collection('users')
-    .findOne(myquery, function (err, result) {
+    .findOne(myquery, function (err, user) {
       if (err) {
         return res.status(500).json({ message: 'Internal server error' });
       }
-      res.json(result);
+      if (!user) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+      const { password, ...userWithoutPassword } = user;
+      res.json(userWithoutPassword);
     });
 });
 


### PR DESCRIPTION
## Summary
- secure GET `/users/:username` with JWT middleware
- strip password before returning user data
- document Authorization header requirement

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check routes/routes.js`


------
https://chatgpt.com/codex/tasks/task_e_689e3a639fa0832e9379a2b0ee63cca2