### PR TITLE
Streamline Zombies page button styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -488,9 +488,14 @@ max-width: 300px;
   align-items: center; /* Center vertically */
 }
 
+.campaign-button {
+  width: 220px;
+}
+
 .fantasy-button {
   background: linear-gradient(135deg, #3e8e41, #2e7d32);
-  border: 2px solid #000;
+  border: none;
+  outline: none;
   border-radius: 50px;
   color: #fff;
   font-family: 'Cinzel', serif;
@@ -827,7 +832,8 @@ h1 {
 
 .create-button {
   background: linear-gradient(135deg, #3e8e41, #2e7d32);
-  border: 2px solid #000;
+  border: none;
+  outline: none;
   border-radius: 50px;
   color: #fff;
   font-family: 'Cinzel', serif;

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -139,9 +139,9 @@ async function onSubmit1(e) {
 <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
       <div style={{paddingTop: "80px"}}></div>
       <div className="d-flex flex-column justify-content-center align-items-center h-100">
-        <Button className="mb-3 fantasy-button" onClick={handleShowJoinCampaign}>Join Campaign</Button>
-        <Button className="mb-3 hostCampaign" onClick={handleShowHostCampaign}>Host Campaign</Button>
-        <Button className="create-button" onClick={handleShow1}>Create Campaign</Button>
+        <Button className="mb-3 fantasy-button campaign-button" onClick={handleShowJoinCampaign}>Join Campaign</Button>
+        <Button className="mb-3 hostCampaign campaign-button" onClick={handleShowHostCampaign}>Host Campaign</Button>
+        <Button className="create-button campaign-button" onClick={handleShow1}>Create Campaign</Button>
       </div>
 
       <Modal className="dnd-modal" centered show={showJoinCampaignModal} onHide={handleCloseJoinCampaign}>


### PR DESCRIPTION
## Summary
- Remove borders and focus outlines from fantasy and create buttons
- Add shared `campaign-button` class for uniform button width
- Apply new class to Zombies page buttons for consistent layout

## Testing
- `cd client && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b25cc6b5d4832eb383e3713b5ea983