### PR TITLE
Refactor feat bonuses to use object properties

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -114,7 +114,7 @@ const itemTotals = SKILLS.reduce((acc, {key, itemIndex}) => {
 }, {});
 
 const featTotals = SKILLS.reduce((acc, {key}) => {
-  acc[key] = form.feat.reduce((sum, el) => sum + Number(el[key] || 0), 0);
+  acc[key] = (form.feat || []).reduce((sum, el) => sum + Number(el[key] || 0), 0);
   return acc;
 }, {});
 

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { Card, Table, Modal, Button } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
-import { SKILLS } from "../skillSchema";
 
 export default function Stats({ form, showStats, handleCloseStats, totalLevel }) {
   const params = useParams();
@@ -31,15 +30,14 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );
 
-  const ABILITY_START_INDEX = SKILLS.length + 2;
   const totalFeatBonus = (form.feat || []).reduce(
     (acc, el) => ({
-      str: acc.str + Number(el[ABILITY_START_INDEX] || 0),
-      dex: acc.dex + Number(el[ABILITY_START_INDEX + 1] || 0),
-      con: acc.con + Number(el[ABILITY_START_INDEX + 2] || 0),
-      int: acc.int + Number(el[ABILITY_START_INDEX + 3] || 0),
-      wis: acc.wis + Number(el[ABILITY_START_INDEX + 4] || 0),
-      cha: acc.cha + Number(el[ABILITY_START_INDEX + 5] || 0),
+      str: acc.str + Number(el.str || 0),
+      dex: acc.dex + Number(el.dex || 0),
+      con: acc.con + Number(el.con || 0),
+      int: acc.int + Number(el.int || 0),
+      wis: acc.wis + Number(el.wis || 0),
+      cha: acc.cha + Number(el.cha || 0),
     }),
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -37,7 +37,21 @@ export default function ZombiesCharacterSheet() {
           throw new Error(`Error fetching character data: ${response.statusText}`);
         }
         const data = await response.json();
-        setForm(data);
+        const feats = (data.feat || []).map((feat) => {
+          if (!Array.isArray(feat)) return feat;
+          const [featName = "", notes = "", ...rest] = feat;
+          const skillVals = rest.slice(0, SKILLS.length);
+          const abilityVals = rest.slice(SKILLS.length, SKILLS.length + 6);
+          const featObj = { featName, notes };
+          SKILLS.forEach(({ key }, idx) => {
+            featObj[key] = Number(skillVals[idx] || 0);
+          });
+          ["str", "dex", "con", "int", "wis", "cha"].forEach((stat, idx) => {
+            featObj[stat] = Number(abilityVals[idx] || 0);
+          });
+          return featObj;
+        });
+        setForm({ ...data, feat: feats });
       } catch (error) {
         console.error(error);
       }
@@ -86,15 +100,14 @@ export default function ZombiesCharacterSheet() {
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );
 
-  const ABILITY_START_INDEX = SKILLS.length + 2;
   const featBonus = (form.feat || []).reduce(
     (acc, el) => ({
-      str: acc.str + Number(el[ABILITY_START_INDEX] || 0),
-      dex: acc.dex + Number(el[ABILITY_START_INDEX + 1] || 0),
-      con: acc.con + Number(el[ABILITY_START_INDEX + 2] || 0),
-      int: acc.int + Number(el[ABILITY_START_INDEX + 3] || 0),
-      wis: acc.wis + Number(el[ABILITY_START_INDEX + 4] || 0),
-      cha: acc.cha + Number(el[ABILITY_START_INDEX + 5] || 0),
+      str: acc.str + Number(el.str || 0),
+      dex: acc.dex + Number(el.dex || 0),
+      con: acc.con + Number(el.con || 0),
+      int: acc.int + Number(el.int || 0),
+      wis: acc.wis + Number(el.wis || 0),
+      cha: acc.cha + Number(el.cha || 0),
     }),
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );


### PR DESCRIPTION
## Summary
- replace index-based feat bonus aggregation with property-based lookup in Stats and ZombiesCharacterSheet
- ensure skills compute feat bonuses from object-based feats
- transform fetched feats to objects before passing to child components

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b48c291b34832ea042d45e4435fc03