### PR TITLE
feat: add useDecodedToken hook and tests

### DIFF
--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -3,27 +3,14 @@ import { Button, Col, Container, Form, Row, Table, Card } from "react-bootstrap"
 import { useNavigate } from "react-router-dom";
 import Modal from 'react-bootstrap/Modal';
 import { Link } from "react-router-dom";
-import { jwtDecode } from 'jwt-decode';
 import zombiesbg from "../../../images/zombiesbg.jpg";
 import { FaDungeon, FaCrown } from 'react-icons/fa';
-import useToken from '../../../useToken';
+import useDecodedToken from '../../../hooks/useDecodedToken';
 
 
 export default function ZombiesHome() {
   const navigate = useNavigate();
-  const { token } = useToken();
-  const [decodedToken, setDecodedToken] = useState(null);
-
-  useEffect(() => {
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, [token]);
+  const decodedToken = useDecodedToken();
 
 //--------------------------------------------Campaign Section------------------------------
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -3,27 +3,14 @@ import Button from 'react-bootstrap/Button';
 import { Table, Form, Modal, Card } from 'react-bootstrap';
 import { useParams, useNavigate } from "react-router-dom";
 import '../../../App.scss';
-import { jwtDecode } from 'jwt-decode';
 import zombiesbg from "../../../images/zombiesbg.jpg";
-import useToken from '../../../useToken';
+import useDecodedToken from '../../../hooks/useDecodedToken';
 
 export default function RecordList() {
   const params = useParams();
   const [records, setRecords] = useState([]);
   const navigate = useNavigate();
-  const { token } = useToken();
-  const [decodedToken, setDecodedToken] = useState(null);
-
-  useEffect(() => {
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, [token]);
+  const decodedToken = useDecodedToken();
 
   useEffect(() => {
     if (!decodedToken) {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1,25 +1,12 @@
 import React, { useState, useEffect } from "react";
 import { Button, Col, Form, Row, Container, Table, Card } from "react-bootstrap";
 import Modal from 'react-bootstrap/Modal';
-import { jwtDecode } from 'jwt-decode';
 import { useNavigate, useParams } from "react-router-dom";
 import zombiesbg from "../../../images/zombiesbg.jpg";
-import useToken from '../../../useToken';
+import useDecodedToken from '../../../hooks/useDecodedToken';
 
 export default function ZombiesDM() {
-  const { token } = useToken();
-  const [decodedToken, setDecodedToken] = useState(null);
-
-  useEffect(() => {
-    if (token) {
-      try {
-        const decoded = jwtDecode(token);
-        setDecodedToken(decoded);
-      } catch (error) {
-        console.error('Failed to decode token:', error);
-      }
-    }
-  }, [token]);
+  const decodedToken = useDecodedToken();
   
     const navigate = useNavigate();
     const params = useParams();

--- a/client/src/hooks/useDecodedToken.js
+++ b/client/src/hooks/useDecodedToken.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { jwtDecode } from 'jwt-decode';
+import useToken from '../useToken';
+
+// Custom hook that retrieves a JWT from cookies via useToken,
+// decodes it and returns the decoded payload. It gracefully
+// handles missing or malformed tokens by returning null.
+export default function useDecodedToken() {
+  const { token } = useToken();
+  const [decodedToken, setDecodedToken] = useState(null);
+
+  useEffect(() => {
+    if (!token) {
+      setDecodedToken(null);
+      return;
+    }
+    try {
+      const decoded = jwtDecode(token);
+      setDecodedToken(decoded);
+    } catch (error) {
+      console.error('Failed to decode token:', error);
+      setDecodedToken(null);
+    }
+  }, [token]);
+
+  return decodedToken;
+}
+

--- a/client/src/hooks/useDecodedToken.test.js
+++ b/client/src/hooks/useDecodedToken.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import useDecodedToken from './useDecodedToken';
+
+// Helper component to expose hook value
+function TestComponent() {
+  const decoded = useDecodedToken();
+  return <div>{decoded ? decoded.username : 'no-token'}</div>;
+}
+
+describe('useDecodedToken', () => {
+  const validToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.signature';
+
+  afterEach(() => {
+    // Clear token cookie after each test
+    document.cookie = 'tokenFront=; Max-Age=0; path=/';
+    jest.restoreAllMocks();
+  });
+
+  test('decodes a valid token', async () => {
+    document.cookie = `tokenFront=${validToken}`;
+    render(<TestComponent />);
+    expect(await screen.findByText('test')).toBeInTheDocument();
+  });
+
+  test('returns null and logs error on invalid token', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    document.cookie = 'tokenFront=invalid.token';
+    render(<TestComponent />);
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(screen.getByText('no-token')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `useDecodedToken` hook for JWT decoding
- refactor Zombie pages to consume new hook
- test decoding behavior and error handling

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a48d0d9db4832eaa6b586b9555c973