### PR TITLE
style: apply semi-transparent modal backgrounds

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -560,9 +560,10 @@ max-width: 300px;
 }
 
 .dnd-modal .modal-content {
-  background-color: transparent !important; /* Make the modal content area transparent */
-  box-shadow: none !important; /* Remove any box shadow */
-  border: none !important; /* Remove any border */
+  background: none !important;
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  box-shadow: none !important;
+  border: none !important;
 }
 
 //vars
@@ -909,6 +910,7 @@ h1 {
 
 /* Modal Header */
 .modal-header {
+  background: none !important;
   background-color: rgba(0, 0, 0, 0.5) !important;
   color: white;
   text-align: center;

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -147,7 +147,7 @@ export default function Login({ onLogin }) {
   </div>
 
   {/* Signup Modal */}
-  <Modal show={show} onHide={handleClose} centered>
+  <Modal className="dnd-modal" show={show} onHide={handleClose} centered>
     <Modal.Header closeButton>
       <Modal.Title>Sign up</Modal.Title>
     </Modal.Header>

--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -133,7 +133,7 @@ return(
     <div>
      {/* ------------------------------------------------Armor Render-----------------------------------------------------------
 ----------------------------------------------------- */}
-<Modal className="modern-modal" show={showArmor} onHide={handleCloseArmor} size="lg" scrollable centered>
+<Modal className="dnd-modal modern-modal" show={showArmor} onHide={handleCloseArmor} size="lg" scrollable centered>
   <div className="text-center">
     <Card className="modern-card">
       <Card.Header className="modal-header">

--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -17,7 +17,7 @@ export default function CharacterInfo({ form, show, handleClose }) {
 
   return (
     <Modal
-      className="modern-modal"
+      className="dnd-modal modern-modal"
       show={show}
       onHide={handleClose}
       size="lg"

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -158,7 +158,7 @@ export default function Feats({ form, showFeats, handleCloseFeats, totalLevel })
   return (
     <div>
       {/* -----------------------------------------Feats Render------------------------------------------------------------------------------------------------------------------------------------ */}
-      <Modal className="modern-modal" show={showFeats} onHide={handleCloseFeats} size="lg" centered>
+      <Modal className="dnd-modal modern-modal" show={showFeats} onHide={handleCloseFeats} size="lg" centered>
         <div className="text-center">
           <Card className="modern-card">
             <Card.Header className="modal-header">
@@ -338,7 +338,7 @@ export default function Feats({ form, showFeats, handleCloseFeats, totalLevel })
               </Button>
             </Card.Footer>
           </Card>
-          <Modal className="modern-modal" show={showFeatNotes} onHide={handleCloseFeatNotes} size="lg" centered>
+          <Modal className="dnd-modal modern-modal" show={showFeatNotes} onHide={handleCloseFeatNotes} size="lg" centered>
               <Card className="modern-card text-center">
                 <Card.Header className="modal-header">
                   <Card.Title className="modal-title">{modalFeatData.featName}</Card.Title>

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -65,7 +65,7 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
 return(
     <div>
         <Modal
-        className="modern-modal text-center"
+        className="dnd-modal modern-modal text-center"
         size="lg"
         aria-labelledby="contained-modal-title-vcenter"
         centered
@@ -109,7 +109,7 @@ return(
           </Card>
         </Modal>
         <Modal
-          className="modern-modal text-center"
+          className="dnd-modal modern-modal text-center"
           size="lg"
           aria-labelledby="contained-modal-title-vcenter"
           centered

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -145,7 +145,7 @@ export default function Items({form, showItems, handleCloseItems}) {
 return(
 <div>
          {/* -----------------------------------------Items Render------------------------------------------------------------------------------------------------------------------------------- */}
-          <Modal className="modern-modal" show={showItems} onHide={handleCloseItems} size="lg" centered>
+          <Modal className="dnd-modal modern-modal" show={showItems} onHide={handleCloseItems} size="lg" centered>
         <div className="text-center">
          <Card className="modern-card">
          <Card.Header className="modal-header">
@@ -251,7 +251,7 @@ return(
            <Button className="action-btn close-btn" onClick={handleCloseItems}>Close</Button>
          </Card.Footer>
         </Card>
-        <Modal className="modern-modal" show={showNotes} onHide={handleCloseNotes} size="lg" centered>
+        <Modal className="dnd-modal modern-modal" show={showNotes} onHide={handleCloseNotes} size="lg" centered>
           <Card className="modern-card text-center">
             <Card.Header className="modal-header">
               <Card.Title className="modal-title">{modalItemData[0]}</Card.Title>

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -183,7 +183,7 @@ export default function LevelUp({ show, handleClose, form }) {
 
   return (
     <div>
-      <Modal className="modern-modal" show={showLvlModal} onHide={handleCloseLvlModal} size="md" centered>
+      <Modal className="dnd-modal modern-modal" show={showLvlModal} onHide={handleCloseLvlModal} size="md" centered>
         <div className="text-center">
           <Card className="modern-card">
             <Card.Header className="modal-header">
@@ -196,7 +196,7 @@ export default function LevelUp({ show, handleClose, form }) {
                   Add Occupation
                 </Button>
                 <Modal
-                  className="modern-modal"
+                  className="dnd-modal modern-modal"
                   centered
                   show={showAddClassModal}
                   onHide={() => { setShowAddClassModal(false); setChosenAddOccupation(''); }}

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -263,7 +263,7 @@ const showSparklesEffect = () => {
   </div>
 </div>
 {/* Attack Modal */}
-      <Modal size="lg" className="modern-modal" centered show={showAttack} onHide={handleCloseAttack}>
+      <Modal size="lg" className="dnd-modal modern-modal" centered show={showAttack} onHide={handleCloseAttack}>
         <Card className="modern-card">
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">Weapons</Card.Title>

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -232,7 +232,7 @@ let firstLevelSkill =
       return (   
       <div>  
        {/* -----------------------------------------------Skill Render--------------------------------------------------------------- */}
-       <Modal className="modern-modal" show={showSkill} onHide={handleCloseSkill} size="lg" scrollable centered>
+       <Modal className="dnd-modal modern-modal" show={showSkill} onHide={handleCloseSkill} size="lg" scrollable centered>
         <Card className="modern-card text-center">
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">Skills</Card.Title>
@@ -341,7 +341,7 @@ let firstLevelSkill =
           </Card.Footer>
         </Card>
 
-        <Modal className="modern-modal" show={showAddSkill} onHide={handleCloseAddSkill} centered>
+        <Modal className="dnd-modal modern-modal" show={showAddSkill} onHide={handleCloseAddSkill} centered>
           <Card className="modern-card text-center">
             <Card.Header className="modal-header">
               <Card.Title className="modal-title">Add Skill</Card.Title>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -95,7 +95,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
       size="lg"
       scrollable
       centered
-      className="modern-modal"
+      className="dnd-modal modern-modal"
     >
       <div className="text-center">
         <Card className="modern-card">

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -152,7 +152,7 @@ const [weapon, setWeapon] = useState({
 return(
     <div>
         {/* -----------------------------------------Weapons Render---------------------------------------------------------------------------------------------------------------------------------- */}
-<Modal className="modern-modal" show={showWeapons} onHide={handleCloseWeapons} size="lg" centered>
+<Modal className="dnd-modal modern-modal" show={showWeapons} onHide={handleCloseWeapons} size="lg" centered>
   <div className="text-center">
     <Card className="modern-card">
       <Card.Header className="modal-header">


### PR DESCRIPTION
## Summary
- give modal content and headers a semi-transparent black background
- apply dnd-modal class across all modals for consistent styling

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b518020cf4832e9799507d53579894