### PR TITLE
feat: use http-only JWT cookie

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -19,6 +19,7 @@ async function loginUser(credentials) {
       headers: {
         'Content-Type': 'application/json'
       },
+      credentials: 'include',
       body: JSON.stringify(credentials)
     });
     if (!response.ok) {
@@ -35,12 +36,7 @@ async function loginUser(credentials) {
 async function fetchUserByUsername(username) {
   username = capitalizeFirstLetter(username);
   try {
-    const token = localStorage.getItem('token');
-    const response = await fetch(`/users/${username}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    const response = await fetch(`/users/${username}`, { credentials: 'include' });
     if (response.ok) {
       const user = await response.json();
       return user;
@@ -60,6 +56,7 @@ async function createUser(newUser) {
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
       body: JSON.stringify(newUser),
     });
     if (!response.ok) {

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -3,44 +3,20 @@ import { Button, Col, Container, Form, Row, Table, Card } from "react-bootstrap"
 import { useNavigate } from "react-router-dom";
 import Modal from 'react-bootstrap/Modal';
 import { Link } from "react-router-dom";
-import { jwtDecode } from 'jwt-decode';
 import zombiesbg from "../../../images/zombiesbg.jpg";
 import { FaDungeon, FaCrown } from 'react-icons/fa';
 
 
 export default function ZombiesHome() {
   const navigate = useNavigate();
-  const [decodedToken, setDecodedToken] = useState(null);
-
-  useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, []);
-
 //--------------------------------------------Campaign Section------------------------------
 
 const [form1, setForm1] = useState({ 
-  campaignName: "", 
+  campaignName: "",
   gameMode: "zombies",
   dm: "",
   players: [],
 });
-
-useEffect(() => {
-  // Update form1 state once the token is decoded
-  if (decodedToken) {
-    setForm1(prevForm1 => ({ ...prevForm1, dm: decodedToken.username }));
-  }
-}, [decodedToken]);
 
 const [campaign, setCampaign] = useState({ 
   campaign: [], 
@@ -64,11 +40,8 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
 
 // Fetch Campaigns
   useEffect(() => {
-    if (!decodedToken || !decodedToken.username) {
-      return;
-    }
   async function fetchData1() {
-    const response = await fetch(`/campaigns/${decodedToken.username}`);    
+    const response = await fetch(`/campaigns`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -87,15 +60,12 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
   fetchData1();   
   return;
   
-}, [navigate, decodedToken]);
+}, [navigate]);
 
 // Fetch CampaignsDM
 useEffect(() => {
-    if (!decodedToken || !decodedToken.username) {
-      return;
-    }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${decodedToken.username}`);    
+    const response = await fetch(`/campaignsDM`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -114,7 +84,7 @@ useEffect(() => {
   fetchCampaignsDM();   
   return;
   
-}, [ navigate, decodedToken ]);
+}, [ navigate ]);
 
 
 function updateForm1(value) {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -3,35 +3,16 @@ import Button from 'react-bootstrap/Button';
 import { Table, Form, Modal, Card } from 'react-bootstrap';
 import { useParams, useNavigate } from "react-router-dom";
 import '../../../App.scss';
-import { jwtDecode } from 'jwt-decode';
 import zombiesbg from "../../../images/zombiesbg.jpg";
 
 export default function RecordList() {
   const params = useParams();
   const [records, setRecords] = useState([]);
   const navigate = useNavigate();
-  const [decodedToken, setDecodedToken] = useState(null);
 
   useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!decodedToken) {
-      return;
-    }
     async function getRecords() {
-      const response = await fetch(`/campaign/${params.campaign}/${decodedToken.username}`);
+      const response = await fetch(`/campaign/${params.campaign}`);
 
       if (!response.ok) {
         const message = `An error occurred: ${response.statusText}`;
@@ -46,29 +27,14 @@ export default function RecordList() {
     getRecords();
 
     return;
-  }, [params.campaign, decodedToken]);
+  }, [params.campaign]);
 
   const navigateToCharacter = (id) => {
     navigate(`/zombies-character-sheet/${id}`);
   }
-
-  useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, []);
 // --------------------------Random Character Creator Section------------------------------------
- const [form, setForm] = useState({ 
-  token: "",
-  characterName: "", 
+ const [form, setForm] = useState({
+  characterName: "",
   campaign: params.campaign.toString(),
   occupation: [""], 
   feat: [["","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","",""]],
@@ -121,13 +87,6 @@ export default function RecordList() {
   newSkill: [["",0]],
   diceColor: "#000000",
 });
-
-useEffect(() => {
-  // Update form state once the token is decoded
-  if (decodedToken) {
-    setForm(prevForm => ({ ...prevForm, token: decodedToken.username }));
-  }
-}, [decodedToken]);
 
 const [occupation, setOccupation] = useState({ 
   occupation: [], 

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1,27 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Button, Col, Form, Row, Container, Table, Card } from "react-bootstrap";
 import Modal from 'react-bootstrap/Modal';
-import { jwtDecode } from 'jwt-decode';
 import { useNavigate, useParams } from "react-router-dom";
 import zombiesbg from "../../../images/zombiesbg.jpg";
 
 export default function ZombiesDM() {
-  const [decodedToken, setDecodedToken] = useState(null);
-
-  useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, []);
-  
     const navigate = useNavigate();
     const params = useParams();
     const [records, setRecords] = useState([]);
@@ -56,11 +39,8 @@ const [campaignDM, setCampaignDM] = useState({ players: [] });
 
 // Fetch CampaignsDM
 useEffect(() => {
-  if (!decodedToken) {
-    return;
-  }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${decodedToken.username}/${params.campaign}`);    
+    const response = await fetch(`/campaignsDM/${params.campaign}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -79,7 +59,7 @@ useEffect(() => {
   fetchCampaignsDM();   
   return;
   
-}, [ navigate, decodedToken, params.campaign ]);
+}, [ navigate, params.campaign ]);
 
 //---------------------------------------Add Player-------------------------------------------
 const [players, setPlayers] = useState({ 
@@ -89,17 +69,8 @@ const [players, setPlayers] = useState({
 const [playersSearch, setPlayersSearch] = useState("");
 
  useEffect(() => {
-    if (!decodedToken) {
-      return;
-    }
-
     async function fetchUsers() {
-      const token = localStorage.getItem('token');
-      const response = await fetch(`/users`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+      const response = await fetch(`/users`);
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -117,7 +88,7 @@ const [playersSearch, setPlayersSearch] = useState("");
     }
 
     fetchUsers();
-  }, [navigate, decodedToken]);
+  }, [navigate]);
 
 async function newPlayerSubmit(e) {
   e.preventDefault();   
@@ -127,13 +98,11 @@ async function newPlayerSubmit(e) {
 const currentCampaign = params.campaign.toString();
 async function sendNewPlayersToDb() {
   const newPlayers = [playersSearch];
-  const token = localStorage.getItem('token');
 
   await fetch(`/players/add/${currentCampaign}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": `Bearer ${token}`, // Include the token in the request headers
     },
     body: JSON.stringify(newPlayers),
   })

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,6 +4,12 @@ import './index.scss';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+// Ensure cookies are sent with all fetch requests
+const originalFetch = window.fetch;
+window.fetch = (input, init = {}) => {
+  return originalFetch(input, { credentials: 'include', ...init });
+};
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>

--- a/client/src/useToken.js
+++ b/client/src/useToken.js
@@ -1,17 +1,13 @@
 import { useState } from 'react';
 
 export default function useToken() {
-  const getToken = () => localStorage.getItem('token');
-
-  const [token, setToken] = useState(getToken());
+  const [token, setToken] = useState(null);
 
   const saveToken = (userToken) => {
-    localStorage.setItem('token', userToken);
     setToken(userToken);
   };
 
   const removeToken = () => {
-    localStorage.removeItem('token');
     setToken(null);
   };
 

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -22,6 +22,7 @@ describe('Users routes', () => {
     const res = await request(app).post('/login').send({ username: 'alice', password: 'secret' });
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
+    expect(res.headers['set-cookie']).toBeDefined();
   });
 
   test('login failure with invalid password', async () => {
@@ -34,6 +35,7 @@ describe('Users routes', () => {
     const res = await request(app).post('/login').send({ username: 'alice', password: 'wrong' });
     expect(res.status).toBe(401);
     expect(res.body.token).toBeUndefined();
+    expect(res.headers['set-cookie']).toBeUndefined();
   });
 
   test('verify success', async () => {

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -3,7 +3,19 @@ const jwtSecretKey = process.env.JWT_SECRET;
 
 module.exports = function authenticateToken(req, res, next) {
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  let token;
+
+  if (req.headers.cookie) {
+    const match = req.headers.cookie
+      .split(';')
+      .map((c) => c.trim())
+      .find((c) => c.startsWith('token='));
+    if (match) {
+      token = match.split('=')[1];
+    }
+  }
+
+  token = token || (authHeader && authHeader.split(' ')[1]);
 
   if (!token) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/server/routes.js
+++ b/server/routes.js
@@ -55,6 +55,16 @@ routes.post(
 
       // Generate JWT token
       const token = jwt.sign({ username: user.username }, jwtSecretKey, { expiresIn: '1h' });
+
+      // Set token as HTTP-only cookie
+      res.cookie('token', token, {
+        httpOnly: true,
+        sameSite: 'strict',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 3600000, // 1 hour
+      });
+
+      // Return token as well for client-side use if needed
       res.json({ token });
       console.debug('JWT token generated for login request', {
         timestamp: new Date().toISOString(),

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,7 @@ const path = require('path');
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes.js");
 
-app.use(cors());
+app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
 app.use(routes);
 


### PR DESCRIPTION
## Summary
- send login JWT as HTTP-only cookie and read it from middleware
- drop localStorage token usage in client and rely on cookies
- always include credentials on fetch requests

## Testing
- `npm test`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689fb99419a4832ebf40d32e33cc90d7