### PR TITLE
Add campaign and character query routes with tests

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -34,4 +34,46 @@ describe('Campaign routes', () => {
       .send({ campaignName: 'Test', dm: 'DM' });
     expect(res.status).toBe(500);
   });
+
+  test('get campaign by name success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOne: async () => ({ campaignName: 'Test', dm: 'DM', players: [] })
+      })
+    });
+    const res = await request(app).get('/campaign/Test');
+    expect(res.status).toBe(200);
+    expect(res.body.dm).toBe('DM');
+  });
+
+  test('get campaign by name failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOne: async () => { throw new Error('db error'); }
+      })
+    });
+    const res = await request(app).get('/campaign/Test');
+    expect(res.status).toBe(500);
+  });
+
+  test('get campaigns by dm success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ campaignName: 'Test', dm: 'DM' }] })
+      })
+    });
+    const res = await request(app).get('/campaignsDM/DM');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  test('get campaigns by dm failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/campaignsDM/DM');
+    expect(res.status).toBe(500);
+  });
 });

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -34,4 +34,25 @@ describe('Character routes', () => {
       .send({ token: 'alice' });
     expect(res.status).toBe(500);
   });
+
+  test('get characters for campaign and user success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ token: 'alice', campaign: 'Camp1' }] })
+      })
+    });
+    const res = await request(app).get('/campaign/Camp1/alice');
+    expect(res.status).toBe(200);
+    expect(res.body[0].token).toBe('alice');
+  });
+
+  test('get characters for campaign and user failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/campaign/Camp1/alice');
+    expect(res.status).toBe(500);
+  });
 });

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -4,6 +4,7 @@ const bcrypt = require('bcryptjs');
 
 jest.mock('../db/conn', () => ({ getDb: jest.fn() }));
 const dbo = require('../db/conn');
+process.env.JWT_SECRET = 'testsecret';
 const usersRouter = require('../routes/users');
 
 const app = express();

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -37,6 +37,33 @@ router.get('/campaigns/:player', async (req, res) => {
   }
 });
 
+// Get campaign details by campaign name
+router.get('/campaign/:campaign', async (req, res) => {
+  try {
+    const db = dbo.getDb();
+    const campaign = await db
+      .collection('Campaigns')
+      .findOne({ campaignName: req.params.campaign });
+    res.json(campaign);
+  } catch (err) {
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+// Get campaigns by dungeon master username
+router.get('/campaignsDM/:username', async (req, res) => {
+  try {
+    const db = dbo.getDb();
+    const campaigns = await db
+      .collection('Campaigns')
+      .find({ dm: req.params.username })
+      .toArray();
+    res.json(campaigns);
+  } catch (err) {
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
 // Create a new campaign
 router.post('/campaign/add', async (req, res) => {
   try {

--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -28,4 +28,18 @@ router.get('/characters/campaign/:campaign', async (req, res) => {
   }
 });
 
+// Get characters for a campaign filtered by username
+router.get('/campaign/:campaign/:username', async (req, res) => {
+  try {
+    const db = dbo.getDb();
+    const characters = await db
+      .collection('Characters')
+      .find({ campaign: req.params.campaign, token: req.params.username })
+      .toArray();
+    res.json(characters);
+  } catch (err) {
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add endpoint to fetch a campaign's details by name
- support listing campaigns by dungeon master
- allow filtering characters by campaign and owner
- expand tests for new routes and configure JWT secret in user tests

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f36fabc5c832ebca4e6e704c563a8