### PR TITLE
Ensure numeric handling for proficiency points

### DIFF
--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -46,7 +46,7 @@ module.exports = (router) => {
         result.proficiencyBonus = proficiencyBonus(totalLevel);
         result.proficiencyPoints = Array.isArray(result.occupation)
           ? result.occupation.reduce(
-              (sum, o) => sum + (o.proficiencyPoints || 0),
+              (sum, o) => sum + Number(o.proficiencyPoints || 0),
               0
             )
           : 0;
@@ -76,7 +76,7 @@ module.exports = (router) => {
           proficiencyBonus: proficiencyBonus(totalLevel),
           proficiencyPoints: Array.isArray(char.occupation)
             ? char.occupation.reduce(
-                (sum, o) => sum + (o.proficiencyPoints || 0),
+                (sum, o) => sum + Number(o.proficiencyPoints || 0),
                 0
               )
             : 0,
@@ -130,7 +130,7 @@ module.exports = (router) => {
       myobj.proficiencyBonus = proficiencyBonus(totalLevel);
       myobj.proficiencyPoints = Array.isArray(myobj.occupation)
         ? myobj.occupation.reduce(
-            (sum, o) => sum + (o.proficiencyPoints || 0),
+            (sum, o) => sum + Number(o.proficiencyPoints || 0),
             0
           )
         : 0;

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -91,7 +91,12 @@ async function applyMulticlass(characterId, newOccupation) {
   });
   delete occDoc.skillMod;
 
-  const occEntry = { ...occDoc, Level: 1, skills };
+  const occEntry = {
+    ...occDoc,
+    Level: 1,
+    skills,
+    proficiencyPoints: Number(occDoc.proficiencyPoints || 0),
+  };
   const hpGain = Math.floor(Math.random() * occDoc.Health) + 1;
   const newHealth = (character.health || 0) + hpGain;
 


### PR DESCRIPTION
## Summary
- Sum proficiency points numerically in character routes
- Store numeric proficiency points when multiclassing

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e (validation script)` *(fails: Cannot read properties of undefined (reading 'startsWith'))*

------
https://chatgpt.com/codex/tasks/task_e_68b73656e16c832ebf25eb7818a78540