### PR TITLE
Add multiclassing mechanics and endpoint

### DIFF
--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -93,66 +93,27 @@ export default function LevelUp({ show, handleClose, form }) {
       setError('');
       setNotification('');
       const selectedAddOccupation = selectedAddOccupationRef.current.value;
-      const selectedAddOccupationObject = getOccupation.find(
-        (occupation) => occupation.Occupation === selectedAddOccupation
-      );
-
-      const addOccupationHealth = Math.floor(Math.random() * Number(selectedAddOccupationObject.Health)) + 1 + Number(form.health);
-      const addOccupationStrTotal = Number(selectedAddOccupationObject.str) + Number(form.str);
-      const addOccupationDexTotal = Number(selectedAddOccupationObject.dex) + Number(form.dex);
-      const addOccupationConTotal = Number(selectedAddOccupationObject.con) + Number(form.con);
-      const addOccupationIntTotal = Number(selectedAddOccupationObject.int) + Number(form.int);
-      const addOccupationWisTotal = Number(selectedAddOccupationObject.wis) + Number(form.wis);
-      const addOccupationChaTotal = Number(selectedAddOccupationObject.cha) + Number(form.cha);
-
-      const addOccupationStr = Number(selectedAddOccupationObject.str);
-      const addOccupationDex = Number(selectedAddOccupationObject.dex);
-      const addOccupationCon = Number(selectedAddOccupationObject.con);
-      const addOccupationInt = Number(selectedAddOccupationObject.int);
-      const addOccupationWis = Number(selectedAddOccupationObject.wis);
-      const addOccupationCha = Number(selectedAddOccupationObject.cha);
-
-      const totalNewStats = addOccupationStr + addOccupationDex + addOccupationCon + addOccupationInt
-        + addOccupationWis + addOccupationCha;
-
-      const newStartStatTotal = Number(totalNewStats) + Number(form.startStatTotal);
-
-      // Push the selected occupation into form.occupation
-      form.occupation.push(selectedOccupation);
-
       try {
-        await apiFetch(`/characters/update-health/${params.id}`, {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json", // Set content type to JSON
-          },
-          body: JSON.stringify({
-            health: addOccupationHealth,
-            str: addOccupationStrTotal,
-            dex: addOccupationDexTotal,
-            con: addOccupationConTotal,
-            int: addOccupationIntTotal,
-            wis: addOccupationWisTotal,
-            cha: addOccupationChaTotal,
-            startStatTotal: newStartStatTotal
-          }), // Send as a JSON object
-        });
-
-        await apiFetch(`/characters/update-occupations/${params.id}`, {
-          method: "PUT",
+        const response = await apiFetch(`/characters/multiclass/${params.id}`, {
+          method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(form.occupation), // Send the array directly
+          body: JSON.stringify({ newOccupation: selectedAddOccupation }),
         });
-
-        setNotification("Database update complete");
-        navigate(0);
+        const data = await response.json();
+        if (response.ok) {
+          setNotification('Database update complete');
+          navigate(0);
+        } else if (response.status === 400) {
+          setValidationError(data.message || 'Multiclass validation failed');
+        } else {
+          setError(data.message || 'Database update failed');
+        }
       } catch (err) {
         console.error(err);
         setError('Database update failed');
       }
-
       setShowAddClassModal(false);
     } else {
       setValidationError('Please select an occupation.');

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -1,0 +1,117 @@
+const ObjectId = require('mongodb').ObjectId;
+const dbo = require('../db/conn');
+const { skillNames } = require('../routes/fieldConstants');
+
+const prereqs = {
+  barbarian: { all: ['str'], min: 13 },
+  bard: { all: ['cha'], min: 13 },
+  cleric: { all: ['wis'], min: 13 },
+  druid: { all: ['wis'], min: 13 },
+  fighter: { any: ['str', 'dex'], min: 13 },
+  monk: { all: ['dex', 'wis'], min: 13 },
+  paladin: { all: ['str', 'cha'], min: 13 },
+  ranger: { all: ['dex', 'wis'], min: 13 },
+  rogue: { all: ['dex'], min: 13 },
+  sorcerer: { all: ['cha'], min: 13 },
+  warlock: { all: ['cha'], min: 13 },
+  wizard: { all: ['int'], min: 13 },
+};
+
+function canMulticlass(character = {}, newOccupation = '') {
+  const name = typeof newOccupation === 'string' ? newOccupation.toLowerCase() : '';
+  const req = prereqs[name];
+  if (!req) return { allowed: true };
+  if (req.all) {
+    const ok = req.all.every((stat) => Number(character[stat]) >= req.min);
+    if (ok) return { allowed: true };
+    return {
+      allowed: false,
+      message: `Requires ${req.all.map((s) => s.toUpperCase()).join(' and ')} ${req.min}`,
+    };
+  }
+  if (req.any) {
+    const ok = req.any.some((stat) => Number(character[stat]) >= req.min);
+    if (ok) return { allowed: true };
+    return {
+      allowed: false,
+      message: `Requires ${req.any.map((s) => s.toUpperCase()).join(' or ')} ${req.min}`,
+    };
+  }
+  return { allowed: true };
+}
+
+function collectAllowedSkills(occupation = []) {
+  if (!Array.isArray(occupation)) return [];
+  const allowed = new Set();
+  occupation.forEach((occ) => {
+    if (occ && occ.skills && typeof occ.skills === 'object') {
+      Object.keys(occ.skills).forEach((skill) => {
+        if (occ.skills[skill] && occ.skills[skill].proficient) {
+          allowed.add(skill);
+        }
+      });
+    }
+  });
+  return Array.from(allowed);
+}
+
+async function applyMulticlass(characterId, newOccupation) {
+  const db = await dbo();
+  const characters = db.collection('Characters');
+  const occupations = db.collection('Occupations');
+  const _id = new ObjectId(characterId);
+  const character = await characters.findOne({ _id });
+  if (!character) throw new Error('Character not found');
+
+  const exists = Array.isArray(character.occupation)
+    && character.occupation.some((o) => (o.Occupation || o.Name) === newOccupation);
+  if (exists) {
+    return { allowed: false, message: 'Occupation already taken' };
+  }
+
+  const validation = canMulticlass(character, newOccupation);
+  if (!validation.allowed) return validation;
+
+  const occDoc = await occupations.findOne({ Occupation: newOccupation });
+  if (!occDoc) throw new Error('Occupation not found');
+
+  const skills = {};
+  skillNames.forEach((skill) => {
+    const rank = occDoc[skill];
+    let proficient = false;
+    let expertise = false;
+    if (typeof rank === 'number') {
+      proficient = rank > 0;
+      expertise = rank > 1;
+    } else if (occDoc.skills && occDoc.skills[skill]) {
+      ({ proficient = false, expertise = false } = occDoc.skills[skill]);
+    }
+    skills[skill] = { proficient, expertise };
+    delete occDoc[skill];
+  });
+  delete occDoc.skillMod;
+
+  const occEntry = { ...occDoc, Level: 1, skills };
+  const hpGain = Math.floor(Math.random() * occDoc.Health) + 1;
+  const newHealth = (character.health || 0) + hpGain;
+
+  const updatedOccupation = Array.isArray(character.occupation)
+    ? [...character.occupation, occEntry]
+    : [occEntry];
+  const allowedSkills = collectAllowedSkills(updatedOccupation);
+
+  await characters.updateOne(
+    { _id },
+    {
+      $set: {
+        occupation: updatedOccupation,
+        health: newHealth,
+        allowedSkills,
+      },
+    }
+  );
+
+  return { allowed: true, occupation: updatedOccupation, health: newHealth, allowedSkills };
+}
+
+module.exports = { canMulticlass, applyMulticlass };


### PR DESCRIPTION
## Summary
- implement multiclassing utility with ability prerequisite checks
- add `/characters/multiclass/:id` route to apply new occupations
- update client level-up flow to call new endpoint and handle errors
- cover valid and invalid multiclass attempts with tests

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7287355c0832e96fd0d24a12cec8b