### PR TITLE
Add DM flag handling for user and DM campaign fetch

### DIFF
--- a/client/src/components/Navbar/Navbar.test.js
+++ b/client/src/components/Navbar/Navbar.test.js
@@ -5,13 +5,16 @@ import Navbar from './Navbar';
 
 beforeEach(() => {
   global.fetch = jest.fn((url) => {
-    if (url === '/csrf-token') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({ csrfToken: 'test-token' }) });
+    if (url.toString().endsWith('/csrf-token')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ csrfToken: 'test-token' }),
+      });
     }
-    return Promise.resolve({ ok: true });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
   });
   delete window.location;
-  window.location = { assign: jest.fn(), href: 'http://localhost/', origin: 'http://localhost' };
+  window.location = { assign: jest.fn(), href: 'http://localhost/', origin: 'http://localhost:3000' };
 });
 
 test('logout calls endpoint and redirects', async () => {
@@ -25,7 +28,7 @@ test('logout calls endpoint and redirects', async () => {
   await userEvent.click(buttons[buttons.length - 1]);
   await waitFor(() =>
     expect(global.fetch).toHaveBeenCalledWith(
-      '/logout',
+      expect.stringContaining('/logout'),
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -78,16 +78,11 @@ const handleShowHostCampaign = () => setShowHostCampaignModal(true);
 
 // Fetch CampaignsDM
 useEffect(() => {
-    if (!user || !user.username || !user.isDM) {
+    if (!user?.isDM) {
       return;
     }
   async function fetchCampaignsDM() {
     const response = await apiFetch(`/campaigns/dm/${user.username}`);
-
-    if (response.status === 401) {
-      // Players aren't authorized to fetch DM campaigns; ignore the error
-      return;
-    }
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -104,7 +99,6 @@ useEffect(() => {
     setCampaignDM({campaign: record});
   }
   fetchCampaignsDM();
-  return;
 
   }, [ navigate, user ]);
 

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -10,7 +10,7 @@ export default function useUser() {
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (isMounted) {
-          setUser(data);
+          setUser(data ? { username: data.username, isDM: data.isDM } : null);
         }
       })
       .catch(() => {

--- a/client/src/hooks/useUser.test.js
+++ b/client/src/hooks/useUser.test.js
@@ -4,7 +4,7 @@ import useUser from './useUser';
 
 function TestComponent() {
   const user = useUser();
-  return <div>{user ? user.username : 'no-user'}</div>;
+  return <div>{user ? `${user.username}-${user.isDM}` : 'no-user'}</div>;
 }
 
 describe('useUser', () => {
@@ -14,11 +14,14 @@ describe('useUser', () => {
 
   test('returns user data', async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve({ username: 'test' }) })
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ username: 'test', isDM: true }) })
     );
     render(<TestComponent />);
-    expect(await screen.findByText('test')).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledWith('/me', { credentials: 'include' });
+    expect(await screen.findByText('test-true')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/me'),
+      { credentials: 'include' }
+    );
   });
 
   test('handles missing user', async () => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -80,7 +80,18 @@ module.exports = (router) => {
     res.json({ message: 'Logged out' });
   });
 
-  router.get('/me', authenticateToken, (req, res) => {
-    res.json({ username: req.user.username });
+  router.get('/me', authenticateToken, async (req, res, next) => {
+    try {
+      const db_connect = req.db;
+      const user = await db_connect
+        .collection('users')
+        .findOne({ username: req.user.username });
+      if (!user) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+      res.json({ username: user.username, isDM: user.isDM });
+    } catch (err) {
+      next(err);
+    }
   });
 };


### PR DESCRIPTION
## Summary
- include `isDM` flag in `/me` server response
- store `isDM` from `/me` in `useUser` hook
- fetch DM campaigns only for users flagged as DMs
- adjust tests for updated API behavior

## Testing
- `npm test -- --watchAll=false` (client)
- `npm test` *(fails: jest: not found)* (server)


------
https://chatgpt.com/codex/tasks/task_e_68b23bb021c0832eb8f30ced1283e35c