### PR TITLE
Add Helmet and rate limiting middleware

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,9 @@
         "express-validator": "^6.15.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^4.4.0",
-        "mongoose": "^7.0.1"
+        "mongoose": "^7.0.1",
+        "helmet": "^7.0.0",
+        "express-rate-limit": "^6.7.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -10291,6 +10293,14 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "helmet": {
+      "version": "7.0.0",
+      "requires": {}
+    },
+    "express-rate-limit": {
+      "version": "6.7.0",
+      "requires": {}
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^4.4.0",
     "mongoose": "^7.0.1",
-    "winston": "^3.10.0"
+    "winston": "^3.10.0",
+    "helmet": "^7.0.0",
+    "express-rate-limit": "^6.7.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,8 @@ const express = require("express");
 const app = express();
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
+const helmet = require("helmet");
+const rateLimit = require("express-rate-limit");
 require("dotenv").config({ path: "./config.env" });
 const port = process.env.PORT || 5000;
 const path = require('path');
@@ -21,6 +23,14 @@ app.use(cors({
 }));
 app.use(express.json());
 app.use(cookieParser());
+app.use(helmet());
+
+const authLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+});
+
+app.use(['/login', '/logout', '/users/verify', '/me'], authLimiter);
 app.use(routes);
 
 // Adjusted to serve static files from the correct build directory


### PR DESCRIPTION
## Summary
- add Helmet and express-rate-limit dependencies
- secure server with Helmet and auth route rate limiting

## Testing
- `npm test`
- `node server.js` *(fails: Cannot find module 'helmet')*

------
https://chatgpt.com/codex/tasks/task_e_68a642020d00832e94d1eba7433810f5