### PR TITLE
Specify realmtracker cookie domain

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -31,6 +31,7 @@ module.exports = (router) => {
           httpOnly: true,
           secure: true,
           sameSite: 'none',
+          domain: '.realmtracker.org',
         });
         res.json({ message: 'Logged in' });
         logger.info('User logged in', {
@@ -73,6 +74,7 @@ module.exports = (router) => {
       secure: true,
       sameSite: 'none',
       path: '/',
+      domain: '.realmtracker.org',
     });
     res.json({ message: 'Logged out' });
   });

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,7 @@ const csrfProtection = csrf({
     httpOnly: true,
     sameSite: 'none',
     secure: true,
+    domain: '.realmtracker.org',
   },
 });
 app.use(csrfProtection);


### PR DESCRIPTION
## Summary
- add realmtracker.org domain to auth cookies
- include same domain in CSRF cookie options

## Testing
- `npm run build`
- `npm test --prefix server` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0da8553c4832ea7ccfad49136d909