### PR TITLE
Exclude password field from user list and update tests

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -7,7 +7,10 @@ module.exports = (router) => {
   router.get('/users', authenticateToken, async (req, res, next) => {
     try {
       const db_connect = req.db;
-      const result = await db_connect.collection('users').find({}).toArray();
+      const result = await db_connect
+        .collection('users')
+        .find({}, { projection: { password: 0 } })
+        .toArray();
       res.json(result);
     } catch (err) {
       next(err);


### PR DESCRIPTION
## Summary
- Exclude `password` from `/users` query results using MongoDB projection
- Add Jest tests ensuring `/users` responses omit passwords

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a793772e4c832e94511e05b0244f64