### PR TITLE
feat: add spell damage and attacks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -87,6 +87,23 @@ const handleWeaponsButtonClick = (el) => {
   }
 };
 
+const handleSpellsButtonClick = (spell) => {
+  if (!spell?.damage) return;
+  const match = spell.damage.match(/(\d+)d(\d+)([+-]\d+)?/);
+  if (match) {
+    const [, numberOfDice, sidesOfDice, modifier] = match;
+    const numberOfDiceValue = parseInt(numberOfDice, 10);
+    const sidesOfDiceValue = parseInt(sidesOfDice, 10);
+    const constantValueValue = modifier ? parseInt(modifier, 10) : 0;
+    const diceRolls = rollDice(numberOfDiceValue, sidesOfDiceValue);
+    const damageSum = diceRolls.reduce((partialSum, a) => partialSum + a, 0);
+    const damageValue = damageSum + constantValueValue;
+    updateDamageValueWithAnimation(damageValue);
+  } else {
+    console.error("Invalid damage string");
+  }
+};
+
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const opacity = 0.85;
 // Calculate RGBA color with opacity
@@ -331,6 +348,42 @@ const showSparklesEffect = () => {
                 ))}
               </tbody>
             </Table>
+            {Array.isArray(form.spells) && form.spells.some((s) => s?.damage) && (
+              <>
+                <Card.Title className="modal-title mt-4">Spells</Card.Title>
+                <Table className="modern-table" striped bordered hover responsive>
+                  <thead>
+                    <tr>
+                      <th>Spell Name</th>
+                      <th>Level</th>
+                      <th>Damage</th>
+                      <th>Attack</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {form.spells
+                      .filter((s) => s && s.damage)
+                      .map((spell, idx) => (
+                        <tr key={idx}>
+                          <td>{spell.name}</td>
+                          <td>{spell.level}</td>
+                          <td>{spell.damage}</td>
+                          <td>
+                            <Button
+                              onClick={() => {
+                                handleSpellsButtonClick(spell);
+                                handleCloseAttack();
+                              }}
+                              size="sm"
+                              className="action-btn fa-solid fa-plus"
+                            ></Button>
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </Table>
+              </>
+            )}
             </Card.Body>
             <Card.Footer className="modal-footer">
               <Button className="close-btn" variant="secondary" onClick={handleCloseAttack}>

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -72,8 +72,13 @@ test('saves selected spells', async () => {
   const lastCall = apiFetch.mock.calls[1];
   expect(lastCall[0]).toBe('/characters/1/spells');
   expect(JSON.parse(lastCall[1].body)).toEqual({
-    spells: ['Fireball'],
+    spells: [{ name: 'Fireball', level: 3, damage: '' }],
     spellPoints: 1,
   });
-  await waitFor(() => expect(onChange).toHaveBeenCalledWith(['Fireball'], 1));
+  await waitFor(() =>
+    expect(onChange).toHaveBeenCalledWith(
+      [{ name: 'Fireball', level: 3, damage: '' }],
+      1
+    )
+  );
 });

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -66,7 +66,7 @@ describe('Character routes', () => {
       weapon: ['Sword'],
       armor: ['Plate'],
       item: ['Potion'],
-      spells: ['Fireball'],
+      spells: [{ name: 'Fireball', level: 3, damage: '8d6' }],
     };
     const res = await request(app)
       .post('/characters/add')
@@ -89,6 +89,7 @@ describe('Character routes', () => {
     expect(Array.isArray(captured.feat)).toBe(true);
     expect(Array.isArray(captured.weapon)).toBe(true);
     expect(Array.isArray(captured.spells)).toBe(true);
+    expect(captured.spells[0]).toMatchObject({ name: 'Fireball', level: 3, damage: '8d6' });
   });
 
   test('add character db failure', async () => {
@@ -123,7 +124,7 @@ describe('Character routes', () => {
     });
     const res = await request(app)
       .put('/characters/507f1f77bcf86cd799439011/spells')
-      .send({ spells: ['Fireball'], spellPoints: 1 });
+      .send({ spells: [{ name: 'Fireball', level: 3, damage: '8d6' }], spellPoints: 1 });
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Spells updated');
   });

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -157,6 +157,9 @@ module.exports = (router) => {
       body('armor').optional().isArray(),
       body('item').optional().isArray(),
       body('spells').optional().isArray(),
+      body('spells.*.name').optional().isString(),
+      body('spells.*.level').optional().isInt().toInt(),
+      body('spells.*.damage').optional().isString(),
       body('sex').optional().trim(),
       body('diceColor').optional().trim(),
       ...numericCharacterFields.map((field) => body(field).optional().isInt().toInt()),
@@ -335,6 +338,9 @@ module.exports = (router) => {
   characterRouter.route('/:id/spells').put(
     [
       body('spells').isArray().withMessage('spells must be an array'),
+      body('spells.*.name').isString(),
+      body('spells.*.level').isInt().toInt(),
+      body('spells.*.damage').optional().isString(),
       body('spellPoints').optional().isInt().toInt(),
     ],
     handleValidationErrors,
@@ -343,7 +349,10 @@ module.exports = (router) => {
         return res.status(400).json({ message: 'Invalid ID' });
       }
       const db_connect = req.db;
-      const { spells, spellPoints } = matchedData(req, { locations: ['body'] });
+      const { spells, spellPoints } = matchedData(req, {
+        locations: ['body'],
+        includeOptionals: true,
+      });
       const update = { spells };
       if (typeof spellPoints === 'number') {
         update.spellPoints = spellPoints;


### PR DESCRIPTION
## Summary
- allow characters to store spells with level and damage
- display spell attacks with damage rolls on player turn
- update selectors and tests to handle spell objects

## Testing
- `npm test --prefix server`
- `npm test --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8e0cdbd60832e8cb12f4021bde8f6