### PR TITLE
Preserve feat skill selections when editing

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -111,7 +111,10 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
       baseFeat.int = featObj.int ?? 0;
       baseFeat.wis = featObj.wis ?? 0;
       baseFeat.cha = featObj.cha ?? 0;
-      baseFeat.skills = existingFeat?.skills || {};
+      baseFeat.skills = featObj.skills || {};
+      if (existingFeat?.skills) {
+        baseFeat.skills = { ...baseFeat.skills, ...existingFeat.skills };
+      }
       setSkillSelections(Object.keys(baseFeat.skills));
       setAddFeat(baseFeat);
     } else {
@@ -151,7 +154,10 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
       return acc;
     }, {});
     setSkillSelections(selected);
-    setAddFeat((prev) => ({ ...prev, skills: skillsObj }));
+    setAddFeat((prev) => ({
+      ...prev,
+      skills: { ...(prev.skills || {}), ...skillsObj },
+    }));
   };
 
   // ---------------------------------------Feats left-----------------------------------------------------


### PR DESCRIPTION
## Summary
- Initialize feat skill selections from base feat defaults and merge existing skills when editing
- Merge new skill choices with existing selections instead of replacing them

## Testing
- `cd client && CI=true npm test`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b782331d94832e85d4bb06c0819181