### PR TITLE
Expand character info modal

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -16,12 +16,19 @@ export default function CharacterInfo({ form, show, handleClose }) {
   };
 
   return (
-    <Modal className="modern-modal" show={show} onHide={handleClose} size="sm" centered>
+    <Modal
+      className="modern-modal"
+      show={show}
+      onHide={handleClose}
+      size="lg"
+      centered
+      scrollable
+    >
       <Card className="modern-card text-center">
         <Card.Header className="modal-header">
           <Card.Title className="modal-title">Character Info</Card.Title>
         </Card.Header>
-        <Card.Body>
+        <Card.Body style={{ overflowY: "auto", maxHeight: "60vh" }}>
           <Table striped bordered hover size="sm" className="modern-table">
             <tbody>
               <tr>


### PR DESCRIPTION
## Summary
- expand character info modal to large and enable internal scrolling
- limit modal body height to keep footer actions visible

## Testing
- `npm test --prefix client -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a8aa42a718832eac9ba4569414e515