### PR TITLE
Add stat breakdown modal with metadata

### DIFF
--- a/client/src/components/Zombies/attributes/StatBreakdownModal.js
+++ b/client/src/components/Zombies/attributes/StatBreakdownModal.js
@@ -1,0 +1,79 @@
+import React from "react";
+import { Modal, Card, Table, Button } from "react-bootstrap";
+import STATS from "../statSchema";
+
+export default function StatBreakdownModal({ show, onHide, statKey, breakdown }) {
+  if (!statKey) return null;
+
+  const statInfo = STATS.find((s) => s.key === statKey) || {};
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      centered
+      className="dnd-modal modern-modal"
+    >
+      <div className="text-center">
+        <Card className="modern-card">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">
+              {statInfo.label} Breakdown
+            </Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <p>{statInfo.description}</p>
+            {breakdown && (
+              <Table
+                striped
+                bordered
+                hover
+                size="sm"
+                responsive
+                className="modern-table"
+              >
+                <thead>
+                  <tr>
+                    <th>Source</th>
+                    <th>Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Base</td>
+                    <td>{breakdown.base}</td>
+                  </tr>
+                  <tr>
+                    <td>Class</td>
+                    <td>{breakdown.class}</td>
+                  </tr>
+                  <tr>
+                    <td>Race</td>
+                    <td>{breakdown.race}</td>
+                  </tr>
+                  <tr>
+                    <td>Feat</td>
+                    <td>{breakdown.feat}</td>
+                  </tr>
+                  <tr>
+                    <td>Item</td>
+                    <td>{breakdown.item}</td>
+                  </tr>
+                  <tr>
+                    <td>Total</td>
+                    <td>{breakdown.total}</td>
+                  </tr>
+                </tbody>
+              </Table>
+            )}
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={onHide}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { Card, Table, Modal, Button } from "react-bootstrap";
+import STATS from "../statSchema";
+import StatBreakdownModal from "./StatBreakdownModal";
 
 export default function Stats({ form, showStats, handleCloseStats }) {
-
   const [stats] = useState({
     str: form.str || 0,
     dex: form.dex || 0,
@@ -11,6 +12,9 @@ export default function Stats({ form, showStats, handleCloseStats }) {
     wis: form.wis || 0,
     cha: form.cha || 0,
   });
+
+  const [showBreakdown, setShowBreakdown] = useState(false);
+  const [selectedStat, setSelectedStat] = useState(null);
 
   const totalItemBonus = (form.item || []).reduce(
     (acc, el) => ({
@@ -37,59 +41,109 @@ export default function Stats({ form, showStats, handleCloseStats }) {
   );
 
   const raceBonus = form.race?.abilities || {};
+  const classBonus = (form.occupation || []).reduce(
+    (acc, occ) => ({
+      str: acc.str + Number(occ.str || 0),
+      dex: acc.dex + Number(occ.dex || 0),
+      con: acc.con + Number(occ.con || 0),
+      int: acc.int + Number(occ.int || 0),
+      wis: acc.wis + Number(occ.wis || 0),
+      cha: acc.cha + Number(occ.cha || 0),
+    }),
+    { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
+  );
 
-  const computedStats = Object.keys(stats).reduce((acc, key) => {
-    acc[key] =
-      stats[key] +
-      totalItemBonus[key] +
-      totalFeatBonus[key] +
-      (raceBonus[key] || 0);
+  const breakdowns = Object.keys(stats).reduce((acc, key) => {
+    const base = stats[key] - classBonus[key];
+    const race = Number(raceBonus[key] || 0);
+    const feat = totalFeatBonus[key];
+    const item = totalItemBonus[key];
+    const cls = classBonus[key];
+    acc[key] = {
+      base,
+      class: cls,
+      race,
+      feat,
+      item,
+      total: base + cls + race + feat + item,
+    };
     return acc;
   }, {});
+
+  const computedStats = Object.fromEntries(
+    Object.entries(breakdowns).map(([key, b]) => [key, b.total])
+  );
 
   const statMods = Object.fromEntries(
     Object.entries(computedStats).map(([key, value]) => [key, Math.floor((value - 10) / 2)])
   );
 
+  const handleView = (stat) => {
+    setSelectedStat(stat);
+    setShowBreakdown(true);
+  };
+
+  const handleCloseBreakdown = () => {
+    setShowBreakdown(false);
+  };
+
   return (
-    <Modal
-      show={showStats}
-      onHide={handleCloseStats}
-      size="lg"
-      scrollable
-      centered
-      className="dnd-modal modern-modal"
-    >
-      <div className="text-center">
-        <Card className="modern-card">
-          <Card.Header className="modal-header">
-            <Card.Title className="modal-title">Stats</Card.Title>
-          </Card.Header>
-          <Card.Body>
-            <Table striped bordered hover size="sm" responsive className="modern-table">
-              <thead>
-                <tr>
-                  <th>Stat</th>
-                  <th>Level</th>
-                  <th>Mod</th>
-                </tr>
-              </thead>
-              <tbody>
-                {["str", "dex", "con", "int", "wis", "cha"].map((stat) => (
-                  <tr key={stat}>
-                    <td>{stat.toUpperCase()}</td>
-                    <td>{computedStats[stat]}</td>
-                    <td>{statMods[stat]}</td>
+    <>
+      <Modal
+        show={showStats}
+        onHide={handleCloseStats}
+        size="lg"
+        scrollable
+        centered
+        className="dnd-modal modern-modal"
+      >
+        <div className="text-center">
+          <Card className="modern-card">
+            <Card.Header className="modal-header">
+              <Card.Title className="modal-title">Stats</Card.Title>
+            </Card.Header>
+            <Card.Body>
+              <Table striped bordered hover size="sm" responsive className="modern-table">
+                <thead>
+                  <tr>
+                    <th>Stat</th>
+                    <th>Level</th>
+                    <th>Mod</th>
+                    <th></th>
                   </tr>
-                ))}
-              </tbody>
-            </Table>
-          </Card.Body>
-          <Card.Footer className="modal-footer">
-            <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>
-          </Card.Footer>
-        </Card>
-      </div>
-    </Modal>
+                </thead>
+                <tbody>
+                  {STATS.map(({ key }) => (
+                    <tr key={key}>
+                      <td>{key.toUpperCase()}</td>
+                      <td>{computedStats[key]}</td>
+                      <td>{statMods[key]}</td>
+                      <td>
+                        <Button
+                          className="action-btn"
+                          onClick={() => handleView(key)}
+                          size="sm"
+                        >
+                          View
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Card.Body>
+            <Card.Footer className="modal-footer">
+              <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>
+            </Card.Footer>
+          </Card>
+        </div>
+      </Modal>
+      <StatBreakdownModal
+        show={showBreakdown}
+        onHide={handleCloseBreakdown}
+        statKey={selectedStat}
+        breakdown={selectedStat ? breakdowns[selectedStat] : null}
+      />
+    </>
   );
 }

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Stats from './Stats';
+
+test('clicking view shows description and breakdown', async () => {
+  const form = {
+    str: 10,
+    dex: 0,
+    con: 0,
+    int: 0,
+    wis: 0,
+    cha: 0,
+    race: { abilities: { str: 2 } },
+    feat: [{ str: 1 }],
+    item: [[0, 0, 1, 0, 0, 0, 0, 0]],
+    occupation: [{ str: 1 }],
+  };
+
+  render(<Stats form={form} showStats={true} handleCloseStats={() => {}} />);
+
+  const strengthRow = screen.getByText('STR').closest('tr');
+  await act(async () => {
+    await userEvent.click(
+      within(strengthRow).getByRole('button', { name: /view/i })
+    );
+  });
+
+  expect(
+    await screen.findByText('Physical power and carrying capacity.')
+  ).toBeInTheDocument();
+
+  const baseRow = screen.getByText('Base').closest('tr');
+  expect(within(baseRow).getByText('9')).toBeInTheDocument();
+  const classRow = screen.getByText('Class').closest('tr');
+  expect(within(classRow).getByText('1')).toBeInTheDocument();
+  const raceRow = screen.getByText('Race').closest('tr');
+  expect(within(raceRow).getByText('2')).toBeInTheDocument();
+  const featRow = screen.getByText('Feat').closest('tr');
+  expect(within(featRow).getByText('1')).toBeInTheDocument();
+  const itemRow = screen.getByText('Item').closest('tr');
+  expect(within(itemRow).getByText('1')).toBeInTheDocument();
+  const totalRow = screen.getByText('Total').closest('tr');
+  expect(within(totalRow).getByText('14')).toBeInTheDocument();
+});

--- a/client/src/components/Zombies/statSchema.js
+++ b/client/src/components/Zombies/statSchema.js
@@ -1,10 +1,34 @@
 export const STATS = [
-  { key: 'str', label: 'Strength' },
-  { key: 'dex', label: 'Dexterity' },
-  { key: 'con', label: 'Constitution' },
-  { key: 'int', label: 'Intellect' },
-  { key: 'wis', label: 'Wisdom' },
-  { key: 'cha', label: 'Charisma' },
+  {
+    key: 'str',
+    label: 'Strength',
+    description: 'Physical power and carrying capacity.'
+  },
+  {
+    key: 'dex',
+    label: 'Dexterity',
+    description: 'Agility, reflexes, and balance.'
+  },
+  {
+    key: 'con',
+    label: 'Constitution',
+    description: 'Endurance and stamina.'
+  },
+  {
+    key: 'int',
+    label: 'Intellect',
+    description: 'Reasoning and memory.'
+  },
+  {
+    key: 'wis',
+    label: 'Wisdom',
+    description: 'Perception and insight.'
+  },
+  {
+    key: 'cha',
+    label: 'Charisma',
+    description: 'Force of personality.'
+  }
 ];
 
 export default STATS;


### PR DESCRIPTION
## Summary
- extend stat schema with descriptions
- compute and display stat bonus breakdowns by source
- add modal to view stat details and unit tests

## Testing
- `cd client && npm test -- Stats.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b89d663c40832ea5f3bdee79971665