### PR TITLE
Expose allowed skills whitelist

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -67,7 +67,7 @@ export default function Skills({
 
   const profBonus = proficiencyBonus(totalLevel);
 
-  const selectableSkills = new Set(Object.keys(skills || {}));
+  const selectableSkills = new Set(form.allowedSkills || []);
 
   async function updateSkill(skill, updated) {
     try {

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -29,6 +29,9 @@ module.exports = (router) => {
           ? result.occupation.reduce((sum, o) => sum + (o.Level || 0), 0)
           : 0;
         result.proficiencyBonus = proficiencyBonus(totalLevel);
+        if (!result.allowedSkills) {
+          result.allowedSkills = Object.keys(result.skills || {});
+        }
       }
       res.json(result);
     } catch (err) {
@@ -48,7 +51,11 @@ module.exports = (router) => {
         const totalLevel = Array.isArray(char.occupation)
           ? char.occupation.reduce((sum, o) => sum + (o.Level || 0), 0)
           : 0;
-        return { ...char, proficiencyBonus: proficiencyBonus(totalLevel) };
+        return {
+          ...char,
+          allowedSkills: char.allowedSkills || Object.keys(char.skills || {}),
+          proficiencyBonus: proficiencyBonus(totalLevel),
+        };
       });
       res.json(withBonus);
     } catch (err) {
@@ -88,6 +95,9 @@ module.exports = (router) => {
         skillNames.forEach((skill) => {
           myobj.skills[skill] = { ...skillFields[skill] };
         });
+      }
+      if (!myobj.allowedSkills) {
+         myobj.allowedSkills = Object.keys(myobj.skills);
       }
 
       // derive proficiency bonus from total character level


### PR DESCRIPTION
## Summary
- send an `allowedSkills` whitelist with character data
- honor `allowedSkills` in the Skills component so only permitted proficiencies are selectable

## Testing
- `CI=true npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68b5ed623f88832eb1ef704eb827bca9