### PR TITLE
Prevent blank feats from being saved with new characters

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -52,7 +52,7 @@ const createDefaultForm = useCallback((campaign) => {
     characterName: "",
     campaign: campaign.toString(),
     occupation: [""],
-    feat: [createEmptyArray(SKILLS.length + 8)],
+    feat: [],
     weapon: [createEmptyArray(6)],
     armor: [createEmptyArray(4)],
     item: [createEmptyArray(SKILLS.length + 8)],
@@ -228,7 +228,10 @@ useEffect(() => {
 
  // Sends form data to database
    const sendToDb = useCallback(async () => {
-    const newCharacter = { ...form };
+    const newCharacter = {
+      ...form,
+      feat: (form.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
+    };
     try {
       await apiFetch("/characters/add", {
         method: "POST",
@@ -309,7 +312,11 @@ const handleConfirmOccupation = useCallback(() => {
 }, [selectedOccupation, isOccupationConfirmed, form, getOccupation, selectedAddOccupationRef, setForm]);
 
 const sendManualToDb = useCallback(async (characterData) => {
-  const newCharacter = characterData ?? form;
+  const baseCharacter = characterData ?? form;
+  const newCharacter = {
+    ...baseCharacter,
+    feat: (baseCharacter.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
+  };
   if (!newCharacter.occupation?.[0]?.Level) {
     window.alert("Occupation level is required.");
     return;


### PR DESCRIPTION
## Summary
- Initialize new characters with no feats by default
- Filter out empty feat entries before posting new characters in both random and manual creation flows

## Testing
- `CI=true npm test`
- `node - <<'NODE'
const sendToDb = (form) => {
  const newCharacter = {
    ...form,
    feat: (form.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
  };
  return newCharacter;
};
const sendManualToDb = (characterData) => {
  const baseCharacter = characterData;
  const newCharacter = {
    ...baseCharacter,
    feat: (baseCharacter.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
  };
  return newCharacter;
};
const form = {feat: [{featName:'Strong'}, {}, {featName:''}, {featName:' Brave'}]};
console.log('random', sendToDb(form));
console.log('manual', sendManualToDb(form));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b611208b20832ea2321ca23f9b9ade