### PR TITLE
fix: update zombie character endpoints

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -230,7 +230,7 @@ useEffect(() => {
    const sendToDb = useCallback(async () => {
     const newCharacter = { ...form };
     try {
-      await apiFetch("/character/add", {
+      await apiFetch("/characters/add", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -315,7 +315,7 @@ const sendManualToDb = useCallback(async() => {
   try {
     // Call the API endpoint for manual character creation
     // Adjust the endpoint URL as needed
-    await apiFetch("/character/add", {
+    await apiFetch("/characters/add", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use new character creation endpoint `/characters/add`
- ensure zombie character selection uses modern campaign and occupation endpoints

## Testing
- `cd client && npm test -- --watchAll=false` *(fails: 2 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a4e94bc832eb6427804b8a87885