### PR TITLE
feat: calculate total feat slots

### DIFF
--- a/server/__tests__/leveling.test.js
+++ b/server/__tests__/leveling.test.js
@@ -1,4 +1,8 @@
-const { calculateFeatSlots, calculateStatPoints } = require('../utils/leveling');
+const {
+  calculateFeatSlots,
+  calculateTotalFeatSlots,
+  calculateStatPoints,
+} = require('../utils/leveling');
 
 describe('Leveling helpers', () => {
   test('non-Fighter/Rogue classes get feats at standard levels', () => {
@@ -20,6 +24,24 @@ describe('Leveling helpers', () => {
   test('rogues receive an additional feat at level 10', () => {
     const get = (lvl) => calculateFeatSlots('Rogue', lvl);
     expect(get(10)).toBe(3); // 4,8,10
+  });
+
+  test('total feat slots are summed across occupations', () => {
+    const occupations = [
+      { className: 'Fighter', level: 6 },
+      { className: 'Wizard', level: 4 },
+    ];
+    // Fighter6 => feats at 4 and 6 (2), Wizard4 => feat at 4 (1)
+    expect(calculateTotalFeatSlots(occupations)).toBe(3);
+  });
+
+  test('total feat slots handle multiple bonus-granting classes', () => {
+    const occupations = [
+      { className: 'Fighter', level: 6 },
+      { className: 'Rogue', level: 10 },
+    ];
+    // Fighter6 => 2, Rogue10 => 3 (4,8,10)
+    expect(calculateTotalFeatSlots(occupations)).toBe(5);
   });
 
   test('no stat points are granted from leveling alone', () => {

--- a/server/utils/leveling.js
+++ b/server/utils/leveling.js
@@ -21,6 +21,19 @@ function calculateFeatSlots(className = '', level = 0) {
 }
 
 /**
+ * Calculate the total number of feat slots across multiple occupations.
+ * @param {Array} occupations - Array of occupations with className and level.
+ * @returns {number} Total feat slots for all occupations.
+ */
+function calculateTotalFeatSlots(occupations = []) {
+  if (!Array.isArray(occupations)) return 0;
+  return occupations.reduce((total, occ) => {
+    const { className = '', level = 0 } = occ || {};
+    return total + calculateFeatSlots(className, level);
+  }, 0);
+}
+
+/**
  * Calculate available stat points from leveling.
  * Currently characters do not gain stat points from leveling alone.
  * @returns {number} Always returns 0.
@@ -29,4 +42,8 @@ function calculateStatPoints() {
   return 0;
 }
 
-module.exports = { calculateFeatSlots, calculateStatPoints };
+module.exports = {
+  calculateFeatSlots,
+  calculateTotalFeatSlots,
+  calculateStatPoints,
+};


### PR DESCRIPTION
## Summary
- add calculateTotalFeatSlots to aggregate feat slots across occupations
- test multiclass feat slot calculations

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68b72bf456a8832eb665c7999fa5cb8c