### PR TITLE
feat: enlarge armor modal with scroll

### DIFF
--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -133,13 +133,13 @@ return(
     <div>
      {/* ------------------------------------------------Armor Render-----------------------------------------------------------
 ----------------------------------------------------- */}
-<Modal className="modern-modal" show={showArmor} onHide={handleCloseArmor} size="sm" centered>
+<Modal className="modern-modal" show={showArmor} onHide={handleCloseArmor} size="lg" scrollable centered>
   <div className="text-center">
     <Card className="modern-card">
       <Card.Header className="modal-header">
         <Card.Title className="modal-title">Armor</Card.Title>
       </Card.Header>
-      <Card.Body>
+      <Card.Body style={{ maxHeight: '60vh', overflowY: 'auto' }}>
         <Table striped bordered hover size="sm" className="modern-table">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- widen Armor modal to large size and allow internal body scrolling
- keep modal header and footer in view while scrolling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8ba0bb420832eaacdfa27b4992924