### PR TITLE
Parse extra numeric feat bonuses in ZombiesCharacterSheet

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -42,12 +42,21 @@ export default function ZombiesCharacterSheet() {
           const [featName = "", notes = "", ...rest] = feat;
           const skillVals = rest.slice(0, SKILLS.length);
           const abilityVals = rest.slice(SKILLS.length, SKILLS.length + 6);
+          const [initiative = 0, ac = 0, speed = 0, hpMaxBonus = 0, hpMaxBonusPerLevel = 0] =
+            rest.slice(SKILLS.length + 6);
           const featObj = { featName, notes };
           SKILLS.forEach(({ key }, idx) => {
             featObj[key] = Number(skillVals[idx] || 0);
           });
           ["str", "dex", "con", "int", "wis", "cha"].forEach((stat, idx) => {
             featObj[stat] = Number(abilityVals[idx] || 0);
+          });
+          Object.assign(featObj, {
+            initiative: Number(initiative || 0),
+            ac: Number(ac || 0),
+            speed: Number(speed || 0),
+            hpMaxBonus: Number(hpMaxBonus || 0),
+            hpMaxBonusPerLevel: Number(hpMaxBonusPerLevel || 0),
           });
           return featObj;
         });


### PR DESCRIPTION
## Summary
- map initiative, AC, speed, HP max bonus, and HP max bonus per level when translating feat arrays

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ed7ed698832e8bb1c082e5eab29e