### PR TITLE
chore: configure token cookie domain

### DIFF
--- a/server/__tests__/authCookies.test.js
+++ b/server/__tests__/authCookies.test.js
@@ -1,0 +1,53 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+process.env.NODE_ENV = 'production';
+
+const request = require('supertest');
+const express = require('express');
+const bcrypt = require('bcryptjs');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Auth cookies in production', () => {
+  test('login sets secure cross-subdomain cookie', async () => {
+    const hashed = await bcrypt.hash('secret', 10);
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({ username: 'alice', password: hashed })
+      })
+    });
+    const res = await request(app).post('/login').send({ username: 'alice', password: 'secret' });
+    expect(res.status).toBe(200);
+    const cookie = res.headers['set-cookie'][0];
+    expect(cookie).toMatch(/Domain=\.realmtracker\.org/);
+    expect(cookie).toMatch(/Secure/);
+    expect(cookie).toMatch(/SameSite=None/);
+  });
+
+  test('logout clears cookie across subdomains', async () => {
+    dbo.mockResolvedValue({ collection: () => ({}) });
+    const res = await request(app).post('/logout');
+    expect(res.status).toBe(200);
+    const cookie = res.headers['set-cookie'][0];
+    expect(cookie).toMatch(/Domain=\.realmtracker\.org/);
+    expect(cookie).toMatch(/Secure/);
+    expect(cookie).toMatch(/SameSite=None/);
+  });
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = 'test';
+});

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -7,6 +7,7 @@ const logger = require('../utils/logger');
 const config = require('../utils/config');
 
 const jwtSecretKey = config.jwtSecret;
+const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = (router) => {
   router.post(
@@ -29,8 +30,9 @@ module.exports = (router) => {
         const token = jwt.sign({ username: user.username }, jwtSecretKey, { expiresIn: '1h' });
         res.cookie('token', token, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'none',
+          secure: isProd,
+          sameSite: isProd ? 'none' : 'lax',
+          domain: isProd ? '.realmtracker.org' : undefined,
         });
         res.json({ message: 'Logged in' });
         logger.info('User logged in', {
@@ -70,9 +72,10 @@ module.exports = (router) => {
   router.post('/logout', (req, res) => {
     res.clearCookie('token', {
       httpOnly: true,
-      secure: true,
-      sameSite: 'none',
+      secure: isProd,
+      sameSite: isProd ? 'none' : 'lax',
       path: '/',
+      domain: isProd ? '.realmtracker.org' : undefined,
     });
     res.json({ message: 'Logged out' });
   });


### PR DESCRIPTION
## Summary
- derive isProd and set dynamic cookie options for auth token
- add tests verifying production cookies support subdomains

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e0bf8990832e95aee09196bc962f