### PR TITLE
refactor: extract login styles into css

### DIFF
--- a/client/src/components/Login/Login.css
+++ b/client/src/components/Login/Login.css
@@ -1,0 +1,23 @@
+.login-background {
+  background-image: url('../../images/loginbg.png');
+  background-size: cover;
+  background-position: center;
+  height: 100vh;
+}
+
+.raleway-font {
+  font-family: 'Raleway, sans-serif';
+}
+
+.login-overlay {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.logo-image {
+  max-height: 200px;
+  max-width: 200px;
+}
+
+.form-width {
+  max-width: 200px;
+}

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -4,8 +4,8 @@ import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
 import { MDBContainer, MDBRow, MDBCol } from 'mdb-react-ui-kit';
-import loginbg from "../../images/loginbg.png";
 import logoLight from "../../images/logo-light.png";
+import './Login.css';
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
@@ -114,24 +114,23 @@ export default function Login({ setToken }) {
       alert('Passwords do not match!');
     }
   };
-
   return (
-    <div style={{ backgroundImage: `url(${loginbg})`, backgroundSize: 'cover', height: '100vh', backgroundPosition: 'center' }}>
+    <div className="login-background">
       <center>
-        <MDBContainer style={{ fontFamily: 'Raleway, sans-serif' }}>
+        <MDBContainer className="raleway-font">
           <MDBRow>
             <MDBCol col='6' className="my-5">
-              <div className="d-flex flex-column" style={{backgroundColor: "rgba(0, 0, 0, 0.7)"}}>
+              <div className="d-flex flex-column login-overlay">
                 <div className="text-center">
-                  <img src={logoLight} alt="logo" className="py-3" style={{maxHeight: "200px", maxWidth: "200px"}} />
+                  <img src={logoLight} alt="logo" className="py-3 logo-image" />
                   {/* <h1 className="mt-5 mb-5 pb-1 text-light" style={{ fontFamily: 'Raleway, sans-serif' }}>Realm Tracker</h1> */}
                 </div>
                 <p className='text-light'>Please login to your account</p>
                 <center>
-                  <Form className="w-100 mb-3" style={{ maxWidth: '200px' }}>
-                    <Form.Group className="" controlId="formUsername">
-                      <Form.Label>Username</Form.Label>
-                      <Form.Control type="text" value={username} onChange={e => setUsername(e.target.value)} placeholder="Enter username" />
+                    <Form className="w-100 mb-3 form-width">
+                      <Form.Group className="" controlId="formUsername">
+                        <Form.Label>Username</Form.Label>
+                        <Form.Control type="text" value={username} onChange={e => setUsername(e.target.value)} placeholder="Enter username" />
                     </Form.Group>
                     <Form.Group className="mb-3" controlId="formPassword">
                       <Form.Label>Password</Form.Label>


### PR DESCRIPTION
## Summary
- move inline styles from Login component to new `Login.css`
- import stylesheet and apply classes instead of inline attributes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fb7d306b0832ea722a20f241b4b4f