### PR TITLE
feat: broaden skill choice detection

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -72,10 +72,15 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
   const [skillSelections, setSkillSelections] = useState([]);
   const [notification, setNotification] = useState(null);
 
-  const hasSkillChoice = Boolean(
-    selectedFeatData?.skillChoiceCount ||
-    selectedFeatData?.skillChoices ||
-    selectedFeatData?.skillOptions
+  const skillChoiceFields = [
+    'skillChoiceCount',
+    'skillChoices',
+    'skillOptions',
+    'skillChoice',
+    'skillProficiencies',
+  ];
+  const hasSkillChoice = skillChoiceFields.some(
+    (field) => selectedFeatData?.[field]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- support additional feat properties (`skillChoice`, `skillProficiencies`) when determining if a feat offers skill selections
- centralize skill-choice field list for easier future maintenance

## Testing
- `cd client && CI=true npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b782c4e73c832ea8f24b1cac778d3b