### PR TITLE
feat: soften navbar background

### DIFF
--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -13,7 +13,7 @@ function NavbarComponent() {
   };
 
   return (
-    <Navbar fixed="top" style={{ fontFamily: 'Raleway, sans-serif', height: "80px", backgroundColor: "rgba(0, 0, 0, 1)" }}>
+    <Navbar fixed="top" style={{ fontFamily: 'Raleway, sans-serif', height: "80px", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
       <Container fluid>
         <Navbar.Brand href="/">
           <img src={logoLight} alt="" width="60px" height="60px" className="d-inline-block align-text-top" />


### PR DESCRIPTION
## Summary
- soften Navbar background to semi-transparent black for a lighter overlay

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5132a5cd8832e82f3773ee8bffa18