### PR TITLE
fix: remove credentials option during signup

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -54,7 +54,6 @@ async function createUser(newUser) {
       headers: {
         'Content-Type': 'application/json',
       },
-      credentials: 'include',
       body: JSON.stringify(newUser),
     });
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- remove `credentials: 'include'` from signup `fetch` call

## Testing
- `npm test --prefix server`
- `CI=true npm test --prefix client`
- `ATLAS_URI=mongodb://localhost:27017/test CLIENT_ORIGIN=http://localhost:3000 node server/server.js` *(fails: requires MongoDB instance)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e722f508832ea45f99c1e5a97e27