### PR TITLE
chore: avoid logging tokens

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -33,9 +33,9 @@ module.exports = (router) => {
           sameSite: 'strict',
         });
         res.json({ message: 'Logged in' });
-        logger.info('JWT token generated for login request', {
+        logger.info('User logged in', {
           timestamp: new Date().toISOString(),
-          token,
+          username: user.username,
         });
       } catch (err) {
         logger.error('Error during login request', { error: err.message });


### PR DESCRIPTION
## Summary
- stop logging JWT tokens during login
- include username in login log for traceability

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e907d48832eacec071d10094ae6