### PR TITLE
Replace deprecated center tags with styled divs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -7,6 +7,10 @@
   text-align: center;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .App-logo {
   height: 40vmin;
   pointer-events: none;

--- a/client/src/components/Home/Home.js
+++ b/client/src/components/Home/Home.js
@@ -4,7 +4,7 @@ import './Home.css';
 export default function Home() {
   return (
     <div className="home-container">
-      <center>
+      <div className="text-center">
         <div className="home-spacer"></div>
 
         <h2 className="text-light home-title">Choose Game Type</h2>
@@ -18,7 +18,7 @@ export default function Home() {
             <span className="px-2 home-button-text">Zombies</span>
           </Button>
         </div>
-      </center>
+      </div>
     </div>
   );
 }

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -117,7 +117,7 @@ export default function Login({ onLogin }) {
   };
   return (
     <div className="login-background">
-      <center>
+      <div className="text-center">
         <MDBContainer className="raleway-font">
           <MDBRow>
             <MDBCol col='6' className="my-5">
@@ -127,7 +127,7 @@ export default function Login({ onLogin }) {
                   {/* <h1 className="mt-5 mb-5 pb-1 text-light" style={{ fontFamily: 'Raleway, sans-serif' }}>Realm Tracker</h1> */}
                 </div>
                 <p className='text-light'>Please login to your account</p>
-                <center>
+                <div className="text-center">
                     <Form className="w-100 mb-3 form-width">
                       <Form.Group className="" controlId="formUsername">
                         <Form.Label>Username</Form.Label>
@@ -144,7 +144,7 @@ export default function Login({ onLogin }) {
                       <a className="text-light" href="#!">Forgot password?</a>
                     </div>
                   </Form>
-                </center>
+                </div>
                 <div className="d-flex flex-row align-items-center justify-content-center pb-4 mb-4">
                   <p className="mb-0 text-light">Don't have an account?</p>
                   <Button variant="success" className="mx-2" onClick={handleShow}>Sign up</Button>
@@ -176,14 +176,14 @@ export default function Login({ onLogin }) {
                   type="password" placeholder="Confirm password"
                 />
               </Form.Group>
-              <center>
+              <div className="text-center">
                 <Button variant="primary" type="submit">Submit</Button>
                 <Button className="ms-4" variant="secondary" onClick={handleClose}>Close</Button>
-              </center>
+              </div>
             </Form>
           </Modal.Body>
         </Modal>
-      </center>
+      </div>
     </div>
   );
 }

--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -160,7 +160,7 @@ return(
        size="sm"
       centered
        >   
-       <center>
+       <div className="text-center">
         <Card className="zombiesArmor" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>       
         <Card.Title>Armor</Card.Title>
         <Table striped bordered hover size="sm">
@@ -205,7 +205,7 @@ return(
         </Col>
       </Row>
       </Card> 
-    </center>
+    </div>
     </Modal>   
     </div>
 )

--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -18,7 +18,7 @@ export default function CharacterInfo({ form, show, handleClose }) {
 
   return (
     <Modal show={show} onHide={handleClose} size="sm" centered>
-      <center>
+      <div className="text-center">
         <Card style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>
           <Card.Title>Character Info</Card.Title>
           <Table striped bordered hover size="sm">
@@ -61,11 +61,11 @@ export default function CharacterInfo({ form, show, handleClose }) {
               </tr>
             </thead>
           </Table>
-          <center>
+          <div className="text-center">
             <Button style={{ backgroundImage: `url(${levelup})`, backgroundSize: "cover",  backgroundRepeat: "no-repeat", height: "40px", width: "40px"}} className="mx-1 mb-3" variant="secondary" onClick={handleShowLevelUpModal}></Button>
-          </center>
+          </div>
         </Card> 
-      </center>
+      </div>
 
       {/* Render LevelUp modal when showLevelUpModal state is true */}
       <LevelUp show={showLevelUpModal} handleClose={handleCloseLevelUpModal} form={form} />

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -161,7 +161,7 @@ return (
        size="sm"
       centered
        >   
-       <center>
+       <div className="text-center">
         <Card className="zombiesFeats" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>     
         <Card.Title>Feats</Card.Title>
         <Card.Title style={{ display: showFeatBtn}}>Points Left:<span className="mx-1" id="featPointLeft">{featPointsLeft}</span></Card.Title>
@@ -252,7 +252,7 @@ return (
       </Row>
       </Card> 
       <Modal show={showFeatNotes} onHide={handleCloseFeatNotes} centered>
-        <center>
+        <div className="text-center">
         <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>
           <Card.Title>{modalFeatData[0]}</Card.Title>
         <Card.Body>{modalFeatData[1]}</Card.Body>
@@ -262,9 +262,9 @@ return (
           </Button>
         </Modal.Footer>
         </Card>
-        </center>
+        </div>
       </Modal>
-</center>
+</div>
 </Modal>
 </div> 
 )

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -69,7 +69,7 @@ return(
         aria-labelledby="contained-modal-title-vcenter"
         centered
         className="text-center" show={showHelpModal} onHide={handleCloseHelpModal}>
-          <center>
+          <div className="text-center">
           <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>
           <Card.Body>
           Actions Left (from left to right)
@@ -115,14 +115,14 @@ return(
           </Button>
           </Modal.Footer>
           </Card>
-          </center>
+          </div>
           </Modal>
           <Modal  {...props}
                   size="lg"
                   aria-labelledby="contained-modal-title-vcenter"
                   centered
                   className="text-center" show={showDeleteCharacter} onHide={handleCloseDeleteCharacter}>
-        <center>
+        <div className="text-center">
         <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>       
           <Card.Title>Are you sure you want to delete your character?</Card.Title>
           <Modal.Footer className="justify-content-between">
@@ -134,7 +134,7 @@ return(
           </Button>
           </Modal.Footer>
           </Card>
-          </center>
+          </div>
         </Modal>
     </div>
 )

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -147,7 +147,7 @@ return(
        size="sm"
       centered
        >   
-       <center>
+       <div className="text-center">
         <Card className="zombiesItems" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>     
         <Card.Title>Items</Card.Title>
         <Table striped bordered hover size="sm">
@@ -267,7 +267,7 @@ return(
           </Button>
         </Modal.Footer>
       </Modal>
-</center>
+</div>
 </Modal>
 </div>
 )

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -187,7 +187,7 @@ export default function LevelUp({ show, handleClose, form }) {
   return (
     <div>
       <Modal show={showLvlModal} onHide={handleCloseLvlModal} size="md" centered>
-        <center>
+        <div className="text-center">
           <Card style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover" }}>
             <Card.Title>Level Up</Card.Title>
             <Card.Body>
@@ -211,7 +211,7 @@ export default function LevelUp({ show, handleClose, form }) {
                   Add Occupation
                 </Button>
                 <Modal centered show={showAddClassModal} onHide={() => setShowAddClassModal(false)}>
-                  <center>
+                  <div className="text-center">
                     <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover" }}>
                       <Card.Body>
                         <Form.Group className="mb-3 mx-5">
@@ -245,7 +245,7 @@ export default function LevelUp({ show, handleClose, form }) {
                         </Button>
                       </Modal.Footer>
                     </Card>
-                  </center>
+                  </div>
                 </Modal>
               </Form>
               {/* Level up known occupation */}
@@ -276,7 +276,7 @@ export default function LevelUp({ show, handleClose, form }) {
               </Form>
             </Card.Body>
           </Card>
-        </center>
+        </div>
       </Modal>
     </div>
   );

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -265,7 +265,7 @@ const showSparklesEffect = () => {
 </div>
 {/* Attack Modal */}
       <Modal centered show={showAttack} onHide={handleCloseAttack}>
-      <center>
+      <div className="text-center">
         <Card className="zombiesWeapons" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>      
         <Card.Title>Weapons</Card.Title>
         <Table striped bordered hover size="sm">
@@ -311,7 +311,7 @@ const showSparklesEffect = () => {
           </tbody>
         </Table>      
       </Card> 
-</center>
+</div>
       </Modal>
       {/* --------------------------------------------------Dice Roller--------------------------------------------------------------- */}
       <div className="content">

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -236,7 +236,7 @@ let firstLevelSkill =
          size="sm"
         centered
          >   
-         <center>
+         <div className="text-center">
           <Card className="zombieSkills" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>       
           <Card.Title>Skills</Card.Title>
           <Card.Title style={{ display: showSkillBtn}}>Points Left:<span className="mx-1" id="skillPointLeft">{totalSkillPointsLeft}</span></Card.Title>
@@ -297,9 +297,9 @@ let firstLevelSkill =
           ></Button>
         </div>
       </Card>   
-      </center>
+      </div>
         <Modal show={showAddSkill} onHide={handleCloseAddSkill} centered>
-        <center>
+        <div className="text-center">
           <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>
           <Card.Body>
           <Form onSubmit={addSkillToDb} className="px-5">
@@ -345,7 +345,7 @@ let firstLevelSkill =
           <Modal.Footer>
           </Modal.Footer>
           </Card>
-          </center>
+          </div>
         </Modal>
   </Modal>
   </div>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -77,7 +77,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
 
   return (
     <Modal show={showStats} onHide={handleCloseStats} size="sm" centered className="modern-modal">
-      <center>
+      <div className="text-center">
         <Card className="modern-card">
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">Stats</Card.Title>
@@ -129,7 +129,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
             <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>
           </Card.Footer>
         </Card>
-      </center>
+      </div>
     </Modal>
   );
 }

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -160,7 +160,7 @@ return(
        size="sm"
       centered
        >   
-       <center>
+       <div className="text-center">
         <Card className="zombiesWeapons" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>      
         <Card.Title>Weapons</Card.Title>
         <Table striped bordered hover size="sm">
@@ -225,7 +225,7 @@ return(
         </Col>
       </Row>
       </Card> 
-</center>
+</div>
 </Modal>
     </div>
 )

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -136,7 +136,7 @@ async function onSubmit1(e) {
 
 // -----------------------------------Display-----------------------------------------------------------------------------
  return (
-<center className="pt-2" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
+<div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
       <div style={{paddingTop: "80px"}}></div>
       <h1 className="text-light"
       style={{            
@@ -160,7 +160,7 @@ async function onSubmit1(e) {
       </Button>
 
       <Modal className="dnd-modal" centered show={showJoinCampaignModal} onHide={handleCloseJoinCampaign}>
-   <center>
+   <div className="text-center">
     <Card className="dnd-background">
     <Card.Title>Join Campaign</Card.Title>
 
@@ -191,7 +191,7 @@ async function onSubmit1(e) {
     </Button>
   </Modal.Footer>
   </Card>
-  </center>
+  </div>
 </Modal>
       <Button className="m-2 hostCampaign" style={{borderColor: "transparent"}} onClick={handleShowHostCampaign}>
         <FaCrown className="icon" />
@@ -199,7 +199,7 @@ async function onSubmit1(e) {
       </Button>
 
   <Modal className="dnd-modal" centered show={showHostCampaignModal} onHide={handleCloseHostCampaign}>
-   <center>
+   <div className="text-center">
     <Card className="dnd-background">
     <Card.Title>Host Campaign</Card.Title>
 
@@ -230,7 +230,7 @@ async function onSubmit1(e) {
     </Button>
   </Modal.Footer>
   </Card>
-  </center>
+  </div>
 </Modal>
         </Col>
       </Row>
@@ -241,31 +241,31 @@ async function onSubmit1(e) {
     </Button>
       {/* -----------------------------------Create Campaign--------------------------------------------- */}
       <Modal centered className="dnd-modal" show={show1} onHide={handleClose1}>
-        <center>
+        <div className="text-center">
         <Card className="dnd-background">
           <Card.Title>Create Campaign</Card.Title>
         <Card.Body>   
-        <center>
+        <div className="text-center">
       <Form onSubmit={onSubmit1} className="px-5">
       <Form.Group className="mb-3 pt-3">
        <Form.Label className="text-light">Campaign Name</Form.Label>
        <Form.Control className="mb-2" onChange={(e) => updateForm1({ campaignName: e.target.value })}
         type="text" placeholder="Enter campaign name" />         
      </Form.Group>
-     <center>
+     <div className="text-center">
      <Button variant="primary" onClick={handleClose1} type="submit">
             Create
           </Button>
           <Button className="ms-4" variant="secondary" onClick={handleClose1}>
             Close
           </Button>
-          </center>
+          </div>
      </Form>
-     </center>
+     </div>
      </Card.Body> 
      </Card>   
-     </center>    
+     </div>    
       </Modal>
-    </center>
+    </div>
  )
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -347,7 +347,7 @@ useEffect(() => {
 }, [isSubmitting, sendManualToDb]);
 
   return (
-    <center className="pt-2" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
+    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
       <div style={{paddingTop: '80px'}}>
       <h1 
   style={{ 
@@ -440,38 +440,38 @@ useEffect(() => {
 </svg>
     {/* ---------------------------Create Character (Random)------------------------------------------------------- */}
     <Modal className="dnd-modal" centered show={show} onHide={handleClose}>
-       <center>
+       <div className="text-center">
         <Card className="dnd-background">
           <Card.Title>Create Random</Card.Title>
         <Card.Body>   
-        <center>
+        <div className="text-center">
       <Form onSubmit={onSubmit} className="px-5">
       <Form.Group className="mb-3 pt-3">
        <Form.Label className="text-light">Character Name</Form.Label>
        <Form.Control className="mb-2" onChange={(e) => updateForm({ characterName: e.target.value })}
         type="text" placeholder="Enter character name" />        
      </Form.Group>
-     <center>
+     <div className="text-center">
      <Button variant="primary" onClick={handleClose} type="submit">
             Create
           </Button>
           <Button className="ms-4" variant="secondary" onClick={handleClose}>
             Close
           </Button>
-          </center>
+          </div>
      </Form>
-     </center>
+     </div>
      </Card.Body> 
      </Card>  
-     </center>      
+     </div>      
       </Modal>
        {/* ---------------------------Create Character (Manual)------------------------------------------------------- */}
     <Modal className="dnd-modal" centered show={show5} onHide={handleClose5}>
-       <center>
+       <div className="text-center">
         <Card className="dnd-background">
           <Card.Title>Create Manual</Card.Title>
         <Card.Body>   
-        <center>
+        <div className="text-center">
       <Form 
       onSubmit={onSubmitManual} 
       className="px-5">
@@ -518,22 +518,22 @@ useEffect(() => {
        <Form.Control className="mb-2" onChange={(e) => updateForm({ health: e.target.value, tempHealth: e.target.value })}
         type="number" placeholder="Enter health" pattern="[0-9]*" />
      </Form.Group>
-     <center>
+     <div className="text-center">
      <Button variant="primary" onClick={handleClose5} type="submit">
             Create
           </Button>
           <Button className="ms-4" variant="secondary" onClick={handleClose5}>
             Close
           </Button>
-          </center>
+          </div>
      </Form>
-     </center>
+     </div>
      </Card.Body> 
      </Card>   
-     </center>    
+     </div>    
       </Modal>
       </div>
-    </center>
+    </div>
     
   );
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -132,10 +132,10 @@ if (!form) {
 }
 
 return (
-<center className="pt-3" 
+<div className="pt-3 text-center"
   style={{
     fontFamily: 'Raleway, sans-serif',
-    background: "#FAFAFA", 
+    background: "#FAFAFA",
     height: "100vh"
   }}
 >
@@ -184,6 +184,6 @@ return (
         <Items form={form} showItems={showItems} handleCloseItems={handleCloseItems} />
         <Help form={form} showHelpModal={showHelpModal} handleCloseHelpModal={handleCloseHelpModal} />
       </div>
-    </center>  
+    </div>
   );
 }

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -349,7 +349,7 @@ const [form2, setForm2] = useState({
 
   // -----------------------------------Display-----------------------------------------------------------------------------
  return (
-    <center className="pt-2" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
+    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
           <div style={{paddingTop: '80px'}}></div>
           <h1 className="text-light" 
            style={{            
@@ -406,11 +406,11 @@ const [form2, setForm2] = useState({
     </div>
 
         <Modal className="dnd-modal" centered show={showPlayers} onHide={handleClosePlayers}>
-         <center>
+         <div className="text-center">
           <Card className="dnd-background">
             <Card.Title>Players</Card.Title>
           <Card.Body>   
-        <center>
+        <div className="text-center">
         <Container className="mt-3">
         <Row>
           <Col>
@@ -454,10 +454,10 @@ const [form2, setForm2] = useState({
             <Button className="ms-4" variant="secondary" onClick={handleClosePlayers}>
               Close
             </Button>
-        </center>
+        </div>
        </Card.Body>     
        </Card>   
-       </center>
+       </div>
         </Modal>
 {/* -------------------------------------Add Weapon/Armor/Item--------------------------------------- */}
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" />
@@ -500,11 +500,11 @@ const [form2, setForm2] = useState({
 </svg>
           {/* ----------------------------------Weapon Modal---------------------------------------- */}
           <Modal className="dnd-modal" centered show={show2} onHide={handleClose2}>
-          <center>
+          <div className="text-center">
           <Card className="dnd-background">
             <Card.Title>Create Weapon</Card.Title>         
           <Card.Body>   
-          <center>
+          <div className="text-center">
         <Form onSubmit={onSubmit2} className="px-5">
         <Form.Group className="mb-3 pt-3" >
   
@@ -538,27 +538,27 @@ const [form2, setForm2] = useState({
           type="text" placeholder="Enter Range" />   
   
        </Form.Group>
-       <center>
+       <div className="text-center">
        <Button variant="primary" onClick={handleClose2} type="submit">
               Create
             </Button>
             <Button className="ms-4" variant="secondary" onClick={handleClose2}>
               Close
             </Button>
-            </center>
+            </div>
        </Form>
-       </center>
+       </div>
        </Card.Body>
        </Card>  
-       </center>      
+       </div>      
         </Modal>
   {/* --------------------------------------- Armor Modal --------------------------------- */}
   <Modal className="dnd-modal" centered show={show3} onHide={handleClose3}>
-  <center>
+  <div className="text-center">
   <Card className="dnd-background">
     <Card.Title>Create Armor</Card.Title>
   <Card.Body>   
-  <center>
+  <div className="text-center">
   <Form onSubmit={onSubmit3} className="px-5">
   <Form.Group className="mb-3 pt-3"  >
   <Form.Label className="text-light">Armor Name</Form.Label>
@@ -574,27 +574,27 @@ const [form2, setForm2] = useState({
   <Form.Control className="mb-2" onChange={(e) => updateForm3({ armorCheckPenalty: e.target.value })}
   type="text" placeholder="Enter Armor Check Penalty" />     
   </Form.Group>
-  <center>
+  <div className="text-center">
   <Button variant="primary" onClick={handleClose3} type="submit">
       Create
     </Button>
     <Button className="ms-4" variant="secondary" onClick={handleClose3}>
       Close
     </Button>
-    </center>
+    </div>
   </Form>
-  </center>
+  </div>
   </Card.Body> 
   </Card> 
-  </center>      
+  </div>      
   </Modal>
   {/* -----------------------------------------Item Modal--------------------------------------------- */}
   <Modal className="dnd-modal" centered show={show4} onHide={handleClose4}>
-       <center>
+       <div className="text-center">
         <Card className="dnd-background">
             <Card.Title>Create Item</Card.Title>
           <Card.Body>   
-          <center>
+          <div className="text-center">
         <Form onSubmit={onSubmit4} className="px-5">
         <Form.Group className="mb-3 pt-3" >
   
@@ -751,20 +751,20 @@ const [form2, setForm2] = useState({
           type="text" placeholder="Enter Use Rope" />
   
        </Form.Group>
-       <center>
+       <div className="text-center">
        <Button variant="primary" onClick={handleClose4} type="submit">
               Create
             </Button>
             <Button className="ms-4" variant="secondary" onClick={handleClose4}>
               Close
             </Button>
-            </center>
+            </div>
        </Form>
-       </center>
+       </div>
        </Card.Body> 
        </Card>
-       </center>       
+       </div>       
         </Modal>
-      </center>
+      </div>
     )
 }


### PR DESCRIPTION
## Summary
- replace `<center>` tags across client components with `<div>` wrappers
- add a reusable `.text-center` utility class to maintain alignment

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a650cab224832e9d675ca7b51e1239