### PR TITLE
Filter weapon payloads in Zombies DM

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -163,6 +163,13 @@ const [form2, setForm2] = useState({
   
   async function sendToDb2(){
     const newWeapon = { ...form2 };
+    Object.keys(newWeapon).forEach((key) => {
+      if (newWeapon[key] === "") {
+        delete newWeapon[key];
+      } else if (!isNaN(newWeapon[key])) {
+        newWeapon[key] = Number(newWeapon[key]);
+      }
+    });
       await apiFetch("/equipment/weapon/add", {
        method: "POST",
        headers: {


### PR DESCRIPTION
## Summary
- Filter out blank weapon fields before sending to API
- Convert numeric weapon fields to numbers so only populated data is sent

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf22c270832ea236c874c870f2b9