### PR TITLE
style: standardize points display in Skills modal

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -238,8 +238,9 @@ let firstLevelSkill =
             <Card.Title className="modal-title">Skills</Card.Title>
           </Card.Header>
           <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-            <div style={{ display: showSkillBtn }}>
-              Points Left:<span className="mx-1" id="skillPointLeft">{totalSkillPointsLeft}</span>
+            <div className="points-container" style={{ display: showSkillBtn }}>
+              <span className="points-label">Points Left:</span>
+              <span className="points-value" id="skillPointLeft">{totalSkillPointsLeft}</span>
             </div>
             <Table striped bordered hover size="sm" className="modern-table">
               <thead>


### PR DESCRIPTION
## Summary
- restyle Skills modal "Points Left" block to use shared points-container classes for consistent appearance

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b5029a9504832e9f54dc7982113e7e