### PR TITLE
Add spells listing and detail components with routing and tests

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,8 @@ import ZombiesCharacterSelect from "./components/Zombies/pages/ZombiesCharacterS
 import ZombiesDM from "./components/Zombies/pages/ZombiesDM";
 import Login from "./components/Login/Login";
 import Notifications from "./components/Notifications";
+import SpellList from "./components/Spells/SpellList";
+import SpellDetail from "./components/Spells/SpellDetail";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import "./App.scss";
@@ -50,6 +52,8 @@ function AppRoutes() {
       {!hideNavbarRoutes.includes(location.pathname) && <Navbar />}
       <Routes>
         <Route path="/" element={<Zombies />} />
+        <Route path="/spells" element={<SpellList />} />
+        <Route path="/spells/:name" element={<SpellDetail />} />
         <Route path="/zombies-character-select/:campaign" element={<ZombiesCharacterSelect />} />
         <Route path="/zombies-character-sheet/:id" element={<ZombiesCharacterSheet />} />
         <Route path="/zombies-dm/:campaign" element={<ZombiesDM />} />

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -3,6 +3,7 @@ import Container from 'react-bootstrap/Container';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
+import { Link } from 'react-router-dom';
 import logoLight from "../../images/logo-light.png";
 import apiFetch from "../../utils/apiFetch";
 
@@ -18,15 +19,16 @@ function NavbarComponent() {
         <Navbar.Brand href="/">
           <img src={logoLight} alt="" width="60px" height="60px" className="d-inline-block align-text-top" />
         </Navbar.Brand>
-        <Nav className="ml-auto">
-          <Nav.Link>
-            <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={handleLogout}>
-              Logout
-            </Button>
-          </Nav.Link>
-        </Nav>
-      </Container>
-    </Navbar>
+          <Nav className="ml-auto">
+            <Nav.Link as={Link} to="/spells">Spells</Nav.Link>
+            <Nav.Link>
+              <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={handleLogout}>
+                Logout
+              </Button>
+            </Nav.Link>
+          </Nav>
+        </Container>
+      </Navbar>
   );
 }
 

--- a/client/src/components/Spells/SpellDetail.js
+++ b/client/src/components/Spells/SpellDetail.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import apiFetch from '../../utils/apiFetch';
+
+function SpellDetail() {
+  const { name } = useParams();
+  const [spell, setSpell] = useState(null);
+
+  useEffect(() => {
+    apiFetch(`/spells/${name}`)
+      .then(res => res.json())
+      .then(setSpell);
+  }, [name]);
+
+  if (!spell) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>{spell.name}</h2>
+      <p><strong>Level:</strong> {spell.level}</p>
+      <p><strong>School:</strong> {spell.school}</p>
+      <p><strong>Casting Time:</strong> {spell.castingTime}</p>
+      <p><strong>Range:</strong> {spell.range}</p>
+      <p><strong>Components:</strong> {spell.components.join(', ')}</p>
+      <p><strong>Duration:</strong> {spell.duration}</p>
+      <p>{spell.description}</p>
+      <p><strong>Classes:</strong> {spell.classes.join(', ')}</p>
+    </div>
+  );
+}
+
+export default SpellDetail;

--- a/client/src/components/Spells/SpellDetail.test.js
+++ b/client/src/components/Spells/SpellDetail.test.js
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import SpellDetail from './SpellDetail';
+import apiFetch from '../../utils/apiFetch';
+
+jest.mock('../../utils/apiFetch');
+
+test('fetches and displays spell detail', async () => {
+  apiFetch.mockResolvedValueOnce({
+    json: async () => ({
+      name: 'Fireball',
+      level: 3,
+      school: 'Evocation',
+      castingTime: '1 action',
+      range: '150 feet',
+      components: ['V', 'S', 'M'],
+      duration: 'Instantaneous',
+      description: 'A bright streak flashes',
+      classes: ['Wizard'],
+    }),
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/spells/fireball']}>
+      <Routes>
+        <Route path="/spells/:name" element={<SpellDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  expect(apiFetch).toHaveBeenCalledWith('/spells/fireball');
+  await waitFor(() => expect(screen.getByText('Fireball')).toBeInTheDocument());
+  expect(screen.getByText(/Evocation/)).toBeInTheDocument();
+  expect(screen.getByText(/bright streak/)).toBeInTheDocument();
+});

--- a/client/src/components/Spells/SpellList.js
+++ b/client/src/components/Spells/SpellList.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import apiFetch from '../../utils/apiFetch';
+
+function SpellList() {
+  const [spells, setSpells] = useState(null);
+
+  useEffect(() => {
+    apiFetch('/spells')
+      .then(res => res.json())
+      .then(data => setSpells(Object.values(data)));
+  }, []);
+
+  if (!spells) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1>Spells</h1>
+      <ul>
+        {spells.map(spell => (
+          <li key={spell.name}>
+            <Link to={`/spells/${spell.name.toLowerCase()}`}>{spell.name}</Link> - Level {spell.level} {spell.school}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default SpellList;

--- a/client/src/components/Spells/SpellList.test.js
+++ b/client/src/components/Spells/SpellList.test.js
@@ -1,0 +1,26 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SpellList from './SpellList';
+import apiFetch from '../../utils/apiFetch';
+
+jest.mock('../../utils/apiFetch');
+
+test('fetches and displays spells', async () => {
+  apiFetch.mockResolvedValueOnce({
+    json: async () => ({
+      fireball: { name: 'Fireball', level: 3, school: 'Evocation' },
+      shield: { name: 'Shield', level: 1, school: 'Abjuration' },
+    }),
+  });
+
+  render(
+    <MemoryRouter>
+      <SpellList />
+    </MemoryRouter>
+  );
+
+  expect(apiFetch).toHaveBeenCalledWith('/spells');
+  await waitFor(() => expect(screen.getByText('Fireball')).toBeInTheDocument());
+  expect(screen.getByText('Shield')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Fireball/ })).toHaveAttribute('href', '/spells/fireball');
+});

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -119,17 +119,18 @@ export default function Stats({ form, showStats, handleCloseStats }) {
                       <td>{computedStats[key]}</td>
                       <td>{statMods[key]}</td>
                       <td>
-                        <Button
-                          className="action-btn fa-regular fa-eye"
-                          onClick={() => handleView(key)}
-                          size="sm"
-                        >
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Table>
+                          <Button
+                            className="action-btn fa-regular fa-eye"
+                            onClick={() => handleView(key)}
+                            size="sm"
+                            aria-label="view"
+                          >
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
             </Card.Body>
             <Card.Footer className="modal-footer">
               <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>


### PR DESCRIPTION
## Summary
- add spell listing and detail components
- integrate new components into router and navbar
- cover spells components with tests
- add missing aria-label on stats view button

## Testing
- `npm test --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8d21d8db8832ea7ea129c4f216699