### PR TITLE
Relax sameSite policy for auth cookies

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -30,7 +30,7 @@ module.exports = (router) => {
         res.cookie('token', token, {
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production',
-          sameSite: 'strict',
+          sameSite: 'lax',
         });
         res.json({ message: 'Logged in' });
         logger.info('User logged in', {
@@ -71,7 +71,7 @@ module.exports = (router) => {
     res.clearCookie('token', {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: 'lax',
       path: '/',
     });
     res.json({ message: 'Logged out' });


### PR DESCRIPTION
## Summary
- Use `sameSite: 'lax'` when issuing the auth token cookie
- Apply the same lax policy when clearing the token on logout

## Testing
- `npm install` *(fails: 403 Forbidden fetching dependencies)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b31a72cc832ea8eccb05f9657aa8