### PR TITLE
style: ensure modal body text uses white color

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -566,6 +566,16 @@ max-width: 300px;
   border: none !important;
 }
 
+.dnd-modal .modal-body {
+  color: white;
+}
+
+.dnd-modal .modal-body .btn,
+.dnd-modal .modal-body table,
+.dnd-modal .modal-body .dropdown-menu {
+  color: inherit;
+}
+
 //vars
 $fg: linear-gradient(135deg, #3e8e41, #2e7d32);
 $fgDM: linear-gradient(135deg, #979940b6, #fffb00);


### PR DESCRIPTION
## Summary
- style modal content body in dnd-modal with white text
- inherit color for buttons, tables and dropdown menus inside modal body

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b77950c4832e90310398b2c09262