### PR TITLE
Fix delete character endpoint path

### DIFF
--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -8,10 +8,10 @@ export default function Help({props, form, showHelpModal, handleCloseHelpModal})
   const navigate = useNavigate();
   const [showDeleteCharacter, setShowDeleteCharacter] = useState(false);
   const handleCloseDeleteCharacter = () => setShowDeleteCharacter(false);
-  const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
+ const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
  // This method will delete a record
  async function deleteRecord() {
- await apiFetch(`/delete-character/${params.id}`, {
+ await apiFetch(`/characters/delete-character/${params.id}`, {
    method: "DELETE",
   });
   navigate(`/zombies-character-select/${form.campaign}`);


### PR DESCRIPTION
## Summary
- fix deleteRecord endpoint so clients target `/characters/delete-character/:id`

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b250e4b858832e9f8d1902f70a8bb7