### PR TITLE
Highlight spells button when spell points available

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -188,6 +188,7 @@ const featBonuses = (form.feat || []).reduce(
 
 const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
 const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
+const spellsGold = (form.spellPoints || 0) > 0 ? "gold" : "#6C757D";
 // ------------------------------------------Attack Bonus---------------------------------------------------
 let atkBonus = 0;
 const occupations = form.occupation;
@@ -348,7 +349,7 @@ return (
               color: "black",
               padding: "8px",
               marginTop: "10px",
-              backgroundColor: "#6C757D",
+              backgroundColor: spellsGold,
             }}
             className="mx-1 fas fa-hat-wizard"
             variant="secondary"


### PR DESCRIPTION
## Summary
- Highlight spell selector button in gold when character has remaining spell points
- Track spell point availability with `spellsGold` constant alongside other UI indicators

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b8eae063ac832ebb486ad45b58b1b8