### PR TITLE
refactor: rely on global fetch credentials

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,7 +18,7 @@ function App() {
   const [checked, setChecked] = useState(false);
 
   useEffect(() => {
-    fetch('/me', { credentials: 'include' })
+    fetch('/me')
       .then(res => (res.ok ? res.json() : null))
       .then(data => setUser(data))
       .finally(() => setChecked(true));

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -19,7 +19,6 @@ async function loginUser(credentials) {
       headers: {
         'Content-Type': 'application/json'
       },
-      credentials: 'include',
       body: JSON.stringify(credentials)
     });
     if (!response.ok) {
@@ -84,7 +83,7 @@ export default function Login({ onLogin }) {
   const handleLogin = async () => {
     try {
       await loginUser({ username, password });
-      const res = await fetch('/me', { credentials: 'include' });
+      const res = await fetch('/me');
       if (res.ok) {
         const user = await res.json();
         onLogin(user);

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -7,7 +7,7 @@ import logoLight from "../../images/logo-light.png";
 
 function NavbarComponent() {
   const handleLogout = async () => {
-    await fetch('/logout', { method: 'POST', credentials: 'include' });
+    await fetch('/logout', { method: 'POST' });
     window.location.assign('/');
   };
 

--- a/client/src/components/Navbar/Navbar.test.js
+++ b/client/src/components/Navbar/Navbar.test.js
@@ -18,7 +18,7 @@ test('logout calls endpoint and redirects', async () => {
 
   const buttons = screen.getAllByRole('button', { name: /logout/i });
   await userEvent.click(buttons[buttons.length - 1]);
-  expect(global.fetch).toHaveBeenCalledWith('/logout', expect.objectContaining({ method: 'POST', credentials: 'include' }));
+  expect(global.fetch).toHaveBeenCalledWith('/logout', expect.objectContaining({ method: 'POST' }));
   expect(window.location.assign).toHaveBeenCalledWith('/');
 });
 

--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -46,9 +46,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
   // Fetch Armors
   useEffect(() => {
     async function fetchArmor() {
-      const response = await fetch(`/armor/${currentCampaign}`, {
-        credentials: 'include',
-      });
+      const response = await fetch(`/armor/${currentCampaign}`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -96,7 +94,6 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       armor: newArmor,
      }),
@@ -127,7 +124,6 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify({
          armor: newArmorForm,
         }),
@@ -144,7 +140,6 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       armor: newArmorForm,
      }),

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -46,9 +46,7 @@ const [feat, setFeat] = useState({
   // ----------------------------------------Fetch Feats-----------------------------------
   useEffect(() => {
     async function fetchFeats() {
-      const response = await fetch(`/feats`, {
-        credentials: 'include',
-      });
+      const response = await fetch(`/feats`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -96,7 +94,6 @@ const [feat, setFeat] = useState({
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       feat: newFeat,
      }),
@@ -127,7 +124,6 @@ const [feat, setFeat] = useState({
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify({
          feat: newFeatForm,
         }),
@@ -144,7 +140,6 @@ const [feat, setFeat] = useState({
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       feat: newFeatForm,
      }),

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -78,7 +78,6 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       tempHealth: health + offset,
      }),

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -11,9 +11,8 @@ export default function Help({props, form, showHelpModal, handleCloseHelpModal})
   const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
  // This method will delete a record
  async function deleteRecord() {
-  await fetch(`/delete-character/${params.id}`, {
-    method: "DELETE",
-    credentials: 'include'
+ await fetch(`/delete-character/${params.id}`, {
+   method: "DELETE",
   });
   navigate(`/zombies-character-select/${form.campaign}`);
 }
@@ -50,12 +49,11 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
 
  // Sends dice color update to database
  async function diceColorUpdate(){
-    await fetch(`/update-dice-color/${params.id}`, {
+   await fetch(`/update-dice-color/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({diceColor: newColor}),
    })
    .catch(error => {

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -34,9 +34,7 @@ export default function Items({form, showItems, handleCloseItems}) {
   // Fetch Items
   useEffect(() => {
     async function fetchItems() {
-      const response = await fetch(`/items/${currentCampaign}`, {
-        credentials: 'include',
-      });
+      const response = await fetch(`/items/${currentCampaign}`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -84,7 +82,6 @@ export default function Items({form, showItems, handleCloseItems}) {
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       item: newItem,
      }),
@@ -115,7 +112,6 @@ export default function Items({form, showItems, handleCloseItems}) {
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify({
          item: newItemForm,
         }),
@@ -132,7 +128,6 @@ export default function Items({form, showItems, handleCloseItems}) {
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       item: newItemForm,
      }),

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -57,7 +57,6 @@ export default function LevelUp({ show, handleClose, form }) {
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify(updatedLevelForm),
       });
       navigate(0);
@@ -120,7 +119,6 @@ export default function LevelUp({ show, handleClose, form }) {
         headers: {
           "Content-Type": "application/json", // Set content type to JSON
         },
-        credentials: 'include',
         body: JSON.stringify({
           health: addOccupationHealth,
           str: addOccupationStrTotal,
@@ -146,7 +144,6 @@ export default function LevelUp({ show, handleClose, form }) {
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify(form.occupation), // Send the array directly
       })
         .then(() => {
@@ -166,9 +163,7 @@ export default function LevelUp({ show, handleClose, form }) {
 
   useEffect(() => {
     async function fetchData() {
-      const response = await fetch(`/occupations`, {
-        credentials: 'include',
-      });
+      const response = await fetch(`/occupations`);
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -71,7 +71,6 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       newSkill: addNewSkill,
      }),
@@ -91,7 +90,6 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
        headers: {
          "Content-Type": "application/json",
        },
-       credentials: 'include',
        body: JSON.stringify(updatedSkills),
      })
      .catch(error => {
@@ -200,7 +198,6 @@ let firstLevelSkill =
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       newSkill: addUpdatedSkill,
      }),

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -51,7 +51,6 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
       headers: {
         "Content-Type": "application/json",
       },
-      credentials: 'include',
       body: JSON.stringify(stats),
     }).catch((error) => window.alert(error));
 

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -45,9 +45,7 @@ const [weapon, setWeapon] = useState({
   // Fetch Weapons
   useEffect(() => {
     async function fetchWeapons() {
-      const response = await fetch(`/weapons/${currentCampaign}`, {
-        credentials: 'include',
-      });
+      const response = await fetch(`/weapons/${currentCampaign}`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -95,7 +93,6 @@ const [weapon, setWeapon] = useState({
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       weapon: newWeapon,
      }),
@@ -128,7 +125,6 @@ const [weapon, setWeapon] = useState({
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify({
          weapon: newWeaponForm,
         }),
@@ -145,7 +141,6 @@ const [weapon, setWeapon] = useState({
      headers: {
        "Content-Type": "application/json",
      },
-     credentials: 'include',
      body: JSON.stringify({
       weapon: newWeaponForm,
      }),

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -54,7 +54,7 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
       return;
     }
   async function fetchData1() {
-    const response = await fetch(`/campaigns/${user.username}`, { credentials: 'include' });
+    const response = await fetch(`/campaigns/${user.username}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -81,7 +81,7 @@ useEffect(() => {
       return;
     }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${user.username}`, { credentials: 'include' });
+    const response = await fetch(`/campaignsDM/${user.username}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -120,7 +120,6 @@ async function onSubmit1(e) {
        headers: {
          "Content-Type": "application/json",
        },
-       credentials: 'include',
        body: JSON.stringify(newCampaign),
      })
      .catch(error => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -19,7 +19,7 @@ export default function RecordList() {
       return;
     }
     async function getRecords() {
-    const response = await fetch(`/campaign/${params.campaign}/${user.username}`, { credentials: 'include' });
+    const response = await fetch(`/campaign/${params.campaign}/${user.username}`);
 
       if (!response.ok) {
         const message = `An error occurred: ${response.statusText}`;
@@ -90,7 +90,7 @@ const handleShow = () => setShow(true);
 // Fetch Occupations
 useEffect(() => {
   async function fetchData() {
-    const response = await fetch(`/occupations`, { credentials: 'include' });
+    const response = await fetch(`/occupations`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -235,7 +235,6 @@ useEffect(() => {
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: 'include',
         body: JSON.stringify(newCharacter),
       });
     } catch (error) {
@@ -321,7 +320,6 @@ const sendManualToDb = useCallback(async() => {
       headers: {
         "Content-Type": "application/json",
       },
-      credentials: 'include',
       body: JSON.stringify(newCharacter),
     });
   } catch (error) {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -32,9 +32,7 @@ export default function ZombiesCharacterSheet() {
   useEffect(() => {
     async function fetchCharacterData(id) {
       try {
-        const response = await fetch(`/characters/${id}`, {
-          credentials: 'include',
-        });
+        const response = await fetch(`/characters/${id}`);
         if (!response.ok) {
           throw new Error(`Error fetching character data: ${response.statusText}`);
         }

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -13,7 +13,7 @@ export default function ZombiesDM() {
     const [records, setRecords] = useState([]);
     useEffect(() => {
       async function getRecords() {
-        const response = await fetch(`/campaign/${params.campaign}/characters`, { credentials: 'include' });
+        const response = await fetch(`/campaign/${params.campaign}/characters`);
 
         if (!response.ok) {
           const message = `An error occurred: ${response.statusText}`;
@@ -46,7 +46,7 @@ useEffect(() => {
     return;
   }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${user.username}/${params.campaign}`, { credentials: 'include' });
+    const response = await fetch(`/campaignsDM/${user.username}/${params.campaign}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -80,9 +80,7 @@ const [playersSearch, setPlayersSearch] = useState("");
     }
 
     async function fetchUsers() {
-      const response = await fetch(`/users`, {
-        credentials: 'include',
-      });
+      const response = await fetch(`/users`);
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -115,7 +113,6 @@ async function sendNewPlayersToDb() {
     headers: {
       "Content-Type": "application/json",
     },
-    credentials: 'include',
     body: JSON.stringify(newPlayers),
   })
   .then(response => {
@@ -169,7 +166,6 @@ const [form2, setForm2] = useState({
        headers: {
          "Content-Type": "application/json",
        },
-       credentials: 'include',
        body: JSON.stringify(newWeapon),
      })
      .catch(error => {
@@ -219,7 +215,6 @@ const [form2, setForm2] = useState({
        headers: {
          "Content-Type": "application/json",
        },
-       credentials: 'include',
        body: JSON.stringify(newArmor),
      })
    .catch(error => {
@@ -301,7 +296,6 @@ const [form2, setForm2] = useState({
       headers: {
         "Content-Type": "application/json",
       },
-      credentials: 'include',
       body: JSON.stringify(newItem),
     })
    .catch(error => {

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -5,7 +5,7 @@ export default function useUser() {
 
   useEffect(() => {
     let isMounted = true;
-    fetch('/me', { credentials: 'include' })
+    fetch('/me')
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (isMounted) {

--- a/client/src/hooks/useUser.test.js
+++ b/client/src/hooks/useUser.test.js
@@ -18,7 +18,7 @@ describe('useUser', () => {
     );
     render(<TestComponent />);
     expect(await screen.findByText('test')).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledWith('/me', expect.objectContaining({ credentials: 'include' }));
+    expect(global.fetch).toHaveBeenCalledWith('/me');
   });
 
   test('handles missing user', async () => {


### PR DESCRIPTION
## Summary
- remove redundant `credentials: 'include'` from component fetch calls
- keep explicit `credentials: 'omit'` where necessary
- update tests to match implicit credentials

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a611c77be4832e8f3b05844201dc31