### PR TITLE
Enable proxy trust for Express server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const app = express();
-app.set('trust proxy', 1); // or `true` if multiple proxies
+app.set('trust proxy', true);
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const helmet = require("helmet");


### PR DESCRIPTION
## Summary
- enable `trust proxy` on the Express app so reverse proxies are trusted

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install jest supertest --save-dev` *(fails: 403 Forbidden retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_68a7469cdf94832eb54061f4aadde261