### PR TITLE
Set white background defaults

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -563,7 +563,6 @@ max-width: 300px;
 //vars
 $fg: linear-gradient(135deg, #3e8e41, #2e7d32);
 $fgDM: linear-gradient(135deg, #979940b6, #fffb00);
-$bg: linear-gradient(135deg, #3e8e41, #2e7d32);
 $pi: 3.14;
 
 //config
@@ -573,8 +572,8 @@ $open-distance: 115px;
 $opening-angle: $pi - 0.2;
 
 body {
-  background: $bg;
-  color: white;
+  background-color: #FFFFFF;
+  color: #000000;
   text-align: center; // Ensure text is centered horizontally
 }
 

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -4,7 +4,7 @@ import { MDBFooter } from 'mdb-react-ui-kit';
 export default function Footer() {
   return (
     <MDBFooter bgColor='light' className='fixed-bottom bg-image text-center text-lg-start text-muted'>
-      <div className='text-center p-4' style={{ backgroundColor: 'rgba(0, 0, 0, 0.05)' }}>
+      <div className='text-center p-4' style={{ backgroundColor: '#FFFFFF' }}>
         © 2023 Copyright:
         <a className='mx-1 text-reset fw-bold' href='https://github.com/rjo6615/DnD'>
           DnD

--- a/client/src/components/Login/Login.css
+++ b/client/src/components/Login/Login.css
@@ -1,7 +1,5 @@
 .login-background {
-  background-image: url('../../images/loginbg.png');
-  background-size: cover;
-  background-position: center;
+  background-color: #FFFFFF;
   height: 100vh;
 }
 
@@ -10,7 +8,7 @@
 }
 
 .login-overlay {
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: #FFFFFF;
 }
 
 .logo-image {

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -13,7 +13,7 @@ function NavbarComponent() {
   };
 
   return (
-    <Navbar fixed="top" style={{ fontFamily: 'Raleway, sans-serif', height: "80px", backgroundColor: "rgba(0, 0, 0, 1)" }}>
+    <Navbar fixed="top" style={{ fontFamily: 'Raleway, sans-serif', height: "80px", backgroundColor: '#FFFFFF' }}>
       <Container fluid>
         <Navbar.Brand href="/">
           <img src={logoLight} alt="" width="60px" height="60px" className="d-inline-block align-text-top" />

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -143,7 +143,7 @@ return (
     <Button
       style={{
         color: "#e74c3c",
-        backgroundColor: "#FAFAFA",
+        backgroundColor: '#FFFFFF',
         border: "none",
         fontSize: "20px",
         width: "44px",
@@ -167,7 +167,7 @@ return (
         position: "relative",
         width: "240px",
         height: "24px",
-        backgroundColor: "#e0e0e0",
+        backgroundColor: '#FFFFFF',
         borderRadius: "12px",
         overflow: "hidden",
         boxShadow: "inset 0 1px 3px rgba(0,0,0,0.25)",
@@ -203,7 +203,7 @@ return (
     <Button
       style={{
         color: "#27ae60",
-        backgroundColor: "#FAFAFA",
+        backgroundColor: '#FFFFFF',
         border: "none",
         fontSize: "20px",
         width: "44px",

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Modal, Card, Table } from "react-bootstrap";
-import sword from "../../../images/sword.png";
 
 export default function PlayerTurnActions ({ form, strMod, atkBonus, dexMod }) { 
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
@@ -221,7 +220,7 @@ const showSparklesEffect = () => {
         height: "48px",
         borderRadius: "50%",
         border: isGold ? "2px solid #FFD700" : "2px solid #B0B0B0",
-        backgroundColor: "#1e1e1e",
+        backgroundColor: '#FFFFFF',
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -247,9 +246,7 @@ const showSparklesEffect = () => {
       style={{
         width: "64px",
         height: "64px",
-        backgroundImage: `url(${sword})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
+        backgroundColor: '#FFFFFF',
         border: "none",
         borderRadius: "12px",
         boxShadow: "0 4px 8px rgba(0, 0, 0, 0.4)",
@@ -259,7 +256,9 @@ const showSparklesEffect = () => {
       onMouseEnter={(e) => e.currentTarget.style.transform = "scale(1.1)"}
       onMouseLeave={(e) => e.currentTarget.style.transform = "scale(1)"}
       title="Attack"
-    />
+    >
+      Attack
+    </button>
   </div>
 </div>
 {/* Attack Modal */}

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -136,7 +136,7 @@ async function onSubmit1(e) {
 
 // -----------------------------------Display-----------------------------------------------------------------------------
  return (
-<div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
+<div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundColor: '#FFFFFF', minHeight: '100vh' }}>
       <div style={{paddingTop: "80px"}}></div>
       <div className="d-flex flex-column justify-content-center align-items-center h-100">
         <Button className="mb-3 fantasy-button" onClick={handleShowJoinCampaign}>Join Campaign</Button>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -343,15 +343,15 @@ const onSubmitManual = async (e) => {
 };
 
   return (
-    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
+    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundColor: '#FFFFFF', minHeight: '100vh' }}>
       <div style={{paddingTop: '80px'}}>
       <h1 
   style={{ 
     fontSize: 28, 
     width: "300px", 
     height: "95px", 
-    backgroundColor: "rgba(0, 0, 0, 0.8)",
-    color: "white", 
+    backgroundColor: '#FFFFFF',
+    color: '#000000',
     display: "flex", 
     alignItems: "center", 
     justifyContent: "center", 
@@ -359,8 +359,7 @@ const onSubmitManual = async (e) => {
     boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)", // Light shadow for depth
     margin: "0 auto"
   }} 
-  className="text-light"
->
+  >
   {params.campaign.toString()}
 </h1>
 <div style={{ maxHeight: '300px', overflowY: 'auto', position: 'relative', zIndex: '4'}}>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -64,7 +64,7 @@ export default function ZombiesCharacterSheet() {
   const handleCloseHelpModal = () => setShowHelpModal(false); 
 
   if (!form) {
-    return <div style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", minHeight: "100vh"}}>Loading...</div>;
+    return <div style={{ fontFamily: 'Raleway, sans-serif', backgroundColor: '#FFFFFF', minHeight: '100vh' }}>Loading...</div>;
   }
 
   // Skills and skill points calculation
@@ -128,16 +128,16 @@ for (const occupation of occupations) {
   }
 }
 if (!form) {
-  return <div style={{ fontFamily: 'Raleway, sans-serif', background: "radial-gradient(circle, #1a1a2e, #16213e, #0f3460)", minHeight: "100vh" }}>Loading...</div>;
+  return <div style={{ fontFamily: 'Raleway, sans-serif', backgroundColor: '#FFFFFF', minHeight: '100vh' }}>Loading...</div>;
 }
 
 return (
 <div className="pt-3 text-center"
   style={{
     fontFamily: 'Raleway, sans-serif',
-    background: "#FAFAFA",
-    minHeight: "100vh",
-    paddingBottom: "70px"
+    backgroundColor: '#FFFFFF',
+    minHeight: '100vh',
+    paddingBottom: '70px'
   }}
 >
       <div style={{paddingTop: '80px'}}>

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -350,22 +350,22 @@ const [form2, setForm2] = useState({
 
   // -----------------------------------Display-----------------------------------------------------------------------------
  return (
-    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${zombiesbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
+    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundColor: '#FFFFFF', minHeight: '100vh' }}>
           <div style={{paddingTop: '80px'}}></div>
-          <h1 className="text-light" 
-           style={{            
-            fontSize: 28, 
-            width: "300px", 
-            height: "95px", 
-            backgroundColor: "rgba(0, 0, 0, 0.8)",
-            color: "white", 
-            display: "flex", 
-            alignItems: "center", 
-            justifyContent: "center", 
+          <h1
+           style={{
+            fontSize: 28,
+            width: "300px",
+            height: "95px",
+            backgroundColor: '#FFFFFF',
+            color: '#000000',
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
             borderRadius: "10px", // Rounded corners
             boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)", // Light shadow for depth
             margin: "0 auto"
-          }}>{params.campaign}</h1>  
+          }}>{params.campaign}</h1>
 {/*-----------------------------------Add Player-----------------------------------------------------*/}
 <Button style={{ position: "relative", zIndex: "4" }} onClick={() => { handleShowPlayers();}} className="p-1 m-2 hostCampaign" size="sm" variant="secondary">View/Add Players</Button>
 <div style={{ maxHeight: '300px', overflowY: 'auto', position: 'relative', zIndex: '4' }}>


### PR DESCRIPTION
## Summary
- Default app body to black text on white background
- Replace image backgrounds with white across Login and Zombies pages
- Standardize component backgrounds including Navbar and Footer to white

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b25cc7f928832ea937751a1ec2a7ea