### PR TITLE
Add new numeric character fields

### DIFF
--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -44,6 +44,7 @@ module.exports = (router) => {
   });
 
   // This section will create a new character.
+  // Includes numeric stats like initiative, AC, speed, passive scores, and HP bonuses.
   const numericCharacterFields = [...numericFields, ...skillFields];
 
   characterRouter.post(

--- a/server/routes/fieldConstants.js
+++ b/server/routes/fieldConstants.js
@@ -11,6 +11,13 @@ const numericFields = [
   'startStatTotal',
   'health',
   'tempHealth',
+  'initiative',
+  'ac',
+  'speed',
+  'passivePerception',
+  'passiveInvestigation',
+  'hpMaxBonus',
+  'hpMaxBonusPerLevel',
 ];
 
 const skillFields = [


### PR DESCRIPTION
## Summary
- extend numeric character field constants with initiative, AC, speed, passive perception/investigation, and HP bonuses
- clarify character creation validation to include new numeric fields

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b486464f40832ea9b9622e3e3d90fa