### PR TITLE
Skip DM campaign fetch for non-DM users

### DIFF
--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -78,11 +78,16 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
 
 // Fetch CampaignsDM
 useEffect(() => {
-    if (!user || !user.username) {
+    if (!user || !user.username || !user.isDM) {
       return;
     }
   async function fetchCampaignsDM() {
     const response = await apiFetch(`/campaigns/dm/${user.username}`);
+
+    if (response.status === 401) {
+      // Players aren't authorized to fetch DM campaigns; ignore the error
+      return;
+    }
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -98,9 +103,9 @@ useEffect(() => {
     }
     setCampaignDM({campaign: record});
   }
-  fetchCampaignsDM();   
+  fetchCampaignsDM();
   return;
-  
+
   }, [ navigate, user ]);
 
 


### PR DESCRIPTION
## Summary
- avoid fetching DM campaigns for non-DM users and silently handle 401 responses

## Testing
- `npm run build`
- `cd client && npm test -- --watchAll=false` *(fails: Navbar tests failing)*
- `cd server && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23a04f188832ebf4145699614539b