### PR TITLE
Scope credentials to same-origin fetch requests

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,8 +5,14 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const originalFetch = window.fetch;
-window.fetch = (url, options = {}) => {
-  return originalFetch(url, { credentials: 'include', ...options });
+window.fetch = (input, init = {}) => {
+  const url = input instanceof Request ? input.url : input;
+  const { origin } = new URL(url, window.location.href);
+  const isSameOrigin = origin === window.location.origin;
+  const options = isSameOrigin
+    ? { credentials: 'include', ...init }
+    : init;
+  return originalFetch(input, options);
 };
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- Only include credentials with fetch when requesting same-origin URLs

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a620e344d0832eb3d595246e24b0ff