### PR TITLE
Refactor skills handling and track proficiency bonus

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -264,6 +264,7 @@ describe('Character routes', () => {
   test('update skill proficiency calculates correct modifier', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
+        findOne: async () => ({ occupation: [{ Level: 1 }] }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
@@ -282,12 +283,14 @@ describe('Character routes', () => {
       proficient: true,
       expertise: false,
       modifier: 3,
+      proficiencyBonus: 2,
     });
   });
 
   test('update skill expertise doubles proficiency bonus', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
+        findOne: async () => ({ occupation: [{ Level: 1 }] }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
@@ -306,12 +309,14 @@ describe('Character routes', () => {
       proficient: true,
       expertise: true,
       modifier: 5,
+      proficiencyBonus: 2,
     });
   });
 
   test('update skills failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
+        findOne: async () => ({ occupation: [{ Level: 1 }] }),
         findOneAndUpdate: async () => {
           throw new Error('db error');
         },

--- a/server/utils/proficiency.js
+++ b/server/utils/proficiency.js
@@ -1,0 +1,8 @@
+function proficiencyBonus(totalLevel = 0) {
+  if (totalLevel >= 17) return 6;
+  if (totalLevel >= 13) return 5;
+  if (totalLevel >= 9) return 4;
+  if (totalLevel >= 5) return 3;
+  return 2;
+}
+module.exports = proficiencyBonus;


### PR DESCRIPTION
## Summary
- compute proficiency bonus from total level via shared utility
- store and return proficiency bonus when updating skills or levels
- translate occupation skill ranks into structured proficiency/expertise objects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d91deee0832eb1f367f899829644