### PR TITLE
Allow empty weapon numeric fields

### DIFF
--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -43,6 +43,22 @@ describe('Equipment routes', () => {
       expect(res.body.acknowledged).toBe(true);
     });
 
+    test('insert success with empty numeric fields', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+      });
+      const res = await request(app)
+        .post('/equipment/weapon/add')
+        .send({
+          campaign: 'Camp1',
+          weaponName: 'Sword',
+          enhancement: '',
+          range: ''
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.acknowledged).toBe(true);
+    });
+
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -64,8 +64,8 @@ module.exports = (router) => {
     [
       body('campaign').trim().notEmpty().withMessage('campaign is required'),
       body('weaponName').trim().notEmpty().withMessage('weaponName is required'),
-      body('enhancement').optional().isInt().toInt(),
-      body('range').optional().isInt().toInt(),
+      body('enhancement').optional({ checkFalsy: true }).isInt().toInt(),
+      body('range').optional({ checkFalsy: true }).isInt().toInt(),
       body('damage').optional().trim(),
       body('critical').optional().trim(),
       body('weaponStyle').optional().trim(),


### PR DESCRIPTION
## Summary
- allow blank enhancement and range fields to bypass validation
- test weapon creation with empty numeric fields

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf215e0c832ebbdf9d1b79b61f41