### PR TITLE
Remove level-based stat gains

### DIFF
--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -3,7 +3,7 @@ import apiFetch from '../../../utils/apiFetch';
 import { Card, Table, Modal, Button } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
 
-export default function Stats({ form, showStats, handleCloseStats, totalLevel }) {
+export default function Stats({ form, showStats, handleCloseStats }) {
   const params = useParams();
   const navigate = useNavigate();
 
@@ -54,9 +54,11 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
   const [statPointsLeft, setStatPointsLeft] = useState(0);
 
   useEffect(() => {
-    const pointsUsed = Object.values(stats).reduce((a, b) => a + b, 0) - startStatTotal;
-    setStatPointsLeft(Math.floor(totalLevel / 4) - pointsUsed);
-  }, [stats, totalLevel, startStatTotal]);
+    const pointsUsed =
+      Object.values(stats).reduce((a, b) => a + b, 0) - startStatTotal;
+    // Characters no longer gain stat points from leveling, so only track points spent
+    setStatPointsLeft(-pointsUsed);
+  }, [stats, startStatTotal]);
 
   async function statsUpdate() {
     await apiFetch(`/characters/update-stats/${params.id}`, {
@@ -103,7 +105,7 @@ export default function Stats({ form, showStats, handleCloseStats, totalLevel })
             <Card.Title className="modal-title">Stats</Card.Title>
           </Card.Header>
           <Card.Body>
-            <div className="points-container" style={{ display: statPointsLeft >= 0 ? "flex" : "none" }}>
+            <div className="points-container" style={{ display: statPointsLeft > 0 ? "flex" : "none" }}>
               <span className="points-label text-light">Points Left:</span>
               <span className="points-value">{isNaN(statPointsLeft) ? 0 : statPointsLeft}</span>
             </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -136,7 +136,8 @@ export default function ZombiesCharacterSheet() {
   const statNames = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
   const statTotal = statNames.reduce((sum, stat) => sum + form[stat], 0);
-  const statPointsLeft = Math.floor((totalLevel / 4) - (statTotal - form.startStatTotal));
+  // Characters no longer receive stat points from leveling
+  const statPointsLeft = form.startStatTotal - statTotal;
 
   const skillPointsLeft =
     (form.proficiencyPoints || 0) -
@@ -247,7 +248,7 @@ return (
         </Navbar>
         <CharacterInfo form={form} show={showCharacterInfo} handleClose={handleCloseCharacterInfo} />
         <Skills form={form} showSkill={showSkill} handleCloseSkill={handleCloseSkill} totalLevel={totalLevel} strMod={statMods.str} dexMod={statMods.dex} conMod={statMods.con} intMod={statMods.int} chaMod={statMods.cha} wisMod={statMods.wis} onSkillsChange={(skills) => setForm(prev => ({ ...prev, skills }))} />
-        <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} totalLevel={totalLevel} />
+        <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
         <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} />
         <Weapons form={form} showWeapons={showWeapons} handleCloseWeapons={handleCloseWeapons} strMod={statMods.str} dexMod={statMods.dex}/>
         <Armor form={form} showArmor={showArmor} handleCloseArmor={handleCloseArmor} dexMod={statMods.dex} />


### PR DESCRIPTION
## Summary
- stop awarding stat points based on level in the Stats modal
- remove level-dependent stat point calculation on the character sheet and Stats button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6094867a4832eaa32317cbe619b0a