### PR TITLE
fix: correct campaign endpoint in ZombiesCharacterSelect

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -20,7 +20,7 @@ export default function RecordList() {
       return;
     }
     async function getRecords() {
-    const response = await apiFetch(`/campaign/${params.campaign}/${user.username}`);
+    const response = await apiFetch(`/campaigns/${params.campaign}/${user.username}`);
 
       if (!response.ok) {
         const message = `An error occurred: ${response.statusText}`;


### PR DESCRIPTION
## Summary
- use `/campaigns/:campaign/:username` endpoint when loading zombie character records

## Testing
- `npm test` (server) *(fails: jest not found)*
- `npm test -- --watchAll=false` (client) *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b2242e2fa0832e85e079cd1a23663e