### PR TITLE
style: darken footer background

### DIFF
--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -3,13 +3,16 @@ import { MDBFooter } from 'mdb-react-ui-kit';
 
 export default function Footer() {
   return (
-    <MDBFooter bgColor='light' className='fixed-bottom bg-image text-center text-lg-start text-muted'>
-      <div className='text-center p-4' style={{ backgroundColor: 'rgba(0, 0, 0, 0.05)' }}>
+    <MDBFooter
+      className='fixed-bottom bg-image text-center text-lg-start text-white'
+      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+    >
+      <div className='text-center p-4' style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}>
         © 2023 Copyright:
-        <a className='mx-1 text-reset fw-bold' href='https://github.com/rjo6615/DnD'>
+        <a className='mx-1 text-white fw-bold' href='https://github.com/rjo6615/DnD'>
           DnD
         </a>
       </div>
-      </MDBFooter>
-    );
+    </MDBFooter>
+  );
 }


### PR DESCRIPTION
## Summary
- darken footer background using a semi-transparent black
- keep footer text white for better readability

## Testing
- `cd client && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5132bc478832ead412dda469f7d02