### PR TITLE
Fix API routes for character stats and temp health

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -74,7 +74,7 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
   const [health, setHealth] = useState(); // Initial health value
  // Sends tempHealth data to database for update
  async function tempHealthUpdate(offset){
-    await apiFetch(`/update-temphealth/${params.id}`, {
+    await apiFetch(`/characters/update-temphealth/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -47,7 +47,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
   }, [stats, totalLevel, startStatTotal]);
 
   async function statsUpdate() {
-    await apiFetch(`/update-stats/${params.id}`, {
+    await apiFetch(`/characters/update-stats/${params.id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- point stats updates to `/characters/update-stats`
- send temp health updates to `/characters/update-temphealth`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b22a54c7cc832eb52bd778280d82f5