### PR TITLE
feat: show feat notes before adding

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -263,21 +263,32 @@ export default function Feats({ form, showFeats, handleCloseFeats, totalLevel })
                   <Form onSubmit={addFeatToDb}>
                     <Form.Group className="mb-3 mx-5">
                       <Form.Label className="text-dark">Select Feat</Form.Label>
-                      <Form.Select
-                        onChange={handleSelectFeat}
-                        defaultValue=""
-                        type="text"
-                        style={{ maxHeight: '200px', overflowY: 'auto' }}
-                      >
-                        <option value="" disabled>
-                          Select your feat
-                        </option>
-                        {feat.feat.map((el) => (
-                          <option key={el.featName} value={el.featName}>
-                            {el.featName}
+                      <div className="d-flex">
+                        <Form.Select
+                          onChange={handleSelectFeat}
+                          defaultValue=""
+                          type="text"
+                          style={{ maxHeight: '200px', overflowY: 'auto' }}
+                        >
+                          <option value="" disabled>
+                            Select your feat
                           </option>
-                        ))}
-                      </Form.Select>
+                          {feat.feat.map((el) => (
+                            <option key={el.featName} value={el.featName}>
+                              {el.featName}
+                            </option>
+                          ))}
+                        </Form.Select>
+                        <Button
+                          size="sm"
+                          className="action-btn fa-regular fa-eye ms-2"
+                          disabled={!selectedFeatData}
+                          onClick={() => {
+                            setModalFeatData(selectedFeatData);
+                            handleShowFeatNotes();
+                          }}
+                        ></Button>
+                      </div>
                     </Form.Group>
 
                     {selectedFeatData?.abilityIncreaseOptions &&


### PR DESCRIPTION
## Summary
- add preview button for feat notes in selection dropdown
- disable preview button until a feat is selected

## Testing
- `cd client && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b4faee3050832ea1324d41cc04453b