### PR TITLE
refactor: use default jwt-decode import

### DIFF
--- a/client/src/hooks/useDecodedToken.js
+++ b/client/src/hooks/useDecodedToken.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import jwtDecode from 'jwt-decode';
+
+// Custom hook that accepts a JWT token, decodes it and returns the payload.
+// Returns null if no token is provided or the token cannot be decoded.
+export default function useDecodedToken(token) {
+  const [decodedToken, setDecodedToken] = useState(null);
+
+  useEffect(() => {
+    if (!token) {
+      setDecodedToken(null);
+      return;
+    }
+    try {
+      const decoded = jwtDecode(token);
+      setDecodedToken(decoded);
+    } catch (error) {
+      console.error('Failed to decode token:', error);
+      setDecodedToken(null);
+    }
+  }, [token]);
+
+  return decodedToken;
+}


### PR DESCRIPTION
## Summary
- add hook to decode JWTs using default jwt-decode import

## Testing
- `CI=true npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68a506ac3b74832eb495c31a6b07dbb5