### PR TITLE
feat: add apiFetch utility for authenticated requests

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import apiFetch from './utils/apiFetch';
 import { BrowserRouter as Router, Route, Routes, Navigate, useLocation } from "react-router-dom";
 import Home from "./components/Home/Home";
 import Navbar from "./components/Navbar/Navbar";
@@ -18,7 +19,7 @@ function App() {
   const [checked, setChecked] = useState(false);
 
   useEffect(() => {
-    fetch('/me')
+    apiFetch('/me')
       .then(res => (res.ok ? res.json() : null))
       .then(data => setUser(data))
       .finally(() => setChecked(true));

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -5,6 +5,7 @@ import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
 import { MDBContainer, MDBRow, MDBCol } from 'mdb-react-ui-kit';
 import logoLight from "../../images/logo-light.png";
+import apiFetch from "../../utils/apiFetch";
 import './Login.css';
 
 function capitalizeFirstLetter(string) {
@@ -14,7 +15,7 @@ function capitalizeFirstLetter(string) {
 async function loginUser(credentials) {
   credentials.username = capitalizeFirstLetter(credentials.username);
   try {
-    const response = await fetch('/login', {
+    const response = await apiFetch('/login', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -33,7 +34,7 @@ async function loginUser(credentials) {
 async function fetchUserByUsername(username) {
   username = capitalizeFirstLetter(username);
   try {
-    const response = await fetch(`/users/exists/${username}`, { credentials: 'omit' });
+    const response = await apiFetch(`/users/exists/${username}`, { credentials: 'omit' });
     if (response.ok) {
       const { exists } = await response.json();
       return exists;
@@ -48,7 +49,7 @@ async function fetchUserByUsername(username) {
 async function createUser(newUser) {
   newUser.username = capitalizeFirstLetter(newUser.username);
   try {
-    const response = await fetch('/users/add', {
+    const response = await apiFetch('/users/add', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -83,7 +84,7 @@ export default function Login({ onLogin }) {
   const handleLogin = async () => {
     try {
       await loginUser({ username, password });
-      const res = await fetch('/me');
+      const res = await apiFetch('/me');
       if (res.ok) {
         const user = await res.json();
         onLogin(user);

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -4,10 +4,11 @@ import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
 import logoLight from "../../images/logo-light.png";
+import apiFetch from "../../utils/apiFetch";
 
 function NavbarComponent() {
   const handleLogout = async () => {
-    await fetch('/logout', { method: 'POST' });
+    await apiFetch('/logout', { method: 'POST' });
     window.location.assign('/');
   };
 

--- a/client/src/components/Navbar/Navbar.test.js
+++ b/client/src/components/Navbar/Navbar.test.js
@@ -6,7 +6,7 @@ import Navbar from './Navbar';
 beforeEach(() => {
   global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
   delete window.location;
-  window.location = { assign: jest.fn() };
+  window.location = { assign: jest.fn(), href: 'http://localhost/', origin: 'http://localhost' };
 });
 
 test('logout calls endpoint and redirects', async () => {
@@ -18,7 +18,7 @@ test('logout calls endpoint and redirects', async () => {
 
   const buttons = screen.getAllByRole('button', { name: /logout/i });
   await userEvent.click(buttons[buttons.length - 1]);
-  expect(global.fetch).toHaveBeenCalledWith('/logout', expect.objectContaining({ method: 'POST' }));
+  expect(global.fetch).toHaveBeenCalledWith('/logout', expect.objectContaining({ method: 'POST', credentials: 'include' }));
   expect(window.location.assign).toHaveBeenCalledWith('/');
 });
 

--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
@@ -46,7 +47,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
   // Fetch Armors
   useEffect(() => {
     async function fetchArmor() {
-      const response = await fetch(`/armor/${currentCampaign}`);
+      const response = await apiFetch(`/armor/${currentCampaign}`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -89,7 +90,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
    }
    async function addArmorToDb(e){
     e.preventDefault();
-    await fetch(`/update-armor/${params.id}`, {
+    await apiFetch(`/update-armor/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
@@ -119,7 +120,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
     let newArmorForm = form.armor;
     if (JSON.stringify(form.armor) === JSON.stringify([])){
       newArmorForm = [["","","",""]];
-      await fetch(`/update-armor/${params.id}`, {
+      await apiFetch(`/update-armor/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -135,7 +136,7 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
       window.alert("Armor Deleted")
       navigate(0);
     } else {
-    await fetch(`/update-armor/${params.id}`, {
+    await apiFetch(`/update-armor/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
@@ -46,7 +47,7 @@ const [feat, setFeat] = useState({
   // ----------------------------------------Fetch Feats-----------------------------------
   useEffect(() => {
     async function fetchFeats() {
-      const response = await fetch(`/feats`);
+      const response = await apiFetch(`/feats`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -89,7 +90,7 @@ const [feat, setFeat] = useState({
    }
    async function addFeatToDb(e){
     e.preventDefault();
-    await fetch(`/update-feat/${params.id}`, {
+    await apiFetch(`/update-feat/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
@@ -119,7 +120,7 @@ const [feat, setFeat] = useState({
     let newFeatForm = form.feat;
     if (JSON.stringify(form.feat) === JSON.stringify([])){
       newFeatForm = [["","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","",""]];
-      await fetch(`/update-feat/${params.id}`, {
+      await apiFetch(`/update-feat/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -135,7 +136,7 @@ const [feat, setFeat] = useState({
       window.alert("Feat Deleted")
       navigate(0);
     } else {
-    await fetch(`/update-feat/${params.id}`, {
+    await apiFetch(`/update-feat/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useParams } from "react-router-dom";
 
@@ -73,7 +74,7 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
   const [health, setHealth] = useState(); // Initial health value
  // Sends tempHealth data to database for update
  async function tempHealthUpdate(offset){
-    await fetch(`/update-temphealth/${params.id}`, {
+    await apiFetch(`/update-temphealth/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
@@ -11,7 +12,7 @@ export default function Help({props, form, showHelpModal, handleCloseHelpModal})
   const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
  // This method will delete a record
  async function deleteRecord() {
- await fetch(`/delete-character/${params.id}`, {
+ await apiFetch(`/delete-character/${params.id}`, {
    method: "DELETE",
   });
   navigate(`/zombies-character-select/${form.campaign}`);
@@ -49,7 +50,7 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
 
  // Sends dice color update to database
  async function diceColorUpdate(){
-   await fetch(`/update-dice-color/${params.id}`, {
+   await apiFetch(`/update-dice-color/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
@@ -34,7 +35,7 @@ export default function Items({form, showItems, handleCloseItems}) {
   // Fetch Items
   useEffect(() => {
     async function fetchItems() {
-      const response = await fetch(`/items/${currentCampaign}`);
+      const response = await apiFetch(`/items/${currentCampaign}`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -77,7 +78,7 @@ export default function Items({form, showItems, handleCloseItems}) {
    }
    async function addItemToDb(e){
     e.preventDefault();
-    await fetch(`/update-item/${params.id}`, {
+    await apiFetch(`/update-item/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
@@ -107,7 +108,7 @@ export default function Items({form, showItems, handleCloseItems}) {
     let newItemForm = form.item;
     if (JSON.stringify(form.item) === JSON.stringify([])){
       newItemForm = [["","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","",""]];
-      await fetch(`/update-item/${params.id}`, {
+      await apiFetch(`/update-item/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -123,7 +124,7 @@ export default function Items({form, showItems, handleCloseItems}) {
       window.alert("Item Deleted")
       navigate(0);
     } else {
-    await fetch(`/update-item/${params.id}`, {
+    await apiFetch(`/update-item/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import apiFetch from '../../../utils/apiFetch';
 import { Card, Modal, Button, Form } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
 import levelup from "../../../images/levelup.png";
@@ -52,7 +53,7 @@ export default function LevelUp({ show, handleClose, form }) {
     };
 
     try {
-      await fetch(`/update-level/${params.id}`, {
+      await apiFetch(`/update-level/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -114,7 +115,7 @@ export default function LevelUp({ show, handleClose, form }) {
       form.occupation.push(selectedOccupation);
 
       // Perform the database update here
-      fetch(`/update-health/${params.id}`, {
+      apiFetch(`/update-health/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json", // Set content type to JSON
@@ -139,7 +140,7 @@ export default function LevelUp({ show, handleClose, form }) {
         });
 
       // Perform the database update with the entire form.occupation array
-      fetch(`/update-occupations/${params.id}`, {
+      apiFetch(`/update-occupations/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -163,7 +164,7 @@ export default function LevelUp({ show, handleClose, form }) {
 
   useEffect(() => {
     async function fetchData() {
-      const response = await fetch(`/occupations`);
+      const response = await apiFetch(`/occupations`);
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg";
@@ -66,7 +67,7 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
    }
   async function addSkillToDb(e){
     e.preventDefault();
-    await fetch(`/update-add-skill/${params.id}`, {
+    await apiFetch(`/update-add-skill/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
@@ -85,7 +86,7 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
    // Sends skillForm data to database for update
    async function skillsUpdate(){
     const updatedSkills = { ...skillForm };
-      await fetch(`/update-skills/${params.id}`, {
+      await apiFetch(`/update-skills/${params.id}`, {
        method: "PUT",
        headers: {
          "Content-Type": "application/json",
@@ -193,7 +194,7 @@ let firstLevelSkill =
   
   async function addUpdatedSkillToDb(){
     const addUpdatedSkill = Object.entries({...newSkillForm});
-    await fetch(`/updated-add-skills/${params.id}`, {
+    await apiFetch(`/updated-add-skills/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import apiFetch from '../../../utils/apiFetch';
 import { Card, Table, Modal, Button } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
 
@@ -46,7 +47,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
   }, [stats, totalLevel, startStatTotal]);
 
   async function statsUpdate() {
-    await fetch(`/update-stats/${params.id}`, {
+    await apiFetch(`/update-stats/${params.id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
+import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import wornpaper from "../../../images/wornpaper.jpg"; 
@@ -45,7 +46,7 @@ const [weapon, setWeapon] = useState({
   // Fetch Weapons
   useEffect(() => {
     async function fetchWeapons() {
-      const response = await fetch(`/weapons/${currentCampaign}`);
+      const response = await apiFetch(`/weapons/${currentCampaign}`);
   
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -88,7 +89,7 @@ const [weapon, setWeapon] = useState({
    }
    async function addWeaponToDb(e){
     e.preventDefault();
-    await fetch(`/update-weapon/${params.id}`, {
+    await apiFetch(`/update-weapon/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
@@ -120,7 +121,7 @@ const [weapon, setWeapon] = useState({
     let newWeaponForm = form.weapon;
     if (JSON.stringify(form.weapon) === JSON.stringify([])){
       newWeaponForm = [["","","","","",""]];
-      await fetch(`/update-weapon/${params.id}`, {
+      await apiFetch(`/update-weapon/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -136,7 +137,7 @@ const [weapon, setWeapon] = useState({
       window.alert("Weapon Deleted")
       navigate(0);
     } else {
-    await fetch(`/update-weapon/${params.id}`, {
+    await apiFetch(`/update-weapon/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, } from "react";
+import apiFetch from '../../../utils/apiFetch';
 import { Button, Col, Container, Form, Row, Table, Card } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import Modal from 'react-bootstrap/Modal';
@@ -54,7 +55,7 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
       return;
     }
   async function fetchData1() {
-    const response = await fetch(`/campaigns/${user.username}`);
+    const response = await apiFetch(`/campaigns/${user.username}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -81,7 +82,7 @@ useEffect(() => {
       return;
     }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${user.username}`);
+    const response = await apiFetch(`/campaignsDM/${user.username}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -115,7 +116,7 @@ async function onSubmit1(e) {
 }
  async function sendToDb1(){
     const newCampaign = { ...form1 };
-      await fetch("/campaign/add", {
+      await apiFetch("/campaign/add", {
        method: "POST",
        headers: {
          "Content-Type": "application/json",

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
+import apiFetch from '../../../utils/apiFetch';
 import Button from 'react-bootstrap/Button';
 import { Table, Form, Modal, Card } from 'react-bootstrap';
 import { useParams, useNavigate } from "react-router-dom";
@@ -19,7 +20,7 @@ export default function RecordList() {
       return;
     }
     async function getRecords() {
-    const response = await fetch(`/campaign/${params.campaign}/${user.username}`);
+    const response = await apiFetch(`/campaign/${params.campaign}/${user.username}`);
 
       if (!response.ok) {
         const message = `An error occurred: ${response.statusText}`;
@@ -90,7 +91,7 @@ const handleShow = () => setShow(true);
 // Fetch Occupations
 useEffect(() => {
   async function fetchData() {
-    const response = await fetch(`/occupations`);
+    const response = await apiFetch(`/occupations`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -230,7 +231,7 @@ useEffect(() => {
    const sendToDb = useCallback(async () => {
     const newCharacter = { ...form };
     try {
-      await fetch("/character/add", {
+      await apiFetch("/character/add", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -315,7 +316,7 @@ const sendManualToDb = useCallback(async() => {
   try {
     // Call the API endpoint for manual character creation
     // Adjust the endpoint URL as needed
-    await fetch("/character/add", {
+    await apiFetch("/character/add", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button } from 'react-bootstrap';
 import '../../../App.scss';
@@ -32,7 +33,7 @@ export default function ZombiesCharacterSheet() {
   useEffect(() => {
     async function fetchCharacterData(id) {
       try {
-        const response = await fetch(`/characters/${id}`);
+        const response = await apiFetch(`/characters/${id}`);
         if (!response.ok) {
           throw new Error(`Error fetching character data: ${response.statusText}`);
         }

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import apiFetch from '../../../utils/apiFetch';
 import { Button, Col, Form, Row, Container, Table, Card } from "react-bootstrap";
 import Modal from 'react-bootstrap/Modal';
 import { useNavigate, useParams } from "react-router-dom";
@@ -13,7 +14,7 @@ export default function ZombiesDM() {
     const [records, setRecords] = useState([]);
     useEffect(() => {
       async function getRecords() {
-        const response = await fetch(`/campaign/${params.campaign}/characters`);
+        const response = await apiFetch(`/campaign/${params.campaign}/characters`);
 
         if (!response.ok) {
           const message = `An error occurred: ${response.statusText}`;
@@ -46,7 +47,7 @@ useEffect(() => {
     return;
   }
   async function fetchCampaignsDM() {
-    const response = await fetch(`/campaignsDM/${user.username}/${params.campaign}`);
+    const response = await apiFetch(`/campaignsDM/${user.username}/${params.campaign}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -80,7 +81,7 @@ const [playersSearch, setPlayersSearch] = useState("");
     }
 
     async function fetchUsers() {
-      const response = await fetch(`/users`);
+      const response = await apiFetch(`/users`);
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -108,7 +109,7 @@ async function newPlayerSubmit(e) {
 const currentCampaign = params.campaign.toString();
 async function sendNewPlayersToDb() {
   const newPlayers = [playersSearch];
-  await fetch(`/players/add/${currentCampaign}`, {
+  await apiFetch(`/players/add/${currentCampaign}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -161,7 +162,7 @@ const [form2, setForm2] = useState({
   
   async function sendToDb2(){
     const newWeapon = { ...form2 };
-      await fetch("/weapon/add", {
+      await apiFetch("/weapon/add", {
        method: "POST",
        headers: {
          "Content-Type": "application/json",
@@ -210,7 +211,7 @@ const [form2, setForm2] = useState({
   
   async function sendToDb3(){
     const newArmor = { ...form3 };
-    await fetch("/armor/add", {
+    await apiFetch("/armor/add", {
        method: "POST",
        headers: {
          "Content-Type": "application/json",
@@ -291,7 +292,7 @@ const [form2, setForm2] = useState({
   
   async function sendToDb4(){
     const newItem = { ...form4 };
-    await fetch("/item/add", {
+    await apiFetch("/item/add", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react';
+import apiFetch from '../utils/apiFetch';
 
 export default function useUser() {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
     let isMounted = true;
-    fetch('/me')
+    apiFetch('/me')
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (isMounted) {

--- a/client/src/hooks/useUser.test.js
+++ b/client/src/hooks/useUser.test.js
@@ -18,7 +18,7 @@ describe('useUser', () => {
     );
     render(<TestComponent />);
     expect(await screen.findByText('test')).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledWith('/me');
+    expect(global.fetch).toHaveBeenCalledWith('/me', { credentials: 'include' });
   });
 
   test('handles missing user', async () => {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,17 +4,6 @@ import './index.scss';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-const originalFetch = window.fetch;
-window.fetch = (input, init = {}) => {
-  const url = input instanceof Request ? input.url : input;
-  const { origin } = new URL(url, window.location.href);
-  const isSameOrigin = origin === window.location.origin;
-  const options = isSameOrigin
-    ? { credentials: 'include', ...init }
-    : init;
-  return originalFetch(input, options);
-};
-
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>

--- a/client/src/utils/apiFetch.js
+++ b/client/src/utils/apiFetch.js
@@ -1,0 +1,13 @@
+export default function apiFetch(input, init = {}) {
+  const hasWindow = typeof window !== 'undefined' && window.location;
+  const base = hasWindow ? window.location.href : 'http://localhost';
+  const urlString = input instanceof Request ? input.url : input;
+  const url = new URL(urlString, base);
+
+  const sameOrigin = !hasWindow || url.origin === window.location.origin;
+  if (sameOrigin) {
+    init = { credentials: 'include', ...init };
+  }
+
+  return window.fetch(input, init);
+}


### PR DESCRIPTION
## Summary
- add `apiFetch` that includes credentials for same-origin requests
- restore native `window.fetch` and use `apiFetch` in components
- adjust tests for new fetch behavior

## Testing
- `cd server && npm test`
- `cd client && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65a39bf04832e91eddeb2fc22fb3e