### PR TITLE
Fix card overflow and add scrolling for feat selector

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -904,7 +904,7 @@ h1 {
   border-radius: 12px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
   background: #f8f9fa;
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* Modal Header */

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -263,7 +263,12 @@ export default function Feats({ form, showFeats, handleCloseFeats, totalLevel })
                   <Form onSubmit={addFeatToDb}>
                     <Form.Group className="mb-3 mx-5">
                       <Form.Label className="text-dark">Select Feat</Form.Label>
-                      <Form.Select onChange={handleSelectFeat} defaultValue="" type="text">
+                      <Form.Select
+                        onChange={handleSelectFeat}
+                        defaultValue=""
+                        type="text"
+                        style={{ maxHeight: '200px', overflowY: 'auto' }}
+                      >
                         <option value="" disabled>
                           Select your feat
                         </option>


### PR DESCRIPTION
## Summary
- prevent clipping by allowing `.modern-card` content to overflow
- add internal scrolling to feat selection dropdown to keep options accessible

## Testing
- `cd client && CI=true npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f97f2330832ebb1e8a6131ec180f