### PR TITLE
feat: limit feat proficiency selections

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -88,6 +88,12 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
     skillChoiceFields.some((field) => selectedFeatData?.[field]) ||
     selectedFeatData?.featName === 'Skilled';
 
+  // Determine how many skills a user may select for the chosen feat.
+  const skillLimit = Math.min(
+    selectedFeatData?.skillChoiceCount || SKILL_SELECT_LIMIT,
+    SKILL_SELECT_LIMIT
+  );
+
   useEffect(() => {
     if (notification) {
       const timer = setTimeout(() => setNotification(null), 3000);
@@ -151,13 +157,9 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
 
   const handleSkillChoice = (e) => {
     // Determine if the selected feat allows the user to pick proficiencies.
-    const limit = Math.min(
-      selectedFeatData?.skillChoiceCount || SKILL_SELECT_LIMIT,
-      SKILL_SELECT_LIMIT
-    );
     let selected = Array.from(e.target.selectedOptions).map((opt) => opt.value);
-    if (selected.length > limit) {
-      selected = selected.slice(0, limit);
+    if (selected.length > skillLimit) {
+      selected = selected.slice(0, skillLimit);
     }
     const skillsObj = selected.reduce((acc, key) => {
       acc[key] = { proficient: true };
@@ -459,15 +461,25 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                           value={skillSelections}
                           onChange={handleSkillChoice}
                         >
-                          {ALL_SKILLS.map(({ key, label }) => (
-                            <option key={key} value={key}>
-                              {label}
-                            </option>
-                          ))}
+                          {ALL_SKILLS.map(({ key, label }) => {
+                            const selected = skillSelections.includes(key);
+                            const disabled =
+                              !selected && skillSelections.length >= skillLimit;
+                            return (
+                              <option key={key} value={key} disabled={disabled}>
+                                {label}
+                              </option>
+                            );
+                          })}
                         </Form.Select>
                         <Form.Text className="text-light">
-                          Select up to {Math.min(selectedFeatData?.skillChoiceCount || SKILL_SELECT_LIMIT, SKILL_SELECT_LIMIT)}
+                          Select up to {skillLimit}
                         </Form.Text>
+                        {skillSelections.length >= skillLimit && (
+                          <Form.Text className="text-danger">
+                            Maximum skill selections reached
+                          </Form.Text>
+                        )}
                       </Form.Group>
                     )}
 

--- a/client/src/components/Zombies/attributes/Feats.test.js
+++ b/client/src/components/Zombies/attributes/Feats.test.js
@@ -96,3 +96,20 @@ describe('Feats skill persistence', () => {
     ).toBe(true);
   });
 });
+
+describe('Feats skill limits', () => {
+  test('disables additional options once limit is reached', async () => {
+    const featData = {
+      featName: 'SkillFeat',
+      skillChoiceCount: 2,
+    };
+    await renderWithFeat(featData);
+    const select = screen.getByRole('listbox');
+    await userEvent.selectOptions(select, ['Acrobatics', 'Stealth']);
+    const arcanaOption = screen.getByRole('option', { name: 'Arcana' });
+    expect(arcanaOption.disabled).toBe(true);
+    await userEvent.selectOptions(select, 'Arcana');
+    expect(arcanaOption.selected).toBe(false);
+    expect(select.selectedOptions).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- disable additional skill/tool options once feat selection limit is reached and show a warning
- test that skill selection for feats does not exceed permitted limit

## Testing
- `CI=true npm test src/components/Zombies/attributes/Feats.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b78c315dd8832ea6833d5bc8eb0535