### PR TITLE
Fix campaign character fetch path

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -14,7 +14,7 @@ export default function ZombiesDM() {
     const [records, setRecords] = useState([]);
     useEffect(() => {
       async function getRecords() {
-        const response = await apiFetch(`/campaign/${params.campaign}/characters`);
+        const response = await apiFetch(`/campaigns/${params.campaign}/characters`);
 
         if (!response.ok) {
           const message = `An error occurred: ${response.statusText}`;


### PR DESCRIPTION
## Summary
- Correct ZombiesDM character fetch API call to use `/campaigns/{campaign}/characters`

## Testing
- `cd client && CI=true npm test` *(fails: 2 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2242fc940832e894f7f91ab9882bc