### PR TITLE
refactor: modularize server routes

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -3,7 +3,7 @@ const express = require('express');
 
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
-const campaignsRouter = require('../routes.js');
+const campaignsRouter = require('../routes');
 
 const app = express();
 app.use(express.json());

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -3,7 +3,7 @@ const express = require('express');
 
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
-const charactersRouter = require('../routes.js');
+const charactersRouter = require('../routes');
 
 const app = express();
 app.use(express.json());

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -5,7 +5,7 @@ const bcrypt = require('bcryptjs');
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
 process.env.JWT_SECRET = 'testsecret';
-const usersRouter = require('../routes.js');
+const usersRouter = require('../routes');
 
 const app = express();
 app.use(express.json());

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -1,0 +1,9 @@
+const { validationResult } = require('express-validator');
+
+module.exports = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+};

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,59 @@
+const jwt = require('jsonwebtoken');
+const { body } = require('express-validator');
+const authenticateUser = require('../utils/authenticateUser');
+const handleValidationErrors = require('../middleware/validation');
+
+const jwtSecretKey = process.env.JWT_SECRET;
+
+module.exports = (router) => {
+  router.post(
+    '/login',
+    [
+      body('username').trim().notEmpty().withMessage('username is required'),
+      body('password').notEmpty().withMessage('password is required'),
+    ],
+    handleValidationErrors,
+    async (req, res) => {
+      const { username, password } = req.body;
+
+      const db_connect = req.db;
+      try {
+        const user = await authenticateUser(db_connect, username, password);
+        if (!user) {
+          return res.status(401).json({ message: 'Invalid username or password' });
+        }
+
+        const token = jwt.sign({ username: user.username }, jwtSecretKey, { expiresIn: '1h' });
+        res.json({ token });
+        console.debug('JWT token generated for login request', {
+          timestamp: new Date().toISOString(),
+        });
+      } catch (err) {
+        res.status(500).json({ message: 'Internal server error' });
+      }
+    }
+  );
+
+  router.post(
+    '/users/verify',
+    [
+      body('username').trim().notEmpty().withMessage('username is required'),
+      body('password').notEmpty().withMessage('password is required'),
+    ],
+    handleValidationErrors,
+    async (req, res) => {
+      const { username, password } = req.body;
+
+      const db_connect = req.db;
+      try {
+        const user = await authenticateUser(db_connect, username, password);
+        if (!user) {
+          return res.status(401).json({ message: 'Invalid username or password' });
+        }
+        res.json({ valid: true });
+      } catch (err) {
+        res.status(500).json({ message: 'Internal server error' });
+      }
+    }
+  );
+};

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1,0 +1,127 @@
+const { param } = require('express-validator');
+const authenticateToken = require('../middleware/auth');
+const handleValidationErrors = require('../middleware/validation');
+
+module.exports = (router) => {
+// Add players to a campaign (protected route)
+router.route('/players/add/:campaign').put(
+  authenticateToken,
+  [
+    param('campaign').trim().notEmpty().withMessage('campaign is required'),
+  ],
+  handleValidationErrors,
+  (req, res) => {
+    if (!Array.isArray(req.body)) {
+      return res
+        .status(400)
+        .json({ errors: [{ msg: 'body must be an array of players', param: 'body' }] });
+    }
+    const campaignName = req.params.campaign;
+    const newPlayers = req.body; // Assuming newPlayers is an array of players
+
+    const db_connect = req.db;
+    db_connect.collection("Campaigns").updateOne(
+      { campaignName: campaignName },
+      { $addToSet: { 'players': { $each: newPlayers } } }, // Add new players to existing array only if they are not already present
+      (err, result) => {
+        if(err) {
+          console.error("Error adding players:", err);
+          return res.status(500).send("Internal Server Error");
+        }
+        console.log("Players added");
+        if (result.modifiedCount === 0) {
+          // If no modifications were made, it means the players were not added because they already exist
+          return res.status(400).send("Players already exist in the array");
+        }
+        res.send('Players added successfully');
+      }
+    );
+  }
+);
+// This section will find all characters in a specific campaign.
+router.route("/campaign/:campaign/characters").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Characters")
+    .find({ campaign: req.params.campaign })
+    .toArray(function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+});
+
+// This section will find all of the users characters in a specific campaign.
+router.route("/campaign/:campaign/:username").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Characters")
+    .find({ campaign: req.params.campaign, token: req.params.username })
+    .toArray(function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+ });
+
+// This section will find a specific campaign.
+router.route("/campaign/:campaign").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Campaigns")
+    .findOne({ campaignName: req.params.campaign }, function (err, result) {
+      if (err) {
+        return res.status(500).json({ message: 'Internal server error' });
+      }
+      res.json(result);
+    });
+});
+
+// This section will get a list of all the campaigns.
+router.route("/campaigns/:player").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Campaigns")
+    .find({ players: { $in: [req.params.player] } }) // Using $in to search for the player in the players array
+    .toArray(function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+});
+
+ // This section will create a new campaign.
+router.route("/campaign/add").post(function (req, response) {
+  let db_connect = req.db;
+  let myobj = {
+  campaignName: req.body.campaignName,
+  gameMode: req.body.gameMode,
+  dm: req.body.dm,
+  players: req.body.players,
+  };
+  db_connect.collection("Campaigns").insertOne(myobj, function (err, res) {
+    if (err) throw err;
+    response.json(res);
+  });
+ });
+
+
+ // This section will be for the DM 
+ router.route("/campaignsDM/:DM").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Campaigns")
+    .find({ dm: req.params.DM })
+    .toArray(function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+ });
+
+ router.route("/campaignsDM/:DM/:campaign").get(function (req, res) {
+  let db_connect = req.db;
+  db_connect
+    .collection("Campaigns")
+    .findOne({ dm: req.params.DM, campaignName: req.params.campaign }, function (err, result) {
+      if (err) throw err;
+      res.json(result);
+    });
+ });
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const routes = express.Router();
+const connectDB = require('../db/conn');
+require('dotenv').config();
+
+const auth = require('./auth');
+const users = require('./users');
+const campaigns = require('./campaigns');
+const characters = require('./characters');
+
+routes.use(async (req, res, next) => {
+  try {
+    req.db = await connectDB();
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+auth(routes);
+users(routes);
+campaigns(routes);
+characters(routes);
+
+module.exports = routes;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,0 +1,69 @@
+const bcrypt = require('bcryptjs');
+const { body } = require('express-validator');
+const authenticateToken = require('../middleware/auth');
+const handleValidationErrors = require('../middleware/validation');
+
+module.exports = (router) => {
+  router.get('/users', authenticateToken, (req, res) => {
+    let db_connect = req.db;
+    db_connect
+      .collection('users')
+      .find({})
+      .toArray(function (err, result) {
+        if (err) {
+          return res.status(500).json({ message: 'Internal server error' });
+        }
+        res.json(result);
+      });
+  });
+
+  router.get('/users/:username', authenticateToken, (req, res) => {
+    let db_connect = req.db;
+    let myquery = { username: req.params.username };
+    db_connect
+      .collection('users')
+      .findOne(myquery, function (err, user) {
+        if (err) {
+          return res.status(500).json({ message: 'Internal server error' });
+        }
+        if (!user) {
+          return res.status(404).json({ message: 'User not found' });
+        }
+        const { password, ...userWithoutPassword } = user;
+        res.json(userWithoutPassword);
+      });
+  });
+
+  router.post(
+    '/users/add',
+    [
+      body('username').trim().notEmpty().withMessage('username is required'),
+      body('password')
+        .isLength({ min: 6 })
+        .withMessage('password must be at least 6 characters'),
+    ],
+    handleValidationErrors,
+    (req, res) => {
+      const { username, password } = req.body;
+
+      bcrypt.hash(password, 10, (err, hashedPassword) => {
+        if (err) {
+          return res.status(500).json({ message: 'Internal server error' });
+        }
+
+        let db_connect = req.db;
+        let myobj = {
+          username: username,
+          password: hashedPassword,
+        };
+
+        db_connect.collection('users').insertOne(myobj, function (err, result) {
+          if (err) {
+            return res.status(500).json({ message: 'Internal server error' });
+          }
+          res.json(result);
+        });
+      });
+    }
+  );
+};

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ require("dotenv").config({ path: "./config.env" });
 const port = process.env.PORT || 5000;
 const path = require('path');
 const connectToDatabase = require("./db/conn");
-const routes = require("./routes.js");
+const routes = require("./routes");
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- split monolithic routes.js into modular routers for auth, users, campaigns, and characters
- add shared validation middleware and new route index
- update server and tests to reference modular routes

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a0b4a5e0832e9913f9df76f23c0a