### PR TITLE
Ensure unique username index and handle duplicates

### DIFF
--- a/server/db/conn.js
+++ b/server/db/conn.js
@@ -14,6 +14,11 @@ async function connectToDatabase() {
 
   db = client.db("dnd");
   logger.info('Successfully connected to MongoDB.');
+
+  // Ensure a unique index on the username field for the users collection
+  await db.collection('users').createIndex({ username: 1 }, { unique: true });
+  logger.info('Ensured unique index on users.username.');
+
   return db;
 }
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -80,6 +80,10 @@ module.exports = (router) => {
         const result = await db_connect.collection('users').insertOne(myobj);
         res.json(result);
       } catch (err) {
+        // Handle duplicate key error thrown by MongoDB unique index
+        if (err.code === 11000) {
+          return res.status(409).json({ message: 'Username already exists' });
+        }
         res.status(500).json({ message: 'Internal server error' });
       }
     }


### PR DESCRIPTION
## Summary
- Ensure a unique `username` index when connecting to MongoDB
- Return HTTP 409 on duplicate usernames during signup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a64ac7ee44832ea3ad3c87288d7591