### PR TITLE
Ensure API fetches include credentials

### DIFF
--- a/client/src/utils/apiFetch.js
+++ b/client/src/utils/apiFetch.js
@@ -1,8 +1,13 @@
 let csrfToken;
+const apiBaseUrl = process.env.REACT_APP_API_URL;
+const apiOrigin = apiBaseUrl ? new URL(apiBaseUrl).origin : null;
 
 async function getCsrfToken() {
   if (!csrfToken) {
-    const response = await window.fetch('/csrf-token', { credentials: 'include' });
+    const tokenUrl = apiBaseUrl
+      ? new URL('/csrf-token', apiBaseUrl).toString()
+      : '/csrf-token';
+    const response = await window.fetch(tokenUrl, { credentials: 'include' });
     const data = await response.json();
     csrfToken = data.csrfToken;
   }
@@ -11,12 +16,13 @@ async function getCsrfToken() {
 
 export default async function apiFetch(input, init = {}) {
   const hasWindow = typeof window !== 'undefined' && window.location;
-  const base = hasWindow ? window.location.href : 'http://localhost';
+  const base = apiBaseUrl || (hasWindow ? window.location.origin : 'http://localhost');
   const urlString = input instanceof Request ? input.url : input;
   const url = new URL(urlString, base);
 
-  const sameOrigin = !hasWindow || url.origin === window.location.origin;
-  if (sameOrigin) {
+  const sameOrigin = hasWindow && url.origin === window.location.origin;
+  const apiRequest = apiOrigin && url.origin === apiOrigin;
+  if (!hasWindow || sameOrigin || apiRequest) {
     init = { credentials: 'include', ...init };
     if (init.method && init.method.toUpperCase() !== 'GET') {
       const token = await getCsrfToken();
@@ -24,5 +30,13 @@ export default async function apiFetch(input, init = {}) {
     }
   }
 
-  return window.fetch(input, init);
+  let finalInput;
+  if (input instanceof Request) {
+    finalInput = new Request(url.toString(), input);
+  } else if (apiBaseUrl) {
+    finalInput = url.toString();
+  } else {
+    finalInput = urlString;
+  }
+  return window.fetch(finalInput, init);
 }


### PR DESCRIPTION
## Summary
- include CSRF token and cookies for API requests even across origins
- centralize API base URL through `REACT_APP_API_URL`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a0ad75e4832e847fa0fd54efc93f