### PR TITLE
Validate feat bonuses and ability increases

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ All API errors are returned as JSON objects with a single `message` property. Fo
 
 Clients should rely on this structure when handling error responses.
 
+## Feats Endpoint
+
+Use `GET /feats` to retrieve all available feats.
+
+Use `POST /feats/add` with a JSON body to create a new feat. Supported fields include:
+
+- `featName` (string, required)
+- `notes` (string, optional)
+- `abilityIncreaseOptions` (array of strings, optional)
+- Numeric bonuses such as ability scores (`str`, `dex`, `con`, `int`, `wis`, `cha`), `initiative`, `ac`, `speed`, `passivePerception`, `passiveInvestigation`, `hpMaxBonus`, and `hpMaxBonusPerLevel`
+- Skill bonuses (`acrobatics`, `animalHandling`, `arcana`, `athletics`, `deception`, `history`, `insight`, `intimidation`, `investigation`, `medicine`, `nature`, `perception`, `performance`, `persuasion`, `religion`, `sleightOfHand`, `stealth`, `survival`)
+
 ## Character Feats Endpoint
 
 Use `PUT /characters/:id/feats` with a JSON body like `{ "feat": ["Feat1"] }` to


### PR DESCRIPTION
## Summary
- extend feats route with ability score and other numeric bonuses plus abilityIncreaseOptions array
- add express-validator checks for new feat fields
- document Feats endpoint and supported fields

## Testing
- `cd server && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4864361bc832ea775dd1e720c8d7e