### PR TITLE
Add spell point tracking for spell selection

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -66,11 +66,14 @@ test('saves selected spells', async () => {
   );
   await screen.findByLabelText('Class');
   await userEvent.selectOptions(screen.getByLabelText('Level'), '3');
-  await userEvent.click(await screen.findByText('Fireball'));
+  const checkbox = (await screen.findAllByRole('checkbox'))[0];
+  await userEvent.click(checkbox);
   await userEvent.click(screen.getByRole('button', { name: /save/i }));
-  expect(apiFetch).toHaveBeenLastCalledWith(
-    '/characters/1/spells',
-    expect.objectContaining({ method: 'PUT' })
-  );
-  await waitFor(() => expect(onChange).toHaveBeenCalledWith(['Fireball']));
+  const lastCall = apiFetch.mock.calls[1];
+  expect(lastCall[0]).toBe('/characters/1/spells');
+  expect(JSON.parse(lastCall[1].body)).toEqual({
+    spells: ['Fireball'],
+    spellPoints: 1,
+  });
+  await waitFor(() => expect(onChange).toHaveBeenCalledWith(['Fireball'], 1));
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -404,7 +404,9 @@ return (
       form={form}
       show={showSpells}
       handleClose={handleCloseSpells}
-      onSpellsChange={(spells) => setForm((prev) => ({ ...prev, spells }))}
+      onSpellsChange={(spells, spellPoints) =>
+        setForm((prev) => ({ ...prev, spells, spellPoints }))
+      }
     />
     <Help
       form={form}

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -123,7 +123,7 @@ describe('Character routes', () => {
     });
     const res = await request(app)
       .put('/characters/507f1f77bcf86cd799439011/spells')
-      .send({ spells: ['Fireball'] });
+      .send({ spells: ['Fireball'], spellPoints: 1 });
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Spells updated');
   });

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -333,18 +333,25 @@ module.exports = (router) => {
 
   // This section will update spells.
   characterRouter.route('/:id/spells').put(
-    [body('spells').isArray().withMessage('spells must be an array')],
+    [
+      body('spells').isArray().withMessage('spells must be an array'),
+      body('spellPoints').optional().isInt().toInt(),
+    ],
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
         return res.status(400).json({ message: 'Invalid ID' });
       }
       const db_connect = req.db;
-      const { spells } = matchedData(req, { locations: ['body'] });
+      const { spells, spellPoints } = matchedData(req, { locations: ['body'] });
+      const update = { spells };
+      if (typeof spellPoints === 'number') {
+        update.spellPoints = spellPoints;
+      }
       try {
         await db_connect.collection('Characters').updateOne(
           { _id: ObjectId(req.params.id) },
-          { $set: { spells } }
+          { $set: update }
         );
         logger.info('Spells updated');
         res.json({ message: 'Spells updated' });


### PR DESCRIPTION
## Summary
- track spell slot points per level and show remaining points in spell selector
- persist spell points to character via API and update character sheet
- support saving spell points in backend

## Testing
- `cd server && npm test`
- `cd client && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8de3a0a9c832eb8332bb65f980187