### PR TITLE
Refactor modals to modern design

### DIFF
--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -2,59 +2,39 @@ import React, { useState, useEffect } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
-import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
   const params = useParams();
   const navigate = useNavigate();
-  // -------------------------------------------Armor---------------------------------------------------------------------------------------------------------------------------------------------------
+  // -------------------------------------------Armor---------------------------------------------------------------------------
+  //------------------------------------------------------------------------
   const currentCampaign = form.campaign.toString();
-  const [armor, setArmor] = useState({ 
-    armor: [], 
+  const [armor, setArmor] = useState({
+    armor: [],
   });
-  const [addArmor, setAddArmor] = useState({ 
+  const [addArmor, setAddArmor] = useState({
     armor: "",
   });
   const [chosenArmor, setChosenArmor] = useState('');
   const handleChosenArmorChange = (e) => {
       setChosenArmor(e.target.value);
-  }; 
+  };
   function updateArmor(value) {
     return setAddArmor((prev) => {
       return { ...prev, ...value };
     });
   }
-   //Armor AC/MaxDex
-  //  let armorAcBonus= [];
-  //  let armorMaxDexBonus= [];
-  //  form.armor.map((el) => (  
-  //    armorAcBonus.push(el[1]) 
-  //  ))
-  //  let totalArmorAcBonus = armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0); 
-  //  form.armor.map((el) => (
-  //   armorMaxDexBonus.push(el[2]) 
-  //  ))
-  //  let filteredMaxDexArray = armorMaxDexBonus.filter(e => e !== '0')
-  //  let armorMaxDexMin = Math.min(...filteredMaxDexArray);
-  
-  //  let armorMaxDex;
-  //  if (Number(armorMaxDexMin) < Number(dexMod) && Number(armorMaxDexMin > 0)) {
-  //     armorMaxDex = armorMaxDexMin;
-  //  } else {
-  //   armorMaxDex = dexMod;
-  //  }
-  
   // Fetch Armors
   useEffect(() => {
     async function fetchArmor() {
       const response = await apiFetch(`/armor/${currentCampaign}`);
-  
+
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
         window.alert(message);
         return;
       }
-  
+
       const record = await response.json();
       if (!record) {
         window.alert(`Record not found`);
@@ -63,12 +43,12 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
       }
       setArmor({armor: record});
     }
-    fetchArmor();   
+    fetchArmor();
     return;
-    
+
   }, [navigate, currentCampaign]);
-   // Sends armor data to database for update
-   const splitArmorArr = (array, size) => {
+  // Sends armor data to database for update
+  const splitArmorArr = (array, size) => {
     let result = [];
     for (let i = 0; i < array.length; i += size) {
       let chunk = array.slice(i, i + size);
@@ -76,19 +56,17 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
     }
     return result;
   };
-   let newArmor;
-   if (JSON.stringify(form.armor) === JSON.stringify([["","","",""]])) {
+  let newArmor;
+  if (JSON.stringify(form.armor) === JSON.stringify([["","","",""]])) {
     let newArmorArr = addArmor.armor.split(',');
-    const armorArrSize = 4;
-    const armorArrChunks = splitArmorArr(newArmorArr, armorArrSize);
+    const armorArrChunks = splitArmorArr(newArmorArr, 4);
     newArmor = armorArrChunks;
-   } else {
+  } else {
     let newArmorArr = (form.armor + "," + addArmor.armor).split(',');
-    const armorArrSize = 4;
-    const armorArrChunks = splitArmorArr(newArmorArr, armorArrSize);
+    const armorArrChunks = splitArmorArr(newArmorArr, 4);
     newArmor = armorArrChunks;
-   }
-   async function addArmorToDb(e){
+  }
+  async function addArmorToDb(e){
     e.preventDefault();
     await apiFetch(`/update-armor/${params.id}`, {
      method: "PUT",
@@ -105,17 +83,14 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
    });
    navigate(0);
   }
-   // This method will delete a armor
-   function deleteArmors(el) {
+  // This method will delete a armor
+  function deleteArmors(el) {
     const index = form.armor.indexOf(el);
     form.armor.splice(index, 1);
     updateArmor(form.armor);
     addDeleteArmorToDb();
-   }
-   let showDeleteArmorBtn = "";
-   if (JSON.stringify(form.armor) === JSON.stringify([["","","",""]])){
-    showDeleteArmorBtn = "none";
-   }
+  }
+  const showDeleteArmorBtn = JSON.stringify(form.armor) !== JSON.stringify([["","","",""]]);
   async function addDeleteArmorToDb(){
     let newArmorForm = form.armor;
     if (JSON.stringify(form.armor) === JSON.stringify([])){
@@ -156,15 +131,16 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
 
 return(
     <div>
-     {/* ------------------------------------------------Armor Render---------------------------------------------------------------------------------------------------------------- */}
-<Modal show={showArmor} onHide={handleCloseArmor}
-       size="sm"
-      centered
-       >   
-       <div className="text-center">
-        <Card className="zombiesArmor" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>       
-        <Card.Title>Armor</Card.Title>
-        <Table striped bordered hover size="sm">
+     {/* ------------------------------------------------Armor Render-----------------------------------------------------------
+----------------------------------------------------- */}
+<Modal className="modern-modal" show={showArmor} onHide={handleCloseArmor} size="sm" centered>
+  <div className="text-center">
+    <Card className="modern-card">
+      <Card.Header className="modal-header">
+        <Card.Title className="modal-title">Armor</Card.Title>
+      </Card.Header>
+      <Card.Body>
+        <Table striped bordered hover size="sm" className="modern-table">
           <thead>
             <tr>
               <th>Armor Name</th>
@@ -175,39 +151,44 @@ return(
             </tr>
           </thead>
           <tbody>
-          {form.armor.map((el) => (  
-            <tr key={el[0]}>           
+          {form.armor.map((el) => (
+            <tr key={el[0]}>
               <td>{el[0]}</td>
               <td>{el[1]}</td>
               <td>{el[2]}</td>
               <td>{el[3]}</td>
-              <td><Button size="sm" style={{ display: showDeleteArmorBtn}} className="fa-solid fa-trash" variant="danger" onClick={() => {deleteArmors(el);}}></Button></td>
+              <td><Button size="sm" className="action-btn fa-solid fa-trash" hidden={!showDeleteArmorBtn} onClick={() => {deleteArmors(el);}}></Button></td>
             </tr>
-            ))}     
+            ))}
           </tbody>
-        </Table>    
+        </Table>
     <Row>
         <Col>
           <Form onSubmit={addArmorToDb}>
           <Form.Group className="mb-3 mx-5">
         <Form.Label className="text-dark">Select Armor</Form.Label>
-        <Form.Select 
+        <Form.Select
         onChange={(e) => {updateArmor({ armor: e.target.value }); handleChosenArmorChange(e);}}
         defaultValue=""
          type="text">
           <option value="" disabled>Select your armor</option>
-          {armor.armor.map((el) => (  
+          {armor.armor.map((el) => (
           <option key={el.armorName} value={[el.armorName, el.armorBonus, el.maxDex, el.armorCheckPenalty]}>{el.armorName}</option>
           ))}
         </Form.Select>
       </Form.Group>
-        <Button disabled={!chosenArmor} className="rounded-pill" variant="outline-dark" type="submit">Add</Button>
+        <Button disabled={!chosenArmor} className="action-btn" type="submit">Add</Button>
           </Form>
         </Col>
       </Row>
-      </Card> 
-    </div>
-    </Modal>   
+      </Card.Body>
+      <Card.Footer className="modal-footer">
+        <Button className="action-btn close-btn" onClick={handleCloseArmor}>Close</Button>
+      </Card.Footer>
+    </Card>
+  </div>
+</Modal>
     </div>
 )
 }
+

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from 'react'; // Import useState a
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
-import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Help({props, form, showHelpModal, handleCloseHelpModal}) {
   const params = useParams();
@@ -65,77 +64,75 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
  } 
 return(
     <div>
-        <Modal  {...props}
+        <Modal
+        className="modern-modal text-center"
         size="lg"
         aria-labelledby="contained-modal-title-vcenter"
         centered
-        className="text-center" show={showHelpModal} onHide={handleCloseHelpModal}>
-          <div className="text-center">
-          <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>
-          <Card.Body>
-          Actions Left (from left to right)
-          <br></br>
-          Move, Action, Bonus Action, Reset
-          <br></br>
-          Reset will allow you to refresh your Actions Left
-          <br></br>
-          <br></br>
-          If you are on a phone press a button to use that action or hold down on it to see what it does!
-          <br></br>
-          <br></br>
-          If you are on pc click the button or hover over it to see what it does!
-          <div className="table-container">
-          <Table striped bordered hover size="sm" className="custom-table">
-            <thead>
-              <tr>
-                <td className="center-td">
-                  <strong>Change Dice Color:</strong>
-                </td>
-                <td className="center-td">
-                  <input
-                    type="color"
-                    id="colorPicker"
-                    ref={colorPickerRef}
-                    value={newColor}
-                    onChange={handleColorChange}
-                  />
-                </td>
-                <td className="center-td">
-                  <Button onClick={diceColorUpdate} className="bg-warning fa-solid fa-floppy-disk"></Button>
-                </td>
-              </tr>
-            </thead>
-          </Table>  
-          </div>      
-          </Card.Body>
-          <Modal.Footer className="justify-content-between">
-          <Button size="lg" className="fa-solid fa-trash delete-button" variant="danger" onClick={() => { handleShowDeleteCharacter(); }}>
-          </Button>
-          <Button variant="secondary" onClick={handleCloseHelpModal}>
-            Close
-          </Button>
-          </Modal.Footer>
+        show={showHelpModal} onHide={handleCloseHelpModal}>
+          <Card className="modern-card text-center">
+            <Card.Header className="modal-header">
+              <Card.Title className="modal-title">Help</Card.Title>
+            </Card.Header>
+            <Card.Body>
+              Actions Left (from left to right)
+              <br></br>
+              Move, Action, Bonus Action, Reset
+              <br></br>
+              Reset will allow you to refresh your Actions Left
+              <br></br>
+              <br></br>
+              If you are on a phone press a button to use that action or hold down on it to see what it does!
+              <br></br>
+              <br></br>
+              If you are on pc click the button or hover over it to see what it does!
+              <div className="table-container">
+                <Table striped bordered hover size="sm" className="custom-table">
+                  <thead>
+                    <tr>
+                      <td className="center-td">
+                        <strong>Change Dice Color:</strong>
+                      </td>
+                      <td className="center-td">
+                        <input
+                          type="color"
+                          id="colorPicker"
+                          ref={colorPickerRef}
+                          value={newColor}
+                          onChange={handleColorChange}
+                        />
+                      </td>
+                      <td className="center-td">
+                        <Button onClick={diceColorUpdate} className="action-btn save-btn fa-solid fa-floppy-disk"></Button>
+                      </td>
+                    </tr>
+                  </thead>
+                </Table>
+              </div>
+            </Card.Body>
+            <Card.Footer className="modal-footer justify-content-between">
+              <Button size="lg" className="action-btn fa-solid fa-trash delete-button" onClick={handleShowDeleteCharacter}></Button>
+              <Button className="action-btn close-btn" onClick={handleCloseHelpModal}>
+                Close
+              </Button>
+            </Card.Footer>
           </Card>
-          </div>
-          </Modal>
-          <Modal  {...props}
-                  size="lg"
-                  aria-labelledby="contained-modal-title-vcenter"
-                  centered
-                  className="text-center" show={showDeleteCharacter} onHide={handleCloseDeleteCharacter}>
-        <div className="text-center">
-        <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>       
-          <Card.Title>Are you sure you want to delete your character?</Card.Title>
-          <Modal.Footer className="justify-content-between">
-          <Button variant="danger" onClick={() => { deleteRecord(); }}>
-            Im Sure
-          </Button>
-          <Button variant="secondary" onClick={handleCloseDeleteCharacter}>
-            Close
-          </Button>
-          </Modal.Footer>
+        </Modal>
+        <Modal
+          className="modern-modal text-center"
+          size="lg"
+          aria-labelledby="contained-modal-title-vcenter"
+          centered
+          show={showDeleteCharacter} onHide={handleCloseDeleteCharacter}>
+          <Card className="modern-card text-center">
+            <Card.Header className="modal-header">
+              <Card.Title className="modal-title">Are you sure you want to delete your character?</Card.Title>
+            </Card.Header>
+            <Card.Footer className="modal-footer">
+              <Button className="action-btn save-btn" onClick={deleteRecord}>Im Sure</Button>
+              <Button className="action-btn close-btn" onClick={handleCloseDeleteCharacter}>Close</Button>
+            </Card.Footer>
           </Card>
-          </div>
         </Modal>
     </div>
 )

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { Card, Modal, Button, Form } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
-import wornpaper from "../../../images/wornpaper.jpg"; // Ensure you have this image
 
 export default function LevelUp({ show, handleClose, form }) {
   //--------------------------------------------Level Up--------------------------------------------------------------------------------------------------------------------------------------------
@@ -181,56 +180,74 @@ export default function LevelUp({ show, handleClose, form }) {
 
   return (
     <div>
-      <Modal show={showLvlModal} onHide={handleCloseLvlModal} size="md" centered>
+      <Modal className="modern-modal" show={showLvlModal} onHide={handleCloseLvlModal} size="md" centered>
         <div className="text-center">
-          <Card style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover" }}>
-            <Card.Title>Level Up</Card.Title>
+          <Card className="modern-card">
+            <Card.Header className="modal-header">
+              <Card.Title className="modal-title">Level Up</Card.Title>
+            </Card.Header>
             <Card.Body>
               {/* Add occupation */}
               <Form>
-                <Button className="rounded-pill bg-warning" variant="outline-dark" onClick={handleAddOccupationClick}>
+                <Button className="action-btn" onClick={handleAddOccupationClick}>
                   Add Occupation
                 </Button>
-                <Modal centered show={showAddClassModal} onHide={() => setShowAddClassModal(false)}>
-                  <div className="text-center">
-                    <Card className="" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover" }}>
-                      <Card.Body>
-                        <Form.Group className="mb-3 mx-5">
-                          <Form.Label className="text-dark">Select Occupation</Form.Label>
-                          <Form.Select
-                            ref={selectedAddOccupationRef}
-                            onChange={handleOccupationChange}
-                            defaultValue=""
-                          >
-                            <option value="" disabled>Select your occupation</option>
-                            {getOccupation.map((occupation, i) => {
-                              const isOccupationSelected = form.occupation.some(
-                                (item) => item.Occupation === occupation.Occupation
-                              );
+                <Modal
+                  className="modern-modal"
+                  centered
+                  show={showAddClassModal}
+                  onHide={() => { setShowAddClassModal(false); setChosenAddOccupation(''); }}
+                >
+                  <Card className="modern-card text-center">
+                    <Card.Header className="modal-header">
+                      <Card.Title className="modal-title">Add Occupation</Card.Title>
+                    </Card.Header>
+                    <Card.Body>
+                      <Form.Group className="mb-3 mx-5">
+                        <Form.Label className="text-dark">Select Occupation</Form.Label>
+                        <Form.Select
+                          ref={selectedAddOccupationRef}
+                          onChange={handleOccupationChange}
+                          defaultValue=""
+                        >
+                          <option value="" disabled>Select your occupation</option>
+                          {getOccupation.map((occupation, i) => {
+                            const isOccupationSelected = form.occupation.some(
+                              (item) => item.Occupation === occupation.Occupation
+                            );
 
-                              return (
-                                <option key={i} disabled={isOccupationSelected}>
-                                  {occupation.Occupation}
-                                </option>
-                              );
-                            })}
-                          </Form.Select>
-                        </Form.Group>
-                      </Card.Body>
-                      <Modal.Footer>
-                        <Button variant="secondary" onClick={() => { setShowAddClassModal(false); setChosenAddOccupation(''); }}>
-                          Close
-                        </Button>
-                        <Button variant="primary" onClick={handleConfirmClick} disabled={!chosenAddOccupation}>
-                          Confirm
-                        </Button>
-                      </Modal.Footer>
-                    </Card>
-                  </div>
+                            return (
+                              <option key={i} disabled={isOccupationSelected}>
+                                {occupation.Occupation}
+                              </option>
+                            );
+                          })}
+                        </Form.Select>
+                      </Form.Group>
+                    </Card.Body>
+                    <Card.Footer className="modal-footer">
+                      <Button
+                        className="action-btn close-btn"
+                        onClick={() => { setShowAddClassModal(false); setChosenAddOccupation(''); }}
+                      >
+                        Close
+                      </Button>
+                      <Button
+                        className="action-btn save-btn"
+                        onClick={handleConfirmClick}
+                        disabled={!chosenAddOccupation}
+                      >
+                        Confirm
+                      </Button>
+                    </Card.Footer>
+                  </Card>
                 </Modal>
               </Form>
               {/* Level up known occupation */}
-              <Form onSubmit={(e) => { e.preventDefault(); handleCloseLvlModal(); levelUpdate(); }}>
+              <Form
+                id="level-up-form"
+                onSubmit={(e) => { e.preventDefault(); handleCloseLvlModal(); levelUpdate(); }}
+              >
                 <br />
                 <span>or</span>
                 <Form.Group className="mb-3 mx-5">
@@ -246,16 +263,21 @@ export default function LevelUp({ show, handleClose, form }) {
                     ))}
                   </Form.Select>
                 </Form.Group>
-                <Modal.Footer>
-                  <Button variant="secondary" onClick={handleCloseLvlModal}>
-                    Close
-                  </Button>
-                  <Button variant="primary" type="submit" disabled={!chosenOccupation}>
-                    Level Up
-                  </Button>
-                </Modal.Footer>
               </Form>
             </Card.Body>
+            <Card.Footer className="modal-footer">
+              <Button className="action-btn close-btn" onClick={handleCloseLvlModal}>
+                Close
+              </Button>
+              <Button
+                className="action-btn save-btn"
+                type="submit"
+                form="level-up-form"
+                disabled={!chosenOccupation}
+              >
+                Level Up
+              </Button>
+            </Card.Footer>
           </Card>
         </div>
       </Modal>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Modal, Card, Table } from "react-bootstrap";
-import wornpaper from "../../../images/wornpaper.jpg";
 import sword from "../../../images/sword.png";
 
 export default function PlayerTurnActions ({ form, strMod, atkBonus, dexMod }) { 
@@ -264,54 +263,74 @@ const showSparklesEffect = () => {
   </div>
 </div>
 {/* Attack Modal */}
-      <Modal centered show={showAttack} onHide={handleCloseAttack}>
-      <div className="text-center">
-        <Card className="zombiesWeapons" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>      
-        <Card.Title>Weapons</Card.Title>
-        <Table striped bordered hover size="sm">
-          <thead>
-            <tr>
-              <th>Weapon Name</th>
-              <th>Attack Bonus</th>
-              <th>Damage</th>
-              <th>Critical</th>
-              <th>Range</th>
-              <th>Attack</th>
-            </tr>
-          </thead>
-          <tbody>
-            {form.weapon.map((el) => (  
-            <tr key={el[0]}>
-              <td>{el[0]}</td>             
-              <td>
-               {(() => {
-              if (el[4] === "0") {
-                return(Number(atkBonus) + Number(strMod) + Number(el[1]));
-              } else if (el[4] === "1") {
-                return(Number(atkBonus) + Number(strMod) + Number(el[1]));
-              } else if (el[4] === "2") {
-                return(Number(atkBonus) + Number(dexMod) + Number(el[1]));
-              }
-              })()}</td>
-              <td>{el[2]}
-              {(() => {
-              if (el[4] === "0") {
-                return("+" + (Number(el[1]) + Number(strMod)));
-              } else if (el[4] === "1") {
-                return("+" + (Number(el[1]) + Math.floor( Number((strMod * 1.5)))));
-              } else if (el[4] === "2") {
-                return("+" + (Number(el[1]) + Number(0)));
-              }
-              })()}</td>
-              <td>{el[3]}</td>
-              <td>{el[5]}</td>
-              <td><Button onClick={() => {handleWeaponsButtonCrit(el); handleWeaponsButtonClick(el); handleCloseAttack();}} size="sm" className="fa-solid fa-plus" variant="primary"></Button></td>
-            </tr>
-             ))}
-          </tbody>
-        </Table>      
-      </Card> 
-</div>
+      <Modal className="modern-modal" centered show={showAttack} onHide={handleCloseAttack}>
+        <Card className="modern-card text-center">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Weapons</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <Table striped bordered hover size="sm" className="modern-table">
+              <thead>
+                <tr>
+                  <th>Weapon Name</th>
+                  <th>Attack Bonus</th>
+                  <th>Damage</th>
+                  <th>Critical</th>
+                  <th>Range</th>
+                  <th>Attack</th>
+                </tr>
+              </thead>
+              <tbody>
+                {form.weapon.map((el) => (
+                  <tr key={el[0]}>
+                    <td>{el[0]}</td>
+                    <td>
+                      {(() => {
+                        if (el[4] === "0") {
+                          return Number(atkBonus) + Number(strMod) + Number(el[1]);
+                        } else if (el[4] === "1") {
+                          return Number(atkBonus) + Number(strMod) + Number(el[1]);
+                        } else if (el[4] === "2") {
+                          return Number(atkBonus) + Number(dexMod) + Number(el[1]);
+                        }
+                      })()}
+                    </td>
+                    <td>
+                      {el[2]}
+                      {(() => {
+                        if (el[4] === "0") {
+                          return "+" + (Number(el[1]) + Number(strMod));
+                        } else if (el[4] === "1") {
+                          return "+" + (Number(el[1]) + Math.floor(Number(strMod * 1.5)));
+                        } else if (el[4] === "2") {
+                          return "+" + (Number(el[1]) + Number(0));
+                        }
+                      })()}
+                    </td>
+                    <td>{el[3]}</td>
+                    <td>{el[5]}</td>
+                    <td>
+                      <Button
+                        onClick={() => {
+                          handleWeaponsButtonCrit(el);
+                          handleWeaponsButtonClick(el);
+                          handleCloseAttack();
+                        }}
+                        size="sm"
+                        className="action-btn fa-solid fa-plus"
+                      ></Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={handleCloseAttack}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
       </Modal>
       {/* --------------------------------------------------Dice Roller--------------------------------------------------------------- */}
       <div className="content">

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
-import wornpaper from "../../../images/wornpaper.jpg"; 
 
 export default function Weapons({form, showWeapons, handleCloseWeapons, strMod, dexMod}) {
   const params = useParams();
@@ -111,12 +110,8 @@ const [weapon, setWeapon] = useState({
     updateWeapon(form.weapon);
     addDeleteWeaponToDb();
    }
-   let showDeleteBtn = "";
-   let showAtkBonusSave= "";
-   if (JSON.stringify(form.weapon) === JSON.stringify([["","","","","",""]])){
-    showDeleteBtn = "none";
-    showAtkBonusSave = "none";
-   }
+   const showDeleteBtn = JSON.stringify(form.weapon) !== JSON.stringify([["","","","","",""]]);
+   const showAtkBonusSave = showDeleteBtn;
   async function addDeleteWeaponToDb(){
     let newWeaponForm = form.weapon;
     if (JSON.stringify(form.weapon) === JSON.stringify([])){
@@ -157,14 +152,14 @@ const [weapon, setWeapon] = useState({
 return(
     <div>
         {/* -----------------------------------------Weapons Render---------------------------------------------------------------------------------------------------------------------------------- */}
-<Modal show={showWeapons} onHide={handleCloseWeapons}
-       size="sm"
-      centered
-       >   
-       <div className="text-center">
-        <Card className="zombiesWeapons" style={{ width: 'auto', backgroundImage: `url(${wornpaper})`, backgroundSize: "cover"}}>      
-        <Card.Title>Weapons</Card.Title>
-        <Table striped bordered hover size="sm">
+<Modal className="modern-modal" show={showWeapons} onHide={handleCloseWeapons} size="sm" centered>
+  <div className="text-center">
+    <Card className="modern-card">
+      <Card.Header className="modal-header">
+        <Card.Title className="modal-title">Weapons</Card.Title>
+      </Card.Header>
+      <Card.Body>
+        <Table striped bordered hover size="sm" className="modern-table">
           <thead>
             <tr>
               <th>Weapon Name</th>
@@ -176,57 +171,95 @@ return(
             </tr>
           </thead>
           <tbody>
-            {form.weapon.map((el) => (  
-            <tr key={el[0]}>
-              <td>{el[0]}</td>             
-              <td style={{display: showAtkBonusSave}}>
-               {(() => {
-              if (el[4] === "0") {
-                return(Number(atkBonus) + Number(strMod) + Number(el[1]));
-              } else if (el[4] === "1") {
-                return(Number(atkBonus) + Number(strMod) + Number(el[1]));
-              } else if (el[4] === "2") {
-                return(Number(atkBonus) + Number(dexMod) + Number(el[1]));
-              }
-              })()}</td>
-              <td style={{display: showAtkBonusSave}}>{el[2]}
-              {(() => {
-              if (el[4] === "0") {
-                return("+" + (Number(el[1]) + Number(strMod)));
-              } else if (el[4] === "1") {
-                return("+" + (Number(el[1]) + Math.floor( Number((strMod * 1.5)))));
-              } else if (el[4] === "2") {
-                return("+" + (Number(el[1]) + Number(0)));
-              }
-              })()}</td>
-              <td>{el[3]}</td>
-              <td>{el[5]}</td>
-              <td><Button size="sm" style={{ display: showDeleteBtn}} className="fa-solid fa-trash" variant="danger" onClick={() => {deleteWeapons(el);}}></Button></td>
-            </tr>
-             ))}
+            {form.weapon.map((el) => (
+              <tr key={el[0]}>
+                <td>{el[0]}</td>
+                <td hidden={!showAtkBonusSave}>
+                  {(() => {
+                    if (el[4] === "0") {
+                      return Number(atkBonus) + Number(strMod) + Number(el[1]);
+                    } else if (el[4] === "1") {
+                      return Number(atkBonus) + Number(strMod) + Number(el[1]);
+                    } else if (el[4] === "2") {
+                      return Number(atkBonus) + Number(dexMod) + Number(el[1]);
+                    }
+                  })()}
+                </td>
+                <td hidden={!showAtkBonusSave}>
+                  {el[2]}
+                  {(() => {
+                    if (el[4] === "0") {
+                      return "+" + (Number(el[1]) + Number(strMod));
+                    } else if (el[4] === "1") {
+                      return "+" + (Number(el[1]) + Math.floor(Number(strMod * 1.5)));
+                    } else if (el[4] === "2") {
+                      return "+" + (Number(el[1]) + Number(0));
+                    }
+                  })()}
+                </td>
+                <td>{el[3]}</td>
+                <td>{el[5]}</td>
+                <td>
+                  <Button
+                    size="sm"
+                    className="action-btn fa-solid fa-trash"
+                    hidden={!showDeleteBtn}
+                    onClick={() => {
+                      deleteWeapons(el);
+                    }}
+                  ></Button>
+                </td>
+              </tr>
+            ))}
           </tbody>
-        </Table>      
-    <Row>
-        <Col>
-          <Form onSubmit={addWeaponToDb}>
-          <Form.Group className="mb-3 mx-5">
-        <Form.Label className="text-dark">Select Weapon</Form.Label>
-        <Form.Select 
-        onChange={(e) => {updateWeapon({ weapon: e.target.value }); handleChosenWeaponChange(e);}}
-        defaultValue=""
-         type="text">
-          <option value="" disabled>Select your weapon</option>
-          {weapon.weapon.map((el) => (  
-          <option key={el.weaponName} value={[el.weaponName, el.enhancement, el.damage, el.critical, el.weaponStyle, el.range]}>{el.weaponName}</option>
-          ))}
-        </Form.Select>
-      </Form.Group>
-        <Button disabled={!chosenWeapon} className="rounded-pill" variant="outline-dark" type="submit">Add</Button>
-          </Form>
-        </Col>
-      </Row>
-      </Card> 
-</div>
+        </Table>
+        <Row>
+          <Col>
+            <Form onSubmit={addWeaponToDb}>
+              <Form.Group className="mb-3 mx-5">
+                <Form.Label className="text-dark">Select Weapon</Form.Label>
+                <Form.Select
+                  onChange={(e) => {
+                    updateWeapon({ weapon: e.target.value });
+                    handleChosenWeaponChange(e);
+                  }}
+                  defaultValue=""
+                  type="text"
+                >
+                  <option value="" disabled>
+                    Select your weapon
+                  </option>
+                  {weapon.weapon.map((el) => (
+                    <option
+                      key={el.weaponName}
+                      value={[
+                        el.weaponName,
+                        el.enhancement,
+                        el.damage,
+                        el.critical,
+                        el.weaponStyle,
+                        el.range,
+                      ]}
+                    >
+                      {el.weaponName}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+              <Button disabled={!chosenWeapon} className="action-btn" type="submit">
+                Add
+              </Button>
+            </Form>
+          </Col>
+        </Row>
+      </Card.Body>
+      <Card.Footer className="modal-footer">
+        <Button className="action-btn close-btn" onClick={handleCloseWeapons}>
+          Close
+        </Button>
+      </Card.Footer>
+    </Card>
+  </div>
 </Modal>
     </div>
 )


### PR DESCRIPTION
## Summary
- Modernize Feats, Weapons, Armor, and other modals with `modern-modal` and `modern-card` classes
- Replace inline styling and remove wornpaper textures
- Standardize card sections and button styles across components

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a88bb79774832eb684f9453a83766b