### PR TITLE
Remove server-side token verification and sensitive logging

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -38,8 +38,9 @@ routes.post('/login', (req, res) => {
         // Generate JWT token
         const token = jwt.sign({ username: user.username }, jwtSecretKey, { expiresIn: '1h' });
         res.json({ token });
-        const decoded = jwt.verify(token, jwtSecretKey);
-        console.log(decoded);
+        console.debug('JWT token generated for login request', {
+          timestamp: new Date().toISOString(),
+        });
       });
     });
 });


### PR DESCRIPTION
## Summary
- remove unnecessary `jwt.verify` call and sensitive `console.log`
- add minimal debug log with timestamp after token generation

## Testing
- `cd server && npm test` *(fails: Users routes – login success timeout, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f7bc6ab64832ea14373c8d9ff8b5f