### PR TITLE
Add leveling helpers for feats and stat points

### DIFF
--- a/server/__tests__/leveling.test.js
+++ b/server/__tests__/leveling.test.js
@@ -1,0 +1,30 @@
+const { calculateFeatSlots, calculateStatPoints } = require('../utils/leveling');
+
+describe('Leveling helpers', () => {
+  test('non-Fighter/Rogue classes get feats at standard levels', () => {
+    const get = (lvl) => calculateFeatSlots('Wizard', lvl);
+    expect(get(3)).toBe(0);
+    expect(get(4)).toBe(1);
+    expect(get(8)).toBe(2);
+    expect(get(12)).toBe(3);
+    expect(get(16)).toBe(4);
+    expect(get(19)).toBe(5);
+  });
+
+  test('fighters receive additional feats at levels 6 and 14', () => {
+    const get = (lvl) => calculateFeatSlots('Fighter', lvl);
+    expect(get(6)).toBe(2); // 4 and 6
+    expect(get(14)).toBe(5); // 4,6,8,12,14
+  });
+
+  test('rogues receive an additional feat at level 10', () => {
+    const get = (lvl) => calculateFeatSlots('Rogue', lvl);
+    expect(get(10)).toBe(3); // 4,8,10
+  });
+
+  test('no stat points are granted from leveling alone', () => {
+    expect(calculateStatPoints(1)).toBe(0);
+    expect(calculateStatPoints(10)).toBe(0);
+    expect(calculateStatPoints(20)).toBe(0);
+  });
+});

--- a/server/utils/leveling.js
+++ b/server/utils/leveling.js
@@ -1,0 +1,32 @@
+const baseFeatLevels = [4, 8, 12, 16, 19];
+const fighterExtraFeatLevels = [6, 14];
+const rogueExtraFeatLevels = [10];
+
+/**
+ * Calculate the number of feat slots a character has earned for a given class and level.
+ * @param {string} className - The character's class name.
+ * @param {number} level - The level within that class.
+ * @returns {number} Number of feat slots.
+ */
+function calculateFeatSlots(className = '', level = 0) {
+  let slots = baseFeatLevels.filter((l) => l <= level).length;
+  const lower = className.toLowerCase();
+  if (lower === 'fighter') {
+    slots += fighterExtraFeatLevels.filter((l) => l <= level).length;
+  }
+  if (lower === 'rogue') {
+    slots += rogueExtraFeatLevels.filter((l) => l <= level).length;
+  }
+  return slots;
+}
+
+/**
+ * Calculate available stat points from leveling.
+ * Currently characters do not gain stat points from leveling alone.
+ * @returns {number} Always returns 0.
+ */
+function calculateStatPoints() {
+  return 0;
+}
+
+module.exports = { calculateFeatSlots, calculateStatPoints };


### PR DESCRIPTION
## Summary
- add helper functions to compute feat slots per class and stat points
- cover feat and stat progression with unit tests

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68b60a6e6988832e81b10342a63524fb