### PR TITLE
Use centralized logger

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ const path = require('path');
 const config = require("./utils/config");
 const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
+const logger = require("./utils/logger");
 const port = process.env.PORT || 5000;
 
 // Restrict cross-origin requests to a single approved client
@@ -44,18 +45,20 @@ app.get('*', (req, res) => {
 // Centralized error-handling middleware
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
-  console.error(err);
-  res.status(err.status || 500).json({ message: err.message || 'Internal Server Error' });
+  logger.error(err);
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
 });
 
 async function startServer() {
   try {
     await connectToDatabase();
     app.listen(port, '0.0.0.0', () => {
-      console.log(`Server is running on port: ${port}`);
+      logger.info(`Server is running on port: ${port}`);
     });
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   }
 }
 


### PR DESCRIPTION
## Summary
- add winston-based logger to server startup
- log errors and sanitized responses via centralized middleware

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65dc3673c832e8be36a8c0a5e2092