### PR TITLE
Validate IDs and sanitize request bodies

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -370,4 +370,48 @@ describe('Character routes', () => {
       .send({ campaign: 'Camp1', itemName: 'Potion' });
     expect(res.status).toBe(500);
   });
+
+  test('get character invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).get('/characters/123');
+    expect(res.status).toBe(400);
+  });
+
+  test('delete character invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).delete('/delete-character/123');
+    expect(res.status).toBe(400);
+  });
+
+  test('update level invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-level/123')
+      .send({ level: 1, health: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  test('update level invalid body', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-level/507f1f77bcf86cd799439011')
+      .send({ level: 'one', health: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  test('update dice color invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-dice-color/123')
+      .send({ diceColor: 'blue' });
+    expect(res.status).toBe(400);
+  });
+
+  test('update dice color invalid body', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-dice-color/507f1f77bcf86cd799439011')
+      .send({ diceColor: 5 });
+    expect(res.status).toBe(400);
+  });
 });

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -40,6 +40,14 @@ describe('Equipment routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.acknowledged).toBe(true);
     });
+
+    test('numeric validation failure', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .post('/weapon/add')
+        .send({ campaign: 'Camp1', weaponName: 'Sword', enhancement: 'bad' });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('update-weapon', () => {
@@ -64,6 +72,22 @@ describe('Equipment routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Weapon not found');
     });
+
+    test('update weapon invalid id', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/update-weapon/123')
+        .send({ weapon: ['Sword'] });
+      expect(res.status).toBe(400);
+    });
+
+    test('update weapon invalid body', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/update-weapon/507f1f77bcf86cd799439011')
+        .send({ weapon: 'Sword' });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('/armor/add', () => {
@@ -83,6 +107,14 @@ describe('Equipment routes', () => {
         .send({ campaign: 'Camp1', armorName: 'Plate' });
       expect(res.status).toBe(200);
       expect(res.body.acknowledged).toBe(true);
+    });
+
+    test('numeric validation failure', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .post('/armor/add')
+        .send({ campaign: 'Camp1', armorName: 'Plate', armorBonus: 'bad' });
+      expect(res.status).toBe(400);
     });
   });
 
@@ -108,6 +140,22 @@ describe('Equipment routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Armor not found');
     });
+
+    test('update armor invalid id', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/update-armor/123')
+        .send({ armor: ['Plate'] });
+      expect(res.status).toBe(400);
+    });
+
+    test('update armor invalid body', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/update-armor/507f1f77bcf86cd799439011')
+        .send({ armor: 'Plate' });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('/item/add', () => {
@@ -127,6 +175,14 @@ describe('Equipment routes', () => {
         .send({ campaign: 'Camp1', itemName: 'Potion' });
       expect(res.status).toBe(200);
       expect(res.body.acknowledged).toBe(true);
+    });
+
+    test('numeric validation failure', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .post('/item/add')
+        .send({ campaign: 'Camp1', itemName: 'Potion', str: 'bad' });
+      expect(res.status).toBe(400);
     });
   });
 
@@ -151,6 +207,22 @@ describe('Equipment routes', () => {
         .send({ item: ['Potion'] });
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Item not found');
+    });
+
+    test('update item invalid id', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/update-item/123')
+        .send({ item: ['Potion'] });
+      expect(res.status).toBe(400);
+    });
+
+    test('update item invalid body', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/update-item/507f1f77bcf86cd799439011')
+        .send({ item: 'Potion' });
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -1,0 +1,52 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGIN = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  res.status(500).json({ message: err.message });
+});
+
+describe('Health routes validation', () => {
+  test('update temphealth invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-temphealth/123')
+      .send({ tempHealth: 5 });
+    expect(res.status).toBe(400);
+  });
+
+  test('update temphealth invalid body', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-temphealth/507f1f77bcf86cd799439011')
+      .send({ tempHealth: 'bad' });
+    expect(res.status).toBe(400);
+  });
+
+  test('update health invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-health/123')
+      .send({ health: 1, str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1, startStatTotal: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  test('update health invalid body', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/update-health/507f1f77bcf86cd799439011')
+      .send({ health: 'bad', str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1, startStatTotal: 1 });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -1,6 +1,8 @@
+const { body, matchedData } = require('express-validator');
 const ObjectId = require('mongodb').ObjectId;
 const express = require('express');
 const authenticateToken = require('../../middleware/auth');
+const handleValidationErrors = require('../../middleware/validation');
 const logger = require('../../utils/logger');
 
 module.exports = (router) => {
@@ -10,45 +12,61 @@ module.exports = (router) => {
   characterRouter.use(authenticateToken);
 
   // This section will update tempHealth.
-  characterRouter.route('/update-temphealth/:id').put(async (req, res, next) => {
-    const id = { _id: ObjectId(req.params.id) };
-    const db_connect = req.db;
-    try {
-      await db_connect.collection('Characters').updateOne(id, {
-        $set: { tempHealth: req.body.tempHealth },
-      });
-      logger.info('character tempHealth updated');
-      res.send('user updated sucessfully');
-    } catch (err) {
-      next(err);
+  characterRouter.route('/update-temphealth/:id').put(
+    [body('tempHealth').isInt().withMessage('tempHealth must be an integer').toInt()],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ error: 'Invalid ID' });
+      }
+      const id = { _id: ObjectId(req.params.id) };
+      const db_connect = req.db;
+      const { tempHealth } = matchedData(req, { locations: ['body'] });
+      try {
+        await db_connect.collection('Characters').updateOne(id, {
+          $set: { tempHealth },
+        });
+        logger.info('character tempHealth updated');
+        res.send('user updated sucessfully');
+      } catch (err) {
+        next(err);
+      }
     }
-  });
+  );
 
   // This section will update health and stats.
-  characterRouter.route('/update-health/:id').put(async (req, res, next) => {
-    const id = { _id: ObjectId(req.params.id) };
-    const db_connect = req.db;
+  characterRouter.route('/update-health/:id').put(
+    [
+      body('health').isInt().withMessage('health must be an integer').toInt(),
+      body('str').isInt().toInt(),
+      body('dex').isInt().toInt(),
+      body('con').isInt().toInt(),
+      body('int').isInt().toInt(),
+      body('wis').isInt().toInt(),
+      body('cha').isInt().toInt(),
+      body('startStatTotal').isInt().toInt(),
+    ],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ error: 'Invalid ID' });
+      }
+      const id = { _id: ObjectId(req.params.id) };
+      const db_connect = req.db;
+      const fields = matchedData(req, { locations: ['body'] });
 
-    try {
-      await db_connect.collection('Characters').updateOne(id, {
-        $set: {
-          health: req.body.health,
-          str: req.body.str,
-          dex: req.body.dex,
-          con: req.body.con,
-          int: req.body.int,
-          wis: req.body.wis,
-          cha: req.body.cha,
-          startStatTotal: req.body.startStatTotal,
-        },
-      });
-      logger.info('Character health and stats updated');
-      res.send('User updated successfully');
-    } catch (error) {
-      logger.error(error);
-      res.status(500).send('Server error');
+      try {
+        await db_connect.collection('Characters').updateOne(id, {
+          $set: fields,
+        });
+        logger.info('Character health and stats updated');
+        res.send('User updated successfully');
+      } catch (error) {
+        logger.error(error);
+        res.status(500).send('Server error');
+      }
     }
-  });
+  );
 
   router.use(characterRouter);
 };


### PR DESCRIPTION
## Summary
- validate MongoDB IDs on character and equipment routes
- enforce numeric and string constraints with express-validator and sanitize with matchedData
- add unit tests for invalid IDs and bodies across character, health, and equipment endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7731e5200832ebfbd7456e4102ed1