### PR TITLE
Add spells routes and tests

### DIFF
--- a/server/__tests__/spells.test.js
+++ b/server/__tests__/spells.test.js
@@ -1,0 +1,47 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Spells routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('GET /spells returns all spells', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).get('/spells');
+    expect(res.status).toBe(200);
+    expect(res.body.fireball.name).toBe('Fireball');
+  });
+
+  test('GET /spells/:name returns spell case-insensitively', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).get('/spells/Fireball');
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Fireball');
+  });
+
+  test('GET /spells/:name returns 404 for missing spell', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).get('/spells/Unknown');
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Spell not found');
+  });
+});

--- a/server/data/spells.js
+++ b/server/data/spells.js
@@ -1,0 +1,40 @@
+const spells = {
+  fireball: {
+    name: 'Fireball',
+    level: 3,
+    school: 'Evocation',
+    castingTime: '1 action',
+    range: '150 feet',
+    components: ['V', 'S', 'M (a tiny ball of bat guano and sulfur)'],
+    duration: 'Instantaneous',
+    description:
+      'A bright streak flashes from your pointing finger to a point you choose and then blossoms with a low roar into an explosion of flame. Each creature in a 20-foot-radius sphere must make a Dexterity saving throw. A target takes 8d6 fire damage on a failed save, or half as much on a successful one.',
+    classes: ['Sorcerer', 'Wizard'],
+  },
+  shield: {
+    name: 'Shield',
+    level: 1,
+    school: 'Abjuration',
+    castingTime: '1 reaction',
+    range: 'Self',
+    components: ['V', 'S'],
+    duration: '1 round',
+    description:
+      'An invisible barrier of magical force appears and protects you. Until the start of your next turn, you have a +5 bonus to AC, including against the triggering attack, and you take no damage from magic missile.',
+    classes: ['Sorcerer', 'Wizard'],
+  },
+  invisibility: {
+    name: 'Invisibility',
+    level: 2,
+    school: 'Illusion',
+    castingTime: '1 action',
+    range: 'Touch',
+    components: ['V', 'S', 'M (an eyelash encased in gum arabic)'],
+    duration: 'Up to 1 hour',
+    description:
+      'A creature you touch becomes invisible until the spell ends. Anything the target is wearing or carrying is invisible as long as it is on the target\'s person.',
+    classes: ['Bard', 'Sorcerer', 'Warlock', 'Wizard'],
+  },
+};
+
+module.exports = spells;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -14,6 +14,7 @@ const skills = require('./skills');
 const feats = require('./feats');
 const equipment = require('./equipment');
 const races = require('./races');
+const spells = require('./spells');
 
 routes.use(async (req, res, next) => {
   try {
@@ -28,6 +29,7 @@ auth(routes);
 users(routes);
 campaigns(routes);
 races(routes);
+spells(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.
 characterOccupations(routes);

--- a/server/routes/spells.js
+++ b/server/routes/spells.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const spells = require('../data/spells');
+
+module.exports = (router) => {
+  const spellRouter = express.Router();
+
+  spellRouter.get('/', (_req, res) => {
+    res.json(spells);
+  });
+
+  spellRouter.get('/:name', (req, res) => {
+    const spell = spells[req.params.name.toLowerCase()];
+    if (!spell) {
+      return res.status(404).json({ message: 'Spell not found' });
+    }
+    res.json(spell);
+  });
+
+  router.use('/spells', spellRouter);
+};


### PR DESCRIPTION
## Summary
- add SRD-based spell data for a few core spells
- expose `/spells` and `/spells/:name` endpoints
- cover spell endpoints and 404 errors with Jest tests

## Testing
- `cd server && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b8d17a10f4832e95b407adb24de2a3