### PR TITLE
feat: apply feat bonuses to stats and defenses

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -3,7 +3,21 @@ import apiFetch from '../../../utils/apiFetch';
 import { Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useParams } from "react-router-dom";
 
-export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
+export default function HealthDefense({
+  form,
+  totalLevel,
+  conMod,
+  dexMod,
+  wisMod,
+  intMod,
+  acBonus = 0,
+  hpMaxBonus = 0,
+  hpMaxBonusPerLevel = 0,
+  initiativeBonus = 0,
+  speedBonus = 0,
+  passivePerceptionBonus = 0,
+  passiveInvestigationBonus = 0,
+}) {
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
   // Saves Maffs
@@ -15,12 +29,12 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
   //Armor AC/MaxDex
      let armorAcBonus= [];
      let armorMaxDexBonus= [];
-     form.armor.map((el) => (  
-       armorAcBonus.push(el[1]) 
-     ))
-     let totalArmorAcBonus = armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0); 
      form.armor.map((el) => (
-      armorMaxDexBonus.push(el[2]) 
+       armorAcBonus.push(el[1])
+     ))
+     let totalArmorAcBonus = armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) + Number(acBonus);
+     form.armor.map((el) => (
+      armorMaxDexBonus.push(el[2])
      ))
      let filteredMaxDexArray = armorMaxDexBonus.filter(e => e !== '0')
      let armorMaxDexMin = Math.min(...filteredMaxDexArray);
@@ -69,8 +83,25 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
       }
     }
   }
-  
+
+  const passivePerception =
+    10 +
+    Number(form.perception || 0) +
+    Number(wisMod) +
+    Number(passivePerceptionBonus);
+
+  const passiveInvestigation =
+    10 +
+    Number(form.investigation || 0) +
+    Number(intMod) +
+    Number(passiveInvestigationBonus);
+
   // Health
+  const maxHealth =
+    Number(form.health) +
+    Number(conMod * totalLevel) +
+    Number(hpMaxBonus) +
+    Number(hpMaxBonusPerLevel * totalLevel);
   const [health, setHealth] = useState(); // Initial health value
  // Sends tempHealth data to database for update
  async function tempHealthUpdate(offset){
@@ -99,7 +130,7 @@ export default function HealthDefense({form, totalLevel, conMod, dexMod }) {
 
   let offset;
   const increaseHealth = () => {
-    if (health === form.health + Number(conMod * totalLevel)){
+    if (health === maxHealth){
     } else {
     setHealth((prevHealth) => prevHealth + 1);
     offset = +1;
@@ -176,9 +207,9 @@ return (
     >
       <div
         style={{
-          width: `${(health / (form.health + Number(conMod * totalLevel))) * 100}%`,
+          width: `${(health / maxHealth) * 100}%`,
           height: "100%",
-          background: health > (form.health + Number(conMod * totalLevel)) * 0.5 ? "#2ecc71" : "#c0392b",
+          background: health > maxHealth * 0.5 ? "#2ecc71" : "#c0392b",
           transition: "width 0.3s ease-in-out",
         }}
       />
@@ -195,7 +226,7 @@ return (
           lineHeight: "24px",
         }}
       >
-        {health}/{form.health + Number(conMod * totalLevel)}
+        {health}/{maxHealth}
       </span>
     </div>
 
@@ -239,7 +270,8 @@ return (
     <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
       <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
       <div><strong>Attack Bonus:</strong> {atkBonus}</div>
-      <div><strong>Initiative:</strong> {dexMod}</div>
+      <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiativeBonus)}</div>
+      <div><strong>Speed:</strong> {(form.speed || 0) + Number(speedBonus)}</div>
     </div>
 
     {/* Saving Throws */}
@@ -247,6 +279,12 @@ return (
       <div><strong>Fort:</strong> {fortSave}</div>
       <div><strong>Reflex:</strong> {reflexSave}</div>
       <div><strong>Will:</strong> {willSave}</div>
+    </div>
+
+    {/* Passive Skills */}
+    <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
+      <div><strong>Passive Perception:</strong> {passivePerception}</div>
+      <div><strong>Passive Investigation:</strong> {passiveInvestigation}</div>
     </div>
   </div>
 </div>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -30,8 +30,29 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );
 
+  const totalFeatBonus = (form.feat || []).reduce(
+    (acc, feat) => {
+      acc.str += Number(feat.str || 0);
+      acc.dex += Number(feat.dex || 0);
+      acc.con += Number(feat.con || 0);
+      acc.int += Number(feat.int || 0);
+      acc.wis += Number(feat.wis || 0);
+      acc.cha += Number(feat.cha || 0);
+      if (
+        feat.selectedAbility &&
+        ["str", "dex", "con", "int", "wis", "cha"].includes(feat.selectedAbility)
+      ) {
+        acc[feat.selectedAbility] += Number(
+          feat.selectedAbilityValue || feat.selectedAbilityBonus || 0
+        );
+      }
+      return acc;
+    },
+    { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
+  );
+
   const computedStats = Object.keys(stats).reduce((acc, key) => {
-    acc[key] = stats[key] + totalItemBonus[key];
+    acc[key] = stats[key] + totalItemBonus[key] + totalFeatBonus[key];
     return acc;
   }, {});
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -100,8 +100,30 @@ export default function ZombiesCharacterSheet() {
   const statTotal = statNames.reduce((sum, stat) => sum + form[stat], 0);
   const statPointsLeft = Math.floor((totalLevel / 4) - (statTotal - form.startStatTotal));
 
-// ---------------------------------------Feats left-----------------------------------------------------
-const activeFeats = form.feat.filter((feat) => feat[0] !== "").length;
+// ---------------------------------------Feats and bonuses----------------------------------------------
+const featBonuses = (form.feat || []).reduce(
+  (acc, feat) => {
+    acc.initiative += Number(feat.initiativeBonus || 0);
+    acc.speed += Number(feat.speedBonus || 0);
+    acc.acBonus += Number(feat.acBonus || 0);
+    acc.hpMaxBonus += Number(feat.hpMaxBonus || 0);
+    acc.hpMaxBonusPerLevel += Number(feat.hpMaxBonusPerLevel || 0);
+    acc.passivePerception += Number(feat.passivePerceptionBonus || 0);
+    acc.passiveInvestigation += Number(feat.passiveInvestigationBonus || 0);
+    return acc;
+  },
+  {
+    initiative: 0,
+    speed: 0,
+    acBonus: 0,
+    hpMaxBonus: 0,
+    hpMaxBonusPerLevel: 0,
+    passivePerception: 0,
+    passiveInvestigation: 0,
+  }
+);
+
+const activeFeats = form.feat.filter((feat) => feat.featName !== "").length;
 const featPointsLeft = Math.floor(totalLevel / 3) + 1 - activeFeats;
 const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
 // ------------------------------------------Attack Bonus---------------------------------------------------
@@ -157,7 +179,21 @@ return (
   {form.characterName}
 </h1>
 
-        <HealthDefense form={form} totalLevel={totalLevel} dexMod={statMods.dex} conMod={statMods.con}  />
+        <HealthDefense
+          form={form}
+          totalLevel={totalLevel}
+          dexMod={statMods.dex}
+          conMod={statMods.con}
+          wisMod={statMods.wis}
+          intMod={statMods.int}
+          initiativeBonus={featBonuses.initiative}
+          speedBonus={featBonuses.speed}
+          acBonus={featBonuses.acBonus}
+          hpMaxBonus={featBonuses.hpMaxBonus}
+          hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
+          passivePerceptionBonus={featBonuses.passivePerception}
+          passiveInvestigationBonus={featBonuses.passiveInvestigation}
+        />
         <PlayerTurnActions form={form} atkBonus={atkBonus} dexMod={statMods.dex} strMod={statMods.str}/>
         <Navbar fixed="bottom" bg="dark" data-bs-theme="dark">
           <Container>


### PR DESCRIPTION
## Summary
- aggregate feat-derived bonuses for initiative, speed, AC, and HP in character sheet
- include feat ability score bonuses in stat computations
- apply feat bonuses to armor class, hit points, initiative, speed, and passive skills

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd client && CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b48644ee9c832e859d6218dbd14a2b