### PR TITLE
feat: sync feat skills with character

### DIFF
--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -7,18 +7,30 @@ const logger = require('../../utils/logger');
 const { numericFields, skillFields, skillNames } = require('../fieldConstants');
 const proficiencyBonus = require('../../utils/proficiency');
 
-const collectAllowedSkills = (occupation) => {
-  if (!Array.isArray(occupation)) return [];
+const collectAllowedSkills = (occupation = [], feat = []) => {
   const allowed = new Set();
-  occupation.forEach((occ) => {
-    if (occ && occ.skills && typeof occ.skills === 'object') {
-      Object.keys(occ.skills).forEach((skill) => {
-        if (occ.skills[skill] && occ.skills[skill].proficient) {
-          allowed.add(skill);
-        }
-      });
-    }
-  });
+  if (Array.isArray(occupation)) {
+    occupation.forEach((occ) => {
+      if (occ && occ.skills && typeof occ.skills === 'object') {
+        Object.keys(occ.skills).forEach((skill) => {
+          if (occ.skills[skill] && occ.skills[skill].proficient) {
+            allowed.add(skill);
+          }
+        });
+      }
+    });
+  }
+  if (Array.isArray(feat)) {
+    feat.forEach((ft) => {
+      if (ft && ft.skills && typeof ft.skills === 'object') {
+        Object.keys(ft.skills).forEach((skill) => {
+          if (ft.skills[skill] && ft.skills[skill].proficient) {
+            allowed.add(skill);
+          }
+        });
+      }
+    });
+  }
   return Array.from(allowed);
 };
 
@@ -50,7 +62,10 @@ module.exports = (router) => {
               0
             )
           : 0;
-        result.allowedSkills = collectAllowedSkills(result.occupation);
+        result.allowedSkills = collectAllowedSkills(
+          result.occupation,
+          result.feat
+        );
       }
       res.json(result);
     } catch (err) {
@@ -72,7 +87,7 @@ module.exports = (router) => {
           : 0;
         return {
           ...char,
-          allowedSkills: collectAllowedSkills(char.occupation),
+          allowedSkills: collectAllowedSkills(char.occupation, char.feat),
           proficiencyBonus: proficiencyBonus(totalLevel),
           proficiencyPoints: Array.isArray(char.occupation)
             ? char.occupation.reduce(
@@ -121,7 +136,7 @@ module.exports = (router) => {
           myobj.skills[skill] = { ...skillFields[skill] };
         });
       }
-      myobj.allowedSkills = collectAllowedSkills(myobj.occupation);
+      myobj.allowedSkills = collectAllowedSkills(myobj.occupation, myobj.feat);
 
       // derive proficiency bonus from total character level
       const totalLevel = Array.isArray(myobj.occupation)

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -3,19 +3,31 @@ const express = require('express');
 const authenticateToken = require('../middleware/auth');
 const proficiencyBonus = require('../utils/proficiency');
 
-// Helper to determine allowed skills from occupations when not precomputed
-const collectAllowedSkills = (occupation) => {
-  if (!Array.isArray(occupation)) return [];
+// Helper to determine allowed skills from occupations and feats when not precomputed
+const collectAllowedSkills = (occupation = [], feat = []) => {
   const allowed = new Set();
-  occupation.forEach((occ) => {
-    if (occ && occ.skills && typeof occ.skills === 'object') {
-      Object.keys(occ.skills).forEach((sk) => {
-        if (occ.skills[sk] && occ.skills[sk].proficient) {
-          allowed.add(sk);
-        }
-      });
-    }
-  });
+  if (Array.isArray(occupation)) {
+    occupation.forEach((occ) => {
+      if (occ && occ.skills && typeof occ.skills === 'object') {
+        Object.keys(occ.skills).forEach((sk) => {
+          if (occ.skills[sk] && occ.skills[sk].proficient) {
+            allowed.add(sk);
+          }
+        });
+      }
+    });
+  }
+  if (Array.isArray(feat)) {
+    feat.forEach((ft) => {
+      if (ft && ft.skills && typeof ft.skills === 'object') {
+        Object.keys(ft.skills).forEach((sk) => {
+          if (ft.skills[sk] && ft.skills[sk].proficient) {
+            allowed.add(sk);
+          }
+        });
+      }
+    });
+  }
   return Array.from(allowed);
 };
 
@@ -72,7 +84,8 @@ module.exports = (router) => {
         return res.status(404).json({ message: 'Character not found' });
       }
 
-      const allowedSkills = charDoc.allowedSkills || collectAllowedSkills(charDoc.occupation);
+      const allowedSkills =
+        charDoc.allowedSkills || collectAllowedSkills(charDoc.occupation, charDoc.feat);
       if (!allowedSkills.includes(skill)) {
         return res.status(400).json({ message: 'Skill not allowed' });
       }


### PR DESCRIPTION
## Summary
- ensure feat updates also adjust character skills & allowed skills
- aggregate skill allowances from both occupations and feats
- test feat skill propagation and removal

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b773aea8fc832eb804e13d7cd4c100