### PR TITLE
Add request validation and error handling

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
+    "express-validator": "^6.15.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^4.4.0",
     "mongoose": "^7.0.1"


### PR DESCRIPTION
## Summary
- integrate express-validator (with fallback) and standardized validation error handler
- enforce body and param schemas on login, user creation, and player-add routes
- fix campaign lookup and skill update endpoints to return proper responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f8bea2790832e8894d33260e2f946