### PR TITLE
Fix route order for occupations endpoint

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -26,8 +26,10 @@ routes.use(async (req, res, next) => {
 auth(routes);
 users(routes);
 campaigns(routes);
-characterBase(routes);
+// Register occupations routes before generic ID-based routes to ensure
+// "/characters/occupations" is matched correctly.
 characterOccupations(routes);
+characterBase(routes);
 characterStats(routes);
 characterHealth(routes);
 skills(routes);


### PR DESCRIPTION
## Summary
- register occupations routes before generic ID routes so `/characters/occupations` resolves correctly

## Testing
- `npm test` *(fails: jest not found)*
- `JWT_SECRET=foo ATLAS_URI=mongodb://localhost/test CLIENT_ORIGINS=http://localhost node ...` *(fails: Cannot find module 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_68b2474669e0832e847cc68ff2daad7c