### PR TITLE
Ensure modal header renders with medium transparency

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -909,7 +909,7 @@ h1 {
 
 /* Modal Header */
 .modal-header {
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.5) !important;
   color: white;
   text-align: center;
   padding: 10px;


### PR DESCRIPTION
## Summary
- enforce medium-transparency background on `.modal-header`

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b516343098832ea56350203776d8c0