### PR TITLE
Protect character creation with auth

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -1,13 +1,16 @@
 const request = require('supertest');
 const express = require('express');
+const jwt = require('jsonwebtoken');
 
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
+process.env.JWT_SECRET = 'testsecret';
 const charactersRouter = require('../routes.js');
 
 const app = express();
 app.use(express.json());
 app.use(charactersRouter);
+const authToken = jwt.sign({ username: 'alice' }, process.env.JWT_SECRET);
 
 describe('Character routes', () => {
   test('add character success', async () => {
@@ -18,7 +21,8 @@ describe('Character routes', () => {
     });
     const res = await request(app)
       .post('/character/add')
-      .send({ token: 'alice', characterName: 'Hero', campaign: 'Camp1' });
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ characterName: 'Hero', campaign: 'Camp1' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
   });
@@ -34,7 +38,6 @@ describe('Character routes', () => {
       })
     });
     const payload = {
-      token: 'alice',
       characterName: 'Hero',
       campaign: 'Camp1',
       occupation: [{ Level: '1', Name: 'Scout' }],
@@ -46,10 +49,12 @@ describe('Character routes', () => {
     };
     const res = await request(app)
       .post('/character/add')
+      .set('Authorization', `Bearer ${authToken}`)
       .send(payload);
     expect(res.status).toBe(200);
     expect(captured).toMatchObject({
       ...payload,
+      token: 'alice',
       occupation: [{ Level: 1, Name: 'Scout' }]
     });
     expect(Array.isArray(captured.feat)).toBe(true);
@@ -64,7 +69,8 @@ describe('Character routes', () => {
     });
     const res = await request(app)
       .post('/character/add')
-      .send({ token: 'alice', characterName: 'Hero', campaign: 'Camp1' });
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ characterName: 'Hero', campaign: 'Camp1' });
     expect(res.status).toBe(500);
   });
 
@@ -76,7 +82,8 @@ describe('Character routes', () => {
     });
     const res = await request(app)
       .post('/character/add')
-      .send({ token: 'alice' });
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
     expect(res.status).toBe(400);
   });
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -266,10 +266,24 @@ const numericCharacterFields = [
   'useRope',
 ];
 
+const allowedCharacterFields = [
+  'characterName',
+  'campaign',
+  'occupation',
+  'feat',
+  'weapon',
+  'armor',
+  'item',
+  'sex',
+  'newSkill',
+  'diceColor',
+  ...numericCharacterFields,
+];
+
 routes.post(
   '/character/add',
+  authenticateToken,
   [
-    body('token').trim().notEmpty().withMessage('token is required'),
     body('characterName').trim().notEmpty().withMessage('characterName is required'),
     body('campaign').trim().notEmpty().withMessage('campaign is required'),
     body('occupation').optional().isArray(),
@@ -286,7 +300,16 @@ routes.post(
   handleValidationErrors,
   (req, res) => {
     const db_connect = req.db;
-    const myobj = matchedData(req, { locations: ['body'], includeOptionals: true });
+    const data = matchedData(req, { locations: ['body'], includeOptionals: true });
+    const myobj = allowedCharacterFields.reduce(
+      (obj, field) => {
+        if (data[field] !== undefined) {
+          obj[field] = data[field];
+        }
+        return obj;
+      },
+      { token: req.user.username }
+    );
     db_connect.collection('Characters').insertOne(myobj, function (err, result) {
       if (err) {
         return res.status(500).json({ message: 'Internal server error' });


### PR DESCRIPTION
## Summary
- require JWT authentication for `/character/add`
- associate characters with authenticated username instead of body token
- whitelist allowed character fields
- update character route tests to use auth header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fbf7f223c832e8373f2bb72da28f8