### PR TITLE
Add DnD 5e race support

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -47,6 +47,10 @@ export default function CharacterInfo({ form, show, handleClose }) {
                 </td>
               </tr>
               <tr>
+                <th>Race</th>
+                <td>{form.race?.name || ''}</td>
+              </tr>
+              <tr>
                 <th>Age</th>
                 <td>{form.age}</td>
               </tr>

--- a/client/src/components/Zombies/attributes/Race.js
+++ b/client/src/components/Zombies/attributes/Race.js
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import apiFetch from '../../../utils/apiFetch';
+import { Modal, Card, Button, Form } from 'react-bootstrap';
+import { useParams } from 'react-router-dom';
+import { SKILLS } from '../skillSchema';
+
+export default function Race({ form, showRace, handleCloseRace, onRaceChange }) {
+  const params = useParams();
+  const [races, setRaces] = useState({});
+  const [selectedKey, setSelectedKey] = useState('');
+  const [selectedRace, setSelectedRace] = useState(null);
+  const [abilitySelections, setAbilitySelections] = useState({});
+  const [skillSelections, setSkillSelections] = useState([]);
+
+  useEffect(() => {
+    if (!showRace) return;
+    async function fetchRaces() {
+      const res = await apiFetch('/races');
+      const data = await res.json();
+      setRaces(data);
+    }
+    fetchRaces();
+  }, [showRace]);
+
+  const handleSelectRace = (e) => {
+    const key = e.target.value;
+    setSelectedKey(key);
+    const race = races[key];
+    setSelectedRace(race || null);
+    setAbilitySelections({});
+    setSkillSelections([]);
+  };
+
+  const handleAbilityChoice = (index, ability) => {
+    setAbilitySelections((prev) => ({ ...prev, [index]: ability }));
+  };
+
+  const handleSkillChoice = (e) => {
+    let selected = Array.from(e.target.selectedOptions).map((o) => o.value);
+    const limit = selectedRace?.skillChoices?.count || selected.length;
+    if (selected.length > limit) selected = selected.slice(0, limit);
+    setSkillSelections(selected);
+  };
+
+  const saveRace = async () => {
+    if (!selectedRace) return;
+    const raceObj = JSON.parse(JSON.stringify(selectedRace));
+    if (raceObj.abilityChoices) {
+      Object.values(abilitySelections).forEach((ab) => {
+        if (ab) {
+          raceObj.abilities[ab] = (raceObj.abilities[ab] || 0) + 1;
+        }
+      });
+      delete raceObj.abilityChoices;
+    }
+    if (raceObj.skillChoices) {
+      const skills = raceObj.skills || {};
+      skillSelections.forEach((sk) => {
+        skills[sk] = { proficient: true };
+      });
+      raceObj.skills = skills;
+      delete raceObj.skillChoices;
+    }
+    const res = await apiFetch(`/characters/${params.id}/race`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ race: raceObj }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      onRaceChange?.(data);
+      handleCloseRace();
+    }
+  };
+
+  const existingProfs = new Set(
+    Object.entries(form.skills || {}).filter(([, v]) => v?.proficient).map(([k]) => k)
+  );
+
+  const skillOptions = SKILLS.filter(({ key }) => !existingProfs.has(key));
+
+  return (
+    <Modal className="dnd-modal modern-modal" show={showRace} onHide={handleCloseRace} centered scrollable>
+      <Card className="modern-card text-center">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Race</Card.Title>
+        </Card.Header>
+        <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+          <Form>
+            <Form.Group className="mb-3">
+              <Form.Label className="text-light">Select Race</Form.Label>
+              <Form.Select value={selectedKey} onChange={handleSelectRace}>
+                <option value="">Choose...</option>
+                {Object.keys(races).map((key) => (
+                  <option key={key} value={key}>{races[key].name}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+            {selectedRace?.abilityChoices && (
+              <div>
+                {[...Array(selectedRace.abilityChoices.count)].map((_, idx) => (
+                  <Form.Group className="mb-2" key={idx}>
+                    <Form.Label className="text-light">Ability Choice {idx + 1}</Form.Label>
+                    <Form.Select value={abilitySelections[idx] || ''} onChange={(e) => handleAbilityChoice(idx, e.target.value)}>
+                      <option value="">Choose...</option>
+                      {selectedRace.abilityChoices.options.map((ab) => (
+                        <option key={ab} value={ab}>{ab.toUpperCase()}</option>
+                      ))}
+                    </Form.Select>
+                  </Form.Group>
+                ))}
+              </div>
+            )}
+            {selectedRace?.skillChoices && (
+              <Form.Group className="mb-3">
+                <Form.Label className="text-light">Skill Choices</Form.Label>
+                <Form.Select multiple value={skillSelections} onChange={handleSkillChoice}>
+                  {skillOptions.map(({ key, label }) => (
+                    <option key={key} value={key}>{label}</option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            )}
+          </Form>
+        </Card.Body>
+        <Card.Footer className="modal-footer">
+          <Button className="action-btn" variant="secondary" onClick={saveRace}>Save</Button>
+          <Button className="action-btn close-btn" variant="secondary" onClick={handleCloseRace}>Close</Button>
+        </Card.Footer>
+      </Card>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -81,6 +81,11 @@ export default function Skills({
     return acc;
   }, {});
 
+  const raceTotals = SKILLS.reduce((acc, { key }) => {
+    acc[key] = Number(form.race?.[key] || 0);
+    return acc;
+  }, {});
+
   const profBonus = proficiencyBonus(totalLevel);
 
   const selectableSkills = new Set(form.allowedSkills || []);
@@ -187,7 +192,8 @@ export default function Skills({
                   profBonus * multiplier +
                   penalty +
                   itemTotals[key] +
-                  featTotals[key];
+                  featTotals[key] +
+                  raceTotals[key];
                 const isSelectable = selectableSkills.has(key);
                 return (
                   <tr key={key}>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -36,8 +36,14 @@ export default function Stats({ form, showStats, handleCloseStats }) {
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );
 
+  const raceBonus = form.race?.abilities || {};
+
   const computedStats = Object.keys(stats).reduce((acc, key) => {
-    acc[key] = stats[key] + totalItemBonus[key] + totalFeatBonus[key];
+    acc[key] =
+      stats[key] +
+      totalItemBonus[key] +
+      totalFeatBonus[key] +
+      (raceBonus[key] || 0);
     return acc;
   }, {});
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -53,6 +53,7 @@ const createDefaultForm = useCallback((campaign) => {
     characterName: "",
     campaign: campaign.toString(),
     occupation: [""],
+    race: null,
     feat: [],
     weapon: [createEmptyArray(6)],
     armor: [createEmptyArray(4)],
@@ -80,9 +81,11 @@ useEffect(() => {
   }
 }, [user]);
 
-const [occupation, setOccupation] = useState({ 
-  occupation: [], 
+const [occupation, setOccupation] = useState({
+  occupation: [],
 });
+
+const [races, setRaces] = useState({});
 
 const [show, setShow] = useState(false);
 const handleClose = () => setShow(false);
@@ -114,6 +117,21 @@ useEffect(() => {
   return;
 
 }, [navigate, user]);
+
+// Fetch Races
+useEffect(() => {
+  if (!user) return;
+  async function fetchRaces() {
+    const response = await apiFetch(`/races`);
+    if (!response.ok) {
+      notify(`An error has occurred: ${response.statusText}`);
+      return;
+    }
+    const data = await response.json();
+    setRaces(data);
+  }
+  fetchRaces();
+}, [user]);
 
 // Update the state properties.
 function updateForm(value) {
@@ -262,6 +280,12 @@ const [getOccupation, setGetOccupation] = useState([]);
 const handleOccupationChange = (event) => {
   const selectedIndex = event.target.selectedIndex;
   setSelectedOccupation(getOccupation[selectedIndex - 1]); // Subtract 1 because the first option is empty
+};
+
+const handleRaceChange = (e) => {
+  const key = e.target.value;
+  const raceObj = races[key] || null;
+  updateForm({ race: raceObj, speed: raceObj ? raceObj.speed : 0 });
 };
 
 const [isOccupationConfirmed, setIsOccupationConfirmed] = useState(false);
@@ -467,7 +491,14 @@ const onSubmitManual = async (e) => {
               {getOccupation.map((occupation, i) => (
                 <option key={i}>{occupation.Occupation}</option>
               ))}
-            </Form.Select>  
+            </Form.Select>
+        <Form.Label className="text-light">Race</Form.Label>
+        <Form.Select onChange={handleRaceChange} defaultValue="">
+          <option value="" disabled>Select your race</option>
+          {Object.keys(races).map((key) => (
+            <option key={key} value={key}>{races[key].name}</option>
+          ))}
+        </Form.Select>
          <Form.Label className="text-light">Age</Form.Label>
        <Form.Control className="mb-2" onChange={(e) => updateForm({ age: e.target.value })}
         type="number" placeholder="Enter age" pattern="[0-9]*" />

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -8,6 +8,7 @@ import CharacterInfo from "../attributes/CharacterInfo";
 import Stats from "../attributes/Stats";
 import Skills from "../attributes/Skills";
 import Feats from "../attributes/Feats";
+import Race from "../attributes/Race";
 import { calculateFeatPointsLeft } from '../../../utils/featUtils';
 import Weapons from "../attributes/Weapons";
 import PlayerTurnActions from "../attributes/PlayerTurnActions";
@@ -27,6 +28,7 @@ export default function ZombiesCharacterSheet() {
   const [showStats, setShowStats] = useState(false);
   const [showSkill, setShowSkill] = useState(false); // State for skills modal
   const [showFeats, setShowFeats] = useState(false);
+  const [showRace, setShowRace] = useState(false);
   const [showWeapons, setShowWeapons] = useState(false);
   const [showArmor, setShowArmor] = useState(false);
   const [showItems, setShowItems] = useState(false);
@@ -96,7 +98,9 @@ export default function ZombiesCharacterSheet() {
   const handleShowSkill = () => setShowSkill(true); // Handler to show skills modal
   const handleCloseSkill = () => setShowSkill(false); // Handler to close skills modal
   const handleShowFeats = () => setShowFeats(true);
-  const handleCloseFeats = () => setShowFeats(false); 
+  const handleCloseFeats = () => setShowFeats(false);
+  const handleShowRace = () => setShowRace(true);
+  const handleCloseRace = () => setShowRace(false);
   const handleShowWeapons = () => setShowWeapons(true);
   const handleCloseWeapons = () => setShowWeapons(false); 
   const handleShowArmor = () => setShowArmor(true);
@@ -135,12 +139,12 @@ export default function ZombiesCharacterSheet() {
   );
 
   const computedStats = {
-    str: form.str + itemBonus.str + featBonus.str,
-    dex: form.dex + itemBonus.dex + featBonus.dex,
-    con: form.con + itemBonus.con + featBonus.con,
-    int: form.int + itemBonus.int + featBonus.int,
-    wis: form.wis + itemBonus.wis + featBonus.wis,
-    cha: form.cha + itemBonus.cha + featBonus.cha,
+    str: form.str + itemBonus.str + featBonus.str + (form.race?.abilities?.str || 0),
+    dex: form.dex + itemBonus.dex + featBonus.dex + (form.race?.abilities?.dex || 0),
+    con: form.con + itemBonus.con + featBonus.con + (form.race?.abilities?.con || 0),
+    int: form.int + itemBonus.int + featBonus.int + (form.race?.abilities?.int || 0),
+    wis: form.wis + itemBonus.wis + featBonus.wis + (form.race?.abilities?.wis || 0),
+    cha: form.cha + itemBonus.cha + featBonus.cha + (form.race?.abilities?.cha || 0),
   };
 
   const statMods = {
@@ -306,6 +310,17 @@ return (
             variant="secondary"
           ></Button>
           <Button
+            onClick={handleShowRace}
+            style={{
+              color: "black",
+              padding: "8px",
+              marginTop: "10px",
+              backgroundColor: "#6C757D",
+            }}
+            className="mx-1 fa-solid fa-person-running"
+            variant="secondary"
+          ></Button>
+          <Button
             onClick={handleShowWeapons}
             style={{
               color: "black",
@@ -367,6 +382,7 @@ return (
     />
     <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
     <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} />
+    <Race form={form} showRace={showRace} handleCloseRace={handleCloseRace} onRaceChange={(updated) => setForm((prev) => ({ ...prev, ...updated }))} />
     <Weapons
       form={form}
       showWeapons={showWeapons}

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -1,0 +1,69 @@
+const races = {
+  human: {
+    name: "Human",
+    speed: 30,
+    abilities: { str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1 },
+    skills: {},
+    languages: ["Common", "Choice"],
+  },
+  dwarf: {
+    name: "Dwarf",
+    speed: 25,
+    abilities: { con: 2 },
+    skills: {},
+    languages: ["Common", "Dwarvish"],
+  },
+  elf: {
+    name: "Elf",
+    speed: 30,
+    abilities: { dex: 2 },
+    skills: { perception: { proficient: true } },
+    languages: ["Common", "Elvish"],
+  },
+  halfling: {
+    name: "Halfling",
+    speed: 25,
+    abilities: { dex: 2 },
+    skills: {},
+    languages: ["Common", "Halfling"],
+  },
+  dragonborn: {
+    name: "Dragonborn",
+    speed: 30,
+    abilities: { str: 2, cha: 1 },
+    skills: {},
+    languages: ["Common", "Draconic"],
+  },
+  gnome: {
+    name: "Gnome",
+    speed: 25,
+    abilities: { int: 2 },
+    skills: {},
+    languages: ["Common", "Gnomish"],
+  },
+  "half-elf": {
+    name: "Half-Elf",
+    speed: 30,
+    abilities: { cha: 2 },
+    abilityChoices: { count: 2, options: ["str", "dex", "con", "int", "wis"] },
+    skillChoices: { count: 2 },
+    skills: {},
+    languages: ["Common", "Elvish", "Choice"],
+  },
+  "half-orc": {
+    name: "Half-Orc",
+    speed: 30,
+    abilities: { str: 2, con: 1 },
+    skills: { intimidation: { proficient: true } },
+    languages: ["Common", "Orc"],
+  },
+  tiefling: {
+    name: "Tiefling",
+    speed: 30,
+    abilities: { cha: 2, int: 1 },
+    skills: {},
+    languages: ["Common", "Infernal"],
+  },
+};
+
+module.exports = races;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -13,6 +13,7 @@ const characterHealth = require('./characters/health');
 const skills = require('./skills');
 const feats = require('./feats');
 const equipment = require('./equipment');
+const races = require('./races');
 
 routes.use(async (req, res, next) => {
   try {
@@ -26,6 +27,7 @@ routes.use(async (req, res, next) => {
 auth(routes);
 users(routes);
 campaigns(routes);
+races(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.
 characterOccupations(routes);

--- a/server/routes/races.js
+++ b/server/routes/races.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const races = require('../data/races');
+
+module.exports = (router) => {
+  const raceRouter = express.Router();
+
+  raceRouter.get('/', (_req, res) => {
+    res.json(races);
+  });
+
+  raceRouter.get('/:name', (req, res) => {
+    const race = races[req.params.name.toLowerCase()];
+    if (!race) {
+      return res.status(404).json({ message: 'Race not found' });
+    }
+    res.json(race);
+  });
+
+  router.use('/races', raceRouter);
+};

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -4,7 +4,7 @@ const authenticateToken = require('../middleware/auth');
 const proficiencyBonus = require('../utils/proficiency');
 
 // Helper to determine allowed skills from occupations and feats when not precomputed
-const collectAllowedSkills = (occupation = [], feat = []) => {
+const collectAllowedSkills = (occupation = [], feat = [], race) => {
   const allowed = new Set();
   if (Array.isArray(occupation)) {
     occupation.forEach((occ) => {
@@ -25,6 +25,13 @@ const collectAllowedSkills = (occupation = [], feat = []) => {
             allowed.add(sk);
           }
         });
+      }
+    });
+  }
+  if (race && race.skills && typeof race.skills === 'object') {
+    Object.keys(race.skills).forEach((sk) => {
+      if (race.skills[sk] && race.skills[sk].proficient) {
+        allowed.add(sk);
       }
     });
   }
@@ -85,7 +92,7 @@ module.exports = (router) => {
       }
 
       const allowedSkills =
-        charDoc.allowedSkills || collectAllowedSkills(charDoc.occupation, charDoc.feat);
+        charDoc.allowedSkills || collectAllowedSkills(charDoc.occupation, charDoc.feat, charDoc.race);
       if (!allowedSkills.includes(skill)) {
         return res.status(400).json({ message: 'Skill not allowed' });
       }


### PR DESCRIPTION
## Summary
- add static race catalog and /races API
- incorporate race data into character creation and skills logic
- expose race selection and stats/skills updates on frontend

## Testing
- `cd server && npm test`
- `cd ../client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b85b79a26c832e89734d932e602175