### PR TITLE
Disable toggling for race-derived skill proficiencies

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -89,6 +89,11 @@ export default function Skills({
   const profBonus = proficiencyBonus(totalLevel);
 
   const selectableSkills = new Set(form.allowedSkills || []);
+  const raceProficiencies = new Set(
+    Object.entries(form.race?.skills || {})
+      .filter(([, s]) => s?.proficient)
+      .map(([key]) => key)
+  );
 
   async function updateSkill(skill, updated) {
     try {
@@ -121,6 +126,7 @@ export default function Skills({
   }
 
   const toggleProficient = (skill) => {
+    if (raceProficiencies.has(skill)) return;
     if (!selectableSkills.has(skill)) return;
     const current = skills[skill] || { proficient: false, expertise: false };
     if (!current.proficient && proficiencyPointsLeft <= 0) return;
@@ -195,6 +201,7 @@ export default function Skills({
                   featTotals[key] +
                   raceTotals[key];
                 const isSelectable = selectableSkills.has(key);
+                const isRaceSkill = raceProficiencies.has(key);
                 return (
                   <tr key={key}>
                     <td>{label}</td>
@@ -204,7 +211,7 @@ export default function Skills({
                       <Form.Check
                         type="checkbox"
                         checked={proficient}
-                        disabled={!isSelectable}
+                        disabled={!isSelectable || isRaceSkill}
                         onChange={() => toggleProficient(key)}
                       />
                     </td>


### PR DESCRIPTION
## Summary
- prevent toggling of proficiencies granted by race
- grey out race-granted skill checkboxes in the skill table

## Testing
- `cd client && CI=true npm test` *(fails: Stats.test.js cannot find "View" button)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b5fb56ec832e972c3253a6c13f59