### PR TITLE
Fix modal body text color and restore nested element styles

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -567,13 +567,13 @@ max-width: 300px;
 }
 
 .dnd-modal .modal-body {
-  color: white;
+  color: #fff !important;
 }
 
 .dnd-modal .modal-body .btn,
 .dnd-modal .modal-body table,
 .dnd-modal .modal-body .dropdown-menu {
-  color: inherit;
+  color: initial;
 }
 
 //vars


### PR DESCRIPTION
## Summary
- ensure `.dnd-modal` body text renders white by default
- keep buttons, tables, and dropdown menus in modals at their default colors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5b96b670c832ea6190e814b9d83fa