### PR TITLE
Replace occupation references with class in Zombies UI

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -40,7 +40,7 @@ export default function CharacterInfo({ form, show, handleClose }) {
                 <td>{totalLevel}</td>
               </tr>
               <tr>
-                <th>Occupation</th>
+                <th>Class</th>
                 <td>
                   {form.occupation.map((el, i) => (
                     <span key={i}>

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -63,7 +63,7 @@ export default function LevelUp({ show, handleClose, form }) {
     }
   };
 
-  //--------------------------------------------Add Occupation--------------------------------------------------------------------------------------------------------------------------------------------
+  //--------------------------------------------Add Class--------------------------------------------------------------------------------------------------------------------------------------------
   const [showAddClassModal, setShowAddClassModal] = useState(false);
   const [selectedOccupation, setSelectedOccupation] = useState(null);
   const selectedAddOccupationRef = useRef();
@@ -116,7 +116,7 @@ export default function LevelUp({ show, handleClose, form }) {
         setError('Database update failed');
       }
     } else {
-      setValidationError('Please select an occupation.');
+      setValidationError('Please select a class.');
     }
   };
 
@@ -168,10 +168,10 @@ export default function LevelUp({ show, handleClose, form }) {
                     {validationError}
                   </Alert>
                 )}
-                {/* Add occupation */}
+                {/* Add class */}
                 <Form>
                   <Button className="action-btn" onClick={handleAddOccupationClick}>
-                    Add Occupation
+                    Add Class
                   </Button>
                   <Modal
                   className="dnd-modal modern-modal"
@@ -181,7 +181,7 @@ export default function LevelUp({ show, handleClose, form }) {
                 >
                   <Card className="modern-card text-center">
                     <Card.Header className="modal-header">
-                      <Card.Title className="modal-title">Add Occupation</Card.Title>
+                      <Card.Title className="modal-title">Add Class</Card.Title>
                     </Card.Header>
                     <Card.Body>
                       {notification && (
@@ -195,13 +195,13 @@ export default function LevelUp({ show, handleClose, form }) {
                         </Alert>
                       )}
                       <Form.Group className="mb-3 mx-5">
-                        <Form.Label className="text-light">Select Occupation</Form.Label>
+                        <Form.Label className="text-light">Select Class</Form.Label>
                         <Form.Select
                           ref={selectedAddOccupationRef}
                           onChange={handleOccupationChange}
                           defaultValue=""
                         >
-                          <option value="" disabled>Select your occupation</option>
+                          <option value="" disabled>Select your class</option>
                           {getOccupation.map((occupation, i) => {
                             const isOccupationSelected = form.occupation.some(
                               (item) => item.Occupation === occupation.Occupation
@@ -243,13 +243,13 @@ export default function LevelUp({ show, handleClose, form }) {
                 <br />
                 <span>or</span>
                 <Form.Group className="mb-3 mx-5">
-                  <Form.Label className="text-light">Select Occupation</Form.Label>
+                  <Form.Label className="text-light">Select Class</Form.Label>
                   <Form.Select
                     ref={selectedOccupationRef}
                     defaultValue=""
                     onChange={handleChosenOccupationChange}
                   >
-                    <option value="" disabled>Select your occupation</option>
+                    <option value="" disabled>Select your class</option>
                     {form.occupation.map((occupation, i) => (
                       <option key={i}>{occupation.Occupation}</option>
                     ))}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -412,7 +412,7 @@ const sendManualToDb = useCallback(async (characterData) => {
     feat: (baseCharacter.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
   };
   if (!newCharacter.occupation?.[0]?.Level) {
-    notify("Occupation level is required.", 'warning');
+    notify("Class level is required.", 'warning');
     return;
   }
   try {
@@ -533,7 +533,7 @@ const getAvailableSkillOptions = (index) => {
             <tr>
               <th>Character</th>
               <th>Level</th>
-              <th>Occupation</th>
+              <th>Class</th>
               <th>View</th>
             </tr>
           </thead>
@@ -604,13 +604,13 @@ const getAvailableSkillOptions = (index) => {
        <Form.Label className="text-light">Character Name</Form.Label>
        <Form.Control className="mb-2" onChange={(e) => updateForm({ characterName: e.target.value })}
         type="text" placeholder="Enter character name max 12 characters" pattern="^([^0-9]{0,12})$"/>        
-        <Form.Label className="text-light">Occupation</Form.Label>
+        <Form.Label className="text-light">Class</Form.Label>
         <Form.Select
               ref={selectedAddOccupationRef}
               onChange={handleOccupationChange}
               defaultValue=""
             >
-              <option value="" disabled>Select your occupation</option>
+              <option value="" disabled>Select your class</option>
               {getOccupation.map((occupation, i) => (
                 <option key={i}>{occupation.Occupation}</option>
               ))}

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -340,7 +340,7 @@ const [form2, setForm2] = useState({
             <th>Player</th>
             <th>Character</th>
             <th>Level</th>
-            <th>Occupation</th>
+            <th>Class</th>
             <th>View</th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary
- rename Occupation references to Class across Zombies character selection, level up, and display components
- update validation and notification messages to mention class

## Testing
- `CI=true npm test --silent` *(fails: Unable to find button named /view/ in Stats.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c24b8d78832e93b486605940dc98