### PR TITLE
Add shopkeeper modal to player turn actions

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1,12 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button, Modal, Card, Table } from "react-bootstrap";
 import sword from "../../../images/sword.png";
+import ShopkeeperModal from "./ShopkeeperModal";
 
 export default function PlayerTurnActions ({ form, strMod, atkBonus, dexMod, headerHeight = 0 }) {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
   const handleShowAttack = () => setShowAttack(true);
+
+  const [showShopkeeper, setShowShopkeeper] = useState(false);
+  const handleShowShopkeeper = () => setShowShopkeeper(true);
+  const handleHideShopkeeper = () => setShowShopkeeper(false);
 
   const FOOTER_HEIGHT = 80;
   const damageRef = useRef(null);
@@ -206,18 +211,25 @@ const showSparklesEffect = () => {
 //-------------------------------------------------------------Display-----------------------------------------------------------------------------------------
   return (
     <div>
-      <div
-        id="damageAmount"
-        ref={damageRef}
-        onClick={handleToggle}
-        className={`mt-3 ${loading ? 'loading' : ''} ${pulse ? 'pulse' : ''} ${isGold ? 'critical-active' : ''}`}
-        style={{ margin: "0 auto", cursor: "pointer" }}
-      >
-        <span id="damageValue" className={loading ? 'hidden' : ''}>
-          {damageValue}
-        </span>
-        <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div
+          id="damageAmount"
+          ref={damageRef}
+          onClick={handleToggle}
+          className={`mt-3 ${loading ? 'loading' : ''} ${pulse ? 'pulse' : ''} ${isGold ? 'critical-active' : ''}`}
+          style={{ margin: "0 auto", cursor: "pointer" }}
+        >
+          <span id="damageValue" className={loading ? 'hidden' : ''}>
+            {damageValue}
+          </span>
+          <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
+        </div>
+        <button style={{ marginLeft: '10px' }} onClick={handleShowShopkeeper}>
+          Shop
+        </button>
       </div>
+
+      <ShopkeeperModal show={showShopkeeper} onHide={handleHideShopkeeper} />
       
       <div
         style={{

--- a/client/src/components/Zombies/attributes/ShopkeeperModal.js
+++ b/client/src/components/Zombies/attributes/ShopkeeperModal.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Modal, Button, Card } from "react-bootstrap";
+
+export default function ShopkeeperModal({ show, onHide }) {
+  return (
+    <Modal show={show} onHide={onHide} centered className="dnd-modal modern-modal">
+      <div className="text-center">
+        <Card className="modern-card">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Shopkeeper</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <p>Welcome to the shop!</p>
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={onHide}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add ShopkeeperModal component and state handlers
- wrap damage display with shopkeeper button to trigger modal

## Testing
- `CI=true npm test -- --runTestsByPath src/components/Zombies/attributes/Feats.test.js src/components/Zombies/attributes/Stats.test.js` *(fails: clicking view shows description and breakdown)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cafd723c8323abe61dced38f0f00