### PR TITLE
Align cookie settings for cross-origin requests

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -7,7 +7,7 @@ const logger = require('../utils/logger');
 const config = require('../utils/config');
 
 const jwtSecretKey = config.jwtSecret;
-const isProd = process.env.NODE_ENV === 'production';
+const cookieDomain = process.env.COOKIE_DOMAIN || '.realmtracker.org';
 
 module.exports = (router) => {
   router.post(
@@ -30,9 +30,9 @@ module.exports = (router) => {
         const token = jwt.sign({ username: user.username }, jwtSecretKey, { expiresIn: '1h' });
         res.cookie('token', token, {
           httpOnly: true,
-          secure: isProd,
-          sameSite: isProd ? 'none' : 'lax',
-          domain: isProd ? '.realmtracker.org' : undefined,
+          secure: true,
+          sameSite: 'none',
+          domain: cookieDomain,
         });
         res.json({ message: 'Logged in' });
         logger.info('User logged in', {
@@ -72,10 +72,10 @@ module.exports = (router) => {
   router.post('/logout', (req, res) => {
     res.clearCookie('token', {
       httpOnly: true,
-      secure: isProd,
-      sameSite: isProd ? 'none' : 'lax',
+      secure: true,
+      sameSite: 'none',
       path: '/',
-      domain: isProd ? '.realmtracker.org' : undefined,
+      domain: cookieDomain,
     });
     res.json({ message: 'Logged out' });
   });

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,7 @@ const logger = require("./utils/logger");
 const port = process.env.PORT || 5000;
 const isProd = process.env.NODE_ENV === 'production';
 const allowedOrigins = config.clientOrigins;
+const cookieDomain = process.env.COOKIE_DOMAIN || '.realmtracker.org';
 
 // Redirect all HTTP traffic to HTTPS in production
 if (isProd) {
@@ -53,9 +54,9 @@ app.use(
 const csrfProtection = csrf({
   cookie: {
     httpOnly: true,
-    secure: isProd,
-    sameSite: isProd ? 'none' : 'lax',
-    domain: isProd ? '.realmtracker.org' : undefined,
+    secure: true,
+    sameSite: 'none',
+    domain: cookieDomain,
   },
 });
 app.use(csrfProtection);
@@ -63,9 +64,9 @@ app.use(csrfProtection);
 app.get('/csrf-token', (req, res) => {
   const token = req.csrfToken();
   res.cookie('XSRF-TOKEN', token, {
-    sameSite: isProd ? 'none' : 'lax',
-    secure: isProd,
-    domain: isProd ? '.realmtracker.org' : undefined,
+    sameSite: 'none',
+    secure: true,
+    domain: cookieDomain,
   });
   res.json({ csrfToken: token });
 });


### PR DESCRIPTION
## Summary
- set token and CSRF cookies with `sameSite: 'none'`, `secure: true`, and configurable `domain`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23df925a4832e82a6b59a9dcf62bb