### PR TITLE
style: add semi-transparent footer class

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1025,3 +1025,9 @@ h1 {
 .close-btn:hover {
   background: #545b62;
 }
+
+// Transparent footer styling
+.footer-transparent {
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  color: #fff;
+}

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -4,10 +4,9 @@ import { MDBFooter } from 'mdb-react-ui-kit';
 export default function Footer() {
   return (
     <MDBFooter
-      className='fixed-bottom text-center text-lg-start text-white'
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+      className='fixed-bottom text-center text-lg-start text-white footer-transparent'
     >
-      <div className='text-center p-4' style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}>
+      <div className='text-center p-4 footer-transparent'>
         © 2023 Copyright:
         <a className='mx-1 text-white fw-bold' href='https://github.com/rjo6615/DnD'>
           DnD


### PR DESCRIPTION
## Summary
- add `.footer-transparent` utility with medium transparency
- apply new class to footer component

## Testing
- `npm run build`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b51805b81c832eb98ad26989738423