### PR TITLE
Show race languages in CharacterInfo

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -15,6 +15,10 @@ export default function CharacterInfo({ form, show, handleClose }) {
     setShowLevelUpModal(false);
   };
 
+  const raceLanguages = (form.race?.languages || [])
+    .filter((language) => language && !language.includes("Choice"))
+    .join(", ");
+
   return (
     <Modal
       className="dnd-modal modern-modal"
@@ -49,6 +53,10 @@ export default function CharacterInfo({ form, show, handleClose }) {
               <tr>
                 <th>Race</th>
                 <td>{form.race?.name || ''}</td>
+              </tr>
+              <tr>
+                <th>Languages</th>
+                <td>{raceLanguages}</td>
               </tr>
               <tr>
                 <th>Age</th>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CharacterInfo from './CharacterInfo';
+
+jest.mock('./LevelUp', () => () => <div />);
+
+test('renders race languages', () => {
+  const form = {
+    occupation: [],
+    race: { name: 'Elf', languages: ['Common', 'Elvish', 'Choice'] },
+    age: 100,
+    sex: 'M',
+    height: "6'",
+    weight: 180,
+  };
+
+  render(<CharacterInfo form={form} show={true} handleClose={() => {}} />);
+
+  expect(screen.getByText('Common, Elvish')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- derive race language string excluding placeholder entries and display it in character info
- add test ensuring languages render in CharacterInfo modal

## Testing
- `CI=true npm test` *(fails: Stats.test.js)*
- `CI=true npm test -- src/components/Zombies/attributes/CharacterInfo.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8f0ff08832e8a6467221fe42f51