### PR TITLE
Switch to cookie-based auth

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -19,6 +19,7 @@ async function loginUser(credentials) {
       headers: {
         'Content-Type': 'application/json'
       },
+      credentials: 'include',
       body: JSON.stringify(credentials)
     });
     if (!response.ok) {
@@ -35,11 +36,8 @@ async function loginUser(credentials) {
 async function fetchUserByUsername(username) {
   username = capitalizeFirstLetter(username);
   try {
-    const token = localStorage.getItem('token');
     const response = await fetch(`/users/${username}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      credentials: 'include',
     });
     if (response.ok) {
       const user = await response.json();
@@ -60,6 +58,7 @@ async function createUser(newUser) {
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
       body: JSON.stringify(newUser),
     });
     if (!response.ok) {

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -11,7 +11,8 @@ function NavbarComponent() {
   const { removeToken } = useToken();
   const navigate = useNavigate();
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await fetch('/logout', { method: 'POST', credentials: 'include' });
     removeToken();
     navigate('/login');
   };

--- a/client/src/components/Navbar/Navbar.test.js
+++ b/client/src/components/Navbar/Navbar.test.js
@@ -10,6 +10,10 @@ jest.mock('../../useToken', () => ({
   })
 }));
 
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+});
+
 test('logout navigates to login route', async () => {
   render(
     <MemoryRouter initialEntries={['/']}>

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -6,16 +6,15 @@ import { Link } from "react-router-dom";
 import { jwtDecode } from 'jwt-decode';
 import zombiesbg from "../../../images/zombiesbg.jpg";
 import { FaDungeon, FaCrown } from 'react-icons/fa';
+import useToken from '../../../useToken';
 
 
 export default function ZombiesHome() {
   const navigate = useNavigate();
+  const { token } = useToken();
   const [decodedToken, setDecodedToken] = useState(null);
 
   useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
     if (token) {
       try {
         const decoded = jwtDecode(token);
@@ -24,7 +23,7 @@ export default function ZombiesHome() {
         console.error('Failed to decode token:', error);
       }
     }
-  }, []);
+  }, [token]);
 
 //--------------------------------------------Campaign Section------------------------------
 
@@ -68,7 +67,7 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
       return;
     }
   async function fetchData1() {
-    const response = await fetch(`/campaigns/${decodedToken.username}`);    
+    const response = await fetch(`/campaigns/${decodedToken.username}`, { credentials: 'include' });
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -95,7 +94,7 @@ useEffect(() => {
       return;
     }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${decodedToken.username}`);    
+    const response = await fetch(`/campaignsDM/${decodedToken.username}`, { credentials: 'include' });
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -134,6 +133,7 @@ async function onSubmit1(e) {
        headers: {
          "Content-Type": "application/json",
        },
+       credentials: 'include',
        body: JSON.stringify(newCampaign),
      })
      .catch(error => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -5,17 +5,16 @@ import { useParams, useNavigate } from "react-router-dom";
 import '../../../App.scss';
 import { jwtDecode } from 'jwt-decode';
 import zombiesbg from "../../../images/zombiesbg.jpg";
+import useToken from '../../../useToken';
 
 export default function RecordList() {
   const params = useParams();
   const [records, setRecords] = useState([]);
   const navigate = useNavigate();
+  const { token } = useToken();
   const [decodedToken, setDecodedToken] = useState(null);
 
   useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
     if (token) {
       try {
         const decoded = jwtDecode(token);
@@ -24,14 +23,14 @@ export default function RecordList() {
         console.error('Failed to decode token:', error);
       }
     }
-  }, []);
+  }, [token]);
 
   useEffect(() => {
     if (!decodedToken) {
       return;
     }
     async function getRecords() {
-      const response = await fetch(`/campaign/${params.campaign}/${decodedToken.username}`);
+    const response = await fetch(`/campaign/${params.campaign}/${decodedToken.username}`, { credentials: 'include' });
 
       if (!response.ok) {
         const message = `An error occurred: ${response.statusText}`;
@@ -52,19 +51,7 @@ export default function RecordList() {
     navigate(`/zombies-character-sheet/${id}`);
   }
 
-  useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, []);
+  // Removed duplicate token decode effect
 // --------------------------Random Character Creator Section------------------------------------
  const [form, setForm] = useState({ 
   token: "",
@@ -140,7 +127,7 @@ const handleShow = () => setShow(true);
 // Fetch Occupations
 useEffect(() => {
   async function fetchData() {
-    const response = await fetch(`/occupations`);    
+    const response = await fetch(`/occupations`, { credentials: 'include' });
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -285,6 +272,7 @@ useEffect(() => {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify(newCharacter),
       });
     } catch (error) {
@@ -423,6 +411,7 @@ const sendManualToDb = useCallback(async() => {
       headers: {
         "Content-Type": "application/json",
       },
+      credentials: 'include',
       body: JSON.stringify(newCharacter),
     });
   } catch (error) {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -4,14 +4,13 @@ import Modal from 'react-bootstrap/Modal';
 import { jwtDecode } from 'jwt-decode';
 import { useNavigate, useParams } from "react-router-dom";
 import zombiesbg from "../../../images/zombiesbg.jpg";
+import useToken from '../../../useToken';
 
 export default function ZombiesDM() {
+  const { token } = useToken();
   const [decodedToken, setDecodedToken] = useState(null);
 
   useEffect(() => {
-    // Assuming you have the JWT stored in localStorage
-    const token = localStorage.getItem('token');
-
     if (token) {
       try {
         const decoded = jwtDecode(token);
@@ -20,14 +19,14 @@ export default function ZombiesDM() {
         console.error('Failed to decode token:', error);
       }
     }
-  }, []);
+  }, [token]);
   
     const navigate = useNavigate();
     const params = useParams();
     const [records, setRecords] = useState([]);
     useEffect(() => {
       async function getRecords() {
-        const response = await fetch(`/campaign/${params.campaign}/characters`);
+        const response = await fetch(`/campaign/${params.campaign}/characters`, { credentials: 'include' });
 
         if (!response.ok) {
           const message = `An error occurred: ${response.statusText}`;
@@ -60,7 +59,7 @@ useEffect(() => {
     return;
   }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${decodedToken.username}/${params.campaign}`);    
+    const response = await fetch(`/campaignsDM/${decodedToken.username}/${params.campaign}`, { credentials: 'include' });
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -94,11 +93,8 @@ const [playersSearch, setPlayersSearch] = useState("");
     }
 
     async function fetchUsers() {
-      const token = localStorage.getItem('token');
       const response = await fetch(`/users`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
+        credentials: 'include',
       });
 
       if (!response.ok) {
@@ -127,14 +123,12 @@ async function newPlayerSubmit(e) {
 const currentCampaign = params.campaign.toString();
 async function sendNewPlayersToDb() {
   const newPlayers = [playersSearch];
-  const token = localStorage.getItem('token');
-
   await fetch(`/players/add/${currentCampaign}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": `Bearer ${token}`, // Include the token in the request headers
     },
+    credentials: 'include',
     body: JSON.stringify(newPlayers),
   })
   .then(response => {
@@ -188,6 +182,7 @@ const [form2, setForm2] = useState({
        headers: {
          "Content-Type": "application/json",
        },
+       credentials: 'include',
        body: JSON.stringify(newWeapon),
      })
      .catch(error => {
@@ -233,12 +228,13 @@ const [form2, setForm2] = useState({
   async function sendToDb3(){
     const newArmor = { ...form3 };
     await fetch("/armor/add", {
-     method: "POST",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify(newArmor),
-   })
+       method: "POST",
+       headers: {
+         "Content-Type": "application/json",
+       },
+       credentials: 'include',
+       body: JSON.stringify(newArmor),
+     })
    .catch(error => {
      window.alert(error);
      return;
@@ -314,12 +310,13 @@ const [form2, setForm2] = useState({
   async function sendToDb4(){
     const newItem = { ...form4 };
     await fetch("/item/add", {
-     method: "POST",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify(newItem),
-   })
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: 'include',
+      body: JSON.stringify(newItem),
+    })
    .catch(error => {
      window.alert(error);
      return;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,6 +4,11 @@ import './index.scss';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+const originalFetch = window.fetch;
+window.fetch = (url, options = {}) => {
+  return originalFetch(url, { ...options, credentials: 'include' });
+};
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>

--- a/client/src/useToken.js
+++ b/client/src/useToken.js
@@ -1,17 +1,21 @@
 import { useState } from 'react';
 
 export default function useToken() {
-  const getToken = () => localStorage.getItem('token');
+  const cookieName = 'tokenFront';
+  const getToken = () => {
+    const match = document.cookie.match(new RegExp('(^| )' + cookieName + '=([^;]+)'));
+    return match ? match[2] : null;
+  };
 
   const [token, setToken] = useState(getToken());
 
   const saveToken = (userToken) => {
-    localStorage.setItem('token', userToken);
+    document.cookie = `${cookieName}=${userToken}; path=/`;
     setToken(userToken);
   };
 
   const removeToken = () => {
-    localStorage.removeItem('token');
+    document.cookie = `${cookieName}=; Max-Age=0; path=/`;
     setToken(null);
   };
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -2,8 +2,7 @@ const jwt = require('jsonwebtoken');
 const jwtSecretKey = process.env.JWT_SECRET;
 
 module.exports = function authenticateToken(req, res, next) {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  const token = req.cookies && req.cookies.token;
 
   if (!token) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -24,6 +24,11 @@ module.exports = (router) => {
         }
 
         const token = jwt.sign({ username: user.username }, jwtSecretKey, { expiresIn: '1h' });
+        res.cookie('token', token, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+        });
         res.json({ token });
         console.debug('JWT token generated for login request', {
           timestamp: new Date().toISOString(),
@@ -56,4 +61,9 @@ module.exports = (router) => {
       }
     }
   );
+
+  router.post('/logout', (req, res) => {
+    res.clearCookie('token');
+    res.json({ message: 'Logged out' });
+  });
 };

--- a/server/server.js
+++ b/server/server.js
@@ -7,8 +7,22 @@ const path = require('path');
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
 
-app.use(cors());
+app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
+function parseCookies(req, res, next) {
+  req.cookies = {};
+  const raw = req.headers.cookie;
+  if (raw) {
+    raw.split(';').forEach(cookie => {
+      const parts = cookie.split('=');
+      const key = parts.shift().trim();
+      const value = decodeURIComponent(parts.join('='));
+      req.cookies[key] = value;
+    });
+  }
+  next();
+}
+app.use(parseCookies);
 app.use(routes);
 
 // Adjusted to serve static files from the correct build directory


### PR DESCRIPTION
## Summary
- store auth token in cookies on the client and send with all requests
- issue and clear httpOnly cookies on login/logout
- authenticate requests via cookies instead of Authorization headers

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a3a65cfbb0832ebc1197f95a8dc9fc