### PR TITLE
Include credentials for session-based requests

### DIFF
--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -46,7 +46,9 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
   // Fetch Armors
   useEffect(() => {
     async function fetchArmor() {
-      const response = await fetch(`/armor/${currentCampaign}`);    
+      const response = await fetch(`/armor/${currentCampaign}`, {
+        credentials: 'include',
+      });
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -94,6 +96,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       armor: newArmor,
      }),
@@ -124,6 +127,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify({
          armor: newArmorForm,
         }),
@@ -140,6 +144,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       armor: newArmorForm,
      }),

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -46,7 +46,9 @@ const [feat, setFeat] = useState({
   // ----------------------------------------Fetch Feats-----------------------------------
   useEffect(() => {
     async function fetchFeats() {
-      const response = await fetch(`/feats`);    
+      const response = await fetch(`/feats`, {
+        credentials: 'include',
+      });
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -94,6 +96,7 @@ const [feat, setFeat] = useState({
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       feat: newFeat,
      }),
@@ -124,6 +127,7 @@ const [feat, setFeat] = useState({
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify({
          feat: newFeatForm,
         }),
@@ -140,6 +144,7 @@ const [feat, setFeat] = useState({
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       feat: newFeatForm,
      }),

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -78,6 +78,7 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       tempHealth: health + offset,
      }),

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -12,7 +12,8 @@ export default function Help({props, form, showHelpModal, handleCloseHelpModal})
  // This method will delete a record
  async function deleteRecord() {
   await fetch(`/delete-character/${params.id}`, {
-    method: "DELETE"
+    method: "DELETE",
+    credentials: 'include'
   });
   navigate(`/zombies-character-select/${form.campaign}`);
 }
@@ -54,6 +55,7 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({diceColor: newColor}),
    })
    .catch(error => {

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -34,7 +34,9 @@ export default function Items({form, showItems, handleCloseItems}) {
   // Fetch Items
   useEffect(() => {
     async function fetchItems() {
-      const response = await fetch(`/items/${currentCampaign}`);    
+      const response = await fetch(`/items/${currentCampaign}`, {
+        credentials: 'include',
+      });
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -82,6 +84,7 @@ export default function Items({form, showItems, handleCloseItems}) {
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       item: newItem,
      }),
@@ -112,6 +115,7 @@ export default function Items({form, showItems, handleCloseItems}) {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify({
          item: newItemForm,
         }),
@@ -128,6 +132,7 @@ export default function Items({form, showItems, handleCloseItems}) {
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       item: newItemForm,
      }),

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -57,6 +57,7 @@ export default function LevelUp({ show, handleClose, form }) {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify(updatedLevelForm),
       });
       navigate(0);
@@ -119,6 +120,7 @@ export default function LevelUp({ show, handleClose, form }) {
         headers: {
           "Content-Type": "application/json", // Set content type to JSON
         },
+        credentials: 'include',
         body: JSON.stringify({
           health: addOccupationHealth,
           str: addOccupationStrTotal,
@@ -144,6 +146,7 @@ export default function LevelUp({ show, handleClose, form }) {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify(form.occupation), // Send the array directly
       })
         .then(() => {
@@ -163,7 +166,9 @@ export default function LevelUp({ show, handleClose, form }) {
 
   useEffect(() => {
     async function fetchData() {
-      const response = await fetch(`/occupations`);
+      const response = await fetch(`/occupations`, {
+        credentials: 'include',
+      });
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -71,6 +71,7 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       newSkill: addNewSkill,
      }),
@@ -90,6 +91,7 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
        headers: {
          "Content-Type": "application/json",
        },
+       credentials: 'include',
        body: JSON.stringify(updatedSkills),
      })
      .catch(error => {
@@ -198,6 +200,7 @@ let firstLevelSkill =
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       newSkill: addUpdatedSkill,
      }),

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -51,6 +51,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
       headers: {
         "Content-Type": "application/json",
       },
+      credentials: 'include',
       body: JSON.stringify(stats),
     }).catch((error) => window.alert(error));
 

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -45,7 +45,9 @@ const [weapon, setWeapon] = useState({
   // Fetch Weapons
   useEffect(() => {
     async function fetchWeapons() {
-      const response = await fetch(`/weapons/${currentCampaign}`);    
+      const response = await fetch(`/weapons/${currentCampaign}`, {
+        credentials: 'include',
+      });
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -93,6 +95,7 @@ const [weapon, setWeapon] = useState({
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       weapon: newWeapon,
      }),
@@ -125,6 +128,7 @@ const [weapon, setWeapon] = useState({
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: 'include',
         body: JSON.stringify({
          weapon: newWeaponForm,
         }),
@@ -141,6 +145,7 @@ const [weapon, setWeapon] = useState({
      headers: {
        "Content-Type": "application/json",
      },
+     credentials: 'include',
      body: JSON.stringify({
       weapon: newWeaponForm,
      }),

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -32,7 +32,9 @@ export default function ZombiesCharacterSheet() {
   useEffect(() => {
     async function fetchCharacterData(id) {
       try {
-        const response = await fetch(`/characters/${id}`);
+        const response = await fetch(`/characters/${id}`, {
+          credentials: 'include',
+        });
         if (!response.ok) {
           throw new Error(`Error fetching character data: ${response.statusText}`);
         }


### PR DESCRIPTION
## Summary
- ensure equipment and character management fetch calls include session cookies
- include credentials for stats, skills, and other session-dependent updates
- retrieve characters with credentials to respect authentication

## Testing
- `npm test -- --watchAll=false`
- `PORT=3001 npm start`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a509e54b54832e9a9b0696af8aebf0