### PR TITLE
Add router prefixes and adjust nested routes

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -27,7 +27,7 @@ describe('Campaign routes', () => {
       })
     });
     const res = await request(app)
-      .post('/campaign/add')
+      .post('/campaigns/add')
       .send({ campaignName: 'Test', dm: 'DM' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
@@ -40,7 +40,7 @@ describe('Campaign routes', () => {
       })
     });
     const res = await request(app)
-      .post('/campaign/add')
+      .post('/campaigns/add')
       .send({ campaignName: 'Test', dm: 'DM' });
     expect(res.status).toBe(500);
     expect(res.body.message).toBe('Internal Server Error');
@@ -52,7 +52,7 @@ describe('Campaign routes', () => {
         findOne: async () => ({ campaignName: 'Test', dm: 'DM', players: [] })
       })
     });
-    const res = await request(app).get('/campaign/Test');
+    const res = await request(app).get('/campaigns/Test');
     expect(res.status).toBe(200);
     expect(res.body.dm).toBe('DM');
   });
@@ -63,7 +63,7 @@ describe('Campaign routes', () => {
         findOne: async () => { throw new Error('db error'); }
       })
     });
-    const res = await request(app).get('/campaign/Test');
+    const res = await request(app).get('/campaigns/Test');
     expect(res.status).toBe(500);
   });
 
@@ -73,7 +73,7 @@ describe('Campaign routes', () => {
         find: () => ({ toArray: async () => [{ campaignName: 'Test', dm: 'DM' }] })
       })
     });
-    const res = await request(app).get('/campaignsDM/DM');
+    const res = await request(app).get('/campaigns/dm/DM');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
   });
@@ -84,7 +84,7 @@ describe('Campaign routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/campaignsDM/DM');
+    const res = await request(app).get('/campaigns/dm/DM');
     expect(res.status).toBe(500);
   });
 
@@ -94,7 +94,7 @@ describe('Campaign routes', () => {
         findOne: async () => ({ campaignName: 'Test', dm: 'DM' })
       })
     });
-    const res = await request(app).get('/campaignsDM/DM/Test');
+    const res = await request(app).get('/campaigns/dm/DM/Test');
     expect(res.status).toBe(200);
     expect(res.body.campaignName).toBe('Test');
   });
@@ -105,7 +105,7 @@ describe('Campaign routes', () => {
         findOne: async () => { throw new Error('db error'); }
       })
     });
-    const res = await request(app).get('/campaignsDM/DM/Test');
+    const res = await request(app).get('/campaigns/dm/DM/Test');
     expect(res.status).toBe(500);
   });
 });

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -27,7 +27,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .post('/character/add')
+      .post('/characters/add')
       .send({ token: 'alice', characterName: 'Hero', campaign: 'Camp1' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
@@ -55,7 +55,7 @@ describe('Character routes', () => {
       newSkill: ['Stealth']
     };
     const res = await request(app)
-      .post('/character/add')
+      .post('/characters/add')
       .send(payload);
     expect(res.status).toBe(200);
     expect(captured).toMatchObject({
@@ -73,7 +73,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .post('/character/add')
+      .post('/characters/add')
       .send({ token: 'alice', characterName: 'Hero', campaign: 'Camp1' });
     expect(res.status).toBe(500);
   });
@@ -85,7 +85,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .post('/character/add')
+      .post('/characters/add')
       .send({ token: 'alice' });
     expect(res.status).toBe(400);
   });
@@ -96,7 +96,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => [{ token: 'alice', campaign: 'Camp1' }] })
       })
     });
-    const res = await request(app).get('/campaign/Camp1/alice');
+    const res = await request(app).get('/campaigns/Camp1/alice');
     expect(res.status).toBe(200);
     expect(res.body[0].token).toBe('alice');
   });
@@ -107,7 +107,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/campaign/Camp1/alice');
+    const res = await request(app).get('/campaigns/Camp1/alice');
     expect(res.status).toBe(500);
   });
 
@@ -120,7 +120,7 @@ describe('Character routes', () => {
         ] })
       })
     });
-    const res = await request(app).get('/campaign/Camp1/characters');
+    const res = await request(app).get('/campaigns/Camp1/characters');
     expect(res.status).toBe(200);
     expect(res.body.length).toBe(2);
   });
@@ -131,7 +131,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/campaign/Camp1/characters');
+    const res = await request(app).get('/campaigns/Camp1/characters');
     expect(res.status).toBe(500);
   });
 
@@ -164,7 +164,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => [{ weaponName: 'Sword' }] })
       })
     });
-    const res = await request(app).get('/weapons/Camp1');
+    const res = await request(app).get('/equipment/weapons/Camp1');
     expect(res.status).toBe(200);
     expect(res.body[0].weaponName).toBe('Sword');
   });
@@ -175,7 +175,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/weapons/Camp1');
+    const res = await request(app).get('/equipment/weapons/Camp1');
     expect(res.status).toBe(500);
   });
 
@@ -185,7 +185,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => [{ armorName: 'Plate' }] })
       })
     });
-    const res = await request(app).get('/armor/Camp1');
+    const res = await request(app).get('/equipment/armor/Camp1');
     expect(res.status).toBe(200);
     expect(res.body[0].armorName).toBe('Plate');
   });
@@ -196,7 +196,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/armor/Camp1');
+    const res = await request(app).get('/equipment/armor/Camp1');
     expect(res.status).toBe(500);
   });
 
@@ -206,7 +206,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => [{ itemName: 'Potion' }] })
       })
     });
-    const res = await request(app).get('/items/Camp1');
+    const res = await request(app).get('/equipment/items/Camp1');
     expect(res.status).toBe(200);
     expect(res.body[0].itemName).toBe('Potion');
   });
@@ -217,7 +217,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/items/Camp1');
+    const res = await request(app).get('/equipment/items/Camp1');
     expect(res.status).toBe(500);
   });
 
@@ -248,7 +248,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => [{ name: 'Soldier' }] })
       })
     });
-    const res = await request(app).get('/occupations');
+    const res = await request(app).get('/characters/occupations');
     expect(res.status).toBe(200);
     expect(res.body[0].name).toBe('Soldier');
   });
@@ -259,7 +259,7 @@ describe('Character routes', () => {
         find: () => ({ toArray: async () => { throw new Error('db error'); } })
       })
     });
-    const res = await request(app).get('/occupations');
+    const res = await request(app).get('/characters/occupations');
     expect(res.status).toBe(500);
   });
 
@@ -270,7 +270,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .put('/update-skills/507f1f77bcf86cd799439011')
+      .put('/skills/update-skills/507f1f77bcf86cd799439011')
       .send({ appraise: 1 });
     expect(res.status).toBe(200);
     expect(res.body.appraise).toBe(1);
@@ -283,7 +283,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .put('/update-skills/507f1f77bcf86cd799439011')
+      .put('/skills/update-skills/507f1f77bcf86cd799439011')
       .send({ appraise: 1 });
     expect(res.status).toBe(500);
   });
@@ -295,7 +295,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .put('/updated-add-skills/507f1f77bcf86cd799439011')
+      .put('/skills/updated-add-skills/507f1f77bcf86cd799439011')
       .send({ newSkill: [['Skill', 1]] });
     expect(res.status).toBe(200);
     expect(res.body.newSkill).toEqual([['Skill', 1]]);
@@ -308,7 +308,7 @@ describe('Character routes', () => {
       })
     });
     const res = await request(app)
-      .put('/updated-add-skills/507f1f77bcf86cd799439011')
+      .put('/skills/updated-add-skills/507f1f77bcf86cd799439011')
       .send({ newSkill: [['Skill', 1]] });
     expect(res.status).toBe(500);
   });
@@ -318,7 +318,7 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
     });
     const res = await request(app)
-      .post('/weapon/add')
+      .post('/equipment/weapon/add')
       .send({ campaign: 'Camp1', weaponName: 'Sword' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
@@ -329,7 +329,7 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
-      .post('/weapon/add')
+      .post('/equipment/weapon/add')
       .send({ campaign: 'Camp1', weaponName: 'Sword' });
     expect(res.status).toBe(500);
   });
@@ -339,7 +339,7 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
     });
     const res = await request(app)
-      .post('/armor/add')
+      .post('/equipment/armor/add')
       .send({ campaign: 'Camp1', armorName: 'Plate' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
@@ -350,7 +350,7 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
-      .post('/armor/add')
+      .post('/equipment/armor/add')
       .send({ campaign: 'Camp1', armorName: 'Plate' });
     expect(res.status).toBe(500);
   });
@@ -360,7 +360,7 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
     });
     const res = await request(app)
-      .post('/item/add')
+      .post('/equipment/item/add')
       .send({ campaign: 'Camp1', itemName: 'Potion' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
@@ -371,7 +371,7 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
-      .post('/item/add')
+      .post('/equipment/item/add')
       .send({ campaign: 'Camp1', itemName: 'Potion' });
     expect(res.status).toBe(500);
   });
@@ -384,14 +384,14 @@ describe('Character routes', () => {
 
   test('delete character invalid id', async () => {
     dbo.mockResolvedValue({});
-    const res = await request(app).delete('/delete-character/123');
+    const res = await request(app).delete('/characters/delete-character/123');
     expect(res.status).toBe(400);
   });
 
   test('update level invalid id', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-level/123')
+      .put('/characters/update-level/123')
       .send({ level: 1, health: 1 });
     expect(res.status).toBe(400);
   });
@@ -399,7 +399,7 @@ describe('Character routes', () => {
   test('update level invalid body', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-level/507f1f77bcf86cd799439011')
+      .put('/characters/update-level/507f1f77bcf86cd799439011')
       .send({ level: 'one', health: 1 });
     expect(res.status).toBe(400);
   });
@@ -407,7 +407,7 @@ describe('Character routes', () => {
   test('update dice color invalid id', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-dice-color/123')
+      .put('/characters/update-dice-color/123')
       .send({ diceColor: 'blue' });
     expect(res.status).toBe(400);
   });
@@ -415,7 +415,7 @@ describe('Character routes', () => {
   test('update dice color invalid body', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-dice-color/507f1f77bcf86cd799439011')
+      .put('/characters/update-dice-color/507f1f77bcf86cd799439011')
       .send({ diceColor: 5 });
     expect(res.status).toBe(400);
   });

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -27,7 +27,7 @@ describe('Equipment routes', () => {
   describe('/weapon/add', () => {
     test('validation failure', async () => {
       dbo.mockResolvedValue({});
-      const res = await request(app).post('/weapon/add').send({});
+      const res = await request(app).post('/equipment/weapon/add').send({});
       expect(res.status).toBe(400);
       expect(res.body.errors).toBeDefined();
     });
@@ -37,7 +37,7 @@ describe('Equipment routes', () => {
         collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
       });
       const res = await request(app)
-        .post('/weapon/add')
+        .post('/equipment/weapon/add')
         .send({ campaign: 'Camp1', weaponName: 'Sword' });
       expect(res.status).toBe(200);
       expect(res.body.acknowledged).toBe(true);
@@ -46,7 +46,7 @@ describe('Equipment routes', () => {
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .post('/weapon/add')
+        .post('/equipment/weapon/add')
         .send({ campaign: 'Camp1', weaponName: 'Sword', enhancement: 'bad' });
       expect(res.status).toBe(400);
     });
@@ -58,7 +58,7 @@ describe('Equipment routes', () => {
         collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
       });
       const res = await request(app)
-        .put('/update-weapon/507f1f77bcf86cd799439011')
+        .put('/equipment/update-weapon/507f1f77bcf86cd799439011')
         .send({ weapon: ['Sword'] });
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Weapon updated');
@@ -69,7 +69,7 @@ describe('Equipment routes', () => {
         collection: () => ({ updateOne: async () => ({ matchedCount: 0 }) })
       });
       const res = await request(app)
-        .put('/update-weapon/507f1f77bcf86cd799439011')
+        .put('/equipment/update-weapon/507f1f77bcf86cd799439011')
         .send({ weapon: ['Sword'] });
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Weapon not found');
@@ -78,7 +78,7 @@ describe('Equipment routes', () => {
     test('update weapon invalid id', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .put('/update-weapon/123')
+        .put('/equipment/update-weapon/123')
         .send({ weapon: ['Sword'] });
       expect(res.status).toBe(400);
     });
@@ -86,7 +86,7 @@ describe('Equipment routes', () => {
     test('update weapon invalid body', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .put('/update-weapon/507f1f77bcf86cd799439011')
+        .put('/equipment/update-weapon/507f1f77bcf86cd799439011')
         .send({ weapon: 'Sword' });
       expect(res.status).toBe(400);
     });
@@ -95,7 +95,7 @@ describe('Equipment routes', () => {
   describe('/armor/add', () => {
     test('validation failure', async () => {
       dbo.mockResolvedValue({});
-      const res = await request(app).post('/armor/add').send({});
+      const res = await request(app).post('/equipment/armor/add').send({});
       expect(res.status).toBe(400);
       expect(res.body.errors).toBeDefined();
     });
@@ -105,7 +105,7 @@ describe('Equipment routes', () => {
         collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
       });
       const res = await request(app)
-        .post('/armor/add')
+        .post('/equipment/armor/add')
         .send({ campaign: 'Camp1', armorName: 'Plate' });
       expect(res.status).toBe(200);
       expect(res.body.acknowledged).toBe(true);
@@ -114,7 +114,7 @@ describe('Equipment routes', () => {
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .post('/armor/add')
+        .post('/equipment/armor/add')
         .send({ campaign: 'Camp1', armorName: 'Plate', armorBonus: 'bad' });
       expect(res.status).toBe(400);
     });
@@ -126,7 +126,7 @@ describe('Equipment routes', () => {
         collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
       });
       const res = await request(app)
-        .put('/update-armor/507f1f77bcf86cd799439011')
+        .put('/equipment/update-armor/507f1f77bcf86cd799439011')
         .send({ armor: ['Plate'] });
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Armor updated');
@@ -137,7 +137,7 @@ describe('Equipment routes', () => {
         collection: () => ({ updateOne: async () => ({ matchedCount: 0 }) })
       });
       const res = await request(app)
-        .put('/update-armor/507f1f77bcf86cd799439011')
+        .put('/equipment/update-armor/507f1f77bcf86cd799439011')
         .send({ armor: ['Plate'] });
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Armor not found');
@@ -146,7 +146,7 @@ describe('Equipment routes', () => {
     test('update armor invalid id', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .put('/update-armor/123')
+        .put('/equipment/update-armor/123')
         .send({ armor: ['Plate'] });
       expect(res.status).toBe(400);
     });
@@ -154,7 +154,7 @@ describe('Equipment routes', () => {
     test('update armor invalid body', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .put('/update-armor/507f1f77bcf86cd799439011')
+        .put('/equipment/update-armor/507f1f77bcf86cd799439011')
         .send({ armor: 'Plate' });
       expect(res.status).toBe(400);
     });
@@ -163,7 +163,7 @@ describe('Equipment routes', () => {
   describe('/item/add', () => {
     test('validation failure', async () => {
       dbo.mockResolvedValue({});
-      const res = await request(app).post('/item/add').send({});
+      const res = await request(app).post('/equipment/item/add').send({});
       expect(res.status).toBe(400);
       expect(res.body.errors).toBeDefined();
     });
@@ -173,7 +173,7 @@ describe('Equipment routes', () => {
         collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
       });
       const res = await request(app)
-        .post('/item/add')
+        .post('/equipment/item/add')
         .send({ campaign: 'Camp1', itemName: 'Potion' });
       expect(res.status).toBe(200);
       expect(res.body.acknowledged).toBe(true);
@@ -182,7 +182,7 @@ describe('Equipment routes', () => {
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .post('/item/add')
+        .post('/equipment/item/add')
         .send({ campaign: 'Camp1', itemName: 'Potion', str: 'bad' });
       expect(res.status).toBe(400);
     });
@@ -194,7 +194,7 @@ describe('Equipment routes', () => {
         collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
       });
       const res = await request(app)
-        .put('/update-item/507f1f77bcf86cd799439011')
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
         .send({ item: ['Potion'] });
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Item updated');
@@ -205,7 +205,7 @@ describe('Equipment routes', () => {
         collection: () => ({ updateOne: async () => ({ matchedCount: 0 }) })
       });
       const res = await request(app)
-        .put('/update-item/507f1f77bcf86cd799439011')
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
         .send({ item: ['Potion'] });
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Item not found');
@@ -214,7 +214,7 @@ describe('Equipment routes', () => {
     test('update item invalid id', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .put('/update-item/123')
+        .put('/equipment/update-item/123')
         .send({ item: ['Potion'] });
       expect(res.status).toBe(400);
     });
@@ -222,7 +222,7 @@ describe('Equipment routes', () => {
     test('update item invalid body', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .put('/update-item/507f1f77bcf86cd799439011')
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
         .send({ item: 'Potion' });
       expect(res.status).toBe(400);
     });

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -23,7 +23,7 @@ describe('Health routes validation', () => {
   test('update temphealth invalid id', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-temphealth/123')
+      .put('/characters/update-temphealth/123')
       .send({ tempHealth: 5 });
     expect(res.status).toBe(400);
   });
@@ -31,7 +31,7 @@ describe('Health routes validation', () => {
   test('update temphealth invalid body', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-temphealth/507f1f77bcf86cd799439011')
+      .put('/characters/update-temphealth/507f1f77bcf86cd799439011')
       .send({ tempHealth: 'bad' });
     expect(res.status).toBe(400);
   });
@@ -39,7 +39,7 @@ describe('Health routes validation', () => {
   test('update health invalid id', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-health/123')
+      .put('/characters/update-health/123')
       .send({ health: 1, str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1, startStatTotal: 1 });
     expect(res.status).toBe(400);
   });
@@ -47,7 +47,7 @@ describe('Health routes validation', () => {
   test('update health invalid body', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)
-      .put('/update-health/507f1f77bcf86cd799439011')
+      .put('/characters/update-health/507f1f77bcf86cd799439011')
       .send({ health: 'bad', str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1, startStatTotal: 1 });
     expect(res.status).toBe(400);
   });

--- a/server/__tests__/unauthorized.test.js
+++ b/server/__tests__/unauthorized.test.js
@@ -17,13 +17,13 @@ app.use(routes);
 
 describe('Unauthorized access', () => {
   test('campaign route without token returns 401', async () => {
-    const res = await request(app).get('/campaign/Test');
+    const res = await request(app).get('/campaigns/Test');
     expect(res.status).toBe(401);
   });
 
   test('character route without token returns 401', async () => {
     const res = await request(app)
-      .post('/character/add')
+      .post('/characters/add')
       .send({ token: 'alice', characterName: 'Hero', campaign: 'Camp1' });
     expect(res.status).toBe(401);
   });

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -44,7 +44,7 @@ module.exports = (router) => {
   );
 
   // This section will find all characters in a specific campaign.
-  campaignRouter.route("/campaign/:campaign/characters").get(async (req, res, next) => {
+  campaignRouter.route('/:campaign/characters').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -58,7 +58,7 @@ module.exports = (router) => {
   });
 
   // This section will find all of the users characters in a specific campaign.
-  campaignRouter.route("/campaign/:campaign/:username").get(async (req, res, next) => {
+  campaignRouter.route('/:campaign/:username').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -72,7 +72,7 @@ module.exports = (router) => {
    });
 
   // This section will find a specific campaign.
-  campaignRouter.route("/campaign/:campaign").get(async (req, res, next) => {
+  campaignRouter.route('/:campaign').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -85,7 +85,7 @@ module.exports = (router) => {
   });
 
   // This section will get a list of all the campaigns.
-  campaignRouter.route("/campaigns/:player").get(async (req, res, next) => {
+  campaignRouter.route('/player/:player').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -99,7 +99,7 @@ module.exports = (router) => {
   });
 
   // This section will create a new campaign.
-  campaignRouter.route("/campaign/add").post(async (req, response, next) => {
+  campaignRouter.route('/add').post(async (req, response, next) => {
     const db_connect = req.db;
     const myobj = {
       campaignName: req.body.campaignName,
@@ -117,7 +117,7 @@ module.exports = (router) => {
 
 
   // This section will be for the DM
-  campaignRouter.route("/campaignsDM/:DM").get(async (req, res, next) => {
+  campaignRouter.route('/dm/:DM').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -130,7 +130,7 @@ module.exports = (router) => {
     }
    });
 
-  campaignRouter.route("/campaignsDM/:DM/:campaign").get(async (req, res, next) => {
+  campaignRouter.route('/dm/:DM/:campaign').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -142,5 +142,5 @@ module.exports = (router) => {
     }
   });
 
-  router.use(campaignRouter);
+  router.use('/campaigns', campaignRouter);
 };

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -13,7 +13,7 @@ module.exports = (router) => {
   characterRouter.use(authenticateToken);
 
   // This section will get a single character by id
-  characterRouter.route('/characters/:id').get(async (req, res, next) => {
+  characterRouter.route('/:id').get(async (req, res, next) => {
     if (!ObjectId.isValid(req.params.id)) {
       return res.status(400).json({ message: 'Invalid ID' });
     }
@@ -30,7 +30,7 @@ module.exports = (router) => {
   });
 
   // This section will get a list of all the characters.
-  characterRouter.route('/character/select').get(async (req, res, next) => {
+  characterRouter.route('/select').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -47,7 +47,7 @@ module.exports = (router) => {
   const numericCharacterFields = [...numericFields, ...skillFields];
 
   characterRouter.post(
-    '/character/add',
+    '/add',
     [
       body('token').trim().notEmpty().withMessage('token is required'),
       body('characterName').trim().notEmpty().withMessage('characterName is required'),
@@ -160,7 +160,7 @@ module.exports = (router) => {
   );
 
   // This section will update feats.
-  characterRouter.route('/characters/:id/feats').put(
+  characterRouter.route('/:id/feats').put(
     [body('feat').isArray().withMessage('feat must be an array')],
     handleValidationErrors,
     async (req, res, next) => {
@@ -185,6 +185,6 @@ module.exports = (router) => {
     }
   );
 
-  router.use(characterRouter);
+  router.use('/characters', characterRouter);
 };
 

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -68,6 +68,6 @@ module.exports = (router) => {
     }
   );
 
-  router.use(characterRouter);
+  router.use('/characters', characterRouter);
 };
 

--- a/server/routes/characters/occupations.js
+++ b/server/routes/characters/occupations.js
@@ -40,6 +40,6 @@ module.exports = (router) => {
     }
   });
 
-  router.use(characterRouter);
+  router.use('/characters', characterRouter);
 };
 

--- a/server/routes/characters/stats.js
+++ b/server/routes/characters/stats.js
@@ -31,6 +31,6 @@ module.exports = (router) => {
     }
   });
 
-  router.use(characterRouter);
+  router.use('/characters', characterRouter);
 };
 

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -208,5 +208,5 @@ module.exports = (router) => {
     }
   );
 
-  router.use(equipmentRouter);
+  router.use('/equipment', equipmentRouter);
 };

--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -10,7 +10,7 @@ module.exports = (router) => {
   featRouter.use(authenticateToken);
 
   // This section will get a list of all the feats.
-  featRouter.route("/feats").get(async (req, res, next) => {
+  featRouter.route('/').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
@@ -24,7 +24,7 @@ module.exports = (router) => {
   });
 
   // This section will create a new feat.
-  featRouter.route("/feat/add").post(async (req, response, next) => {
+  featRouter.route('/add').post(async (req, response, next) => {
     const db_connect = req.db;
     const myobj = {
       featName: req.body.featName,
@@ -69,7 +69,7 @@ module.exports = (router) => {
   });
 
   // This section will update feats.
-  featRouter.route('/update-feat/:id').put(async (req, res, next) => {
+  featRouter.route('/update/:id').put(async (req, res, next) => {
     const id = { _id: ObjectId(req.params.id) };
     const db_connect = req.db;
     try {
@@ -83,5 +83,5 @@ module.exports = (router) => {
     }
   });
 
-  router.use(featRouter);
+  router.use('/feats', featRouter);
 };

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -89,5 +89,5 @@ module.exports = (router) => {
     }
   });
 
-  router.use(skillsRouter);
+  router.use('/skills', skillsRouter);
 };


### PR DESCRIPTION
## Summary
- mount equipment, feats, campaigns, skills, and character sub-routers with explicit path prefixes
- normalize internal route paths to avoid duplicated prefixes
- update tests for new endpoint locations

## Testing
- `npm test` *(fails: jest: not found after package install attempts (403 from registry))*

------
https://chatgpt.com/codex/tasks/task_e_68b10ddd1ba4832ea523289543f075cc