### PR TITLE
Add public user existence check for signup

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -34,17 +34,15 @@ async function loginUser(credentials) {
 async function fetchUserByUsername(username) {
   username = capitalizeFirstLetter(username);
   try {
-    const response = await fetch(`/users/${username}`, {
-      credentials: 'include',
-    });
+    const response = await fetch(`/users/exists/${username}`);
     if (response.ok) {
-      const user = await response.json();
-      return user;
+      const { exists } = await response.json();
+      return exists;
     }
-    return null;
+    return false;
   } catch (error) {
     console.error('Fetch user error:', error);
-    return null;
+    return false;
   }
 }
 
@@ -101,8 +99,8 @@ export default function Login({ onLogin }) {
 
   const onSubmit = async (e) => {
     e.preventDefault();
-    const existingUser = await fetchUserByUsername(newUser.username);
-    if (existingUser) {
+    const userExists = await fetchUserByUsername(newUser.username);
+    if (userExists) {
       alert('Username already in use!');
     } else if (newUser.password === newUser.confirmPassword) {
       try {

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -66,6 +66,28 @@ describe('Users routes', () => {
     expect(res.body.valid).toBeUndefined();
   });
 
+  test('user exists endpoint reports existing user', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({ username: 'alice' })
+      })
+    });
+    const res = await request(app).get('/users/exists/alice');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ exists: true });
+  });
+
+  test('user exists endpoint reports non-existing user', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => null
+      })
+    });
+    const res = await request(app).get('/users/exists/bob');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ exists: false });
+  });
+
   test('get users failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -14,6 +14,18 @@ module.exports = (router) => {
     }
   });
 
+  router.get('/users/exists/:username', async (req, res) => {
+    try {
+      const db_connect = req.db;
+      const user = await db_connect
+        .collection('users')
+        .findOne({ username: req.params.username });
+      res.json({ exists: !!user });
+    } catch (err) {
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  });
+
   router.get('/users/:username', authenticateToken, async (req, res) => {
     try {
       const db_connect = req.db;


### PR DESCRIPTION
## Summary
- add `/users/exists/:username` endpoint to check if a username is already taken
- use new existence API in login signup flow without credentials
- test user existence endpoint

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5d20a6c68832eb2a5f99e33d51791