### PR TITLE
fix: merge feat skills with existing selections

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -121,10 +121,10 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
       baseFeat.int = featObj.int ?? 0;
       baseFeat.wis = featObj.wis ?? 0;
       baseFeat.cha = featObj.cha ?? 0;
-      baseFeat.skills = featObj.skills || {};
-      if (existingFeat?.skills) {
-        baseFeat.skills = { ...baseFeat.skills, ...existingFeat.skills };
-      }
+      baseFeat.skills = {
+        ...(featObj.skills || {}),
+        ...(existingFeat?.skills || {}),
+      };
       setSkillSelections(Object.keys(baseFeat.skills));
       setAddFeat(baseFeat);
     } else {


### PR DESCRIPTION
## Summary
- merge base feat skills with existing selections when editing feats

## Testing
- `cd client && CI=true npm test src/components/Zombies/attributes/Feats.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b787fb83f8832eb8370d7f838b6f1f