### PR TITLE
fix: use react-router-dom for navigation hooks

### DIFF
--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
  
  export default function Feats({form, showFeats, handleCloseFeats, totalLevel}) {

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import { Button } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useParams } from "react-router";
+import { useParams } from "react-router-dom";
 
 export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
   const params = useParams();

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'; // Import useState and React
 import { Modal, Card, Table, Button } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Help({props, form, showHelpModal, handleCloseHelpModal}) {

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Items({form, showItems, handleCloseItems}) {

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'; // Import useState and React
 import { Modal, Card, Table, Button, Form } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg";
 
 export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, strMod, dexMod, conMod, intMod, chaMod, wisMod}) {

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Weapons({form, showWeapons, handleCloseWeapons, strMod, dexMod}) {

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, } from "react";
 import { Button, Col, Container, Form, Row, Table, Card } from "react-bootstrap";
-import { useNavigate } from "react-router";
+import { useNavigate } from "react-router-dom";
 import Modal from 'react-bootstrap/Modal';
 import { Link } from "react-router-dom";
 import { jwtDecode } from 'jwt-decode';

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router";
+import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button } from 'react-bootstrap';
 import '../../../App.scss';
 import zombiesbg from "../../../images/zombiesbg.jpg";

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { Button, Col, Form, Row, Container, Table, Card } from "react-bootstrap";
-import { useNavigate } from "react-router";
 import Modal from 'react-bootstrap/Modal';
 import { jwtDecode } from 'jwt-decode';
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router-dom";
 import zombiesbg from "../../../images/zombiesbg.jpg";
 
 export default function ZombiesDM() {


### PR DESCRIPTION
## Summary
- source useNavigate from react-router-dom in Zombies.js
- ensure all Zombies components import navigation hooks from react-router-dom

## Testing
- `CI=true npm test` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_689e45a3ae28832eb3cacd8b4f60f35b