### PR TITLE
Refactor routes to async/await

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -17,7 +17,7 @@ describe('Campaign routes', () => {
   test('create campaign success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: (doc, cb) => cb(null, { acknowledged: true })
+        insertOne: async () => ({ acknowledged: true })
       })
     });
     const res = await request(app)
@@ -30,7 +30,7 @@ describe('Campaign routes', () => {
   test('create campaign failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: (doc, cb) => cb(new Error('db error'))
+        insertOne: async () => { throw new Error('db error'); }
       })
     });
     const res = await request(app)
@@ -43,7 +43,7 @@ describe('Campaign routes', () => {
   test('get campaign by name success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: (query, cb) => cb(null, { campaignName: 'Test', dm: 'DM', players: [] })
+        findOne: async () => ({ campaignName: 'Test', dm: 'DM', players: [] })
       })
     });
     const res = await request(app).get('/campaign/Test');
@@ -54,7 +54,7 @@ describe('Campaign routes', () => {
   test('get campaign by name failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: (query, cb) => cb(new Error('db error'))
+        findOne: async () => { throw new Error('db error'); }
       })
     });
     const res = await request(app).get('/campaign/Test');
@@ -64,7 +64,7 @@ describe('Campaign routes', () => {
   test('get campaigns by dm success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ campaignName: 'Test', dm: 'DM' }]) })
+        find: () => ({ toArray: async () => [{ campaignName: 'Test', dm: 'DM' }] })
       })
     });
     const res = await request(app).get('/campaignsDM/DM');
@@ -75,7 +75,7 @@ describe('Campaign routes', () => {
   test('get campaigns by dm failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/campaignsDM/DM');
@@ -85,7 +85,7 @@ describe('Campaign routes', () => {
   test('get campaign by dm and name success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: (query, cb) => cb(null, { campaignName: 'Test', dm: 'DM' })
+        findOne: async () => ({ campaignName: 'Test', dm: 'DM' })
       })
     });
     const res = await request(app).get('/campaignsDM/DM/Test');
@@ -96,7 +96,7 @@ describe('Campaign routes', () => {
   test('get campaign by dm and name failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: (query, cb) => cb(new Error('db error'))
+        findOne: async () => { throw new Error('db error'); }
       })
     });
     const res = await request(app).get('/campaignsDM/DM/Test');

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -14,7 +14,7 @@ describe('Character routes', () => {
   test('add character success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: (doc, cb) => cb(null, { acknowledged: true })
+        insertOne: async () => ({ acknowledged: true })
       })
     });
     const res = await request(app)
@@ -28,9 +28,9 @@ describe('Character routes', () => {
     let captured;
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: (doc, cb) => {
+        insertOne: async (doc) => {
           captured = doc;
-          cb(null, { acknowledged: true });
+          return { acknowledged: true };
         }
       })
     });
@@ -60,7 +60,7 @@ describe('Character routes', () => {
   test('add character db failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: (doc, cb) => cb(new Error('db error'))
+        insertOne: async () => { throw new Error('db error'); }
       })
     });
     const res = await request(app)
@@ -72,7 +72,7 @@ describe('Character routes', () => {
   test('add character validation failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: (doc, cb) => cb(null, { acknowledged: true })
+        insertOne: async () => ({ acknowledged: true })
       })
     });
     const res = await request(app)
@@ -84,7 +84,7 @@ describe('Character routes', () => {
   test('get characters for campaign and user success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ token: 'alice', campaign: 'Camp1' }]) })
+        find: () => ({ toArray: async () => [{ token: 'alice', campaign: 'Camp1' }] })
       })
     });
     const res = await request(app).get('/campaign/Camp1/alice');
@@ -95,7 +95,7 @@ describe('Character routes', () => {
   test('get characters for campaign and user failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/campaign/Camp1/alice');
@@ -105,10 +105,10 @@ describe('Character routes', () => {
   test('get all characters for campaign success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [
+        find: () => ({ toArray: async () => [
           { token: 'alice', campaign: 'Camp1' },
           { token: 'bob', campaign: 'Camp1' }
-        ]) })
+        ] })
       })
     });
     const res = await request(app).get('/campaign/Camp1/characters');
@@ -119,7 +119,7 @@ describe('Character routes', () => {
   test('get all characters for campaign failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/campaign/Camp1/characters');
@@ -139,7 +139,7 @@ describe('Character routes', () => {
     };
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: (query, cb) => cb(null, character)
+        findOne: async () => character
       })
     });
     const res = await request(app).get('/characters/507f1f77bcf86cd799439011');
@@ -152,7 +152,7 @@ describe('Character routes', () => {
   test('get weapons success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ weaponName: 'Sword' }]) })
+        find: () => ({ toArray: async () => [{ weaponName: 'Sword' }] })
       })
     });
     const res = await request(app).get('/weapons/Camp1');
@@ -163,7 +163,7 @@ describe('Character routes', () => {
   test('get weapons failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/weapons/Camp1');
@@ -173,7 +173,7 @@ describe('Character routes', () => {
   test('get armor success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ armorName: 'Plate' }]) })
+        find: () => ({ toArray: async () => [{ armorName: 'Plate' }] })
       })
     });
     const res = await request(app).get('/armor/Camp1');
@@ -184,7 +184,7 @@ describe('Character routes', () => {
   test('get armor failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/armor/Camp1');
@@ -194,7 +194,7 @@ describe('Character routes', () => {
   test('get items success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ itemName: 'Potion' }]) })
+        find: () => ({ toArray: async () => [{ itemName: 'Potion' }] })
       })
     });
     const res = await request(app).get('/items/Camp1');
@@ -205,7 +205,7 @@ describe('Character routes', () => {
   test('get items failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/items/Camp1');
@@ -215,7 +215,7 @@ describe('Character routes', () => {
   test('get feats success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ feat: 'Power Attack' }]) })
+        find: () => ({ toArray: async () => [{ feat: 'Power Attack' }] })
       })
     });
     const res = await request(app).get('/feats');
@@ -226,7 +226,7 @@ describe('Character routes', () => {
   test('get feats failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/feats');
@@ -236,7 +236,7 @@ describe('Character routes', () => {
   test('get occupations success', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(null, [{ name: 'Soldier' }]) })
+        find: () => ({ toArray: async () => [{ name: 'Soldier' }] })
       })
     });
     const res = await request(app).get('/occupations');
@@ -247,7 +247,7 @@ describe('Character routes', () => {
   test('get occupations failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/occupations');
@@ -306,7 +306,7 @@ describe('Character routes', () => {
 
   test('add weapon success', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: (doc, cb) => cb(null, { acknowledged: true }) })
+      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
     });
     const res = await request(app)
       .post('/weapon/add')
@@ -317,7 +317,7 @@ describe('Character routes', () => {
 
   test('add weapon failure', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: (doc, cb) => cb(new Error('db error')) })
+      collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
       .post('/weapon/add')
@@ -327,7 +327,7 @@ describe('Character routes', () => {
 
   test('add armor success', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: (doc, cb) => cb(null, { acknowledged: true }) })
+      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
     });
     const res = await request(app)
       .post('/armor/add')
@@ -338,7 +338,7 @@ describe('Character routes', () => {
 
   test('add armor failure', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: (doc, cb) => cb(new Error('db error')) })
+      collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
       .post('/armor/add')
@@ -348,7 +348,7 @@ describe('Character routes', () => {
 
   test('add item success', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: (doc, cb) => cb(null, { acknowledged: true }) })
+      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
     });
     const res = await request(app)
       .post('/item/add')
@@ -359,7 +359,7 @@ describe('Character routes', () => {
 
   test('add item failure', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: (doc, cb) => cb(new Error('db error')) })
+      collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
       .post('/item/add')

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -67,7 +67,7 @@ describe('Users routes', () => {
   test('get users failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        find: () => ({ toArray: (cb) => cb(new Error('db error')) })
+        find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
     const res = await request(app).get('/users');

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -15,7 +15,7 @@ module.exports = (router) => {
       param('campaign').trim().notEmpty().withMessage('campaign is required'),
     ],
     handleValidationErrors,
-     (req, res, next) => {
+    async (req, res) => {
       if (!Array.isArray(req.body)) {
         return res
           .status(400)
@@ -24,111 +24,121 @@ module.exports = (router) => {
       const campaignName = req.params.campaign;
       const newPlayers = req.body; // Assuming newPlayers is an array of players
 
-      const db_connect = req.db;
-      db_connect.collection("Campaigns").updateOne(
-        { campaignName: campaignName },
-        { $addToSet: { 'players': { $each: newPlayers } } }, // Add new players to existing array only if they are not already present
-        (err, result) => {
-          if(err) {
-            console.error("Error adding players:", err);
-            return res.status(500).send("Internal Server Error");
-          }
-          console.log("Players added");
-          if (result.modifiedCount === 0) {
-            // If no modifications were made, it means the players were not added because they already exist
-            return res.status(400).send("Players already exist in the array");
-          }
-          res.send('Players added successfully');
+      try {
+        const db_connect = req.db;
+        const result = await db_connect.collection("Campaigns").updateOne(
+          { campaignName: campaignName },
+          { $addToSet: { players: { $each: newPlayers } } }
+        );
+        console.log("Players added");
+        if (result.modifiedCount === 0) {
+          return res.status(400).send("Players already exist in the array");
         }
-      );
+        res.send('Players added successfully');
+      } catch (err) {
+        console.error("Error adding players:", err);
+        res.status(500).send("Internal Server Error");
+      }
     }
   );
 
   // This section will find all characters in a specific campaign.
-  campaignRouter.route("/campaign/:campaign/characters").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Characters")
-      .find({ campaign: req.params.campaign })
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  campaignRouter.route("/campaign/:campaign/characters").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Characters")
+        .find({ campaign: req.params.campaign })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will find all of the users characters in a specific campaign.
-  campaignRouter.route("/campaign/:campaign/:username").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Characters")
-      .find({ campaign: req.params.campaign, token: req.params.username })
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  campaignRouter.route("/campaign/:campaign/:username").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Characters")
+        .find({ campaign: req.params.campaign, token: req.params.username })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
    });
 
   // This section will find a specific campaign.
-  campaignRouter.route("/campaign/:campaign").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Campaigns")
-      .findOne({ campaignName: req.params.campaign }, function (err, result) {
-        if (err) {
-          return res.status(500).json({ message: 'Internal server error' });
-        }
-        res.json(result);
-      });
+  campaignRouter.route("/campaign/:campaign").get(async (req, res) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Campaigns")
+        .findOne({ campaignName: req.params.campaign });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ message: 'Internal server error' });
+    }
   });
 
   // This section will get a list of all the campaigns.
-  campaignRouter.route("/campaigns/:player").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Campaigns")
-      .find({ players: { $in: [req.params.player] } }) // Using $in to search for the player in the players array
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  campaignRouter.route("/campaigns/:player").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Campaigns")
+        .find({ players: { $in: [req.params.player] } })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will create a new campaign.
-  campaignRouter.route("/campaign/add").post(function (req, response, next) {
-    let db_connect = req.db;
-    let myobj = {
+  campaignRouter.route("/campaign/add").post(async (req, response, next) => {
+    const db_connect = req.db;
+    const myobj = {
       campaignName: req.body.campaignName,
       gameMode: req.body.gameMode,
       dm: req.body.dm,
       players: req.body.players,
     };
-    db_connect.collection("Campaigns").insertOne(myobj, function (err, res) {
-      if (err) return next(err);
-      response.json(res);
-    });
+    try {
+      const result = await db_connect.collection("Campaigns").insertOne(myobj);
+      response.json(result);
+    } catch (err) {
+      next(err);
+    }
    });
 
 
   // This section will be for the DM
-  campaignRouter.route("/campaignsDM/:DM").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Campaigns")
-      .find({ dm: req.params.DM })
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  campaignRouter.route("/campaignsDM/:DM").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Campaigns")
+        .find({ dm: req.params.DM })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
    });
 
-  campaignRouter.route("/campaignsDM/:DM/:campaign").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Campaigns")
-      .findOne({ dm: req.params.DM, campaignName: req.params.campaign }, function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  campaignRouter.route("/campaignsDM/:DM/:campaign").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Campaigns")
+        .findOne({ dm: req.params.DM, campaignName: req.params.campaign });
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   router.use(campaignRouter);

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -11,109 +11,123 @@ module.exports = (router) => {
   // ----------------------------------------------------Weapon Section----------------------------------------------------
 
   // This section will get a list of all the weapons.
-  equipmentRouter.route("/weapons/:campaign").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Weapons")
-      .find({ campaign: req.params.campaign })
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  equipmentRouter.route("/weapons/:campaign").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Weapons")
+        .find({ campaign: req.params.campaign })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will update weapons.
-  equipmentRouter.route('/update-weapon/:id').put((req, res, next) => {
-    let id = { _id: ObjectId(req.params.id) };
-    let db_connect = req.db;
-    db_connect.collection("Characters").updateOne(id, {$set:{
-    'weapon': req.body.weapon
-  }}, (err, result) => {
-      if (err) { return next(err); }
+  equipmentRouter.route('/update-weapon/:id').put(async (req, res, next) => {
+    const id = { _id: ObjectId(req.params.id) };
+    const db_connect = req.db;
+    try {
+      await db_connect.collection("Characters").updateOne(id, {
+        $set: { 'weapon': req.body.weapon }
+      });
       console.log("character weapon updated");
       res.send('user updated sucessfully');
-    });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will create a new weapon.
-  equipmentRouter.route("/weapon/add").post(function  (req, response, next) {
-    let db_connect = req.db;
-    let myobj = {
-    campaign: req.body.campaign,
-    weaponName: req.body.weaponName,
-    enhancement: req.body.enhancement,
-    damage: req.body.damage,
-    critical: req.body.critical,
-    weaponStyle: req.body.weaponStyle,
-    range: req.body.range
+  equipmentRouter.route("/weapon/add").post(async (req, response, next) => {
+    const db_connect = req.db;
+    const myobj = {
+      campaign: req.body.campaign,
+      weaponName: req.body.weaponName,
+      enhancement: req.body.enhancement,
+      damage: req.body.damage,
+      critical: req.body.critical,
+      weaponStyle: req.body.weaponStyle,
+      range: req.body.range
     };
-    db_connect.collection("Weapons").insertOne(myobj, function (err, res) {
-      if (err) return next(err);
-      response.json(res);
-    });
+    try {
+      const result = await db_connect.collection("Weapons").insertOne(myobj);
+      response.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // -----------------------------------------------------Armor Section--------------------------------------------------------
 
   // This section will get a list of all the armor.
-  equipmentRouter.route("/armor/:campaign").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Armor")
-      .find({ campaign: req.params.campaign })
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  equipmentRouter.route("/armor/:campaign").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Armor")
+        .find({ campaign: req.params.campaign })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will create a new armor.
-  equipmentRouter.route("/armor/add").post(function  (req, response, next) {
-    let db_connect = req.db;
-    let myobj = {
-    campaign: req.body.campaign,
-    armorName: req.body.armorName,
-    armorBonus: req.body.armorBonus,
-    maxDex: req.body.maxDex,
-    armorCheckPenalty: req.body.armorCheckPenalty
+  equipmentRouter.route("/armor/add").post(async (req, response, next) => {
+    const db_connect = req.db;
+    const myobj = {
+      campaign: req.body.campaign,
+      armorName: req.body.armorName,
+      armorBonus: req.body.armorBonus,
+      maxDex: req.body.maxDex,
+      armorCheckPenalty: req.body.armorCheckPenalty
     };
-    db_connect.collection("Armor").insertOne(myobj, function (err, res) {
-      if (err) return next(err);
-      response.json(res);
-    });
+    try {
+      const result = await db_connect.collection("Armor").insertOne(myobj);
+      response.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will update armors.
-  equipmentRouter.route('/update-armor/:id').put((req, res, next) => {
-    let id = { _id: ObjectId(req.params.id) };
-    let db_connect = req.db;
-    db_connect.collection("Characters").updateOne(id, {$set:{
-    'armor': req.body.armor
-  }}, (err, result) => {
-      if (err) { return next(err); }
+  equipmentRouter.route('/update-armor/:id').put(async (req, res, next) => {
+    const id = { _id: ObjectId(req.params.id) };
+    const db_connect = req.db;
+    try {
+      await db_connect.collection("Characters").updateOne(id, {
+        $set: { 'armor': req.body.armor }
+      });
       console.log("character armor updated");
       res.send('user updated sucessfully');
-    });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // ------------------------------------------------------Item Section-----------------------------------------------------------
 
   // This section will get a list of all the items.
-  equipmentRouter.route("/items/:campaign").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Items")
-      .find({ campaign: req.params.campaign })
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  equipmentRouter.route("/items/:campaign").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Items")
+        .find({ campaign: req.params.campaign })
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will create a new item.
-  equipmentRouter.route("/item/add").post(function  (req, response, next) {
-    let db_connect = req.db;
-    let myobj = {
+  equipmentRouter.route("/item/add").post(async (req, response, next) => {
+    const db_connect = req.db;
+    const myobj = {
       campaign: req.body.campaign,
       itemName: req.body.itemName,
       notes: req.body.notes,
@@ -154,23 +168,27 @@ module.exports = (router) => {
       useTech: req.body.useTech,
       useRope: req.body.useRope
     };
-    db_connect.collection("Items").insertOne(myobj, function (err, res) {
-      if (err) return next(err);
-      response.json(res);
-    });
+    try {
+      const result = await db_connect.collection("Items").insertOne(myobj);
+      response.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will update items.
-  equipmentRouter.route('/update-item/:id').put((req, res, next) => {
-    let id = { _id: ObjectId(req.params.id) };
-    let db_connect = req.db;
-    db_connect.collection("Characters").updateOne(id, {$set:{
-    'item': req.body.item
-  }}, (err, result) => {
-      if (err) { return next(err); }
+  equipmentRouter.route('/update-item/:id').put(async (req, res, next) => {
+    const id = { _id: ObjectId(req.params.id) };
+    const db_connect = req.db;
+    try {
+      await db_connect.collection("Characters").updateOne(id, {
+        $set: { 'item': req.body.item }
+      });
       console.log("character item updated");
       res.send('user updated sucessfully');
-    });
+    } catch (err) {
+      next(err);
+    }
   });
 
   router.use(equipmentRouter);

--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -9,21 +9,23 @@ module.exports = (router) => {
   featRouter.use(authenticateToken);
 
   // This section will get a list of all the feats.
-  featRouter.route("/feats").get(function (req, res, next) {
-    let db_connect = req.db;
-    db_connect
-      .collection("Feats")
-      .find({})
-      .toArray(function (err, result) {
-        if (err) return next(err);
-        res.json(result);
-      });
+  featRouter.route("/feats").get(async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect
+        .collection("Feats")
+        .find({})
+        .toArray();
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will create a new feat.
-  featRouter.route("/feat/add").post(function  (req, response, next) {
-    let db_connect = req.db;
-    let myobj = {
+  featRouter.route("/feat/add").post(async (req, response, next) => {
+    const db_connect = req.db;
+    const myobj = {
       featName: req.body.featName,
       notes: req.body.notes,
       appraise: req.body.appraise,
@@ -57,23 +59,27 @@ module.exports = (router) => {
       useTech: req.body.useTech,
       useRope: req.body.useRope
     };
-    db_connect.collection("Feats").insertOne(myobj, function (err, res) {
-      if (err) return next(err);
-      response.json(res);
-    });
+    try {
+      const result = await db_connect.collection("Feats").insertOne(myobj);
+      response.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will update feats.
-  featRouter.route('/update-feat/:id').put((req, res, next) => {
-    let id = { _id: ObjectId(req.params.id) };
-    let db_connect = req.db;
-    db_connect.collection("Characters").updateOne(id, {$set:{
-    'feat': req.body.feat
-  }}, (err, result) => {
-      if (err) { return next(err); }
+  featRouter.route('/update-feat/:id').put(async (req, res, next) => {
+    const id = { _id: ObjectId(req.params.id) };
+    const db_connect = req.db;
+    try {
+      await db_connect.collection("Characters").updateOne(id, {
+        $set: { 'feat': req.body.feat }
+      });
       console.log("character feat updated");
       res.send('user updated sucessfully');
-    });
+    } catch (err) {
+      next(err);
+    }
   });
 
   router.use(featRouter);

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -58,16 +58,18 @@ module.exports = (router) => {
   });
 
   // This section will update added skills.
-  skillsRouter.route('/update-add-skill/:id').put((req, res, next) => {
-    let id = { _id: ObjectId(req.params.id) };
-    let db_connect = req.db;
-    db_connect.collection("Characters").updateOne(id, {$set:{
-    'newSkill': req.body.newSkill
-  }}, (err, result) => {
-      if (err) { return next(err); }
+  skillsRouter.route('/update-add-skill/:id').put(async (req, res, next) => {
+    const id = { _id: ObjectId(req.params.id) };
+    const db_connect = req.db;
+    try {
+      await db_connect.collection("Characters").updateOne(id, {
+        $set: { 'newSkill': req.body.newSkill }
+      });
       console.log("character knowledge updated");
       res.send('user updated sucessfully');
-    });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // This section will update ranks of skills.

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -4,34 +4,29 @@ const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 
 module.exports = (router) => {
-  router.get('/users', authenticateToken, (req, res) => {
-    let db_connect = req.db;
-    db_connect
-      .collection('users')
-      .find({})
-      .toArray(function (err, result) {
-        if (err) {
-          return res.status(500).json({ message: 'Internal server error' });
-        }
-        res.json(result);
-      });
+  router.get('/users', authenticateToken, async (req, res) => {
+    try {
+      const db_connect = req.db;
+      const result = await db_connect.collection('users').find({}).toArray();
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ message: 'Internal server error' });
+    }
   });
 
-  router.get('/users/:username', authenticateToken, (req, res) => {
-    let db_connect = req.db;
-    let myquery = { username: req.params.username };
-    db_connect
-      .collection('users')
-      .findOne(myquery, function (err, user) {
-        if (err) {
-          return res.status(500).json({ message: 'Internal server error' });
-        }
-        if (!user) {
-          return res.status(404).json({ message: 'User not found' });
-        }
-        const { password, ...userWithoutPassword } = user;
-        res.json(userWithoutPassword);
-      });
+  router.get('/users/:username', authenticateToken, async (req, res) => {
+    try {
+      const db_connect = req.db;
+      const myquery = { username: req.params.username };
+      const user = await db_connect.collection('users').findOne(myquery);
+      if (!user) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+      const { password, ...userWithoutPassword } = user;
+      res.json(userWithoutPassword);
+    } catch (err) {
+      res.status(500).json({ message: 'Internal server error' });
+    }
   });
 
   router.post(


### PR DESCRIPTION
## Summary
- refactor server MongoDB routes to use async/await with error handling
- update tests to mock async database calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb27bb28832ebae53e4952e2725f