### PR TITLE
feat: compute allowed skills from occupations

### DIFF
--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -50,9 +50,7 @@ module.exports = (router) => {
               0
             )
           : 0;
-        if (!result.allowedSkills) {
-          result.allowedSkills = collectAllowedSkills(result.occupation);
-        }
+        result.allowedSkills = collectAllowedSkills(result.occupation);
       }
       res.json(result);
     } catch (err) {
@@ -74,8 +72,7 @@ module.exports = (router) => {
           : 0;
         return {
           ...char,
-          allowedSkills:
-            char.allowedSkills || collectAllowedSkills(char.occupation),
+          allowedSkills: collectAllowedSkills(char.occupation),
           proficiencyBonus: proficiencyBonus(totalLevel),
           proficiencyPoints: Array.isArray(char.occupation)
             ? char.occupation.reduce(
@@ -124,9 +121,7 @@ module.exports = (router) => {
           myobj.skills[skill] = { ...skillFields[skill] };
         });
       }
-      if (!myobj.allowedSkills) {
-        myobj.allowedSkills = collectAllowedSkills(myobj.occupation);
-      }
+      myobj.allowedSkills = collectAllowedSkills(myobj.occupation);
 
       // derive proficiency bonus from total character level
       const totalLevel = Array.isArray(myobj.occupation)


### PR DESCRIPTION
## Summary
- derive allowedSkills from occupations by unioning proficient skills
- persist computed allowedSkills on character creation and expose in character endpoints
- test allowedSkills persistence and default empty behavior

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68b5f8d1447c832e86cece101ac5f7d7