### PR TITLE
Allow unauthenticated access to occupations list

### DIFF
--- a/server/routes/characters/occupations.js
+++ b/server/routes/characters/occupations.js
@@ -6,9 +6,6 @@ const logger = require('../../utils/logger');
 module.exports = (router) => {
   const characterRouter = express.Router();
 
-  // Apply authentication to all character routes
-  characterRouter.use(authenticateToken);
-
   // This section will get a list of all the occupations.
   characterRouter.route('/occupations').get(async (req, res, next) => {
     try {
@@ -22,6 +19,9 @@ module.exports = (router) => {
       next(err);
     }
   });
+
+  // Apply authentication to all character routes after occupations
+  characterRouter.use(authenticateToken);
 
   // This section will update occupations.
   characterRouter.route('/update-occupations/:id').put(async (req, res, next) => {


### PR DESCRIPTION
## Summary
- Move auth middleware below occupations route so the list can be retrieved without authentication

## Testing
- `npm test` *(fails: jest: not found)*
- `node server/server.js` *(fails: Cannot find module 'has')*

------
https://chatgpt.com/codex/tasks/task_e_68b2360c1f90832e810298bedc3b1898