### PR TITLE
feat: switch skills to proficiency system

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -1,402 +1,185 @@
-import React, { useState } from 'react'; // Import useState and React
+import React, { useState } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button, Form } from 'react-bootstrap'; // Adjust as per your actual UI library
-import { useNavigate, useParams } from "react-router-dom";
+import { Modal, Card, Table, Button, Form } from 'react-bootstrap';
+import { useParams } from 'react-router-dom';
 
-import { SKILLS } from "../skillSchema";
-export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, strMod, dexMod, conMod, intMod, chaMod, wisMod}) {
+import { SKILLS } from '../skillSchema';
+
+// Compute 5e proficiency bonus from total character level
+function proficiencyBonus(level = 0) {
+  if (level >= 17) return 6;
+  if (level >= 13) return 5;
+  if (level >= 9) return 4;
+  if (level >= 5) return 3;
+  return 2;
+}
+
+export default function Skills({
+  form,
+  showSkill,
+  handleCloseSkill,
+  totalLevel,
+  strMod,
+  dexMod,
+  conMod,
+  intMod,
+  chaMod,
+  wisMod,
+}) {
   const params = useParams();
-  const navigate = useNavigate();
+  const [skills, setSkills] = useState(form.skills || {});
 
-  //-----------------------Skills--------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  const [showAddSkill, setShowAddSkill] = useState(false);
-  const handleShowAddSkill = () => setShowAddSkill(true);
-  const handleCloseAddSkill = () => {setShowAddSkill(false); setChosenSkill('');};
-  const [chosenSkill, setChosenSkill] = useState('');
-  const handleChosenSkillChange = (e) => {
-      setChosenSkill(e.target.value);
-  }
-  
-  const [addSkillForm, setAddSkillForm] = useState({ 
-    newSkill: "",
-  });
-  function updateAddSkill(value) {
-    return setAddSkillForm((prev) => {
-      return { ...prev, ...value };
-    });
-  }
-  const [newSkill, setNewSkill] = useState({ 
-    skill: "",
-  });
-  function updateNewSkill(value) {
-    return setNewSkill((prev) => {
-      return { ...prev, ...value };
-    });
-  }
-  
   if (!form) {
     return <div>Loading...</div>;
   }
 
-  const occupations = form.occupation;
-  const splitSkillArr = (array, size) => {
-    let result = [];
-    for (let i = 0; i < array.length; i += size) {
-      let chunk = array.slice(i, i + size);
-      result.push(chunk);
-    }
-    return result;
+  // Armor Check Penalty
+  const checkPenalty = form.armor.map((el) => el[3]);
+  const totalCheckPenalty = checkPenalty.reduce(
+    (sum, a) => Number(sum) + Number(a),
+    0
+  );
+
+  const modMap = {
+    str: strMod,
+    dex: dexMod,
+    con: conMod,
+    int: intMod,
+    wis: wisMod,
+    cha: chaMod,
   };
-  let addNewSkill;
-   if (JSON.stringify(form.newSkill) === JSON.stringify([["",0]])) {
-    let addNewSkillArr = addSkillForm.newSkill.split(',');
-    const skillArrSize = 2;
-    const skillArrChunks = splitSkillArr(addNewSkillArr, skillArrSize);
-    addNewSkill = skillArrChunks;
-   } else {
-    let addNewSkillArr = (form.newSkill + "," + addSkillForm.newSkill).split(',');
-    const skillArrSize = 2;
-    const skillArrChunks = splitSkillArr(addNewSkillArr, skillArrSize);
-    addNewSkill = skillArrChunks;
-   }
-  
-   let showSkills = "";
-   if (JSON.stringify(form.newSkill) === JSON.stringify([["",0]])){
-    showSkills = "none";
-   }
-  async function addSkillToDb(e){
-    e.preventDefault();
-    await apiFetch(`/skills/update-add-skill/${params.id}`, {
-     method: "PUT",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify({
-      newSkill: addNewSkill,
-     }),
-   })
-   .catch(error => {
-     window.alert(error);
-     return;
-   });
-   navigate(0);
-  }
-  
-   // Sends skillForm data to database for update
-   async function skillsUpdate(){
-    const updatedSkills = { ...skillForm };
-      await apiFetch(`/skills/update-skills/${params.id}`, {
-       method: "PUT",
-       headers: {
-         "Content-Type": "application/json",
-       },
-       body: JSON.stringify(updatedSkills),
-     })
-     .catch(error => {
-      //  window.alert(error);
-       return;
-     });
-     navigate(0);
-   }
- 
-//Armor Check Penalty
-let checkPenalty= [];
- form.armor.map((el) => (
-  checkPenalty.push(el[3])
-))
-let totalCheckPenalty = checkPenalty.reduce((partialSum, a) => Number(partialSum) + Number(a), 0);
 
-const modMap = { str: strMod, dex: dexMod, con: conMod, int: intMod, wis: wisMod, cha: chaMod };
+  const itemTotals = SKILLS.reduce((acc, { key, itemBonusIndex }) => {
+    acc[key] = form.item.reduce(
+      (sum, el) => sum + Number(el[itemBonusIndex] || 0),
+      0
+    );
+    return acc;
+  }, {});
 
-const itemTotals = SKILLS.reduce((acc, {key, itemBonusIndex}) => {
-  acc[key] = form.item.reduce((sum, el) => sum + Number(el[itemBonusIndex] || 0), 0);
-  return acc;
-}, {});
+  const featTotals = SKILLS.reduce((acc, { key }) => {
+    acc[key] = (form.feat || []).reduce(
+      (sum, el) => sum + Number(el[key] || 0),
+      0
+    );
+    return acc;
+  }, {});
 
-const featTotals = SKILLS.reduce((acc, {key}) => {
-  acc[key] = (form.feat || []).reduce((sum, el) => sum + Number(el[key] || 0), 0);
-  return acc;
-}, {});
+  const profBonus = proficiencyBonus(totalLevel);
 
-const skillForm = SKILLS.reduce((acc, {key}) => ({ ...acc, [key]: form[key] }), {});
-
-const skillTotalForm = SKILLS.reduce((acc, {key, ability, armorPenalty = 0}) => {
-  const penalty = armorPenalty ? armorPenalty * totalCheckPenalty : 0;
-  acc[key] = form[key] + modMap[ability] + penalty + itemTotals[key] + featTotals[key];
-  return acc;
-}, {});
-
-let skillTotal = SKILLS.reduce((sum, {key}) => sum + form[key], 0);
-
-let addedSkillsRanks= [];
-form.newSkill.map((el) => (
-  addedSkillsRanks.push(el[1])
-))
-let totalAddedSkills = addedSkillsRanks.reduce((partialSum, a) => Number(partialSum) + Number(a), 0);
-
-let firstLevelSkill =
- Math.floor((Number(form.occupation[0].skillMod) + intMod) * 4);
-  let allSkillPointsLeft = 0;
-  let skillPointsLeft;
-  for (const occupation of occupations) {
-      if (occupation.Occupation === form.occupation[0].Occupation) {
-        let occupationLevel = occupation.Level - 1;
-        const skillMod = Number(occupation.skillMod);
-        skillPointsLeft = Math.floor((skillMod + intMod) * (occupationLevel));
-        allSkillPointsLeft += skillPointsLeft;
-      } else {
-        let occupationLevel = occupation.Level;
-        const skillMod = Number(occupation.skillMod);
-        skillPointsLeft = Math.floor((skillMod + intMod) * (occupationLevel));
-        allSkillPointsLeft += skillPointsLeft;
+  async function updateSkill(skill, updated) {
+    try {
+      const res = await apiFetch(`/skills/update-skills/${params.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skill, ...updated }),
+      });
+      if (!res.ok) {
+        throw new Error('Network response was not ok');
       }
+      const data = await res.json();
+      setSkills((prev) => ({
+        ...prev,
+        [skill]: { proficient: data.proficient, expertise: data.expertise },
+      }));
+    } catch (err) {
+      console.error(err);
+    }
   }
-  let totalSkillPointsLeft = allSkillPointsLeft + firstLevelSkill  - skillTotal - totalAddedSkills;
-  let showSkillBtn = "";
-  if (totalSkillPointsLeft === 0) {
-    showSkillBtn = "none";
-  }
-  
-  const skillKnown = SKILLS.reduce((acc, {key}) => ({ ...acc, [key]: "" }), {});
 
-  function addSkill(skill, totalSkill) {
-    if (totalSkillPointsLeft === 0){
-    } else if (skillKnown[skill] === "0" && skillForm[skill] === Math.floor((Number(totalLevel) + 3) / 2)) {
-    } else if (skillKnown[skill] === "1" && skillForm[skill] === Math.floor(Number(totalLevel) + 3)){
-    } else {
-    skillForm[skill]++;
-    skillTotalForm[skill]++;
-    totalSkillPointsLeft--;
-    document.getElementById(skill).innerHTML = skillForm[skill];
-    document.getElementById(totalSkill).innerHTML = skillTotalForm[skill];
-    document.getElementById("skillPointLeft").innerHTML = totalSkillPointsLeft;
+  const toggleProficient = (skill) => {
+    const current = skills[skill] || { proficient: false, expertise: false };
+    const updated = {
+      proficient: !current.proficient,
+      expertise: current.proficient ? current.expertise : false,
+    };
+    if (!updated.proficient) {
+      updated.expertise = false;
     }
+    updateSkill(skill, updated);
   };
 
-  function removeSkill(skill, totalSkill) {
-    if (skillForm[skill] === form[skill]){
-    } else {
-    skillForm[skill]--;
-    skillTotalForm[skill]--;
-    totalSkillPointsLeft++;
-    document.getElementById(skill).innerHTML = skillForm[skill];
-    document.getElementById(totalSkill).innerHTML = skillTotalForm[skill];
-    document.getElementById("skillPointLeft").innerHTML = totalSkillPointsLeft;
-    }
+  const toggleExpertise = (skill) => {
+    const current = skills[skill] || { proficient: false, expertise: false };
+    const updated = {
+      proficient: true,
+      expertise: !current.expertise,
+    };
+    updateSkill(skill, updated);
   };
-  // New Added Skills Button Control
-  const newSkillForm = {};
-  
-  form.newSkill.forEach((el) => {
-    newSkillForm[el[0]] = el[1];
-  });
-  
-  async function addUpdatedSkillToDb(){
-    const addUpdatedSkill = Object.entries({...newSkillForm});
-    await apiFetch(`/skills/updated-add-skills/${params.id}`, {
-     method: "PUT",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify({
-      newSkill: addUpdatedSkill,
-     }),
-   })
-   .catch(error => {
-     window.alert(error);
-     return;
-   });
-   navigate(0);
-  }
-  function addSkillNew(skill) {  
-    if (totalSkillPointsLeft === 0){
-    } else if (newSkillForm[skill] === Math.floor(Number(totalLevel) + 3)){
-    } else {
-    newSkillForm[skill]++;
-    totalSkillPointsLeft--;
-    document.getElementById(skill).innerHTML = newSkillForm[skill];
-    document.getElementById(skill + "total").innerHTML = newSkillForm[skill] + intMod;
-    document.getElementById("skillPointLeft").innerHTML = totalSkillPointsLeft;
-    }
-  };
-  function removeSkillNew(skill, rank) {
-    if (Number(newSkillForm[skill]) === Number(rank)){
-    } else {
-    newSkillForm[skill]--;
-    totalSkillPointsLeft++;
-    document.getElementById(skill).innerHTML = newSkillForm[skill];
-    document.getElementById(skill + "total").innerHTML = newSkillForm[skill] + intMod;
-    document.getElementById("skillPointLeft").innerHTML = totalSkillPointsLeft;
-    }
-  };
-      return (   
-      <div>  
-       {/* -----------------------------------------------Skill Render--------------------------------------------------------------- */}
-       <Modal className="dnd-modal modern-modal" show={showSkill} onHide={handleCloseSkill} size="lg" scrollable centered>
-        <Card className="modern-card text-center">
-          <Card.Header className="modal-header">
-            <Card.Title className="modal-title">Skills</Card.Title>
-          </Card.Header>
-          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-            <div className="points-container" style={{ display: showSkillBtn }}>
-              <span className="points-label text-light">Points Left:</span>
-              <span className="points-value" id="skillPointLeft">{totalSkillPointsLeft}</span>
-            </div>
-            <Table striped bordered hover size="sm" className="modern-table">
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>Skill</th>
-                  <th>Total</th>
-                  <th>Rank</th>
-                  <th>Mod</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {SKILLS.map(({ key, label, ability }) => {
-                  const totalId = `total${key.charAt(0).toUpperCase() + key.slice(1)}`;
-                  return (
-                    <tr key={key}>
-                      <td>
-                        <Button
-                          size="sm"
-                          style={{ display: showSkillBtn }}
-                          onClick={() => removeSkill(key, totalId)}
-                          className="action-btn bg-danger fa-solid fa-minus"
-                        ></Button>
-                      </td>
-                      <td>{label}</td>
-                      <td>
-                        <span id={totalId}>{skillTotalForm[key]} </span>
-                      </td>
-                      <td>
-                        <span id={key}>{skillForm[key]} </span>
-                      </td>
-                      <td>
-                        <span id={`${ability}Mod`}>{modMap[ability]} </span>
-                      </td>
-                      <td>
-                        <Button
-                          size="sm"
-                          style={{ display: showSkillBtn }}
-                          onClick={() => addSkill(key, totalId)}
-                          className="action-btn fa-solid fa-plus"
-                        ></Button>
-                      </td>
-                    </tr>
-                  );
-                })}
 
-                {form.newSkill.map((el) => (
-                  <tr key={el[0]} style={{ display: showSkills }}>
+  return (
+    <Modal
+      className="dnd-modal modern-modal"
+      show={showSkill}
+      onHide={handleCloseSkill}
+      size="lg"
+      scrollable
+      centered
+    >
+      <Card className="modern-card text-center">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Skills</Card.Title>
+        </Card.Header>
+        <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+          <Table striped bordered hover size="sm" className="modern-table">
+            <thead>
+              <tr>
+                <th>Skill</th>
+                <th>Total</th>
+                <th>Mod</th>
+                <th>Prof</th>
+                <th>Exp</th>
+              </tr>
+            </thead>
+            <tbody>
+              {SKILLS.map(({ key, label, ability, armorPenalty = 0 }) => {
+                const { proficient = false, expertise = false } =
+                  skills[key] || {};
+                const penalty = armorPenalty
+                  ? armorPenalty * totalCheckPenalty
+                  : 0;
+                const multiplier = expertise ? 2 : proficient ? 1 : 0;
+                const total =
+                  modMap[ability] +
+                  profBonus * multiplier +
+                  penalty +
+                  itemTotals[key] +
+                  featTotals[key];
+                return (
+                  <tr key={key}>
+                    <td>{label}</td>
+                    <td>{total}</td>
+                    <td>{modMap[ability]}</td>
                     <td>
-                      <Button
-                        size="sm"
-                        style={{ display: showSkillBtn }}
-                        onClick={() => removeSkillNew(el[0], el[1])}
-                        className="action-btn bg-danger fa-solid fa-minus"
-                      ></Button>
+                      <Form.Check
+                        type="checkbox"
+                        checked={proficient}
+                        onChange={() => toggleProficient(key)}
+                      />
                     </td>
-                    <td>{el[0]}</td>
                     <td>
-                      <span id={el[0] + "total"}>{Number(el[1]) + intMod}</span>
-                    </td>
-                    <td>
-                      <span id={el[0]}>{Number(el[1])}</span>
-                    </td>
-                    <td>
-                      <span>{intMod}</span>
-                    </td>
-                    <td>
-                      <Button
-                        size="sm"
-                        style={{ display: showSkillBtn }}
-                        onClick={() => addSkillNew(el[0])}
-                        className="action-btn fa-solid fa-plus"
-                      ></Button>
+                      <Form.Check
+                        type="checkbox"
+                        checked={expertise}
+                        disabled={!proficient}
+                        onChange={() => toggleExpertise(key)}
+                      />
                     </td>
                   </tr>
-                ))}
-              </tbody>
-            </Table>
-          </Card.Body>
-          <Card.Footer className="modal-footer d-flex">
-            <Button
-              style={{ display: showSkillBtn }}
-              onClick={() => {
-                skillsUpdate();
-                addUpdatedSkillToDb();
-              }}
-              className="action-btn save-btn fa-solid fa-floppy-disk flex-fill"
-            ></Button>
-            <Button
-              onClick={() => handleShowAddSkill()}
-              className="action-btn fa-solid fa-plus flex-fill"
-            ></Button>
-            <Button
-              onClick={() => handleCloseSkill()}
-              className="action-btn close-btn fa-solid fa-xmark flex-fill"
-            ></Button>
-          </Card.Footer>
-        </Card>
+                );
+              })}
+            </tbody>
+          </Table>
+        </Card.Body>
+        <Card.Footer className="modal-footer d-flex">
+          <Button
+            onClick={() => handleCloseSkill()}
+            className="action-btn close-btn fa-solid fa-xmark flex-fill"
+          ></Button>
+        </Card.Footer>
+      </Card>
+    </Modal>
+  );
+}
 
-        <Modal className="dnd-modal modern-modal" show={showAddSkill} onHide={handleCloseAddSkill} centered>
-          <Card className="modern-card text-center">
-            <Card.Header className="modal-header">
-              <Card.Title className="modal-title">Add Skill</Card.Title>
-            </Card.Header>
-            <Card.Body>
-              <Form id="addSkillForm" onSubmit={addSkillToDb} className="px-5">
-                <Form.Group className="mb-3 pt-3">
-                  <Form.Label className="text-dark">Skill</Form.Label>
-                  <Form.Control
-                    className="mb-2"
-                    onChange={(e) => updateNewSkill({ skill: e.target.value })}
-                    type="text"
-                    placeholder="Enter Skill"
-                  />
-                  <Form.Label className="text-dark">Skill Type</Form.Label>
-                  <Form.Select
-                    className="mb-2"
-                    onChange={(e) => {
-                      const newSkill = e.target.value;
-                      updateAddSkill({ newSkill });
-                      handleChosenSkillChange(e);
-                    }}
-                    defaultValue=""
-                    type="text"
-                  >
-                    <option value="" disabled>
-                      Select skill type
-                    </option>
-                    <option value={["Knowledge " + newSkill.skill, 0]}>Knowledge</option>
-                    <option value={["Craft " + newSkill.skill, 0]}>Craft</option>
-                  </Form.Select>
-                </Form.Group>
-              </Form>
-            </Card.Body>
-            <Card.Footer className="modal-footer">
-              <Button
-                className="action-btn close-btn"
-                variant="secondary"
-                onClick={handleCloseAddSkill}
-              >
-                Close
-              </Button>
-              <Button
-                disabled={!chosenSkill || !newSkill.skill}
-                className="action-btn save-btn ms-4"
-                variant="primary"
-                type="submit"
-                form="addSkillForm"
-              >
-                Create
-              </Button>
-            </Card.Footer>
-          </Card>
-        </Modal>
-      </Modal>
-      </div>
-   );
-  }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -90,13 +90,6 @@ export default function ZombiesCharacterSheet() {
     return <div style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${loginbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", minHeight: "100vh"}}>Loading...</div>;
   }
 
-  // Skills and skill points calculation
-  let addedSkillsRanks= [];
-  form.newSkill.map((el) => addedSkillsRanks.push(el[1]));
-  let totalAddedSkills = addedSkillsRanks.reduce((partialSum, a) => Number(partialSum) + Number(a), 0); 
-
-  let skillTotal = SKILLS.reduce((sum, { key }) => sum + form[key], 0);
-
   const itemBonus = (form.item || []).reduce(
     (acc, el) => ({
       str: acc.str + Number(el[2] || 0),
@@ -138,18 +131,6 @@ export default function ZombiesCharacterSheet() {
     wis: Math.floor((computedStats.wis - 10) / 2),
     cha: Math.floor((computedStats.cha - 10) / 2),
   };
-
-  let firstLevelSkill = Math.floor((Number(form.occupation[0].skillMod) + statMods.int) * 4);
-  let allSkillPointsLeft = 0;
-  let skillPointsLeft;
-  for (const occupation of form.occupation) {
-    let occupationLevel = occupation.Occupation === form.occupation[0].Occupation ? occupation.Level - 1 : occupation.Level;
-    const skillMod = Number(occupation.skillMod);
-    skillPointsLeft = Math.floor((skillMod + statMods.int) * occupationLevel);
-    allSkillPointsLeft += skillPointsLeft;
-  }
-  let totalSkillPointsLeft = allSkillPointsLeft + firstLevelSkill - skillTotal - totalAddedSkills;
-  let skillGold = totalSkillPointsLeft === 0 ? "#6C757D" : "gold";
 
   const statNames = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
@@ -250,7 +231,7 @@ return (
             <Nav className="me-auto mx-auto" style={{ backgroundColor: 'transparent' }}>
               <Button onClick={handleShowCharacterInfo} style={{color: "black", padding: "8px", marginTop: "10px"}} className="mx-1 fas fa-image-portrait" variant="secondary"></Button>
               <Button onClick={handleShowStats} style={{color: "black", padding: "8px", marginTop: "10px", backgroundColor: statPointsLeft > 0 ? "gold" : "#6C757D"}} className="mx-1 fas fa-scroll" variant="secondary"></Button>
-              <Button onClick={handleShowSkill} style={{color: "black", padding: "8px", marginTop: "10px", backgroundColor: skillGold}} className="mx-1 fas fa-book-open" variant="secondary"></Button>
+              <Button onClick={handleShowSkill} style={{color: "black", padding: "8px", marginTop: "10px", backgroundColor: "#6C757D"}} className="mx-1 fas fa-book-open" variant="secondary"></Button>
               <Button onClick={handleShowFeats} style={{color: "black", padding: "8px", marginTop: "10px", backgroundColor: featsGold}} className="mx-1 fas fa-hand-fist" variant="secondary"></Button>
               <Button onClick={handleShowWeapons} style={{color: "black", padding: "8px", marginTop: "10px", backgroundColor: "#6C757D"}} className="mx-1 fas fa-wand-sparkles" variant="secondary"></Button>
               <Button onClick={handleShowArmor} style={{color: "black", padding: "8px", marginTop: "10px", backgroundColor: "#6C757D"}} className="mx-1 fas fa-shield" variant="secondary"></Button>   


### PR DESCRIPTION
## Summary
- remove legacy skill point/rank calculations from character sheet
- add proficiency and expertise toggles with automatic proficiency bonus
- compute skill totals as ability mod plus proficiency bonus

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d163b9c4832e86d20ef8cc2240fc