### PR TITLE
feat: toggle damage display

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -275,6 +275,12 @@ $rotateX: -$angle;
   background-size: 70px;
 }
 
+#damageAmount.critical-active {
+  border: 2px solid #FFD700;
+  color: #FFD700;
+  box-shadow: 0 0 10px #FFD700;
+}
+
 #damageValue {
   padding-top: 5px;
   display: inline-block; /* Make the text an inline block */

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -194,25 +194,30 @@ const showSparklesEffect = () => {
 //-------------------------------------------------------------Display-----------------------------------------------------------------------------------------
   return (
     <div style={{ marginTop: "-40px", paddingBottom: "80px" }}>
-    <div className={`mt-3 ${loading ? 'loading' : ''} ${pulse ? 'pulse' : ''}`} id="damageAmount" style={{margin: "0 auto"}}>
-      <span id="damageValue" className={loading ? 'hidden' : ''}>
-        {damageValue}
-      </span>
-      <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
-    </div>
-<div style={{ 
-  display: "flex", 
-  justifyContent: "center", 
-  alignItems: "center", 
-  height: "100%", 
-  marginTop: "20px"
-}}>
-  <div style={{ 
-    display: "flex", 
-    flexDirection: "column", 
-    alignItems: "center", 
-    gap: "12px" 
-  }}>
+      <div
+        id="damageAmount"
+        onClick={handleToggle}
+        className={`mt-3 ${loading ? 'loading' : ''} ${pulse ? 'pulse' : ''} ${isGold ? 'critical-active' : ''}`}
+        style={{ margin: "0 auto", cursor: "pointer" }}
+      >
+        <span id="damageValue" className={loading ? 'hidden' : ''}>
+          {damageValue}
+        </span>
+        <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
+      </div>
+      <div style={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        height: "100%",
+        marginTop: "20px"
+      }}>
+        <div style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "12px"
+        }}>
     {/* Critical Hit Toggle (Above) */}
     <button
       onClick={handleToggle}


### PR DESCRIPTION
## Summary
- toggle critical hit by clicking damage display
- highlight damage readout with gold glow when active

## Testing
- `cd client && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b634526e7c832eb06ccd9bf2bbc64d