### PR TITLE
Use programmatic logout navigation and add tests

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login page when no token is present', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
 });

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -3,11 +3,19 @@ import Container from 'react-bootstrap/Container';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
+import { useNavigate } from 'react-router-dom';
 import useToken from '../../useToken';
 import logoLight from "../../images/logo-light.png";
 
 function NavbarComponent() {
   const { removeToken } = useToken();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    removeToken();
+    navigate('/login');
+  };
+
   return (
     <Navbar fixed="top" style={{ fontFamily: 'Raleway, sans-serif', height: "80px", backgroundColor: "rgba(0, 0, 0, 1)" }}>
       <Container fluid>
@@ -15,8 +23,8 @@ function NavbarComponent() {
           <img src={logoLight} alt="" width="60px" height="60px" className="d-inline-block align-text-top" />
         </Navbar.Brand>
         <Nav className="ml-auto">
-          <Nav.Link href='/logout'>
-            <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={removeToken}>
+          <Nav.Link>
+            <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={handleLogout}>
               Logout
             </Button>
           </Nav.Link>

--- a/client/src/components/Navbar/Navbar.test.js
+++ b/client/src/components/Navbar/Navbar.test.js
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Navbar from './Navbar';
+
+jest.mock('../../useToken', () => ({
+  __esModule: true,
+  default: () => ({
+    removeToken: jest.fn()
+  })
+}));
+
+test('logout navigates to login route', async () => {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<Navbar />} />
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  const buttons = screen.getAllByRole('button', { name: /logout/i });
+  await userEvent.click(buttons[buttons.length - 1]);
+  expect(await screen.findByText('Login Page')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- remove `href='/logout'` from Navbar logout link and navigate to `/login` after token removal
- add tests verifying login screen rendering and logout navigation

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689e480c2ce4832ebf08504e086acf98