### PR TITLE
Configure CSP to allow API host and align client API URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .env
+!client/.env
 server/config.env
 
 client/build/

--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://realmtracker.org

--- a/server/server.js
+++ b/server/server.js
@@ -38,7 +38,17 @@ app.use(cors({
 }));
 app.use(express.json());
 app.use(cookieParser());
-app.use(helmet());
+const apiHost = process.env.API_ORIGIN || 'https://realmtracker.org';
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        connectSrc: ["'self'", apiHost],
+      },
+    },
+  })
+);
 
 const csrfProtection = csrf({
   cookie: {


### PR DESCRIPTION
## Summary
- configure Helmet with custom content security policy allowing API_ORIGIN in connect-src
- track client `.env` with REACT_APP_API_URL to match allowed API host

## Testing
- `npm test` (server) *(fails: jest not found)*
- `CI=true npm test` (client) *(fails: useUser and Navbar tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1db7482a4832e96ec3f208863c214