### PR TITLE
fix: retain campaign in weapon form resets

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -176,7 +176,8 @@ const [form2, setForm2] = useState({
      });
    
      setForm2({
-      weaponName: "", 
+      campaign: currentCampaign,
+      weaponName: "",
       enhancement: "",
       damage: "",
       critical: "",


### PR DESCRIPTION
## Summary
- keep campaign id when resetting weapon form

## Testing
- `node - <<'NODE' ...` (simulate consecutive weapon submissions)
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5bf221508832eb1f85c7d856b9be5