### PR TITLE
Add configuration utility with env var validation

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -1,3 +1,7 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGIN = 'http://localhost';
+
 const request = require('supertest');
 const express = require('express');
 

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -1,3 +1,7 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGIN = 'http://localhost';
+
 const request = require('supertest');
 const express = require('express');
 

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -1,3 +1,7 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGIN = 'http://localhost';
+
 const request = require('supertest');
 const express = require('express');
 

--- a/server/__tests__/unauthorized.test.js
+++ b/server/__tests__/unauthorized.test.js
@@ -1,3 +1,7 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGIN = 'http://localhost';
+
 const request = require('supertest');
 const express = require('express');
 

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -1,3 +1,7 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGIN = 'http://localhost';
+
 const request = require('supertest');
 const express = require('express');
 const bcrypt = require('bcryptjs');
@@ -5,7 +9,6 @@ const bcrypt = require('bcryptjs');
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
 jest.mock('../middleware/auth', () => (req, res, next) => next());
-process.env.JWT_SECRET = 'testsecret';
 const usersRouter = require('../routes');
 
 const app = express();

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -4,8 +4,9 @@ const authenticateUser = require('../utils/authenticateUser');
 const handleValidationErrors = require('../middleware/validation');
 const authenticateToken = require('../middleware/auth');
 const logger = require('../utils/logger');
+const config = require('../utils/config');
 
-const jwtSecretKey = process.env.JWT_SECRET;
+const jwtSecretKey = config.jwtSecret;
 
 module.exports = (router) => {
   router.post(

--- a/server/server.js
+++ b/server/server.js
@@ -4,16 +4,16 @@ const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const helmet = require("helmet");
 const rateLimit = require("express-rate-limit");
-require("dotenv").config({ path: "./config.env" });
-const port = process.env.PORT || 5000;
 const path = require('path');
+const config = require("./utils/config");
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
+const port = process.env.PORT || 5000;
 
 // Restrict cross-origin requests to a single approved client
 app.use(cors({
   origin(origin, callback) {
-    if (!origin || origin === process.env.CLIENT_ORIGIN) {
+    if (!origin || origin === config.clientOrigin) {
       callback(null, true);
     } else {
       callback(new Error('Not allowed by CORS'));

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Load environment variables from config.env located one directory up
+dotenv.config({ path: path.resolve(__dirname, '../config.env') });
+
+const requiredEnv = ['JWT_SECRET', 'ATLAS_URI', 'CLIENT_ORIGIN'];
+
+const missing = requiredEnv.filter((name) => !process.env[name]);
+
+if (missing.length > 0) {
+  throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+}
+
+module.exports = {
+  jwtSecret: process.env.JWT_SECRET,
+  atlasUri: process.env.ATLAS_URI,
+  clientOrigin: process.env.CLIENT_ORIGIN,
+};


### PR DESCRIPTION
## Summary
- centralize environment configuration in `server/utils/config.js`
- use config in server setup and auth routes
- ensure tests define required environment variables

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a64688f6e4832ea4cf85960796bf3c