### PR TITLE
Enable vertical scrolling in Skills modal

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -237,7 +237,7 @@ let firstLevelSkill =
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">Skills</Card.Title>
           </Card.Header>
-          <Card.Body style={{ overflowY: 'auto' }}>
+          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
             <div style={{ display: showSkillBtn }}>
               Points Left:<span className="mx-1" id="skillPointLeft">{totalSkillPointsLeft}</span>
             </div>


### PR DESCRIPTION
## Summary
- constrain Skills modal height to 70vh so overflow scrolls vertically

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b50120d244832e90d72ddad67d3e7b