### PR TITLE
Refactor spell selector to table with view modal

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Button, Form, Tabs, Tab } from 'react-bootstrap';
+import { Modal, Card, Button, Form, Tabs, Tab, Table } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 
 /**
@@ -113,6 +113,7 @@ export default function SpellSelector({
   const [pointsLeft, setPointsLeft] = useState({});
   const [activeClass, setActiveClass] = useState(classesInfo[0]?.name || '');
   const [error, setError] = useState(null);
+  const [viewSpell, setViewSpell] = useState(null);
 
   useEffect(() => {
     apiFetch('/spells')
@@ -181,7 +182,7 @@ export default function SpellSelector({
           selectedLevel === 0
             ? CANTRIP_TABLE[level] || 0
             : slotRow[selectedLevel] || 0;
-        const count = selectedSpells.reduce((acc, spellName) => {
+        const count = spells.reduce((acc, spellName) => {
           const info = Object.values(allSpells).find((s) => s.name === spellName);
           return info &&
             info.level === selectedLevel &&
@@ -218,132 +219,214 @@ export default function SpellSelector({
   }
 
   return (
-    <Modal
-      className="dnd-modal modern-modal"
-      show={show}
-      onHide={handleClose}
-      size="lg"
-      centered
-    >
-      <Card className="modern-card">
-        <Card.Header className="modal-header">
-          <Card.Title className="modal-title">Spells</Card.Title>
-        </Card.Header>
-        <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
-          {error && <div className="text-danger mb-2">{error}</div>}
-          {classesInfo.length === 1 ? (
-            (() => {
-              const cls = classesInfo[0].name;
-              return (
-                <>
-                  <Form className="mb-3">
-                    <Form.Group>
-                      <Form.Label htmlFor={`spellLevel-${cls}`}>Level</Form.Label>
-                      <Form.Select
-                        id={`spellLevel-${cls}`}
-                        value={selectedLevels[cls]}
-                        onChange={(e) =>
-                          setSelectedLevels((prev) => ({
-                            ...prev,
-                            [cls]: Number(e.target.value),
-                          }))
-                        }
-                      >
-                        {levelOptions[cls].map((lvl) => (
-                          <option key={lvl} value={lvl}>
-                            {lvl}
-                          </option>
+    <>
+      <Modal
+        className="dnd-modal modern-modal"
+        show={show}
+        onHide={handleClose}
+        size="lg"
+        centered
+      >
+        <Card className="modern-card">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Spells</Card.Title>
+          </Card.Header>
+          <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+            {error && <div className="text-danger mb-2">{error}</div>}
+            {classesInfo.length === 1 ? (
+              (() => {
+                const cls = classesInfo[0].name;
+                return (
+                  <>
+                    <Form className="mb-3">
+                      <Form.Group>
+                        <Form.Label htmlFor={`spellLevel-${cls}`}>
+                          Level
+                        </Form.Label>
+                        <Form.Select
+                          id={`spellLevel-${cls}`}
+                          value={selectedLevels[cls]}
+                          onChange={(e) =>
+                            setSelectedLevels((prev) => ({
+                              ...prev,
+                              [cls]: Number(e.target.value),
+                            }))
+                          }
+                        >
+                          {levelOptions[cls].map((lvl) => (
+                            <option key={lvl} value={lvl}>
+                              {lvl}
+                            </option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                    </Form>
+                    <div className="points-container" style={{ display: 'flex' }}>
+                      <span className="points-label text-light">
+                        Points Left:
+                      </span>
+                      <span className="points-value">
+                        {pointsLeft[cls] || 0}
+                      </span>
+                    </div>
+                    <Table striped bordered hover size="sm">
+                      <thead>
+                        <tr>
+                          <th></th>
+                          <th>Name</th>
+                          <th>School</th>
+                          <th>Casting Time</th>
+                          <th>Range</th>
+                          <th>Duration</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {spellsForClass(cls).map((spell) => (
+                          <tr key={spell.name}>
+                            <td>
+                              <Form.Check
+                                id={`spell-${spell.name}`}
+                                type="checkbox"
+                                checked={selectedSpells.includes(spell.name)}
+                                disabled={
+                                  !selectedSpells.includes(spell.name) &&
+                                  (pointsLeft[cls] || 0) <= 0
+                                }
+                                onChange={() => toggleSpell(spell.name)}
+                              />
+                            </td>
+                            <td>{spell.name}</td>
+                            <td>{spell.school}</td>
+                            <td>{spell.castingTime}</td>
+                            <td>{spell.range}</td>
+                            <td>{spell.duration}</td>
+                            <td>
+                              <Button
+                                variant="link"
+                                onClick={() => setViewSpell(spell)}
+                              >
+                                <i className="fa-solid fa-eye"></i>
+                              </Button>
+                            </td>
+                          </tr>
                         ))}
-                      </Form.Select>
-                    </Form.Group>
-                  </Form>
-                  <div className="points-container" style={{ display: 'flex' }}>
-                    <span className="points-label text-light">Points Left:</span>
-                    <span className="points-value">{pointsLeft[cls] || 0}</span>
-                  </div>
-                  {spellsForClass(cls).map((spell) => (
-                    <Form.Check
-                      key={spell.name}
-                      id={`spell-${spell.name}`}
-                      type="checkbox"
-                      label={spell.name}
-                      checked={selectedSpells.includes(spell.name)}
-                      disabled={
-                        !selectedSpells.includes(spell.name) &&
-                        (pointsLeft[cls] || 0) <= 0
-                      }
-                      onChange={() => toggleSpell(spell.name)}
-                      className="mb-2"
-                    />
-                  ))}
-                </>
-              );
-            })()
-          ) : (
-            <Tabs
-              activeKey={activeClass}
-              onSelect={(k) => setActiveClass(k || '')}
-              className="mb-3"
-            >
-              {classesInfo.map(({ name }) => (
-                <Tab eventKey={name} title={name} key={name}>
-                  <Form className="mb-3">
-                    <Form.Group>
-                      <Form.Label htmlFor={`spellLevel-${name}`}>
-                        Level
-                      </Form.Label>
-                      <Form.Select
-                        id={`spellLevel-${name}`}
-                        value={selectedLevels[name]}
-                        onChange={(e) =>
-                          setSelectedLevels((prev) => ({
-                            ...prev,
-                            [name]: Number(e.target.value),
-                          }))
-                        }
-                      >
-                        {levelOptions[name].map((lvl) => (
-                          <option key={lvl} value={lvl}>
-                            {lvl}
-                          </option>
+                      </tbody>
+                    </Table>
+                  </>
+                );
+              })()
+            ) : (
+              <Tabs
+                activeKey={activeClass}
+                onSelect={(k) => setActiveClass(k || '')}
+                className="mb-3"
+              >
+                {classesInfo.map(({ name }) => (
+                  <Tab eventKey={name} title={name} key={name}>
+                    <Form className="mb-3">
+                      <Form.Group>
+                        <Form.Label htmlFor={`spellLevel-${name}`}>
+                          Level
+                        </Form.Label>
+                        <Form.Select
+                          id={`spellLevel-${name}`}
+                          value={selectedLevels[name]}
+                          onChange={(e) =>
+                            setSelectedLevels((prev) => ({
+                              ...prev,
+                              [name]: Number(e.target.value),
+                            }))
+                          }
+                        >
+                          {levelOptions[name].map((lvl) => (
+                            <option key={lvl} value={lvl}>
+                              {lvl}
+                            </option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                    </Form>
+                    <div className="points-container" style={{ display: 'flex' }}>
+                      <span className="points-label text-light">
+                        Points Left:
+                      </span>
+                      <span className="points-value">
+                        {pointsLeft[name] || 0}
+                      </span>
+                    </div>
+                    <Table striped bordered hover size="sm">
+                      <thead>
+                        <tr>
+                          <th></th>
+                          <th>Name</th>
+                          <th>School</th>
+                          <th>Casting Time</th>
+                          <th>Range</th>
+                          <th>Duration</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {spellsForClass(name).map((spell) => (
+                          <tr key={spell.name}>
+                            <td>
+                              <Form.Check
+                                id={`spell-${spell.name}`}
+                                type="checkbox"
+                                checked={selectedSpells.includes(spell.name)}
+                                disabled={
+                                  !selectedSpells.includes(spell.name) &&
+                                  (pointsLeft[name] || 0) <= 0
+                                }
+                                onChange={() => toggleSpell(spell.name)}
+                              />
+                            </td>
+                            <td>{spell.name}</td>
+                            <td>{spell.school}</td>
+                            <td>{spell.castingTime}</td>
+                            <td>{spell.range}</td>
+                            <td>{spell.duration}</td>
+                            <td>
+                              <Button
+                                variant="link"
+                                onClick={() => setViewSpell(spell)}
+                              >
+                                <i className="fa-solid fa-eye"></i>
+                              </Button>
+                            </td>
+                          </tr>
                         ))}
-                      </Form.Select>
-                    </Form.Group>
-                  </Form>
-                  <div className="points-container" style={{ display: 'flex' }}>
-                    <span className="points-label text-light">
-                      Points Left:
-                    </span>
-                    <span className="points-value">
-                      {pointsLeft[name] || 0}
-                    </span>
-                  </div>
-                  {spellsForClass(name).map((spell) => (
-                    <Form.Check
-                      key={spell.name}
-                      id={`spell-${spell.name}`}
-                      type="checkbox"
-                      label={spell.name}
-                      checked={selectedSpells.includes(spell.name)}
-                      disabled={
-                        !selectedSpells.includes(spell.name) &&
-                        (pointsLeft[name] || 0) <= 0
-                      }
-                      onChange={() => toggleSpell(spell.name)}
-                      className="mb-2"
-                    />
-                  ))}
-                </Tab>
-              ))}
-            </Tabs>
-          )}
-        </Card.Body>
-        <Card.Footer className="text-end">
-          <Button variant="secondary" onClick={handleClose}>
+                      </tbody>
+                    </Table>
+                  </Tab>
+                ))}
+              </Tabs>
+            )}
+          </Card.Body>
+          <Card.Footer className="text-end">
+            <Button variant="secondary" onClick={handleClose}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </Modal>
+      <Modal
+        show={!!viewSpell}
+        onHide={() => setViewSpell(null)}
+        centered
+        size="lg"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>{viewSpell?.name}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{viewSpell?.description}</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setViewSpell(null)}>
             Close
           </Button>
-        </Card.Footer>
-      </Card>
-    </Modal>
+        </Modal.Footer>
+      </Modal>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Replace spell checkbox list with tabular layout including spell details and view buttons
- Track selected spell for viewing and display description in nested modal
- Use updated save logic to respect current selection when counting slots

## Testing
- `CI=true npm test`
- `CI=true npm test src/components/Zombies/attributes/SpellSelector.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8f44e001c832e959f8c4fb19a9068