### PR TITLE
Expand weapons modal and enable scrolling

### DIFF
--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -152,13 +152,13 @@ const [weapon, setWeapon] = useState({
 return(
     <div>
         {/* -----------------------------------------Weapons Render---------------------------------------------------------------------------------------------------------------------------------- */}
-<Modal className="modern-modal" show={showWeapons} onHide={handleCloseWeapons} size="sm" centered>
+<Modal className="modern-modal" show={showWeapons} onHide={handleCloseWeapons} size="lg" centered>
   <div className="text-center">
     <Card className="modern-card">
       <Card.Header className="modal-header">
         <Card.Title className="modal-title">Weapons</Card.Title>
       </Card.Header>
-      <Card.Body>
+      <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
         <Table striped bordered hover size="sm" className="modern-table">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- enlarge weapons modal
- enable scrolling within weapons card

## Testing
- `npm test`
- `npm test` (from repository root, fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a8b3a4db48832eb01d5429c744ecda