### PR TITLE
Allow overriding fetch credentials and omit cookies for public calls

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -34,7 +34,7 @@ async function loginUser(credentials) {
 async function fetchUserByUsername(username) {
   username = capitalizeFirstLetter(username);
   try {
-    const response = await fetch(`/users/exists/${username}`);
+    const response = await fetch(`/users/exists/${username}`, { credentials: 'omit' });
     if (response.ok) {
       const { exists } = await response.json();
       return exists;
@@ -54,6 +54,7 @@ async function createUser(newUser) {
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'omit',
       body: JSON.stringify(newUser),
     });
     if (!response.ok) {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -6,7 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 const originalFetch = window.fetch;
 window.fetch = (url, options = {}) => {
-  return originalFetch(url, { ...options, credentials: 'include' });
+  return originalFetch(url, { credentials: 'include', ...options });
 };
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- Allow fetch credentials to be overridden by placing default before options
- Skip sending cookies for unauthenticated signup and username lookup requests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd server && npm test -- --runInBand`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a60c39bb80832eafede5d456b38b01