### PR TITLE
Introduce structured logging with winston

### DIFF
--- a/server/db/conn.js
+++ b/server/db/conn.js
@@ -1,4 +1,5 @@
 const { MongoClient } = require("mongodb");
+const logger = require('../utils/logger');
 
 const uri = process.env.ATLAS_URI;
 let db;
@@ -12,7 +13,7 @@ async function connectToDatabase() {
   });
 
   db = client.db("dnd");
-  console.log("Successfully connected to MongoDB.");
+  logger.info('Successfully connected to MongoDB.');
   return db;
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,8 @@
     "express-validator": "^6.15.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^4.4.0",
-    "mongoose": "^7.0.1"
+    "mongoose": "^7.0.1",
+    "winston": "^3.10.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,6 +3,7 @@ const { body } = require('express-validator');
 const authenticateUser = require('../utils/authenticateUser');
 const handleValidationErrors = require('../middleware/validation');
 const authenticateToken = require('../middleware/auth');
+const logger = require('../utils/logger');
 
 const jwtSecretKey = process.env.JWT_SECRET;
 
@@ -31,10 +32,12 @@ module.exports = (router) => {
           sameSite: 'strict',
         });
         res.json({ message: 'Logged in' });
-        console.debug('JWT token generated for login request', {
+        logger.info('JWT token generated for login request', {
           timestamp: new Date().toISOString(),
+          token,
         });
       } catch (err) {
+        logger.error('Error during login request', { error: err.message });
         res.status(500).json({ message: 'Internal server error' });
       }
     }

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,10 +1,33 @@
-const logger = {
-  info: (message) => {
-    console.log(message);
-  },
-  error: (message) => {
-    console.error(message);
-  }
-};
+const { createLogger, format, transports } = require('winston');
+
+// Fields that should not appear in logs
+const SENSITIVE_FIELDS = ['password', 'token'];
+
+// Recursively redact sensitive fields from log info
+const redactSensitive = format((info) => {
+  const redact = (obj) => {
+    Object.keys(obj).forEach((key) => {
+      if (SENSITIVE_FIELDS.includes(key)) {
+        obj[key] = '[REDACTED]';
+      } else if (obj[key] && typeof obj[key] === 'object') {
+        redact(obj[key]);
+      }
+    });
+  };
+
+  redact(info);
+  return info;
+});
+
+const logger = createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: format.combine(
+    redactSensitive(),
+    format.timestamp(),
+    format.json()
+  ),
+  transports: [new transports.Console()],
+});
 
 module.exports = logger;
+


### PR DESCRIPTION
## Summary
- add winston-based logger with redaction
- use logger in auth and db connection modules
- record login token generation and DB connection with appropriate log levels

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find module 'winston')*


------
https://chatgpt.com/codex/tasks/task_e_68a63ae075dc832e904df5bd65c524c2