### PR TITLE
feat: add feat update endpoint

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -419,4 +419,29 @@ describe('Character routes', () => {
       .send({ diceColor: 5 });
     expect(res.status).toBe(400);
   });
+
+  test('update feats success', async () => {
+    let captured;
+    dbo.mockResolvedValue({
+      collection: () => ({
+        updateOne: async (filter, update) => {
+          captured = { filter, update };
+          return { modifiedCount: 1 };
+        }
+      })
+    });
+    const res = await request(app)
+      .put('/characters/507f1f77bcf86cd799439011/feats')
+      .send({ feat: ['Power Attack'] });
+    expect(res.status).toBe(200);
+    expect(captured.update.$set.feat).toEqual(['Power Attack']);
+  });
+
+  test('update feats invalid body', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/characters/507f1f77bcf86cd799439011/feats')
+      .send({ feat: 'Power Attack' });
+    expect(res.status).toBe(400);
+  });
 });

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -201,6 +201,28 @@ module.exports = (router) => {
     }
   );
 
+  // This section will update feats.
+  characterRouter.route('/characters/:id/feats').put(
+    [body('feat').isArray().withMessage('feat must be an array')],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid ID' });
+      }
+      const db_connect = req.db;
+      try {
+        await db_connect.collection('Characters').updateOne(
+          { _id: ObjectId(req.params.id) },
+          { $set: { feat: matchedData(req, { locations: ['body'] }).feat } }
+        );
+        logger.info('Feats updated');
+        res.json({ message: 'Feats updated' });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
   router.use(characterRouter);
 };
 


### PR DESCRIPTION
## Summary
- allow updating character feats via PUT /characters/:id/feats
- validate feat input array and add unit tests

## Testing
- `npm test --prefix server` *(fails: sh: 1: jest: not found)*
- `npm install --prefix server` *(fails: 403 Forbidden - GET https://registry.npmjs.org/csurf)*

------
https://chatgpt.com/codex/tasks/task_e_68a798dee278832eb61ca87bdc46039c