### PR TITLE
Prevent selecting existing proficiencies in feat picker

### DIFF
--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -94,6 +94,15 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
     SKILL_SELECT_LIMIT
   );
 
+  // Track the character's existing skill and tool proficiencies so feats
+  // can't grant duplicates. The form.skills object stores both skills and
+  // tools with a `proficient` flag.
+  const existingProficiencies = new Set(
+    Object.entries(form.skills || {})
+      .filter(([, value]) => value?.proficient)
+      .map(([key]) => key)
+  );
+
   useEffect(() => {
     if (notification) {
       const timer = setTimeout(() => setNotification(null), 3000);
@@ -463,8 +472,10 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                         >
                           {ALL_SKILLS.map(({ key, label }) => {
                             const selected = skillSelections.includes(key);
+                            const alreadyProficient = existingProficiencies.has(key);
                             const disabled =
-                              !selected && skillSelections.length >= skillLimit;
+                              (!selected && skillSelections.length >= skillLimit) ||
+                              (!selected && alreadyProficient);
                             return (
                               <option key={key} value={key} disabled={disabled}>
                                 {label}

--- a/client/src/components/Zombies/attributes/Feats.test.js
+++ b/client/src/components/Zombies/attributes/Feats.test.js
@@ -113,3 +113,23 @@ describe('Feats skill limits', () => {
     expect(select.selectedOptions).toHaveLength(2);
   });
 });
+
+describe('Feats existing proficiencies', () => {
+  test('disables skills the character is already proficient in', async () => {
+    await renderWithFeat({ featName: 'Skilled' }, {
+      skills: { stealth: { proficient: true } },
+    });
+    expect(
+      screen.getByRole('option', { name: 'Stealth' }).disabled
+    ).toBe(true);
+  });
+
+  test('disables tool proficiencies the character already has', async () => {
+    await renderWithFeat({ featName: 'Skilled' }, {
+      skills: { smithsTools: { proficient: true } },
+    });
+    expect(
+      screen.getByRole('option', { name: "Smith's Tools" }).disabled
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- build set of a character's current skill and tool proficiencies
- disable skill/tool options in feat modal if already proficient
- add tests ensuring existing proficiencies are excluded

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b790b9d26c832e91e5e0d2550529b5