### PR TITLE
Refactor feat bonus fields

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -10,11 +10,11 @@ export default function HealthDefense({
   dexMod,
   wisMod,
   intMod,
-  acBonus = 0,
+  ac = 0,
   hpMaxBonus = 0,
   hpMaxBonusPerLevel = 0,
-  initiativeBonus = 0,
-  speedBonus = 0,
+  initiative = 0,
+  speed = 0,
 }) {
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
@@ -30,7 +30,7 @@ export default function HealthDefense({
      form.armor.map((el) => (
        armorAcBonus.push(el[1])
      ))
-     let totalArmorAcBonus = armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) + Number(acBonus);
+    let totalArmorAcBonus = armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) + Number(ac);
      form.armor.map((el) => (
       armorMaxDexBonus.push(el[2])
      ))
@@ -256,8 +256,8 @@ return (
     <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
       <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
       <div><strong>Attack Bonus:</strong> {atkBonus}</div>
-      <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiativeBonus)}</div>
-      <div><strong>Speed:</strong> {(form.speed || 0) + Number(speedBonus)}</div>
+      <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
+      <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
     </div>
 
     {/* Saving Throws */}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -150,9 +150,9 @@ export default function ZombiesCharacterSheet() {
 // ---------------------------------------Feats and bonuses----------------------------------------------
 const featBonuses = (form.feat || []).reduce(
   (acc, feat) => {
-    acc.initiative += Number(feat.initiativeBonus || 0);
-    acc.speed += Number(feat.speedBonus || 0);
-    acc.acBonus += Number(feat.acBonus || 0);
+    acc.initiative += Number(feat.initiative || 0);
+    acc.speed += Number(feat.speed || 0);
+    acc.ac += Number(feat.ac || 0);
     acc.hpMaxBonus += Number(feat.hpMaxBonus || 0);
     acc.hpMaxBonusPerLevel += Number(feat.hpMaxBonusPerLevel || 0);
     return acc;
@@ -160,7 +160,7 @@ const featBonuses = (form.feat || []).reduce(
   {
     initiative: 0,
     speed: 0,
-    acBonus: 0,
+    ac: 0,
     hpMaxBonus: 0,
     hpMaxBonusPerLevel: 0,
   }
@@ -229,9 +229,9 @@ return (
           conMod={statMods.con}
           wisMod={statMods.wis}
           intMod={statMods.int}
-          initiativeBonus={featBonuses.initiative}
-          speedBonus={featBonuses.speed}
-          acBonus={featBonuses.acBonus}
+          initiative={featBonuses.initiative}
+          speed={featBonuses.speed}
+          ac={featBonuses.ac}
           hpMaxBonus={featBonuses.hpMaxBonus}
           hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
         />


### PR DESCRIPTION
## Summary
- rename feat bonuses from initiativeBonus/speedBonus/acBonus to initiative/speed/ac
- propagate new feat bonus names to HealthDefense component

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4ec6502e4832eb636f2d2b812dcd9