### PR TITLE
Allow multiple Stat Increase feats

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Characters gain feats instead of automatic ability score increases. Feats are ea
 - **Rogue:** Additional feat at level 10
 
 Ability scores do not automatically increase at any level. To improve statistics, choose feats that grant ability bonuses.
+Most feats may only be selected once per character; however, the **Stat Increase** feat can be taken multiple times.
 
 ## Feats Endpoint
 

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -97,13 +97,19 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
   async function addFeatToDb(e) {
     e.preventDefault();
     if (!addFeat) return;
-    const existingIndex = form.feat.findIndex(f => f.featName === addFeat.featName);
     let updatedFeats;
-    if (existingIndex >= 0) {
-      updatedFeats = [...form.feat];
-      updatedFeats[existingIndex] = addFeat;
-    } else {
+    if (addFeat.featName === 'Stat Increase') {
       updatedFeats = [...form.feat, addFeat];
+    } else {
+      const existingIndex = form.feat.findIndex(
+        (f) => f.featName === addFeat.featName
+      );
+      if (existingIndex >= 0) {
+        updatedFeats = [...form.feat];
+        updatedFeats[existingIndex] = addFeat;
+      } else {
+        updatedFeats = [...form.feat, addFeat];
+      }
     }
     await apiFetch(`/feats/update/${params.id}`, {
       method: "PUT",
@@ -120,8 +126,8 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
     navigate(0);
   }
   // This method will delete a feat
-  function deleteFeats(el) {
-    const updatedFeats = form.feat.filter(f => f.featName !== el.featName);
+  function deleteFeats(index) {
+    const updatedFeats = form.feat.filter((_, i) => i !== index);
     addDeleteFeatToDb(updatedFeats);
   }
   let showDeleteFeatBtn = "";
@@ -181,8 +187,8 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                   </tr>
                 </thead>
                 <tbody>
-                  {form.feat.map((el) => (
-                    <tr key={el.featName}>
+                  {form.feat.map((el, index) => (
+                    <tr key={`${el.featName}-${index}`}>
                       <td>{el.featName}</td>
                       <td style={{ display: showDeleteFeatBtn }}>
                         <Button
@@ -250,7 +256,7 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                           style={{ display: showDeleteFeatBtn }}
                           className="btn-danger action-btn fa-solid fa-trash"
                           onClick={() => {
-                            deleteFeats(el);
+                            deleteFeats(index);
                           }}
                         ></Button>
                       </td>


### PR DESCRIPTION
## Summary
- Allow `Stat Increase` feat to be selected multiple times
- Use index-based keys and deletion logic to support duplicate feats
- Document that only `Stat Increase` can be taken repeatedly

## Testing
- `cd server && npm test`
- `cd client && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b619ee16c0832ea204729c3721dbce