### PR TITLE
Use explicit env config path for server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2,9 +2,9 @@ const express = require("express");
 const app = express();
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
-require("dotenv").config({ path: "./config.env" });
-const port = process.env.PORT || 5000;
 const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, 'config.env') });
+const port = process.env.PORT || 5000;
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
 


### PR DESCRIPTION
## Summary
- load environment variables from server/config.env using path-aware require

## Testing
- `npm --prefix server test`
- `npm --prefix server start` *(fails: TypeError: Cannot read properties of undefined (reading 'startsWith'))*

------
https://chatgpt.com/codex/tasks/task_e_68a52895afcc832eb6342c262c08809f