### PR TITLE
refactor: standardize error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ The server uses a `config.env` file for configuration. Ensure the following vari
 | `CLIENT_ORIGIN` | The URL of the client application allowed to make cross-origin requests. |
 
 
+## API Error Format
+
+All API errors are returned as JSON objects with a single `message` property. For example:
+
+```
+{
+  "message": "Description of the error"
+}
+```
+
+Clients should rely on this structure when handling error responses.
+
 ## Support
 For help with this webpage please contact
 |Name | Email |

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -14,7 +14,9 @@ const app = express();
 app.use(express.json());
 app.use(campaignsRouter);
 app.use((err, req, res, next) => {
-  res.status(500).json({ message: err.message });
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
 });
 
 describe('Campaign routes', () => {
@@ -41,7 +43,7 @@ describe('Campaign routes', () => {
       .post('/campaign/add')
       .send({ campaignName: 'Test', dm: 'DM' });
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('db error');
+    expect(res.body.message).toBe('Internal Server Error');
   });
 
   test('get campaign by name success', async () => {

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -13,6 +13,11 @@ const charactersRouter = require('../routes');
 const app = express();
 app.use(express.json());
 app.use(charactersRouter);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
 
 describe('Character routes', () => {
   test('add character success', async () => {

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -14,7 +14,9 @@ const app = express();
 app.use(express.json());
 app.use(routes);
 app.use((err, req, res, next) => {
-  res.status(500).json({ message: err.message });
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
 });
 
 beforeEach(() => {
@@ -70,7 +72,7 @@ describe('Equipment routes', () => {
         .put('/update-weapon/507f1f77bcf86cd799439011')
         .send({ weapon: ['Sword'] });
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe('Weapon not found');
+      expect(res.body.message).toBe('Weapon not found');
     });
 
     test('update weapon invalid id', async () => {
@@ -138,7 +140,7 @@ describe('Equipment routes', () => {
         .put('/update-armor/507f1f77bcf86cd799439011')
         .send({ armor: ['Plate'] });
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe('Armor not found');
+      expect(res.body.message).toBe('Armor not found');
     });
 
     test('update armor invalid id', async () => {
@@ -206,7 +208,7 @@ describe('Equipment routes', () => {
         .put('/update-item/507f1f77bcf86cd799439011')
         .send({ item: ['Potion'] });
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe('Item not found');
+      expect(res.body.message).toBe('Item not found');
     });
 
     test('update item invalid id', async () => {

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -14,7 +14,9 @@ const app = express();
 app.use(express.json());
 app.use(routes);
 app.use((err, req, res, next) => {
-  res.status(500).json({ message: err.message });
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
 });
 
 describe('Health routes validation', () => {

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -15,7 +15,9 @@ const app = express();
 app.use(express.json());
 app.use(usersRouter);
 app.use((err, req, res, next) => {
-  res.status(500).json({ message: err.message });
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
 });
 
 describe('Users routes', () => {
@@ -101,7 +103,7 @@ describe('Users routes', () => {
     });
     const res = await request(app).get('/users');
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Internal server error');
+    expect(res.body.message).toBe('Internal Server Error');
   });
 
   test('register failure with duplicate username', async () => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -16,7 +16,7 @@ module.exports = (router) => {
       body('password').notEmpty().withMessage('password is required'),
     ],
     handleValidationErrors,
-    async (req, res) => {
+    async (req, res, next) => {
       const { username, password } = req.body;
 
       const db_connect = req.db;
@@ -39,7 +39,7 @@ module.exports = (router) => {
         });
       } catch (err) {
         logger.error('Error during login request', { error: err.message });
-        res.status(500).json({ message: 'Internal server error' });
+        next(err);
       }
     }
   );
@@ -51,7 +51,7 @@ module.exports = (router) => {
       body('password').notEmpty().withMessage('password is required'),
     ],
     handleValidationErrors,
-    async (req, res) => {
+    async (req, res, next) => {
       const { username, password } = req.body;
 
       const db_connect = req.db;
@@ -62,7 +62,7 @@ module.exports = (router) => {
         }
         res.json({ valid: true });
       } catch (err) {
-        res.status(500).json({ message: 'Internal server error' });
+        next(err);
       }
     }
   );

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -16,7 +16,7 @@ module.exports = (router) => {
       param('campaign').trim().notEmpty().withMessage('campaign is required'),
     ],
     handleValidationErrors,
-    async (req, res) => {
+    async (req, res, next) => {
       if (!Array.isArray(req.body)) {
         return res
           .status(400)
@@ -33,12 +33,12 @@ module.exports = (router) => {
         );
         logger.info("Players added");
         if (result.modifiedCount === 0) {
-          return res.status(400).send("Players already exist in the array");
+          return res.status(400).json({ message: 'Players already exist in the array' });
         }
-        res.send('Players added successfully');
+        res.json({ message: 'Players added successfully' });
       } catch (err) {
         logger.error(`Error adding players: ${err}`);
-        res.status(500).send("Internal Server Error");
+        next(err);
       }
     }
   );
@@ -72,7 +72,7 @@ module.exports = (router) => {
    });
 
   // This section will find a specific campaign.
-  campaignRouter.route("/campaign/:campaign").get(async (req, res) => {
+  campaignRouter.route("/campaign/:campaign").get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -80,7 +80,7 @@ module.exports = (router) => {
         .findOne({ campaignName: req.params.campaign });
       res.json(result);
     } catch (err) {
-      res.status(500).json({ message: 'Internal server error' });
+      next(err);
     }
   });
 

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -14,7 +14,7 @@ module.exports = (router) => {
   // This section will get a single character by id
   characterRouter.route('/characters/:id').get(async (req, res, next) => {
     if (!ObjectId.isValid(req.params.id)) {
-      return res.status(400).json({ error: 'Invalid ID' });
+      return res.status(400).json({ message: 'Invalid ID' });
     }
     try {
       const db_connect = req.db;
@@ -106,14 +106,14 @@ module.exports = (router) => {
       ...numericCharacterFields.map((field) => body(field).optional().isInt().toInt()),
     ],
     handleValidationErrors,
-    async (req, res) => {
+    async (req, res, next) => {
       const db_connect = req.db;
       const myobj = matchedData(req, { locations: ['body'], includeOptionals: true });
       try {
         const result = await db_connect.collection('Characters').insertOne(myobj);
         res.json(result);
       } catch (err) {
-        res.status(500).json({ message: 'Internal server error' });
+        next(err);
       }
     }
   );
@@ -121,7 +121,7 @@ module.exports = (router) => {
   // This section will delete a character
   characterRouter.route('/delete-character/:id').delete(async (req, response, next) => {
     if (!ObjectId.isValid(req.params.id)) {
-      return response.status(400).json({ error: 'Invalid ID' });
+      return response.status(400).json({ message: 'Invalid ID' });
     }
     const db_connect = req.db;
     const myquery = { _id: ObjectId(req.params.id) };
@@ -143,7 +143,7 @@ module.exports = (router) => {
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
+        return res.status(400).json({ message: 'Invalid ID' });
       }
       const db_connect = req.db;
       const selectedOccupation = req.body.selectedOccupation;
@@ -170,7 +170,7 @@ module.exports = (router) => {
         );
         if (result.modifiedCount !== 0) {
           logger.info(`Character updated for Occupation: ${selectedOccupation}`);
-          res.send('Update complete');
+          res.json({ message: 'Update complete' });
         }
       } catch (err) {
         next(err);
@@ -184,7 +184,7 @@ module.exports = (router) => {
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
+        return res.status(400).json({ message: 'Invalid ID' });
       }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
@@ -194,7 +194,7 @@ module.exports = (router) => {
           $set: { diceColor },
         });
         logger.info('Dice Color updated');
-        res.send('user updated sucessfully');
+        res.json({ message: 'User updated successfully' });
       } catch (err) {
         next(err);
       }

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -17,7 +17,7 @@ module.exports = (router) => {
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
+        return res.status(400).json({ message: 'Invalid ID' });
       }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
@@ -27,7 +27,7 @@ module.exports = (router) => {
           $set: { tempHealth },
         });
         logger.info('character tempHealth updated');
-        res.send('user updated sucessfully');
+        res.json({ message: 'User updated successfully' });
       } catch (err) {
         next(err);
       }
@@ -49,7 +49,7 @@ module.exports = (router) => {
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
+        return res.status(400).json({ message: 'Invalid ID' });
       }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
@@ -60,10 +60,10 @@ module.exports = (router) => {
           $set: fields,
         });
         logger.info('Character health and stats updated');
-        res.send('User updated successfully');
+        res.json({ message: 'User updated successfully' });
       } catch (error) {
         logger.error(error);
-        res.status(500).send('Server error');
+        next(error);
       }
     }
   );

--- a/server/routes/characters/occupations.js
+++ b/server/routes/characters/occupations.js
@@ -33,10 +33,10 @@ module.exports = (router) => {
         $set: { occupation: req.body },
       });
       logger.info('Character occupations updated');
-      res.send('User updated successfully');
+      res.json({ message: 'User updated successfully' });
     } catch (error) {
       logger.error(error);
-      res.status(500).send('Server error');
+      next(error);
     }
   });
 

--- a/server/routes/characters/stats.js
+++ b/server/routes/characters/stats.js
@@ -25,7 +25,7 @@ module.exports = (router) => {
         },
       });
       logger.info('character stats updated');
-      res.send('user updated sucessfully');
+      res.json({ message: 'User updated successfully' });
     } catch (err) {
       next(err);
     }

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -31,9 +31,9 @@ module.exports = (router) => {
     [body('weapon').isArray().withMessage('weapon must be an array')],
     handleValidationErrors,
     async (req, res, next) => {
-      if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
-      }
+        if (!ObjectId.isValid(req.params.id)) {
+          return res.status(400).json({ message: 'Invalid ID' });
+        }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
       const { weapon } = matchedData(req, { locations: ['body'] });
@@ -41,9 +41,9 @@ module.exports = (router) => {
         const result = await db_connect.collection('Characters').updateOne(id, {
           $set: { weapon },
         });
-        if (result.matchedCount === 0) {
-          return res.status(404).json({ error: 'Weapon not found' });
-        }
+          if (result.matchedCount === 0) {
+            return res.status(404).json({ message: 'Weapon not found' });
+          }
         res.json({ message: 'Weapon updated' });
       } catch (err) {
         next(err);
@@ -118,9 +118,9 @@ module.exports = (router) => {
     [body('armor').isArray().withMessage('armor must be an array')],
     handleValidationErrors,
     async (req, res, next) => {
-      if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
-      }
+        if (!ObjectId.isValid(req.params.id)) {
+          return res.status(400).json({ message: 'Invalid ID' });
+        }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
       const { armor } = matchedData(req, { locations: ['body'] });
@@ -128,9 +128,9 @@ module.exports = (router) => {
         const result = await db_connect.collection('Characters').updateOne(id, {
           $set: { armor },
         });
-        if (result.matchedCount === 0) {
-          return res.status(404).json({ error: 'Armor not found' });
-        }
+          if (result.matchedCount === 0) {
+            return res.status(404).json({ message: 'Armor not found' });
+          }
         res.json({ message: 'Armor updated' });
       } catch (err) {
         next(err);
@@ -217,9 +217,9 @@ module.exports = (router) => {
     [body('item').isArray().withMessage('item must be an array')],
     handleValidationErrors,
     async (req, res, next) => {
-      if (!ObjectId.isValid(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID' });
-      }
+        if (!ObjectId.isValid(req.params.id)) {
+          return res.status(400).json({ message: 'Invalid ID' });
+        }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
       const { item } = matchedData(req, { locations: ['body'] });
@@ -227,9 +227,9 @@ module.exports = (router) => {
         const result = await db_connect.collection('Characters').updateOne(id, {
           $set: { item },
         });
-        if (result.matchedCount === 0) {
-          return res.status(404).json({ error: 'Item not found' });
-        }
+          if (result.matchedCount === 0) {
+            return res.status(404).json({ message: 'Item not found' });
+          }
         res.json({ message: 'Item updated' });
       } catch (err) {
         next(err);

--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -77,7 +77,7 @@ module.exports = (router) => {
         $set: { 'feat': req.body.feat }
       });
       logger.info("character feat updated");
-      res.send('user updated sucessfully');
+      res.json({ message: 'User updated successfully' });
     } catch (err) {
       next(err);
     }

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -54,7 +54,7 @@ module.exports = (router) => {
       );
       res.status(200).json(result.value);
     } catch (err) {
-      res.status(500).send('Server error');
+      next(err);
     }
   });
 
@@ -66,8 +66,8 @@ module.exports = (router) => {
       await db_connect.collection("Characters").updateOne(id, {
         $set: { 'newSkill': req.body.newSkill }
       });
-      logger.info("character knowledge updated");
-      res.send('user updated sucessfully');
+        logger.info("character knowledge updated");
+        res.json({ message: 'User updated successfully' });
     } catch (err) {
       next(err);
     }
@@ -85,7 +85,7 @@ module.exports = (router) => {
       );
       res.status(200).json(result.value);
     } catch (err) {
-      res.status(500).send('Server error');
+      next(err);
     }
   });
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -4,17 +4,17 @@ const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 
 module.exports = (router) => {
-  router.get('/users', authenticateToken, async (req, res) => {
+  router.get('/users', authenticateToken, async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect.collection('users').find({}).toArray();
       res.json(result);
     } catch (err) {
-      res.status(500).json({ message: 'Internal server error' });
+      next(err);
     }
   });
 
-  router.get('/users/exists/:username', async (req, res) => {
+  router.get('/users/exists/:username', async (req, res, next) => {
     try {
       const db_connect = req.db;
       const user = await db_connect
@@ -22,11 +22,11 @@ module.exports = (router) => {
         .findOne({ username: req.params.username });
       res.json({ exists: !!user });
     } catch (err) {
-      res.status(500).json({ message: 'Internal server error' });
+      next(err);
     }
   });
 
-  router.get('/users/:username', authenticateToken, async (req, res) => {
+  router.get('/users/:username', authenticateToken, async (req, res, next) => {
     try {
       const db_connect = req.db;
       const myquery = { username: req.params.username };
@@ -37,7 +37,7 @@ module.exports = (router) => {
       const { password, ...userWithoutPassword } = user;
       res.json(userWithoutPassword);
     } catch (err) {
-      res.status(500).json({ message: 'Internal server error' });
+      next(err);
     }
   });
 
@@ -58,7 +58,7 @@ module.exports = (router) => {
         .withMessage('password must contain at least one special character'),
     ],
     handleValidationErrors,
-    async (req, res) => {
+    async (req, res, next) => {
       const { username, password } = req.body;
 
       try {
@@ -84,7 +84,7 @@ module.exports = (router) => {
         if (err.code === 11000) {
           return res.status(409).json({ message: 'Username already exists' });
         }
-        res.status(500).json({ message: 'Internal server error' });
+        next(err);
       }
     }
   );


### PR DESCRIPTION
## Summary
- centralize error handling across routes by forwarding unexpected errors to middleware
- replace text responses with JSON `{ message }` payloads
- document API error response format and align tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a779fc1674832eb6ec1dbf3e53ce07