### PR TITLE
Support multiple client origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The server uses a `config.env` file for configuration. Ensure the following vari
 
 | Variable | Description |
 |----------|-------------|
-| `CLIENT_ORIGIN` | The URL of the client application allowed to make cross-origin requests. |
+| `CLIENT_ORIGINS` | Comma-separated list of client application URLs allowed to make cross-origin requests, e.g., `http://localhost,http://example.com`. |
 
 
 ## API Error Format

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -1,6 +1,6 @@
 process.env.JWT_SECRET = 'testsecret';
 process.env.ATLAS_URI = 'mongodb://localhost/test';
-process.env.CLIENT_ORIGIN = 'http://localhost';
+process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -1,6 +1,6 @@
 process.env.JWT_SECRET = 'testsecret';
 process.env.ATLAS_URI = 'mongodb://localhost/test';
-process.env.CLIENT_ORIGIN = 'http://localhost';
+process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -1,6 +1,6 @@
 process.env.JWT_SECRET = 'testsecret';
 process.env.ATLAS_URI = 'mongodb://localhost/test';
-process.env.CLIENT_ORIGIN = 'http://localhost';
+process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -1,6 +1,6 @@
 process.env.JWT_SECRET = 'testsecret';
 process.env.ATLAS_URI = 'mongodb://localhost/test';
-process.env.CLIENT_ORIGIN = 'http://localhost';
+process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');

--- a/server/__tests__/unauthorized.test.js
+++ b/server/__tests__/unauthorized.test.js
@@ -1,6 +1,6 @@
 process.env.JWT_SECRET = 'testsecret';
 process.env.ATLAS_URI = 'mongodb://localhost/test';
-process.env.CLIENT_ORIGIN = 'http://localhost';
+process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -1,6 +1,6 @@
 process.env.JWT_SECRET = 'testsecret';
 process.env.ATLAS_URI = 'mongodb://localhost/test';
-process.env.CLIENT_ORIGIN = 'http://localhost';
+process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');

--- a/server/server.js
+++ b/server/server.js
@@ -12,11 +12,12 @@ const connectToDatabase = require("./db/conn");
 const routes = require("./routes");
 const logger = require("./utils/logger");
 const port = process.env.PORT || 5000;
+const allowedOrigins = config.clientOrigins;
 
-// Restrict cross-origin requests to a single approved client
+// Restrict cross-origin requests to approved clients
 app.use(cors({
   origin(origin, callback) {
-    if (!origin || origin === config.clientOrigin) {
+    if (!origin || allowedOrigins.includes(origin)) {
       callback(null, true);
     } else {
       callback(new Error('Not allowed by CORS'));

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -4,7 +4,7 @@ const dotenv = require('dotenv');
 // Load environment variables from config.env located one directory up
 dotenv.config({ path: path.resolve(__dirname, '../config.env') });
 
-const requiredEnv = ['JWT_SECRET', 'ATLAS_URI', 'CLIENT_ORIGIN'];
+const requiredEnv = ['JWT_SECRET', 'ATLAS_URI', 'CLIENT_ORIGINS'];
 
 const missing = requiredEnv.filter((name) => !process.env[name]);
 
@@ -15,5 +15,5 @@ if (missing.length > 0) {
 module.exports = {
   jwtSecret: process.env.JWT_SECRET,
   atlasUri: process.env.ATLAS_URI,
-  clientOrigin: process.env.CLIENT_ORIGIN,
+  clientOrigins: process.env.CLIENT_ORIGINS.split(',').map((origin) => origin.trim()).filter(Boolean),
 };


### PR DESCRIPTION
## Summary
- Allow multiple allowed origins via `CLIENT_ORIGINS` environment variable
- Update CORS middleware to check requests against allowed origin list
- Document `CLIENT_ORIGINS` format and adjust tests for new env variable

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a42d2c34832eb8b3bdab3735ef76