### PR TITLE
style: apply transparent background to modern-card

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -904,7 +904,8 @@ h1 {
   width: 100%;
   border-radius: 12px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
-  background: #f8f9fa;
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  color: white;
   overflow: visible;
 }
 


### PR DESCRIPTION
## Summary
- use semi-transparent background for modern-card container for modal headers
- set text color to white for readability

## Testing
- `npm run build`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5b48c0e5c832ea7f3b6938883d41e