### PR TITLE
feat: replace alerts with notification system

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,6 +8,7 @@ import ZombiesCharacterSheet from "./components/Zombies/pages/ZombiesCharacterSh
 import ZombiesCharacterSelect from "./components/Zombies/pages/ZombiesCharacterSelect";
 import ZombiesDM from "./components/Zombies/pages/ZombiesDM";
 import Login from "./components/Login/Login";
+import Notifications from "./components/Notifications";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import "./App.scss";
@@ -45,6 +46,7 @@ function AppRoutes() {
 
   return (
     <>
+      <Notifications />
       {!hideNavbarRoutes.includes(location.pathname) && <Navbar />}
       <Routes>
         <Route path="/" element={<Zombies />} />

--- a/client/src/components/Notifications.js
+++ b/client/src/components/Notifications.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { Alert } from 'react-bootstrap';
+import { subscribe } from '../utils/notification';
+
+export default function Notifications() {
+  const [notification, setNotification] = useState(null);
+
+  useEffect(() => {
+    let timer;
+    const unsubscribe = subscribe((n) => {
+      setNotification(n);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setNotification(null), 5000);
+    });
+    return () => {
+      unsubscribe();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (!notification) return null;
+
+  return (
+    <Alert
+      variant={notification.variant}
+      style={{ position: 'fixed', top: 20, right: 20, zIndex: 2000 }}
+    >
+      {notification.message}
+    </Alert>
+  );
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -8,6 +8,7 @@ import loginbg from "../../../images/loginbg.png";
 import useUser from '../../../hooks/useUser';
 import { SKILLS } from "../skillSchema";
 import { STATS } from "../statSchema";
+import { notify } from '../../../utils/notification';
 
 export default function RecordList() {
   const params = useParams();
@@ -24,7 +25,7 @@ export default function RecordList() {
 
       if (!response.ok) {
         const message = `An error occurred: ${response.statusText}`;
-        window.alert(message);
+        notify(message);
         return;
       }
 
@@ -95,13 +96,13 @@ useEffect(() => {
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
-      window.alert(message);
+      notify(message);
       return;
     }
 
     const record = await response.json();
     if (!record) {
-      window.alert(`Record not found`);
+      notify(`Record not found`, 'warning');
       navigate("/");
       return;
     }
@@ -241,7 +242,7 @@ useEffect(() => {
         body: JSON.stringify(newCharacter),
       });
     } catch (error) {
-      window.alert(error);
+      notify(error.toString());
       return;
     };
    setForm(createDefaultForm(params.campaign));
@@ -318,7 +319,7 @@ const sendManualToDb = useCallback(async (characterData) => {
     feat: (baseCharacter.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
   };
   if (!newCharacter.occupation?.[0]?.Level) {
-    window.alert("Occupation level is required.");
+    notify("Occupation level is required.", 'warning');
     return;
   }
   try {
@@ -330,7 +331,7 @@ const sendManualToDb = useCallback(async (characterData) => {
       body: JSON.stringify(newCharacter),
     });
     if (!response.ok) {
-      window.alert(`An error occurred: ${response.statusText}`);
+      notify(`An error occurred: ${response.statusText}`);
       return;
     }
     const { insertedId } = await response.json();
@@ -338,7 +339,7 @@ const sendManualToDb = useCallback(async (characterData) => {
     setRecords((prev) => [...prev, { ...newCharacter, _id: insertedId }]);
     setForm(createDefaultForm(params.campaign));
   } catch (error) {
-    window.alert(error);
+    notify(error.toString());
   }
 }, [form, params.campaign, handleClose5, setRecords, setForm, createDefaultForm]);
 

--- a/client/src/utils/notification.js
+++ b/client/src/utils/notification.js
@@ -1,0 +1,15 @@
+const subscribers = [];
+
+export function notify(message, variant = 'danger') {
+  subscribers.forEach((cb) => cb({ message, variant }));
+}
+
+export function subscribe(callback) {
+  subscribers.push(callback);
+  return () => {
+    const index = subscribers.indexOf(callback);
+    if (index > -1) {
+      subscribers.splice(index, 1);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add simple notification utility and display component
- use notification system instead of blocking alerts in character selection
- wire notifications into app

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b621244350832e8b9a82f68b5cb6b9