### PR TITLE
feat: use default jwt decode import

### DIFF
--- a/client/src/hooks/useDecodedToken.js
+++ b/client/src/hooks/useDecodedToken.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import jwtDecode from 'jwt-decode';
+import { jwtDecode as jwtDecodeNamed } from 'jwt-decode';
+import useToken from '../useToken';
+
+// Custom hook that retrieves a JWT from cookies via useToken,
+// decodes it and returns the decoded payload. It gracefully
+// handles missing or malformed tokens by returning null.
+export default function useDecodedToken() {
+  const { token } = useToken();
+  const [decodedToken, setDecodedToken] = useState(null);
+
+  useEffect(() => {
+    if (!token) {
+      setDecodedToken(null);
+      return;
+    }
+    try {
+      const decode = jwtDecode || jwtDecodeNamed;
+      const decoded = decode(token);
+      setDecodedToken(decoded);
+    } catch (error) {
+      console.error('Failed to decode token:', error);
+      setDecodedToken(null);
+    }
+  }, [token]);
+
+  return decodedToken;
+}

--- a/client/src/hooks/useDecodedToken.test.js
+++ b/client/src/hooks/useDecodedToken.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import useDecodedToken from './useDecodedToken';
+
+// Helper component to expose hook value
+function TestComponent() {
+  const decoded = useDecodedToken();
+  return <div>{decoded ? decoded.username : 'no-token'}</div>;
+}
+
+describe('useDecodedToken', () => {
+  const validToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.signature';
+
+  afterEach(() => {
+    // Clear token cookie after each test
+    document.cookie = 'tokenFront=; Max-Age=0; path=/';
+    jest.restoreAllMocks();
+  });
+
+  test('decodes a valid token', async () => {
+    document.cookie = `tokenFront=${validToken}`;
+    render(<TestComponent />);
+    expect(await screen.findByText('test')).toBeInTheDocument();
+  });
+
+  test('returns null and logs error on invalid token', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    document.cookie = 'tokenFront=invalid.token';
+    render(<TestComponent />);
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(screen.getByText('no-token')).toBeInTheDocument();
+  });
+});

--- a/client/src/useToken.js
+++ b/client/src/useToken.js
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export default function useToken() {
+  const cookieName = 'tokenFront';
+  const getToken = () => {
+    const match = document.cookie.match(new RegExp('(^| )' + cookieName + '=([^;]+)'));
+    return match ? match[2] : null;
+  };
+
+  const [token, setToken] = useState(getToken());
+
+  const saveToken = (userToken) => {
+    document.cookie = `${cookieName}=${userToken}; path=/`;
+    setToken(userToken);
+  };
+
+  const removeToken = () => {
+    document.cookie = `${cookieName}=; Max-Age=0; path=/`;
+    setToken(null);
+  };
+
+  return {
+    setToken: saveToken,
+    token,
+    removeToken,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useDecodedToken` hook using `jwtDecode` default import
- include tests ensuring tokens decode correctly
- restore `useToken` helper for cookie-based JWT access

## Testing
- `CI=true npm test src/hooks/useDecodedToken.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd2d25a4832e9a7bc8640f3830d2