### PR TITLE
Add campaign gear and skill routes with tests

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -76,4 +76,25 @@ describe('Campaign routes', () => {
     const res = await request(app).get('/campaignsDM/DM');
     expect(res.status).toBe(500);
   });
+
+  test('get campaign by dm and name success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOne: async () => ({ campaignName: 'Test', dm: 'DM' })
+      })
+    });
+    const res = await request(app).get('/campaignsDM/DM/Test');
+    expect(res.status).toBe(200);
+    expect(res.body.campaignName).toBe('Test');
+  });
+
+  test('get campaign by dm and name failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOne: async () => { throw new Error('db error'); }
+      })
+    });
+    const res = await request(app).get('/campaignsDM/DM/Test');
+    expect(res.status).toBe(500);
+  });
 });

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -55,4 +55,222 @@ describe('Character routes', () => {
     const res = await request(app).get('/campaign/Camp1/alice');
     expect(res.status).toBe(500);
   });
+
+  test('get weapons success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ weaponName: 'Sword' }] })
+      })
+    });
+    const res = await request(app).get('/weapons/Camp1');
+    expect(res.status).toBe(200);
+    expect(res.body[0].weaponName).toBe('Sword');
+  });
+
+  test('get weapons failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/weapons/Camp1');
+    expect(res.status).toBe(500);
+  });
+
+  test('get armor success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ armorName: 'Plate' }] })
+      })
+    });
+    const res = await request(app).get('/armor/Camp1');
+    expect(res.status).toBe(200);
+    expect(res.body[0].armorName).toBe('Plate');
+  });
+
+  test('get armor failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/armor/Camp1');
+    expect(res.status).toBe(500);
+  });
+
+  test('get items success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ itemName: 'Potion' }] })
+      })
+    });
+    const res = await request(app).get('/items/Camp1');
+    expect(res.status).toBe(200);
+    expect(res.body[0].itemName).toBe('Potion');
+  });
+
+  test('get items failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/items/Camp1');
+    expect(res.status).toBe(500);
+  });
+
+  test('get feats success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ feat: 'Power Attack' }] })
+      })
+    });
+    const res = await request(app).get('/feats');
+    expect(res.status).toBe(200);
+    expect(res.body[0].feat).toBe('Power Attack');
+  });
+
+  test('get feats failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/feats');
+    expect(res.status).toBe(500);
+  });
+
+  test('get occupations success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => [{ name: 'Soldier' }] })
+      })
+    });
+    const res = await request(app).get('/occupations');
+    expect(res.status).toBe(200);
+    expect(res.body[0].name).toBe('Soldier');
+  });
+
+  test('get occupations failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
+      })
+    });
+    const res = await request(app).get('/occupations');
+    expect(res.status).toBe(500);
+  });
+
+  test('update skills success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOneAndUpdate: async () => ({ value: { appraise: 1 } })
+      })
+    });
+    const res = await request(app)
+      .put('/update-skills/507f1f77bcf86cd799439011')
+      .send({ appraise: 1 });
+    expect(res.status).toBe(200);
+    expect(res.body.appraise).toBe(1);
+  });
+
+  test('update skills failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOneAndUpdate: async () => { throw new Error('db error'); }
+      })
+    });
+    const res = await request(app)
+      .put('/update-skills/507f1f77bcf86cd799439011')
+      .send({ appraise: 1 });
+    expect(res.status).toBe(500);
+  });
+
+  test('update added skills success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOneAndUpdate: async () => ({ value: { newSkill: [['Skill', 1]] } })
+      })
+    });
+    const res = await request(app)
+      .put('/updated-add-skills/507f1f77bcf86cd799439011')
+      .send({ newSkill: [['Skill', 1]] });
+    expect(res.status).toBe(200);
+    expect(res.body.newSkill).toEqual([['Skill', 1]]);
+  });
+
+  test('update added skills failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({
+        findOneAndUpdate: async () => { throw new Error('db error'); }
+      })
+    });
+    const res = await request(app)
+      .put('/updated-add-skills/507f1f77bcf86cd799439011')
+      .send({ newSkill: [['Skill', 1]] });
+    expect(res.status).toBe(500);
+  });
+
+  test('add weapon success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+    });
+    const res = await request(app)
+      .post('/weapon/add')
+      .send({ campaign: 'Camp1', weaponName: 'Sword' });
+    expect(res.status).toBe(200);
+    expect(res.body.acknowledged).toBe(true);
+  });
+
+  test('add weapon failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
+    });
+    const res = await request(app)
+      .post('/weapon/add')
+      .send({ campaign: 'Camp1', weaponName: 'Sword' });
+    expect(res.status).toBe(500);
+  });
+
+  test('add armor success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+    });
+    const res = await request(app)
+      .post('/armor/add')
+      .send({ campaign: 'Camp1', armorName: 'Plate' });
+    expect(res.status).toBe(200);
+    expect(res.body.acknowledged).toBe(true);
+  });
+
+  test('add armor failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
+    });
+    const res = await request(app)
+      .post('/armor/add')
+      .send({ campaign: 'Camp1', armorName: 'Plate' });
+    expect(res.status).toBe(500);
+  });
+
+  test('add item success', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+    });
+    const res = await request(app)
+      .post('/item/add')
+      .send({ campaign: 'Camp1', itemName: 'Potion' });
+    expect(res.status).toBe(200);
+    expect(res.body.acknowledged).toBe(true);
+  });
+
+  test('add item failure', async () => {
+    dbo.getDb.mockReturnValue({
+      collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
+    });
+    const res = await request(app)
+      .post('/item/add')
+      .send({ campaign: 'Camp1', itemName: 'Potion' });
+    expect(res.status).toBe(500);
+  });
 });

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -64,6 +64,26 @@ router.get('/campaignsDM/:username', async (req, res) => {
   }
 });
 
+// Get single campaign by dm and name
+router.get('/campaignsDM/:username/:campaign', async (req, res) => {
+  const { username, campaign } = req.params;
+  if (!username || !campaign) {
+    return res.status(400).json({ message: 'Invalid parameters' });
+  }
+  try {
+    const db = dbo.getDb();
+    const record = await db
+      .collection('Campaigns')
+      .findOne({ dm: username, campaignName: campaign });
+    if (!record) {
+      return res.status(404).json({ message: 'Campaign not found' });
+    }
+    res.json(record);
+  } catch (err) {
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
 // Create a new campaign
 router.post('/campaign/add', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- port legacy campaign gear GET endpoints and seeding routes
- implement remaining character skill update APIs
- restore DM campaign lookup and expand unit tests

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_689f4fc71918832ead19df773d4e951e