### PR TITLE
Use config secret for auth middleware

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
-const jwtSecretKey = process.env.JWT_SECRET;
+const { jwtSecret } = require('../utils/config');
+const jwtSecretKey = jwtSecret;
 
 module.exports = function authenticateToken(req, res, next) {
   const token = req.cookies && req.cookies.token;


### PR DESCRIPTION
## Summary
- Use `jwtSecret` from config for JWT verification in auth middleware

## Testing
- `npm test` *(fails: jest not found)*
- `node` login/route script *(fails: Cannot find module 'get-intrinsic')*

------
https://chatgpt.com/codex/tasks/task_e_68a73895390c832eb168288dac051c6b