### PR TITLE
Remove passive perception and investigation bonuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Use `POST /feats/add` with a JSON body to create a new feat. Supported fields in
 - `featName` (string, required)
 - `notes` (string, optional)
 - `abilityIncreaseOptions` (array of strings, optional)
-- Numeric bonuses such as ability scores (`str`, `dex`, `con`, `int`, `wis`, `cha`), `initiative`, `ac`, `speed`, `passivePerception`, `passiveInvestigation`, `hpMaxBonus`, and `hpMaxBonusPerLevel`
+- Numeric bonuses such as ability scores (`str`, `dex`, `con`, `int`, `wis`, `cha`), `initiative`, `ac`, `speed`, `hpMaxBonus`, and `hpMaxBonusPerLevel`
 - Skill bonuses (`acrobatics`, `animalHandling`, `arcana`, `athletics`, `deception`, `history`, `insight`, `intimidation`, `investigation`, `medicine`, `nature`, `perception`, `performance`, `persuasion`, `religion`, `sleightOfHand`, `stealth`, `survival`)
 
 ## Character Feats Endpoint

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -15,8 +15,6 @@ export default function HealthDefense({
   hpMaxBonusPerLevel = 0,
   initiativeBonus = 0,
   speedBonus = 0,
-  passivePerceptionBonus = 0,
-  passiveInvestigationBonus = 0,
 }) {
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
@@ -83,18 +81,6 @@ export default function HealthDefense({
       }
     }
   }
-
-  const passivePerception =
-    10 +
-    Number(form.perception || 0) +
-    Number(wisMod) +
-    Number(passivePerceptionBonus);
-
-  const passiveInvestigation =
-    10 +
-    Number(form.investigation || 0) +
-    Number(intMod) +
-    Number(passiveInvestigationBonus);
 
   // Health
   const maxHealth =
@@ -281,11 +267,6 @@ return (
       <div><strong>Will:</strong> {willSave}</div>
     </div>
 
-    {/* Passive Skills */}
-    <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
-      <div><strong>Passive Perception:</strong> {passivePerception}</div>
-      <div><strong>Passive Investigation:</strong> {passiveInvestigation}</div>
-    </div>
   </div>
 </div>
 )

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -142,8 +142,6 @@ const featBonuses = (form.feat || []).reduce(
     acc.acBonus += Number(feat.acBonus || 0);
     acc.hpMaxBonus += Number(feat.hpMaxBonus || 0);
     acc.hpMaxBonusPerLevel += Number(feat.hpMaxBonusPerLevel || 0);
-    acc.passivePerception += Number(feat.passivePerceptionBonus || 0);
-    acc.passiveInvestigation += Number(feat.passiveInvestigationBonus || 0);
     return acc;
   },
   {
@@ -152,8 +150,6 @@ const featBonuses = (form.feat || []).reduce(
     acBonus: 0,
     hpMaxBonus: 0,
     hpMaxBonusPerLevel: 0,
-    passivePerception: 0,
-    passiveInvestigation: 0,
   }
 );
 
@@ -225,8 +221,6 @@ return (
           acBonus={featBonuses.acBonus}
           hpMaxBonus={featBonuses.hpMaxBonus}
           hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
-          passivePerceptionBonus={featBonuses.passivePerception}
-          passiveInvestigationBonus={featBonuses.passiveInvestigation}
         />
         <PlayerTurnActions form={form} atkBonus={atkBonus} dexMod={statMods.dex} strMod={statMods.str}/>
         <Navbar fixed="bottom" bg="dark" data-bs-theme="dark">

--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -19,8 +19,6 @@ module.exports = (router) => {
     'initiative',
     'ac',
     'speed',
-    'passivePerception',
-    'passiveInvestigation',
     'hpMaxBonus',
     'hpMaxBonusPerLevel',
   ];

--- a/server/routes/fieldConstants.js
+++ b/server/routes/fieldConstants.js
@@ -14,8 +14,6 @@ const numericFields = [
   'initiative',
   'ac',
   'speed',
-  'passivePerception',
-  'passiveInvestigation',
   'hpMaxBonus',
   'hpMaxBonusPerLevel',
 ];


### PR DESCRIPTION
## Summary
- Drop passive perception/investigation fields from feat handling and constants
- Clean Zombies character sheet and health/defense components of passive bonuses
- Update documentation to reflect removed passive fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b48c2a3df8832e90f3c3d976adbac6