### PR TITLE
Add proficiency point tracking and skill limits

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -264,7 +264,12 @@ describe('Character routes', () => {
   test('update skill proficiency calculates correct modifier', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: async () => ({ occupation: [{ Level: 1 }] }),
+        findOne: async () => ({
+          occupation: [{ Level: 1 }],
+          allowedSkills: ['acrobatics'],
+          skills: {},
+          proficiencyPoints: 1,
+        }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
@@ -290,7 +295,12 @@ describe('Character routes', () => {
   test('update skill expertise doubles proficiency bonus', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: async () => ({ occupation: [{ Level: 1 }] }),
+        findOne: async () => ({
+          occupation: [{ Level: 1 }],
+          allowedSkills: ['acrobatics'],
+          skills: {},
+          proficiencyPoints: 1,
+        }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
@@ -316,7 +326,12 @@ describe('Character routes', () => {
   test('update skills failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
-        findOne: async () => ({ occupation: [{ Level: 1 }] }),
+        findOne: async () => ({
+          occupation: [{ Level: 1 }],
+          allowedSkills: ['acrobatics'],
+          skills: {},
+          proficiencyPoints: 1,
+        }),
         findOneAndUpdate: async () => {
           throw new Error('db error');
         },

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -44,6 +44,12 @@ module.exports = (router) => {
           ? result.occupation.reduce((sum, o) => sum + (o.Level || 0), 0)
           : 0;
         result.proficiencyBonus = proficiencyBonus(totalLevel);
+        result.proficiencyPoints = Array.isArray(result.occupation)
+          ? result.occupation.reduce(
+              (sum, o) => sum + (o.proficiencyPoints || 0),
+              0
+            )
+          : 0;
         if (!result.allowedSkills) {
           result.allowedSkills = collectAllowedSkills(result.occupation);
         }
@@ -71,6 +77,12 @@ module.exports = (router) => {
           allowedSkills:
             char.allowedSkills || collectAllowedSkills(char.occupation),
           proficiencyBonus: proficiencyBonus(totalLevel),
+          proficiencyPoints: Array.isArray(char.occupation)
+            ? char.occupation.reduce(
+                (sum, o) => sum + (o.proficiencyPoints || 0),
+                0
+              )
+            : 0,
         };
       });
       res.json(withBonus);
@@ -121,10 +133,16 @@ module.exports = (router) => {
         ? myobj.occupation.reduce((sum, o) => sum + (o.Level || 0), 0)
         : 0;
       myobj.proficiencyBonus = proficiencyBonus(totalLevel);
+      myobj.proficiencyPoints = Array.isArray(myobj.occupation)
+        ? myobj.occupation.reduce(
+            (sum, o) => sum + (o.proficiencyPoints || 0),
+            0
+          )
+        : 0;
 
       try {
         const result = await db_connect.collection('Characters').insertOne(myobj);
-        res.json(result);
+        res.json({ ...result, proficiencyPoints: myobj.proficiencyPoints });
       } catch (err) {
         next(err);
       }


### PR DESCRIPTION
## Summary
- compute and expose cumulative proficiency points for characters
- enforce allowed skills and proficiency point limits when updating proficiencies
- adjust tests for new skill restrictions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f5c21124832ea3b5e4bbb480c3a8