### PR TITLE
feat: enlarge skills modal and keep footer visible

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -232,12 +232,12 @@ let firstLevelSkill =
       return (   
       <div>  
        {/* -----------------------------------------------Skill Render--------------------------------------------------------------- */}
-       <Modal className="modern-modal" show={showSkill} onHide={handleCloseSkill} size="sm" centered>
+       <Modal className="modern-modal" show={showSkill} onHide={handleCloseSkill} size="lg" scrollable centered>
         <Card className="modern-card text-center">
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">Skills</Card.Title>
           </Card.Header>
-          <Card.Body>
+          <Card.Body style={{ overflowY: 'auto' }}>
             <div style={{ display: showSkillBtn }}>
               Points Left:<span className="mx-1" id="skillPointLeft">{totalSkillPointsLeft}</span>
             </div>


### PR DESCRIPTION
## Summary
- enlarge skills modal to large and enable scrolling
- ensure card body scrolls so footer buttons stay accessible

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a885fb9750832eb24280d1ae637acc