### PR TITLE
Align tests with current auth flow

### DIFF
--- a/client/src/hooks/useUser.test.js
+++ b/client/src/hooks/useUser.test.js
@@ -26,4 +26,10 @@ describe('useUser', () => {
     render(<TestComponent />);
     await waitFor(() => expect(screen.getByText('no-user')).toBeInTheDocument());
   });
+
+  test('handles fetch error', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('network error')));
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByText('no-user')).toBeInTheDocument());
+  });
 });


### PR DESCRIPTION
## Summary
- Replace outdated token test coverage by exercising `useUser` hook which fetches `/me`
- Add coverage for failed `/me` requests to ensure `useUser` handles errors

## Testing
- `npm test -- --runTestsByPath src/hooks/useUser.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a510d0d3cc832e8a9104d788806314