### PR TITLE
Handle skill/tool proficiency choices on feats

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -78,10 +78,15 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
     'skillOptions',
     'skillChoice',
     'skillProficiencies',
+    'toolChoiceCount',
+    'toolChoices',
+    'toolOptions',
+    'toolChoice',
+    'toolProficiencies',
   ];
-  const hasSkillChoice = skillChoiceFields.some(
-    (field) => selectedFeatData?.[field]
-  );
+  const hasSkillChoice =
+    skillChoiceFields.some((field) => selectedFeatData?.[field]) ||
+    selectedFeatData?.featName === 'Skilled';
 
   useEffect(() => {
     if (notification) {

--- a/client/src/components/Zombies/attributes/Feats.test.js
+++ b/client/src/components/Zombies/attributes/Feats.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Feats from './Feats';
+
+jest.mock('../../../utils/apiFetch');
+import apiFetch from '../../../utils/apiFetch';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+  useParams: () => ({ id: '1' }),
+}));
+
+async function renderWithFeat(featData) {
+  apiFetch.mockReset();
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => [featData],
+  });
+  const form = { feat: [], occupation: [{ Level: 4, Name: 'Fighter' }] };
+  render(<Feats form={form} showFeats={true} handleCloseFeats={() => {}} />);
+  await screen.findByRole('option', { name: featData.featName });
+  await userEvent.selectOptions(
+    screen.getByRole('combobox'),
+    featData.featName
+  );
+}
+
+describe('Feats skill selection', () => {
+  test('renders for skill choices', async () => {
+    await renderWithFeat({ featName: 'SkillFeat', skillChoiceCount: 1 });
+    expect(
+      await screen.findByText('Skill/Tool Proficiencies')
+    ).toBeInTheDocument();
+  });
+
+  test('renders for tool proficiencies', async () => {
+    await renderWithFeat({ featName: 'ToolFeat', toolProficiencies: ['smithsTools'] });
+    expect(
+      await screen.findByText('Skill/Tool Proficiencies')
+    ).toBeInTheDocument();
+  });
+
+  test('renders for Skilled feat', async () => {
+    await renderWithFeat({ featName: 'Skilled' });
+    expect(
+      await screen.findByText('Skill/Tool Proficiencies')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Expand skill choice detection to include tool proficiency fields and handle the Skilled feat
- Test that feats with selectable skills or tools render a proficiency multi-select

## Testing
- `cd client && npm test -- --watchAll=false`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b78598ae78832e9aa006f860a798ea