### PR TITLE
fix: update occupations API endpoint for zombies character select

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -90,7 +90,7 @@ const handleShow = () => setShow(true);
 // Fetch Occupations
 useEffect(() => {
   async function fetchData() {
-    const response = await apiFetch(`/occupations`);
+    const response = await apiFetch(`/characters/occupations`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;


### PR DESCRIPTION
## Summary
- fetch character occupations from `/characters/occupations` endpoint

## Testing
- `cd client && npm test -- --watchAll=false` *(fails: Test Suites: 2 failed, 2 passed, 4 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b228207e5c832eb23fc0de7e4b356b