### PR TITLE
chore: trust proxy for express app

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const app = express();
+app.set('trust proxy', 1); // or `true` if multiple proxies
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const helmet = require("helmet");


### PR DESCRIPTION
## Summary
- trust proxy for Express server to allow reverse proxy headers

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: ENOTEMPTY directory not empty rename)*
- `ATLAS_URI=mongodb://localhost:27017/test node server.js` *(fails: Cannot find module 'get-intrinsic')*

------
https://chatgpt.com/codex/tasks/task_e_68a742b0254c832ead1a16e795295776