### PR TITLE
Replace custom cookie parser with cookie-parser middleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "express-validator": "^6.15.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const app = express();
 const cors = require("cors");
+const cookieParser = require("cookie-parser");
 require("dotenv").config({ path: "./config.env" });
 const port = process.env.PORT || 5000;
 const path = require('path');
@@ -9,20 +10,7 @@ const routes = require("./routes");
 
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
-function parseCookies(req, res, next) {
-  req.cookies = {};
-  const raw = req.headers.cookie;
-  if (raw) {
-    raw.split(';').forEach(cookie => {
-      const parts = cookie.split('=');
-      const key = parts.shift().trim();
-      const value = decodeURIComponent(parts.join('='));
-      req.cookies[key] = value;
-    });
-  }
-  next();
-}
-app.use(parseCookies);
+app.use(cookieParser());
 app.use(routes);
 
 // Adjusted to serve static files from the correct build directory


### PR DESCRIPTION
## Summary
- add cookie-parser dependency to server package
- replace homemade cookie parsing with cookie-parser middleware

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c251f6d0832eaf58880155b1af68