### PR TITLE
Fix font-family declaration for Home component

### DIFF
--- a/client/src/components/Home/Home.css
+++ b/client/src/components/Home/Home.css
@@ -3,7 +3,7 @@
   background-size: cover;
   height: 100vh;
   background-position: center;
-  font-family: 'Raleway, sans-serif';
+  font-family: 'Raleway', sans-serif;
 }
 
 .home-spacer {


### PR DESCRIPTION
## Summary
- fix Home page font stack so Raleway falls back to sans-serif correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd client && npm test -- --watchAll=false`
- `fc-list | head -n 20`
- `npm install puppeteer --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a656203264832eb0476d52904d3188