### PR TITLE
Use translucent background for modal header

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -909,7 +909,7 @@ h1 {
 
 /* Modal Header */
 .modal-header {
-  background: linear-gradient(135deg, #4CAF50, #388E3C);
+  background-color: rgba(0, 0, 0, 0.5);
   color: white;
   text-align: center;
   padding: 10px;


### PR DESCRIPTION
## Summary
- replace modal header gradient with a semi-transparent black background and keep text white

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5131808b4832e8ee86c3eb2d13098