### PR TITLE
feat: restrict cors origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Example gif is listed below:
 
 ![Example](./client/public/images/Gif-for-Dnd.gif)
 
+## Configuration
+
+The server expects a comma-separated list of allowed origins in
+`server/config.env` via the `ALLOWED_ORIGINS` variable. For example:
+
+```
+ALLOWED_ORIGINS=http://localhost:3000,https://example.com
+```
+
+Requests from origins not included in this list will be rejected by the
+server's CORS configuration.
+
 
 ## Support
 For help with this webpage please contact

--- a/server/__tests__/cors.test.js
+++ b/server/__tests__/cors.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+const cors = require('cors');
+
+// Set allowed origins for the test
+process.env.ALLOWED_ORIGINS = 'http://allowed.com';
+
+// Re-create the CORS configuration from the server
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+const app = express();
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+    credentials: true,
+  })
+);
+app.get('/test', (req, res) => res.json({ ok: true }));
+app.use((err, req, res, next) => {
+  res.status(500).json({ message: err.message });
+});
+
+describe('CORS origin handling', () => {
+  test('allows requests from configured origins', async () => {
+    const res = await request(app).get('/test').set('Origin', 'http://allowed.com');
+    expect(res.status).toBe(200);
+  });
+
+  test('rejects requests from disallowed origins', async () => {
+    const res = await request(app).get('/test').set('Origin', 'http://bad.com');
+    expect(res.status).toBe(500);
+    expect(res.body.message).toMatch(/Not allowed by CORS/);
+  });
+});

--- a/server/config.env.example
+++ b/server/config.env.example
@@ -1,0 +1,1 @@
+ALLOWED_ORIGINS=http://localhost:3000

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,23 @@ const path = require('path');
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
 
-app.use(cors({ origin: true, credentials: true }));
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
+  .split(",")
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
+  })
+);
 app.use(express.json());
 app.use(cookieParser());
 app.use(routes);


### PR DESCRIPTION
## Summary
- configure CORS middleware to allow only origins specified in `ALLOWED_ORIGINS`
- document origin configuration and provide example env file
- add tests verifying disallowed origins are rejected

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a50cf2dc90832eb1d488d9a96829f0