### PR TITLE
Add shared Spell type and validation across client and server

### DIFF
--- a/client/src/components/Spells/SpellDetail.js
+++ b/client/src/components/Spells/SpellDetail.js
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import apiFetch from '../../utils/apiFetch';
 
+/** @typedef {import('../../../../types/spell').Spell} Spell */
+
 function SpellDetail() {
   const { name } = useParams();
-  const [spell, setSpell] = useState(null);
+  const [spell, setSpell] = useState/** @type {Spell | null} */(null);
 
   useEffect(() => {
     apiFetch(`/spells/${name}`)

--- a/client/src/components/Spells/SpellList.js
+++ b/client/src/components/Spells/SpellList.js
@@ -2,8 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import apiFetch from '../../utils/apiFetch';
 
+/** @typedef {import('../../../../types/spell').Spell} Spell */
+
 function SpellList() {
-  const [spells, setSpells] = useState(null);
+  const [spells, setSpells] = useState/** @type {Spell[] | null} */(null);
 
   useEffect(() => {
     apiFetch('/spells')

--- a/docs/spells.md
+++ b/docs/spells.md
@@ -1,0 +1,17 @@
+# Spell data structure
+
+The `Spell` type is shared between the client and server to ensure consistent data.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Name of the spell |
+| `level` | number | Spell level |
+| `school` | string | Magic school |
+| `castingTime` | string | Time required to cast |
+| `range` | string | Effective range |
+| `components` | string[] | Components required |
+| `duration` | string | Spell duration |
+| `description` | string | Full description |
+| `classes` | string[] | Classes that can use the spell |
+
+The type definition lives in [`types/spell.d.ts`](../types/spell.d.ts) and is used by client components and server validation.

--- a/server/data/spells.js
+++ b/server/data/spells.js
@@ -1,3 +1,7 @@
+const { isSpell } = require('../validation/spell');
+/** @typedef {import('../../types/spell').Spell} Spell */
+
+/** @type {Record<string, Spell>} */
 const spells = {
   fireball: {
     name: 'Fireball',
@@ -36,5 +40,11 @@ const spells = {
     classes: ['Bard', 'Sorcerer', 'Warlock', 'Wizard'],
   },
 };
+
+Object.values(spells).forEach(spell => {
+  if (!isSpell(spell)) {
+    throw new Error(`Invalid spell data: ${spell && spell.name}`);
+  }
+});
 
 module.exports = spells;

--- a/server/validation/spell.js
+++ b/server/validation/spell.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {import('../../types/spell').Spell} Spell
+ */
+
+/**
+ * Validate a value conforms to the Spell structure.
+ * @param {any} spell
+ * @returns {spell is Spell}
+ */
+function isSpell(spell) {
+  return (
+    spell !== null &&
+    typeof spell === 'object' &&
+    typeof spell.name === 'string' &&
+    typeof spell.level === 'number' &&
+    typeof spell.school === 'string' &&
+    typeof spell.castingTime === 'string' &&
+    typeof spell.range === 'string' &&
+    Array.isArray(spell.components) &&
+    spell.components.every(c => typeof c === 'string') &&
+    typeof spell.duration === 'string' &&
+    typeof spell.description === 'string' &&
+    Array.isArray(spell.classes) &&
+    spell.classes.every(c => typeof c === 'string')
+  );
+}
+
+module.exports = { isSpell };

--- a/types/spell.d.ts
+++ b/types/spell.d.ts
@@ -1,0 +1,11 @@
+export interface Spell {
+  name: string;
+  level: number;
+  school: string;
+  castingTime: string;
+  range: string;
+  components: string[];
+  duration: string;
+  description: string;
+  classes: string[];
+}


### PR DESCRIPTION
## Summary
- define shared `Spell` type in `types/spell.d.ts`
- validate spell data on the server using this type
- annotate client spell components and document the structure

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8d314fd40832e94af14be56afd92e