### PR TITLE
Attach auth token to user lookup

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -35,7 +35,12 @@ async function loginUser(credentials) {
 async function fetchUserByUsername(username) {
   username = capitalizeFirstLetter(username);
   try {
-    const response = await fetch(`/users/${username}`);
+    const token = localStorage.getItem('token');
+    const response = await fetch(`/users/${username}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
     if (response.ok) {
       const user = await response.json();
       return user;


### PR DESCRIPTION
## Summary
- add Authorization header in fetchUserByUsername to include stored token

## Testing
- `npm test -- --watchAll=false` in `client`
- `npm test` (fails: Exceeded timeout of 5000 ms for a test) in `server`


------
https://chatgpt.com/codex/tasks/task_e_689f7f61f1e8832ea8a46dd76d81a8ec