### PR TITLE
fix: update Zombies campaign API endpoints

### DIFF
--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -55,7 +55,7 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
       return;
     }
   async function fetchData1() {
-    const response = await apiFetch(`/campaigns/${user.username}`);
+    const response = await apiFetch(`/campaigns/player/${user.username}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -82,7 +82,7 @@ useEffect(() => {
       return;
     }
   async function fetchCampaignsDM() {
-    const response = await apiFetch(`/campaignsDM/${user.username}`);
+    const response = await apiFetch(`/campaigns/dm/${user.username}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -116,7 +116,7 @@ async function onSubmit1(e) {
 }
  async function sendToDb1(){
     const newCampaign = { ...form1 };
-      await apiFetch("/campaign/add", {
+      await apiFetch("/campaigns/add", {
        method: "POST",
        headers: {
          "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Update player campaign fetch to `/campaigns/player/:username`
- Update DM campaign fetch to `/campaigns/dm/:username`
- Post new campaigns via `/campaigns/add`

## Testing
- `npm run build`
- `CI=true npm test -- --watchAll=false` *(fails: useUser returns user data; logout calls endpoint and redirects)*

------
https://chatgpt.com/codex/tasks/task_e_68b220b8b238832e840d85e719e0eeee