### PR TITLE
Fix feat point calculation for Zombies character sheet

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -32,18 +32,10 @@ const [feat, setFeat] = useState({
     });
   }
   // ---------------------------------------Feats left-----------------------------------------------------
-    let featLength;
-  if (JSON.stringify(form.feat) === JSON.stringify(emptyFeat)) { 
-    featLength = 0; 
-  } else {
-     featLength = form.feat.length 
-    }
-  let featPointsLeft = Math.floor((totalLevel / 3) - (featLength)) + 1;
-  
-    let showFeatBtn = "";
-    if (featPointsLeft === 0) {
-      showFeatBtn = "none";
-    }
+  const activeFeats = form.feat.filter((feat) => feat[0] !== "").length;
+  const featPointsLeft = Math.floor(totalLevel / 3) + 1 - activeFeats;
+
+  const showFeatBtn = featPointsLeft > 0 ? "" : "none";
   
   // ----------------------------------------Fetch Feats-----------------------------------
   useEffect(() => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -101,14 +101,9 @@ export default function ZombiesCharacterSheet() {
   const statPointsLeft = Math.floor((totalLevel / 4) - (statTotal - form.startStatTotal));
 
 // ---------------------------------------Feats left-----------------------------------------------------
-let featLength;
-if (JSON.stringify(form.feat) === JSON.stringify([["","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","",""]])) { 
-  featLength = 0; 
-} else {
-   featLength = form.feat.length 
-  }
-let featPointsLeft = Math.floor((totalLevel / 3) - (featLength)) + 1;
-let featsGold = featPointsLeft === 0 ? "#6C757D" : "gold";
+const activeFeats = form.feat.filter((feat) => feat[0] !== "").length;
+const featPointsLeft = Math.floor(totalLevel / 3) + 1 - activeFeats;
+const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
 // ------------------------------------------Attack Bonus---------------------------------------------------
 let atkBonus = 0;
 const occupations = form.occupation;


### PR DESCRIPTION
## Summary
- compute remaining feat points based on non-empty feat names
- update feats button color logic

## Testing
- `cd client && npm test -- --watchAll=false`
- `node -e "const totalLevel=3;const form={feat:[['']]};const activeFeats=form.feat.filter(f=>f[0]!=='' ).length;const left=Math.floor(totalLevel/3)+1-activeFeats;console.log(left);"`


------
https://chatgpt.com/codex/tasks/task_e_68b46657e4f8832e9b564a8eebe0ebee