### PR TITLE
feat: add spell selection

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react';
+import apiFetch from '../../../utils/apiFetch';
+import { Modal, Card, Button, Form, ListGroup } from 'react-bootstrap';
+import { useParams } from 'react-router-dom';
+
+/**
+ * Modal component allowing users to select spells for their character.
+ * Spells are fetched from the server and filtered by class and level.
+ */
+export default function SpellSelector({
+  form,
+  show,
+  handleClose,
+  onSpellsChange,
+}) {
+  const params = useParams();
+  const [allSpells, setAllSpells] = useState({});
+  const [selectedClass, setSelectedClass] = useState(
+    form.occupation?.[0]?.Name || ''
+  );
+  const [selectedLevel, setSelectedLevel] = useState(0);
+  const [selectedSpells, setSelectedSpells] = useState(form.spells || []);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    apiFetch('/spells')
+      .then((res) => res.json())
+      .then((data) => setAllSpells(data))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  useEffect(() => {
+    setSelectedSpells(form.spells || []);
+  }, [form.spells]);
+
+  const classes = Array.from(new Set(form.occupation.map((o) => o.Name)));
+  const levelOptions = Array.from({ length: 10 }, (_, i) => i);
+
+  const spellsForFilter = Object.values(allSpells).filter(
+    (spell) =>
+      (!selectedClass || spell.classes.includes(selectedClass)) &&
+      spell.level === Number(selectedLevel)
+  );
+
+  function toggleSpell(name) {
+    setSelectedSpells((prev) =>
+      prev.includes(name)
+        ? prev.filter((s) => s !== name)
+        : [...prev, name]
+    );
+  }
+
+  async function saveSpells() {
+    try {
+      const res = await apiFetch(`/characters/${params.id}/spells`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ spells: selectedSpells }),
+      });
+      if (!res.ok) {
+        throw new Error('Failed to save spells');
+      }
+      onSpellsChange?.(selectedSpells);
+      handleClose();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <Modal
+      className="dnd-modal modern-modal"
+      show={show}
+      onHide={handleClose}
+      size="lg"
+      centered
+    >
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Spells</Card.Title>
+        </Card.Header>
+        <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+          {error && <div className="text-danger mb-2">{error}</div>}
+          <Form className="mb-3">
+            <Form.Group className="mb-2">
+              <Form.Label htmlFor="spellClass">Class</Form.Label>
+              <Form.Select
+                id="spellClass"
+                value={selectedClass}
+                onChange={(e) => setSelectedClass(e.target.value)}
+              >
+                {classes.map((cls) => (
+                  <option key={cls} value={cls}>
+                    {cls}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+            <Form.Group>
+              <Form.Label htmlFor="spellLevel">Level</Form.Label>
+              <Form.Select
+                id="spellLevel"
+                value={selectedLevel}
+                onChange={(e) => setSelectedLevel(e.target.value)}
+              >
+                {levelOptions.map((lvl) => (
+                  <option key={lvl} value={lvl}>
+                    {lvl}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Form>
+          <ListGroup>
+            {spellsForFilter.map((spell) => (
+              <ListGroup.Item
+                key={spell.name}
+                action
+                active={selectedSpells.includes(spell.name)}
+                onClick={() => toggleSpell(spell.name)}
+              >
+                {spell.name}
+              </ListGroup.Item>
+            ))}
+          </ListGroup>
+        </Card.Body>
+        <Card.Footer className="text-end">
+          <Button variant="secondary" className="me-2" onClick={handleClose}>
+            Close
+          </Button>
+          <Button variant="primary" onClick={saveSpells}>
+            Save
+          </Button>
+        </Card.Footer>
+      </Card>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SpellSelector from './SpellSelector';
+
+jest.mock('../../../utils/apiFetch');
+import apiFetch from '../../../utils/apiFetch';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+}));
+
+const spellsData = {
+  fireball: {
+    name: 'Fireball',
+    level: 3,
+    school: 'Evocation',
+    castingTime: '1 action',
+    range: '150 feet',
+    components: [],
+    duration: 'Instantaneous',
+    description: '',
+    classes: ['Wizard'],
+  },
+  'cure-wounds': {
+    name: 'Cure Wounds',
+    level: 1,
+    school: 'Evocation',
+    castingTime: '1 action',
+    range: 'Touch',
+    components: [],
+    duration: 'Instantaneous',
+    description: '',
+    classes: ['Cleric'],
+  },
+};
+
+test('filters spells by class and level', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => spellsData });
+  render(
+    <SpellSelector
+      form={{ occupation: [{ Name: 'Wizard', Level: 5 }], spells: [] }}
+      show={true}
+      handleClose={() => {}}
+    />
+  );
+  await screen.findByLabelText('Class');
+  await userEvent.selectOptions(screen.getByLabelText('Level'), '3');
+  expect(await screen.findByText('Fireball')).toBeInTheDocument();
+  expect(screen.queryByText('Cure Wounds')).toBeNull();
+});
+
+test('saves selected spells', async () => {
+  apiFetch
+    .mockResolvedValueOnce({ ok: true, json: async () => spellsData })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+  const onChange = jest.fn();
+  render(
+    <SpellSelector
+      form={{ occupation: [{ Name: 'Wizard', Level: 5 }], spells: [] }}
+      show={true}
+      handleClose={() => {}}
+      onSpellsChange={onChange}
+    />
+  );
+  await screen.findByLabelText('Class');
+  await userEvent.selectOptions(screen.getByLabelText('Level'), '3');
+  await userEvent.click(await screen.findByText('Fireball'));
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(apiFetch).toHaveBeenLastCalledWith(
+    '/characters/1/spells',
+    expect.objectContaining({ method: 'PUT' })
+  );
+  await waitFor(() => expect(onChange).toHaveBeenCalledWith(['Fireball']));
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -16,6 +16,7 @@ import Items from "../attributes/Items";
 import Help from "../attributes/Help";
 import { SKILLS } from "../skillSchema";
 import HealthDefense from "../attributes/HealthDefense";
+import SpellSelector from "../attributes/SpellSelector";
 
 const HEADER_PADDING = 16;
 
@@ -30,6 +31,7 @@ export default function ZombiesCharacterSheet() {
   const [showWeapons, setShowWeapons] = useState(false);
   const [showArmor, setShowArmor] = useState(false);
   const [showItems, setShowItems] = useState(false);
+  const [showSpells, setShowSpells] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
 
   const headerRef = useRef(null);
@@ -102,9 +104,11 @@ export default function ZombiesCharacterSheet() {
   const handleShowArmor = () => setShowArmor(true);
   const handleCloseArmor = () => setShowArmor(false); 
   const handleShowItems = () => setShowItems(true);
-  const handleCloseItems = () => setShowItems(false); 
+  const handleCloseItems = () => setShowItems(false);
+  const handleShowSpells = () => setShowSpells(true);
+  const handleCloseSpells = () => setShowSpells(false);
   const handleShowHelpModal = () => setShowHelpModal(true);
-  const handleCloseHelpModal = () => setShowHelpModal(false); 
+  const handleCloseHelpModal = () => setShowHelpModal(false);
 
   if (!form) {
     return <div style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${loginbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", minHeight: "100vh"}}>Loading...</div>;
@@ -339,6 +343,17 @@ return (
             variant="secondary"
           ></Button>
           <Button
+            onClick={handleShowSpells}
+            style={{
+              color: "black",
+              padding: "8px",
+              marginTop: "10px",
+              backgroundColor: "#6C757D",
+            }}
+            className="mx-1 fas fa-hat-wizard"
+            variant="secondary"
+          ></Button>
+          <Button
             onClick={handleShowHelpModal}
             style={{ color: "white", padding: "8px", marginTop: "10px" }}
             className="mx-1 fas fa-info"
@@ -384,6 +399,12 @@ return (
       form={form}
       showItems={showItems}
       handleCloseItems={handleCloseItems}
+    />
+    <SpellSelector
+      form={form}
+      show={showSpells}
+      handleClose={handleCloseSpells}
+      onSpellsChange={(spells) => setForm((prev) => ({ ...prev, spells }))}
     />
     <Help
       form={form}

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -65,7 +65,8 @@ describe('Character routes', () => {
       feat: ['Power Attack'],
       weapon: ['Sword'],
       armor: ['Plate'],
-      item: ['Potion']
+      item: ['Potion'],
+      spells: ['Fireball'],
     };
     const res = await request(app)
       .post('/characters/add')
@@ -87,6 +88,7 @@ describe('Character routes', () => {
     });
     expect(Array.isArray(captured.feat)).toBe(true);
     expect(Array.isArray(captured.weapon)).toBe(true);
+    expect(Array.isArray(captured.spells)).toBe(true);
   });
 
   test('add character db failure', async () => {
@@ -111,6 +113,19 @@ describe('Character routes', () => {
       .post('/characters/add')
       .send({ token: 'alice' });
     expect(res.status).toBe(400);
+  });
+
+  test('update spells success', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        updateOne: async () => ({ matchedCount: 1 }),
+      }),
+    });
+    const res = await request(app)
+      .put('/characters/507f1f77bcf86cd799439011/spells')
+      .send({ spells: ['Fireball'] });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Spells updated');
   });
 
   test('get characters for campaign and user success', async () => {

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -156,6 +156,7 @@ module.exports = (router) => {
       body('weapon').optional().isArray(),
       body('armor').optional().isArray(),
       body('item').optional().isArray(),
+      body('spells').optional().isArray(),
       body('sex').optional().trim(),
       body('diceColor').optional().trim(),
       ...numericCharacterFields.map((field) => body(field).optional().isInt().toInt()),
@@ -324,6 +325,29 @@ module.exports = (router) => {
         );
         logger.info('Feats updated');
         res.json({ message: 'Feats updated' });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // This section will update spells.
+  characterRouter.route('/:id/spells').put(
+    [body('spells').isArray().withMessage('spells must be an array')],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid ID' });
+      }
+      const db_connect = req.db;
+      const { spells } = matchedData(req, { locations: ['body'] });
+      try {
+        await db_connect.collection('Characters').updateOne(
+          { _id: ObjectId(req.params.id) },
+          { $set: { spells } }
+        );
+        logger.info('Spells updated');
+        res.json({ message: 'Spells updated' });
       } catch (err) {
         next(err);
       }


### PR DESCRIPTION
## Summary
- enable spell selection on character sheet
- store selected spells in backend models
- add tests for spell picking and persistence

## Testing
- `npm test --prefix client`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6a016c0832eaf670434f78b3603