### PR TITLE
Adjust Zombies layout for full viewport

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Button, Modal, Card, Table } from "react-bootstrap";
 import sword from "../../../images/sword.png";
 
-export default function PlayerTurnActions ({ form, strMod, atkBonus, dexMod }) { 
+export default function PlayerTurnActions ({ form, strMod, atkBonus, dexMod, headerHeight = 0 }) {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
@@ -195,7 +195,7 @@ const showSparklesEffect = () => {
 };
 //-------------------------------------------------------------Display-----------------------------------------------------------------------------------------
   return (
-    <div style={{ marginTop: "-40px", paddingBottom: "80px" }}>
+    <div>
       <div
         id="damageAmount"
         onClick={handleToggle}
@@ -212,7 +212,7 @@ const showSparklesEffect = () => {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          height: `calc(100vh - ${FOOTER_HEIGHT}px)`
+          height: `calc(100vh - ${FOOTER_HEIGHT + headerHeight}px)`
         }}
       >
         <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button } from 'react-bootstrap';
@@ -29,6 +29,15 @@ export default function ZombiesCharacterSheet() {
   const [showArmor, setShowArmor] = useState(false);
   const [showItems, setShowItems] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
+
+  const headerRef = useRef(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight);
+    }
+  }, [form]);
 
   useEffect(() => {
     async function fetchCharacterData(id) {
@@ -198,7 +207,7 @@ return (
     backgroundRepeat: "no-repeat"
   }}
 >
-      <div style={{paddingTop: '80px'}}>
+      <div ref={headerRef}>
       <h1
   style={{
     fontSize: "28px",
@@ -229,7 +238,8 @@ return (
             hpMaxBonus={featBonuses.hpMaxBonus}
             hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
           />
-        <PlayerTurnActions form={form} atkBonus={atkBonus} dexMod={statMods.dex} strMod={statMods.str}/>
+        </div>
+        <PlayerTurnActions form={form} atkBonus={atkBonus} dexMod={statMods.dex} strMod={statMods.str} headerHeight={headerHeight}/>
         <Navbar fixed="bottom" data-bs-theme="dark" style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}>
           <Container style={{ backgroundColor: 'transparent' }}>
             <Nav className="me-auto mx-auto" style={{ backgroundColor: 'transparent' }}>
@@ -252,7 +262,6 @@ return (
         <Armor form={form} showArmor={showArmor} handleCloseArmor={handleCloseArmor} dexMod={statMods.dex} />
         <Items form={form} showItems={showItems} handleCloseItems={handleCloseItems} />
         <Help form={form} showHelpModal={showHelpModal} handleCloseHelpModal={handleCloseHelpModal} />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove extra wrapper spacing from PlayerTurnActions and allow height to account for header
- Replace fixed padding with dynamic header measurement in ZombiesCharacterSheet
- Ensure dice area flexes to remaining viewport between header and footer

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b64131da04832eb0e51bb100183de8