### PR TITLE
Add validation and sanitization for character creation

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -23,7 +23,7 @@ describe('Character routes', () => {
     expect(res.body.acknowledged).toBe(true);
   });
 
-  test('add character failure', async () => {
+  test('add character db failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
         insertOne: (doc, cb) => cb(new Error('db error'))
@@ -31,8 +31,20 @@ describe('Character routes', () => {
     });
     const res = await request(app)
       .post('/character/add')
-      .send({ token: 'alice' });
+      .send({ token: 'alice', characterName: 'Hero', campaign: 'Camp1' });
     expect(res.status).toBe(500);
+  });
+
+  test('add character validation failure', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        insertOne: (doc, cb) => cb(null, { acknowledged: true })
+      })
+    });
+    const res = await request(app)
+      .post('/character/add')
+      .send({ token: 'alice' });
+    expect(res.status).toBe(400);
   });
 
   test('get characters for campaign and user success', async () => {


### PR DESCRIPTION
## Summary
- validate character creation request body using express-validator
- enforce 400 responses on invalid character data
- only insert whitelisted fields into Characters collection and expand tests

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_689faffd3518832e8f6da29339307da0