### PR TITLE
Add endpoint to fetch campaign characters and update ZombiesDM

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -27,20 +27,20 @@ export default function ZombiesDM() {
     const [records, setRecords] = useState([]);
     useEffect(() => {
       async function getRecords() {
-        const response = await fetch(`/campaign/${params.campaign}`);
-  
+        const response = await fetch(`/campaign/${params.campaign}/characters`);
+
         if (!response.ok) {
           const message = `An error occurred: ${response.statusText}`;
           window.alert(message);
           return;
         }
-  
-        const records = await response.json();
-        setRecords(records);
+
+        const data = await response.json();
+        setRecords(data);
       }
-  
+
       getRecords();
-  
+
       return;
     }, [params.campaign]);
   
@@ -400,7 +400,7 @@ const [form2, setForm2] = useState({
           </tr>
         </thead>
         <tbody>
-          {records.map((Characters) => (
+          {Array.isArray(records) && records.map((Characters) => (
             <tr key={Characters._id}>
               <td>{Characters.token}</td>
               <td>{Characters.characterName}</td>

--- a/server/routes.js
+++ b/server/routes.js
@@ -396,7 +396,19 @@ routes.route("/campaign/:campaign/:username").get(function (req, res) {
     });
  });
 
- // This section will find all characters in a specific campaign.
+// This section will find all characters in a specific campaign.
+routes.route("/campaign/:campaign/characters").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Characters")
+    .find({ campaign: req.params.campaign })
+    .toArray(function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+});
+
+// This section will find a specific campaign.
 routes.route("/campaign/:campaign").get(function (req, res) {
   let db_connect = req.db;
   db_connect


### PR DESCRIPTION
## Summary
- backend: add GET `/campaign/:campaign/characters` to return characters for a campaign
- frontend: query new endpoint in ZombiesDM and guard map rendering

## Testing
- `cd server && npm test`
- `cd ../client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689f96d03c3c832e846ab68f77b227b6