### PR TITLE
Replace blocking alert with inline error in HealthDefense

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -62,22 +62,26 @@ export default function HealthDefense({
     Number(hpMaxBonus) +
     Number(hpMaxBonusPerLevel * totalLevel);
   const [health, setHealth] = useState(); // Initial health value
- // Sends tempHealth data to database for update
- async function tempHealthUpdate(offset){
-    await apiFetch(`/characters/update-temphealth/${params.id}`, {
-     method: "PUT",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify({
-      tempHealth: health + offset,
-     }),
-   })
-   .catch(error => {
-     window.alert(error);
-     return;
-   });
- }
+  const [error, setError] = useState(null); // Error message state
+
+  // Sends tempHealth data to database for update
+  async function tempHealthUpdate(offset) {
+    try {
+      await apiFetch(`/characters/update-temphealth/${params.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tempHealth: health + offset,
+        }),
+      });
+      setError(null);
+    } catch (error) {
+      console.error(error);
+      setError("Failed to update health.");
+    }
+  }
 
   useEffect(() => {
     const parsedValue = parseFloat(form.tempHealth);
@@ -211,8 +215,13 @@ return (
       onMouseLeave={(e) => (e.target.style.transform = "scale(1)")}
     />
   </div>
+  {error && (
+    <div className="text-danger" style={{ marginTop: "8px" }}>
+      {error}
+    </div>
+  )}
 
-    {/* Stats Section */}
+      {/* Stats Section */}
   <div
     style={{
       display: "flex",


### PR DESCRIPTION
## Summary
- handle temp health update errors without blocking alert
- show inline error message and log to console

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b621205390832e8ee37805245e04e3