### PR TITLE
Guard occupation fetch until user present

### DIFF
--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { Card, Modal, Button, Form } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
+import useUser from '../../../hooks/useUser';
 
 export default function LevelUp({ show, handleClose, form }) {
   //--------------------------------------------Level Up--------------------------------------------------------------------------------------------------------------------------------------------
@@ -10,6 +11,7 @@ export default function LevelUp({ show, handleClose, form }) {
   const selectedOccupationRef = useRef();
   const params = useParams();
   const navigate = useNavigate();
+  const user = useUser();
 
   useEffect(() => {
     setShowLvlModal(show);
@@ -156,6 +158,7 @@ export default function LevelUp({ show, handleClose, form }) {
   };
 
   useEffect(() => {
+    if (!user) return;
     async function fetchData() {
       const response = await apiFetch('/characters/occupations');
 
@@ -176,7 +179,7 @@ export default function LevelUp({ show, handleClose, form }) {
     fetchData();
     return;
 
-  }, [navigate]);
+  }, [navigate, user]);
 
   return (
     <div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -89,6 +89,7 @@ const handleShow = () => setShow(true);
 
 // Fetch Occupations
 useEffect(() => {
+  if (!user) return;
   async function fetchData() {
     const response = await apiFetch(`/characters/occupations`);
 
@@ -108,10 +109,10 @@ useEffect(() => {
     setOccupation(record);
     setGetOccupation(record);
   }
-  fetchData();   
+  fetchData();
   return;
-  
-}, [navigate]);
+
+}, [navigate, user]);
 
 // Update the state properties.
 function updateForm(value) {


### PR DESCRIPTION
## Summary
- avoid fetching occupations before authentication in character select and level up components

## Testing
- `cd server && npm test` *(fails: jest: not found)*
- `cd client && npm test`
- `npm run build`
- `curl -i http://localhost:5000/characters/occupations` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b2360b34bc832eb0b2a4419a4723d4