### PR TITLE
Restrict server CORS to configured client origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ https://github.com/rjo6615/DnD
 
 ## Usage
 
-to use this on your own 
+to use this on your own
 
 Example gif is listed below:
 
 ![Example](./client/public/images/Gif-for-Dnd.gif)
+
+## Environment Variables
+
+The server uses a `config.env` file for configuration. Ensure the following variable is set:
+
+| Variable | Description |
+|----------|-------------|
+| `CLIENT_ORIGIN` | The URL of the client application allowed to make cross-origin requests. |
 
 
 ## Support

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,17 @@ const path = require('path');
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
 
-app.use(cors({ origin: true, credentials: true }));
+// Restrict cross-origin requests to a single approved client
+app.use(cors({
+  origin(origin, callback) {
+    if (!origin || origin === process.env.CLIENT_ORIGIN) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
+}));
 app.use(express.json());
 app.use(cookieParser());
 app.use(routes);


### PR DESCRIPTION
## Summary
- limit CORS requests to `CLIENT_ORIGIN` environment variable
- document `CLIENT_ORIGIN` in README

## Testing
- `npm test`
- `curl -I -H "Origin: http://allowed.com" http://localhost:5000/`
- `curl -I -H "Origin: http://disallowed.com" http://localhost:5000/`

------
https://chatgpt.com/codex/tasks/task_e_68a5da4a64a0832eb618547646d99baf