### PR TITLE
feat: allow skill choices for feats

### DIFF
--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -133,6 +133,15 @@ module.exports = (router) => {
     const id = { _id: ObjectId(req.params.id) };
     const db_connect = req.db;
     const newFeats = Array.isArray(req.body.feat) ? req.body.feat : [];
+    const incomingSkills = req.body.skills || {};
+    const featName = req.body.featName;
+
+    if (featName && newFeats.length) {
+      const featIndex = newFeats.findIndex((f) => f.featName === featName);
+      if (featIndex >= 0) {
+        newFeats[featIndex].skills = incomingSkills;
+      }
+    }
 
     try {
       const character = await db_connect.collection('Characters').findOne(id);


### PR DESCRIPTION
## Summary
- add multi-select for feat-granted skill or tool proficiencies
- persist chosen proficiencies and update character skills on the server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b77c125150832eb7ad4fc728388856