### PR TITLE
Compute feat slots per occupation levels

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -3,8 +3,9 @@ import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form, Col, Row } from 'react-bootstrap';
 import { useNavigate, useParams } from "react-router-dom";
 import { SKILLS } from "../skillSchema";
+import { calculateFeatPointsLeft } from '../../../utils/featUtils';
 
-export default function Feats({ form, showFeats, handleCloseFeats, totalLevel }) {
+export default function Feats({ form, showFeats, handleCloseFeats }) {
   const params = useParams();
   const navigate = useNavigate();
   //----------------------------------------------Feats Section-----------------------------------------------------------------
@@ -67,8 +68,7 @@ export default function Feats({ form, showFeats, handleCloseFeats, totalLevel })
   };
 
   // ---------------------------------------Feats left-----------------------------------------------------
-  const activeFeats = form.feat.filter(f => f.featName && f.featName !== "").length;
-  const featPointsLeft = Math.floor(totalLevel / 3) + 1 - activeFeats;
+  const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
   const showFeatBtn = featPointsLeft > 0 ? "" : "none";
 
   // ----------------------------------------Fetch Feats-----------------------------------

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -8,6 +8,7 @@ import CharacterInfo from "../attributes/CharacterInfo";
 import Stats from "../attributes/Stats";
 import Skills from "../attributes/Skills";
 import Feats from "../attributes/Feats";
+import { calculateFeatPointsLeft } from '../../../utils/featUtils';
 import Weapons from "../attributes/Weapons";
 import PlayerTurnActions from "../attributes/PlayerTurnActions";
 import Armor from "../attributes/Armor";
@@ -161,8 +162,7 @@ const featBonuses = (form.feat || []).reduce(
   }
 );
 
-const activeFeats = form.feat.filter((feat) => feat.featName !== "").length;
-const featPointsLeft = Math.floor(totalLevel / 3) + 1 - activeFeats;
+const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
 const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
 // ------------------------------------------Attack Bonus---------------------------------------------------
 let atkBonus = 0;
@@ -248,7 +248,7 @@ return (
         <CharacterInfo form={form} show={showCharacterInfo} handleClose={handleCloseCharacterInfo} />
         <Skills form={form} showSkill={showSkill} handleCloseSkill={handleCloseSkill} totalLevel={totalLevel} strMod={statMods.str} dexMod={statMods.dex} conMod={statMods.con} intMod={statMods.int} chaMod={statMods.cha} wisMod={statMods.wis} onSkillsChange={(skills) => setForm(prev => ({ ...prev, skills }))} />
         <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} totalLevel={totalLevel} />
-        <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} totalLevel={totalLevel} />
+        <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} />
         <Weapons form={form} showWeapons={showWeapons} handleCloseWeapons={handleCloseWeapons} strMod={statMods.str} dexMod={statMods.dex}/>
         <Armor form={form} showArmor={showArmor} handleCloseArmor={handleCloseArmor} dexMod={statMods.dex} />
         <Items form={form} showItems={showItems} handleCloseItems={handleCloseItems} />

--- a/client/src/utils/featUtils.js
+++ b/client/src/utils/featUtils.js
@@ -1,0 +1,23 @@
+export function calculateFeatPointsLeft(occupations = [], feats = []) {
+  const thresholds = [4, 8, 12, 16, 19];
+  const totalSlots = (Array.isArray(occupations) ? occupations : []).reduce(
+    (total, occ) => {
+      const level = Number(occ.Level) || 0;
+      const name = occ.Name || occ.Occupation || '';
+      let count = thresholds.filter((t) => level >= t).length;
+      if (name === 'Fighter') {
+        if (level >= 6) count += 1;
+        if (level >= 14) count += 1;
+      }
+      if (name === 'Rogue' && level >= 10) {
+        count += 1;
+      }
+      return total + count;
+    },
+    0
+  );
+  const activeFeats = Array.isArray(feats)
+    ? feats.filter((f) => f.featName && f.featName !== '').length
+    : 0;
+  return totalSlots - activeFeats;
+}


### PR DESCRIPTION
## Summary
- derive feat slot counts from occupation levels with class-specific bonuses
- centralize feat point calculation in new `calculateFeatPointsLeft` helper
- remove `totalLevel` prop and update feat components to use shared helper

## Testing
- `npm test --prefix client`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68b6014ae76c832e9f81742d5e9feafb