### PR TITLE
Make dice responsive and adjust layout spacing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -107,12 +107,6 @@ label {
 }
 
 // Dice Roller----------------------------------------------------------------------------------------------
-$containerWidth: 120px;
-$containerHeight: $containerWidth;
-
-$faceWidth:  $containerWidth*0.5;
-$faceHeight: $faceWidth*0.86;
-
 $transitionDuration: 0.5s;
 $animationDuration:  3s;
 
@@ -122,12 +116,130 @@ $sideAngle: calc(360deg / 5);
 $color: var(--dice-face-color);
 
 $rotateX: -$angle;
-$translateZ: $faceWidth*0.335;
-$translateY: -$faceHeight*0.15;
-$translateRingZ: $faceWidth*0.75;
-$translateRingY: $faceHeight*0.78 + $translateY;
-$translateLowerZ: $translateZ;
-$translateLowerY: $faceHeight*0.78 + $translateRingY;
+
+@mixin dice-size($containerWidth) {
+  $containerHeight: $containerWidth;
+  $faceWidth:  $containerWidth*0.5;
+  $faceHeight: $faceWidth*0.86;
+
+  $translateZ: $faceWidth*0.335;
+  $translateY: -$faceHeight*0.15;
+  $translateRingZ: $faceWidth*0.75;
+  $translateRingY: $faceHeight*0.78 + $translateY;
+  $translateLowerZ: $translateZ;
+  $translateLowerY: $faceHeight*0.78 + $translateRingY;
+
+  .content {
+    margin: auto auto;
+    position: relative;
+    width: $containerWidth;
+    height: $containerHeight;
+    perspective: 1500px;
+  }
+
+  .die {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    transition: transform $transitionDuration ease-out;
+    cursor: pointer;
+
+    transform: rotateX($rotateX);
+
+    &.rolling {
+      animation: roll $animationDuration linear;
+    }
+
+    @for $i from 1 through 5 {
+      &[data-face="#{$i}"] {
+        $angleMultiplier: $i - 1;
+        transform: rotateX(-$angle) rotateY($sideAngle * $angleMultiplier);
+      }
+    }
+
+    @for $i from 16 through 20 {
+      &[data-face="#{$i}"] {
+        $angleMultiplier: $i - 15;
+        transform: rotateX(-$angle + 180deg) rotateY(-$sideAngle * $angleMultiplier);
+      }
+    }
+
+    @for $i from 6 through 10 {
+      &[data-face="#{$i}"] {
+        $angleMultiplier: $i - 6;
+        transform: rotateX(-$ringAngle) rotateZ(180deg) rotateY($sideAngle * $angleMultiplier);
+      }
+    }
+
+    @for $i from 11 through 15 {
+      &[data-face="#{$i}"] {
+        $angleMultiplier: $i - 8;
+        transform: rotateX(-$ringAngle) rotateY(-$sideAngle * $angleMultiplier - calc($sideAngle / 2));
+      }
+    }
+
+    .face {
+      $horizontalMargin: -$faceWidth*0.5;
+
+      position: absolute;
+      left: 50%;
+      top: 0;
+      margin: 0 $horizontalMargin;
+      border-left: $faceWidth*0.5 solid transparent;
+      border-right: $faceWidth*0.5 solid transparent;
+      border-bottom: $faceHeight solid $color;
+      width: 0px;
+      height: 0px;
+      transform-style: preserve-3d;
+      backface-visibility: hidden;
+
+      counter-increment: steps 1;
+
+      &:before {
+        content: counter(steps);
+        position: absolute;
+        top: $faceHeight*0.25;
+        left: -$faceWidth;
+        color: #fff;
+        text-shadow: 1px 1px 3px #000;
+        font-size: $faceHeight*0.5;
+        text-align: center;
+        line-height: $faceHeight*0.9;
+        width: $faceWidth*2;
+        height: $faceHeight;
+      }
+
+      @for $i from 1 through 5 {
+        &:nth-child(#{$i}) {
+          $angleMultiplier: $i - 1;
+          transform: rotateY(-$sideAngle * $angleMultiplier) translateZ($translateZ) translateY($translateY) rotateX($angle);
+        }
+      }
+
+      @for $i from 16 through 20 {
+        &:nth-child(#{$i}) {
+          $angleMultiplier: $i - 18;
+          transform: rotateY($sideAngle * $angleMultiplier + calc($sideAngle / 2)) translateZ($translateLowerZ) translateY($translateLowerY) rotateZ(180deg) rotateX($angle);
+        }
+      }
+
+      @for $i from 6 through 10 {
+        &:nth-child(#{$i}) {
+          $angleMultiplier: $i - 11;
+          transform: rotateY(-$sideAngle * $angleMultiplier) translateZ($translateRingZ) translateY($translateRingY) rotateZ(180deg) rotateX($ringAngle);
+        }
+      }
+
+      @for $i from 11 through 15 {
+        &:nth-child(#{$i}) {
+          $angleMultiplier: $i - 8;
+          transform: rotateY($sideAngle * $angleMultiplier + calc($sideAngle / 2)) translateZ($translateRingZ) translateY($translateRingY) rotateX($ringAngle);
+        }
+      }
+    }
+  }
+}
 
 @keyframes roll {
   10% { transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) }
@@ -137,116 +249,12 @@ $translateLowerY: $faceHeight*0.78 + $translateRingY;
   90% { transform: rotateX(480deg) rotateY(960deg) rotateZ(0deg) }
 }
 
-.content {
-  margin: auto auto;
-  position: relative;
-  width: $containerWidth;
-  height: $containerHeight;
-  perspective: 1500px;
+@include dice-size(min(25vw, 120px));
+
+@media (max-height: 600px) {
+  @include dice-size(min(20vw, 100px));
 }
 
-.die {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  transform-style: preserve-3d;
-  transition: transform $transitionDuration ease-out;
-  cursor: pointer;
-  
-  transform: rotateX($rotateX);
-  
-  &.rolling {
-    animation: roll $animationDuration linear;
-  }
-  
-  @for $i from 1 through 5 {
-    &[data-face="#{$i}"] {
-      $angleMultiplier: $i - 1;
-      transform: rotateX(-$angle) rotateY($sideAngle * $angleMultiplier);
-    }
-  }
-  
-  @for $i from 16 through 20 {
-    &[data-face="#{$i}"] {
-      $angleMultiplier: $i - 15;
-      transform: rotateX(-$angle + 180deg) rotateY(-$sideAngle * $angleMultiplier);
-    }
-  }
-  
-  @for $i from 6 through 10 {
-    &[data-face="#{$i}"] {
-      $angleMultiplier: $i - 6;
-      transform: rotateX(-$ringAngle) rotateZ(180deg) rotateY($sideAngle * $angleMultiplier);
-    }
-  }
-  
-  @for $i from 11 through 15 {
-    &[data-face="#{$i}"] {
-      $angleMultiplier: $i - 8;
-      transform: rotateX(-$ringAngle) rotateY(-$sideAngle * $angleMultiplier - calc($sideAngle / 2));
-    }
-  }
-  
-  .face {
-    $horizontalMargin: -$faceWidth*0.5;
-    
-    position: absolute;
-    left: 50%;
-    top: 0;
-    margin: 0 $horizontalMargin;
-    border-left: $faceWidth*0.5 solid transparent;
-    border-right: $faceWidth*0.5 solid transparent;
-    border-bottom: $faceHeight solid $color;
-    width: 0px;
-    height: 0px;
-    transform-style: preserve-3d;
-    backface-visibility: hidden;
-    
-    counter-increment: steps 1;
-  
-    &:before {
-      content: counter(steps);
-      position: absolute;
-      top: $faceHeight*0.25;
-      left: -$faceWidth;
-      color: #fff;
-      text-shadow: 1px 1px 3px #000;
-      font-size: $faceHeight*0.5;
-      text-align: center;
-      line-height: $faceHeight*0.9;
-      width: $faceWidth*2;
-      height: $faceHeight;
-    }
-    
-    @for $i from 1 through 5 {
-      &:nth-child(#{$i}) {
-        $angleMultiplier: $i - 1;
-        transform: rotateY(-$sideAngle * $angleMultiplier) translateZ($translateZ) translateY($translateY) rotateX($angle);
-      }
-    }
-      
-    @for $i from 16 through 20 {
-      &:nth-child(#{$i}) {
-        $angleMultiplier: $i - 18;
-        transform: rotateY($sideAngle * $angleMultiplier + calc($sideAngle / 2)) translateZ($translateLowerZ) translateY($translateLowerY) rotateZ(180deg) rotateX($angle);
-      }
-    }
-      
-    @for $i from 6 through 10 {
-      &:nth-child(#{$i}) {
-        $angleMultiplier: $i - 11;
-        transform: rotateY(-$sideAngle * $angleMultiplier) translateZ($translateRingZ) translateY($translateRingY) rotateZ(180deg) rotateX($ringAngle);
-      }
-    }
-      
-    @for $i from 11 through 15 {
-      &:nth-child(#{$i}) {
-        $angleMultiplier: $i - 8;
-        transform: rotateY($sideAngle * $angleMultiplier + calc($sideAngle / 2)) translateZ($translateRingZ) translateY($translateRingY) rotateX($ringAngle);
-      }
-    }
-  }
-}
 // Damage display-------------------------------------------------------
 #damageAmount {
   width: 70px;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -193,7 +193,7 @@ const showSparklesEffect = () => {
 };
 //-------------------------------------------------------------Display-----------------------------------------------------------------------------------------
   return (
-    <div style={{ marginTop: "-40px"}}>
+    <div style={{ marginTop: "-40px", paddingBottom: "80px" }}>
     <div className={`mt-3 ${loading ? 'loading' : ''} ${pulse ? 'pulse' : ''}`} id="damageAmount" style={{margin: "0 auto"}}>
       <span id="damageValue" className={loading ? 'hidden' : ''}>
         {damageValue}


### PR DESCRIPTION
## Summary
- Replace fixed dice dimensions with mixin-driven sizing and viewport-based min expressions
- Add media query to shrink dice on short viewports
- Provide bottom padding in PlayerTurnActions to keep dice clear of other UI

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a8ce7e9750832e9956b4d24d59da7e