### PR TITLE
Prioritize campaign characters route to avoid username conflict

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -56,6 +56,30 @@ describe('Character routes', () => {
     expect(res.status).toBe(500);
   });
 
+  test('get all characters for campaign success', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        find: () => ({ toArray: (cb) => cb(null, [
+          { token: 'alice', campaign: 'Camp1' },
+          { token: 'bob', campaign: 'Camp1' }
+        ]) })
+      })
+    });
+    const res = await request(app).get('/campaign/Camp1/characters');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+  });
+
+  test('get all characters for campaign failure', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+      })
+    });
+    const res = await request(app).get('/campaign/Camp1/characters');
+    expect(res.status).toBe(500);
+  });
+
   test('get weapons success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({

--- a/server/routes.js
+++ b/server/routes.js
@@ -384,18 +384,6 @@ routes.route("/delete-character/:id").delete((req, response) => {
 
 // -------------------------------------------------Campaign Section---------------------------------------------------
 
-// This section will find all of the users characters in a specific campaign.
-routes.route("/campaign/:campaign/:username").get(function (req, res) {
-  let db_connect = req.db;
-  db_connect
-    .collection("Characters")
-    .find({ campaign: req.params.campaign, token: req.params.username })
-    .toArray(function (err, result) {
-      if (err) throw err;
-      res.json(result);
-    });
- });
-
 // This section will find all characters in a specific campaign.
 routes.route("/campaign/:campaign/characters").get(function (req, res) {
   let db_connect = req.db;
@@ -407,6 +395,18 @@ routes.route("/campaign/:campaign/characters").get(function (req, res) {
       res.json(result);
     });
 });
+
+// This section will find all of the users characters in a specific campaign.
+routes.route("/campaign/:campaign/:username").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Characters")
+    .find({ campaign: req.params.campaign, token: req.params.username })
+    .toArray(function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+ });
 
 // This section will find a specific campaign.
 routes.route("/campaign/:campaign").get(function (req, res) {


### PR DESCRIPTION
## Summary
- Move `/campaign/:campaign/characters` route above user-specific route so it is matched correctly
- Add unit tests verifying campaign characters endpoint returns all characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa89abd20832e859d7de2a202bb2a