### PR TITLE
Enforce HTTPS in production

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -15,6 +15,16 @@ const port = process.env.PORT || 5000;
 const isProd = process.env.NODE_ENV === 'production';
 const allowedOrigins = config.clientOrigins;
 
+// Redirect all HTTP traffic to HTTPS in production
+if (isProd) {
+  app.use((req, res, next) => {
+    if (req.secure) {
+      return next();
+    }
+    res.redirect(301, `https://${req.headers.host}${req.originalUrl}`);
+  });
+}
+
 // Restrict cross-origin requests to approved clients
 app.use(cors({
   origin(origin, callback) {


### PR DESCRIPTION
## Summary
- redirect HTTP to HTTPS when running in production so secure cookies are honored

## Testing
- `npm test --prefix server` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ff3e5c74832ea5db02d03c54e313