### PR TITLE
Refactor Zombies campaign buttons into flex layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -826,35 +826,29 @@ h1 {
 }
 
 .create-button {
+  background: linear-gradient(135deg, #3e8e41, #2e7d32);
+  border: 2px solid #000;
+  border-radius: 50px;
+  color: #fff;
+  font-family: 'Cinzel', serif;
+  font-size: 16px;
+  padding: 10px 20px;
+  text-shadow: 1px 1px 2px #000;
+  transition: all 0.3s ease;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  background-color: #3e8e41 !important; /* Green background */
-  border: none !important;
-  color: white;
-  border-radius: 50% !important; /* Makes the button circular */
-  width: 65px; /* Ensure width and height are the same */
-  height: 65px; /* Ensure width and height are the same */
-  position: relative;
-  padding: 0; /* Remove padding to maintain the circular shape */
-  overflow: hidden; /* Ensures the circular shape */
-  transition: transform 0.2s, background-color 0.2s;
 }
 
 .create-button:hover {
-  background-color: #45a049 !important; /* Darker green on hover */
-  transform: scale(1.1); /* Slightly enlarge the button on hover */
+  background: linear-gradient(135deg, #4caf50, #388e3c);
+  color: #f8e71c;
+  text-shadow: 2px 2px 4px #000;
+  transform: scale(1.05);
 }
 
 .create-button:active {
-  background-color: #2e7d32 !important; /* Even darker green on click */
-  transform: scale(0.9); /* Slightly shrink the button on click */
-}
-
-.fa-plus {
-  font-size: 24px; /* Adjust as needed */
-  color: white;
+  transform: scale(0.95);
 }
 
 @keyframes pulseOnce {

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -1,11 +1,10 @@
 import React, { useState, useEffect, } from "react";
 import apiFetch from '../../../utils/apiFetch';
-import { Button, Col, Container, Form, Row, Table, Card } from "react-bootstrap";
+import { Button, Form, Table, Card } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import Modal from 'react-bootstrap/Modal';
 import { Link } from "react-router-dom";
 import zombiesbg from "../../../images/zombiesbg.jpg";
-import { FaDungeon, FaCrown } from 'react-icons/fa';
 import useUser from '../../../hooks/useUser';
 
 
@@ -139,27 +138,11 @@ async function onSubmit1(e) {
  return (
 <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
       <div style={{paddingTop: "80px"}}></div>
-      <h1 className="text-light"
-      style={{            
-            fontSize: 28, 
-            width: "300px", 
-            height: "95px", 
-            backgroundColor: "rgba(0, 0, 0, 0.8)",
-            color: "white", 
-            display: "flex", 
-            alignItems: "center", 
-            justifyContent: "center", 
-            borderRadius: "10px", // Rounded corners
-            boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)", // Light shadow for depth
-            margin: "0 auto"
-          }}>Zombies</h1>    
-      <Container className="mt-3">
-      <Row>
-        <Col>
-        <Button className="m-2 fantasy-button" style={{borderColor: "transparent"}} onClick={handleShowJoinCampaign}>
-        <FaDungeon className="icon" /> {/* Add an icon */}
-        Join Campaign
-      </Button>
+      <div className="d-flex flex-column justify-content-center align-items-center h-100">
+        <Button className="mb-3 fantasy-button" onClick={handleShowJoinCampaign}>Join Campaign</Button>
+        <Button className="mb-3 hostCampaign" onClick={handleShowHostCampaign}>Host Campaign</Button>
+        <Button className="create-button" onClick={handleShow1}>Create Campaign</Button>
+      </div>
 
       <Modal className="dnd-modal" centered show={showJoinCampaignModal} onHide={handleCloseJoinCampaign}>
    <div className="text-center">
@@ -195,10 +178,6 @@ async function onSubmit1(e) {
   </Card>
   </div>
 </Modal>
-      <Button className="m-2 hostCampaign" style={{borderColor: "transparent"}} onClick={handleShowHostCampaign}>
-        <FaCrown className="icon" />
-        Host Campaign
-      </Button>
 
   <Modal className="dnd-modal" centered show={showHostCampaignModal} onHide={handleCloseHostCampaign}>
    <div className="text-center">
@@ -234,13 +213,7 @@ async function onSubmit1(e) {
   </Card>
   </div>
 </Modal>
-        </Col>
-      </Row>
-    </Container>
-    <br></br>    
-    <Button onClick={() => { handleShow1(); }} className="create-button">
-      <i className="fa fa-plus"></i>
-    </Button>
+
       {/* -----------------------------------Create Campaign--------------------------------------------- */}
       <Modal centered className="dnd-modal" show={show1} onHide={handleClose1}>
         <div className="text-center">


### PR DESCRIPTION
## Summary
- simplify Zombies page by replacing grid layout with centered flex column of buttons
- restyle create button as rectangular text button

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b25a3726c4832e86ddaab05e008ec7