### PR TITLE
refactor: centralize auth middleware in routes

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -5,26 +5,9 @@ const routes = express.Router();
 const dbo = require('./db/conn');
 require('dotenv').config();
 const ObjectId = require("mongodb").ObjectId;
+const authenticateToken = require('./middleware/auth');
 
 const jwtSecretKey = process.env.JWT_SECRET;
-
-// Middleware to verify JWT token
-const authenticateToken = (req, res, next) => {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
-
-  if (!token) {
-    return res.status(401).json({ message: 'Unauthorized' });
-  }
-
-  jwt.verify(token, jwtSecretKey, (err, user) => {
-    if (err) {
-      return res.status(403).json({ message: 'Forbidden' });
-    }
-    req.user = user;
-    next();
-  });
-};
 
 
 // Login route


### PR DESCRIPTION
## Summary
- replace inline JWT middleware with shared `middleware/auth`
- apply middleware across protected routes to avoid duplication

## Testing
- `cd server && npm test` *(fails: Exceeded timeout of 5000 ms for tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f7686a890832eb68892ccbfca2f92