### PR TITLE
Handle manual character create without manual close

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -315,19 +315,25 @@ const sendManualToDb = useCallback(async (characterData) => {
     return;
   }
   try {
-    await apiFetch("/characters/add", {
+    const response = await apiFetch("/characters/add", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(newCharacter),
     });
+    if (!response.ok) {
+      window.alert(`An error occurred: ${response.statusText}`);
+      return;
+    }
+    const { insertedId } = await response.json();
+    handleClose5();
+    setRecords((prev) => [...prev, { ...newCharacter, _id: insertedId }]);
+    setForm(createDefaultForm(params.campaign));
   } catch (error) {
     window.alert(error);
-    return;
   }
-  navigate(`/zombies-character-select/${newCharacter.campaign}`);
-}, [form, navigate]);
+}, [form, params.campaign, handleClose5, setRecords, setForm, createDefaultForm]);
 
 // Function to handle submission for manual character creation.
 const onSubmitManual = async (e) => {
@@ -510,7 +516,7 @@ const onSubmitManual = async (e) => {
         type="number" placeholder="Enter health" pattern="[0-9]*" />
      </Form.Group>
      <div className="text-center">
-     <Button variant="primary" onClick={handleClose5} type="submit">
+     <Button variant="primary" type="submit">
             Create
           </Button>
           <Button className="ms-4" variant="secondary" onClick={handleClose5}>


### PR DESCRIPTION
## Summary
- Remove manual create modal `onClick` handler from submit button
- Close modal and update character list after successful manual creation
- Surface error alerts when manual character creation fails

## Testing
- `npm test --prefix client -- --watchAll=false`
- `npm test --prefix server` *(fails: jest: not found; installation attempt hit package errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b24d7a2694832ea7460fa5d7bf102c