### PR TITLE
Document character feat deletion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Use `PUT /characters/:id/feats` with a JSON body like `{ "feat": ["Feat1"] }` to
 append new feats to a character. Each request adds feats to the existing list
 rather than replacing the current feats.
 
+Use `DELETE /characters/:id/feats` with a JSON body like `{ "feat": "Cleave" }`
+to remove a feat from a character.
+
+`PUT` appends feats, while `DELETE` removes them.
+
 ## Support
 For help with this webpage please contact
 |Name | Email |


### PR DESCRIPTION
## Summary
- document how to remove a feat via `DELETE /characters/:id/feats`
- clarify that `PUT` appends feats while `DELETE` removes them

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a79f27e384832eb244f29ec9f4f653