### PR TITLE
Fix DM campaign fetch endpoint path

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -47,7 +47,7 @@ useEffect(() => {
     return;
   }
   async function fetchCampaignsDM() {
-    const response = await apiFetch(`/campaignsDM/${user.username}/${params.campaign}`);
+    const response = await apiFetch(`/campaigns/dm/${user.username}/${params.campaign}`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;


### PR DESCRIPTION
## Summary
- use updated `/campaigns/dm/{username}/{campaign}` endpoint for DM campaign data

## Testing
- `cd client && npm test -- --watchAll=false` *(fails: 2 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b225a1fd34832e9548f25ef87c074e