### PR TITLE
Harden user registration against enumeration

### DIFF
--- a/client/src/components/Login/Login.test.js
+++ b/client/src/components/Login/Login.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import Login from './Login';
+import apiFetch from '../../utils/apiFetch';
+
+jest.mock('../../utils/apiFetch', () => jest.fn());
+
+describe('Login component errors', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+  });
+
+  test('shows login error on failed login', async () => {
+    apiFetch.mockResolvedValueOnce({ ok: false });
+    render(<Login onLogin={() => {}} />);
+    fireEvent.change(screen.getByLabelText(/Username/i), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByLabelText(/^Password$/i), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    await waitFor(() => expect(screen.getByText(/Failed to log in/i)).toBeInTheDocument());
+  });
+
+  test('shows signup error when user creation fails', async () => {
+    apiFetch.mockImplementation((url) => {
+      if (url === '/users/add') {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ message: 'Unable to create user' }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(<Login onLogin={() => {}} />);
+    fireEvent.click(screen.getByText(/sign up/i));
+    const modal = await screen.findByRole('dialog');
+    fireEvent.change(within(modal).getByLabelText(/Username/i), { target: { value: 'Alice' } });
+    fireEvent.change(within(modal).getByLabelText(/^Password$/i), { target: { value: 'Strongpass1!' } });
+    fireEvent.change(within(modal).getByLabelText(/Confirm Password/i), { target: { value: 'Strongpass1!' } });
+    fireEvent.click(within(modal).getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(within(modal).getByText(/Unable to create user/i)).toBeInTheDocument());
+  });
+});

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -71,30 +71,6 @@ describe('Users routes', () => {
     expect(res.body.valid).toBeUndefined();
   });
 
-  describe('GET /users/exists/:username', () => {
-    test('returns { exists: true } for existing user', async () => {
-      dbo.mockResolvedValue({
-        collection: () => ({
-          findOne: async () => ({ username: 'alice' })
-        })
-      });
-      const res = await request(app).get('/users/exists/alice');
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ exists: true });
-    });
-
-    test('returns { exists: false } for missing user', async () => {
-      dbo.mockResolvedValue({
-        collection: () => ({
-          findOne: async () => null
-        })
-      });
-      const res = await request(app).get('/users/exists/bob');
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ exists: false });
-    });
-  });
-
   test('get users success excludes password', async () => {
     const findMock = jest.fn((query, options) => ({
       toArray: async () => {
@@ -131,7 +107,7 @@ describe('Users routes', () => {
     expect(res.body.message).toBe('Internal Server Error');
   });
 
-  test('register failure with duplicate username', async () => {
+  test('register failure with duplicate username returns generic message', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
         findOne: async () => ({ username: 'alice' }),
@@ -141,8 +117,8 @@ describe('Users routes', () => {
     const res = await request(app)
       .post('/users/add')
       .send({ username: 'alice', password: 'Strongpass1!' });
-    expect(res.status).toBe(409);
-    expect(res.body.message).toBe('Username already exists');
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Unable to create user');
   });
 
   test('register failure with weak password', async () => {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -17,18 +17,6 @@ module.exports = (router) => {
     }
   });
 
-  router.get('/users/exists/:username', async (req, res, next) => {
-    try {
-      const db_connect = req.db;
-      const user = await db_connect
-        .collection('users')
-        .findOne({ username: req.params.username });
-      res.json({ exists: !!user });
-    } catch (err) {
-      next(err);
-    }
-  });
-
   router.get('/users/:username', authenticateToken, async (req, res, next) => {
     try {
       const db_connect = req.db;
@@ -64,6 +52,8 @@ module.exports = (router) => {
     async (req, res, next) => {
       const { username, password } = req.body;
 
+      const genericMessage = 'Unable to create user';
+
       try {
         const db_connect = req.db;
 
@@ -71,7 +61,7 @@ module.exports = (router) => {
           .collection('users')
           .findOne({ username });
         if (existingUser) {
-          return res.status(409).json({ message: 'Username already exists' });
+          return res.status(400).json({ message: genericMessage });
         }
 
         const hashedPassword = await bcrypt.hash(password, 10);
@@ -83,11 +73,7 @@ module.exports = (router) => {
         const result = await db_connect.collection('users').insertOne(myobj);
         res.json(result);
       } catch (err) {
-        // Handle duplicate key error thrown by MongoDB unique index
-        if (err.code === 11000) {
-          return res.status(409).json({ message: 'Username already exists' });
-        }
-        next(err);
+        return res.status(400).json({ message: genericMessage });
       }
     }
   );


### PR DESCRIPTION
## Summary
- drop user existence endpoint and unify `/users/add` errors
- show login and signup errors inline instead of browser alerts
- add tests for login error rendering

## Testing
- `cd server && npm test` *(fails: sh: 1: jest: not found)*
- `cd client && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7a235d618832ebebbac2feb40e361