### PR TITLE
refactor: replace console logs with notifications

### DIFF
--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -132,7 +132,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
         window.alert(error);
         return;
       });
-      console.log("Armor Deleted")
+      window.alert("Armor Deleted")
       navigate(0);
     } else {
     await fetch(`/update-armor/${params.id}`, {
@@ -148,7 +148,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
      window.alert(error);
      return;
    });
-   console.log("Armor Deleted")
+   window.alert("Armor Deleted")
    navigate(0);
   }
   }

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -132,7 +132,7 @@ const [feat, setFeat] = useState({
         window.alert(error);
         return;
       });
-      console.log("Feat Deleted")
+      window.alert("Feat Deleted")
       navigate(0);
     } else {
     await fetch(`/update-feat/${params.id}`, {
@@ -148,7 +148,7 @@ const [feat, setFeat] = useState({
      window.alert(error);
      return;
    });
-   console.log("Feat Deleted")
+   window.alert("Feat Deleted")
    navigate(0);
   }
   }

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -120,7 +120,7 @@ export default function Items({form, showItems, handleCloseItems}) {
         window.alert(error);
         return;
       });
-      console.log("Item Deleted")
+      window.alert("Item Deleted")
       navigate(0);
     } else {
     await fetch(`/update-item/${params.id}`, {
@@ -136,7 +136,7 @@ export default function Items({form, showItems, handleCloseItems}) {
      window.alert(error);
      return;
    });
-   console.log("Item Deleted")
+   window.alert("Item Deleted")
    navigate(0);
   }
   }

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -131,7 +131,7 @@ export default function LevelUp({ show, handleClose, form }) {
         }), // Send as a JSON object
       })
         .then(() => {
-          console.log("Database update complete");
+          window.alert("Database update complete");
         })
         .catch((error) => {
           // Handle errors here
@@ -147,7 +147,7 @@ export default function LevelUp({ show, handleClose, form }) {
         body: JSON.stringify(form.occupation), // Send the array directly
       })
         .then(() => {
-          console.log("Database update complete");
+          window.alert("Database update complete");
           navigate(0);
         })
         .catch((error) => {

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -133,7 +133,7 @@ const [weapon, setWeapon] = useState({
         window.alert(error);
         return;
       });
-      console.log("Weapon Deleted")
+      window.alert("Weapon Deleted")
       navigate(0);
     } else {
     await fetch(`/update-weapon/${params.id}`, {
@@ -149,7 +149,7 @@ const [weapon, setWeapon] = useState({
      window.alert(error);
      return;
    });
-   console.log("Weapon Deleted")
+   window.alert("Weapon Deleted")
    navigate(0);
   }
   }

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -2,6 +2,7 @@ const { param } = require('express-validator');
 const express = require('express');
 const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
+const logger = require('../utils/logger');
 
 module.exports = (router) => {
   const campaignRouter = express.Router();
@@ -30,13 +31,13 @@ module.exports = (router) => {
           { campaignName: campaignName },
           { $addToSet: { players: { $each: newPlayers } } }
         );
-        console.log("Players added");
+        logger.info("Players added");
         if (result.modifiedCount === 0) {
           return res.status(400).send("Players already exist in the array");
         }
         res.send('Players added successfully');
       } catch (err) {
-        console.error("Error adding players:", err);
+        logger.error(`Error adding players: ${err}`);
         res.status(500).send("Internal Server Error");
       }
     }

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -3,6 +3,7 @@ const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../../middleware/auth');
 const handleValidationErrors = require('../../middleware/validation');
+const logger = require('../../utils/logger');
 
 module.exports = (router) => {
   const characterRouter = express.Router();
@@ -120,7 +121,7 @@ module.exports = (router) => {
     const myquery = { _id: ObjectId(req.params.id) };
     try {
       const obj = await db_connect.collection('Characters').deleteOne(myquery);
-      console.log('1 character deleted');
+      logger.info('1 character deleted');
       response.json(obj);
     } catch (err) {
       next(err);
@@ -152,7 +153,7 @@ module.exports = (router) => {
         updateOperation
       );
       if (result.modifiedCount !== 0) {
-        console.log(`Character updated for Occupation: ${selectedOccupation}`);
+        logger.info(`Character updated for Occupation: ${selectedOccupation}`);
         res.send('Update complete');
       }
     } catch (err) {
@@ -168,7 +169,7 @@ module.exports = (router) => {
       await db_connect.collection('Characters').updateOne(id, {
         $set: { diceColor: req.body.diceColor },
       });
-      console.log('Dice Color updated');
+      logger.info('Dice Color updated');
       res.send('user updated sucessfully');
     } catch (err) {
       next(err);

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -1,6 +1,7 @@
 const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../../middleware/auth');
+const logger = require('../../utils/logger');
 
 module.exports = (router) => {
   const characterRouter = express.Router();
@@ -16,7 +17,7 @@ module.exports = (router) => {
       await db_connect.collection('Characters').updateOne(id, {
         $set: { tempHealth: req.body.tempHealth },
       });
-      console.log('character tempHealth updated');
+      logger.info('character tempHealth updated');
       res.send('user updated sucessfully');
     } catch (err) {
       next(err);
@@ -41,10 +42,10 @@ module.exports = (router) => {
           startStatTotal: req.body.startStatTotal,
         },
       });
-      console.log('Character health and stats updated');
+      logger.info('Character health and stats updated');
       res.send('User updated successfully');
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       res.status(500).send('Server error');
     }
   });

--- a/server/routes/characters/occupations.js
+++ b/server/routes/characters/occupations.js
@@ -1,6 +1,7 @@
 const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../../middleware/auth');
+const logger = require('../../utils/logger');
 
 module.exports = (router) => {
   const characterRouter = express.Router();
@@ -31,10 +32,10 @@ module.exports = (router) => {
       await db_connect.collection('Characters').updateOne(id, {
         $set: { occupation: req.body },
       });
-      console.log('Character occupations updated');
+      logger.info('Character occupations updated');
       res.send('User updated successfully');
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       res.status(500).send('Server error');
     }
   });

--- a/server/routes/characters/stats.js
+++ b/server/routes/characters/stats.js
@@ -1,6 +1,7 @@
 const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../../middleware/auth');
+const logger = require('../../utils/logger');
 
 module.exports = (router) => {
   const characterRouter = express.Router();
@@ -23,7 +24,7 @@ module.exports = (router) => {
           cha: req.body.cha,
         },
       });
-      console.log('character stats updated');
+      logger.info('character stats updated');
       res.send('user updated sucessfully');
     } catch (err) {
       next(err);

--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -1,6 +1,7 @@
 const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../middleware/auth');
+const logger = require('../utils/logger');
 
 module.exports = (router) => {
   const featRouter = express.Router();
@@ -75,7 +76,7 @@ module.exports = (router) => {
       await db_connect.collection("Characters").updateOne(id, {
         $set: { 'feat': req.body.feat }
       });
-      console.log("character feat updated");
+      logger.info("character feat updated");
       res.send('user updated sucessfully');
     } catch (err) {
       next(err);

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -1,6 +1,7 @@
 const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../middleware/auth');
+const logger = require('../utils/logger');
 
 module.exports = (router) => {
   const skillsRouter = express.Router();
@@ -65,7 +66,7 @@ module.exports = (router) => {
       await db_connect.collection("Characters").updateOne(id, {
         $set: { 'newSkill': req.body.newSkill }
       });
-      console.log("character knowledge updated");
+      logger.info("character knowledge updated");
       res.send('user updated sucessfully');
     } catch (err) {
       next(err);

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,10 @@
+const logger = {
+  info: (message) => {
+    console.log(message);
+  },
+  error: (message) => {
+    console.error(message);
+  }
+};
+
+module.exports = logger;


### PR DESCRIPTION
## Summary
- replace console logging in server routes with a shared logger
- notify users via alerts instead of console logging in client components

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a61bf07f64832e987b6663ad1e0a95