### PR TITLE
refactor: extract Home styles into CSS

### DIFF
--- a/client/src/components/Home/Home.css
+++ b/client/src/components/Home/Home.css
@@ -1,0 +1,37 @@
+.home-container {
+  background-image: url("../../images/loginbg.png");
+  background-size: cover;
+  height: 100vh;
+  background-position: center;
+  font-family: 'Raleway, sans-serif';
+}
+
+.home-spacer {
+  padding-top: 90px;
+}
+
+.home-title {
+  font-size: 28px;
+  width: 300px;
+  height: 95px;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.home-button {
+  border-color: transparent;
+  background-image: url("../../images/zombiesbg.jpg");
+  background-position: 50% 25%;
+  background-size: cover;
+  min-width: 300px;
+}
+
+.home-button-text {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+

--- a/client/src/components/Home/Home.js
+++ b/client/src/components/Home/Home.js
@@ -1,32 +1,24 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import loginbg from "../../images/loginbg.png";
-import zombiesbg from "../../images/zombiesbg.jpg";
+import './Home.css';
 export default function Home() {
   return (
-    <div style={{ backgroundImage: `url(${loginbg})`, backgroundSize: 'cover', height: '100vh', backgroundPosition: 'center', fontFamily: 'Raleway, sans-serif' }}>
+    <div className="home-container">
       <center>
-      <div style={{ paddingTop: '90px' }}></div>
-        
-          <h2 className='text-light'
-            style={{            
-            fontSize: 28, 
-            width: "300px", 
-            height: "95px", 
-            backgroundColor: "rgba(0, 0, 0, 0.8)",
-            color: "white", 
-            display: "flex", 
-            alignItems: "center", 
-            justifyContent: "center", 
-            borderRadius: "10px", // Rounded corners
-            boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)" // Light shadow for depth
-          }}>Choose Game Type</h2>
-          <div>
-            <Button href='/zombies' className='p-4 m-1' size='lg' style={{borderColor: "transparent", backgroundImage: `url(${zombiesbg})`, backgroundPosition: '50% 25%', backgroundSize: 'cover', minWidth: 300 }} variant='primary'>
-             <span className="px-2" style={{backgroundColor: "rgba(0, 0, 0, 0.3)"}}>Zombies</span> 
-            </Button>
-          </div>
-        </center>
-      </div>
+        <div className="home-spacer"></div>
+
+        <h2 className="text-light home-title">Choose Game Type</h2>
+        <div>
+          <Button
+            href="/zombies"
+            className="p-4 m-1 home-button"
+            size="lg"
+            variant="primary"
+          >
+            <span className="px-2 home-button-text">Zombies</span>
+          </Button>
+        </div>
+      </center>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Home component stylesheet and move inline styles into classes
- import Home stylesheet and use class names instead of inline style objects

## Testing
- `npm test --prefix client -- --watchAll=false`
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68a5d62c2114832eb6f29f8617c1e113