### PR TITLE
feat: add weapon interface

### DIFF
--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -1,0 +1,30 @@
+export interface Weapon {
+  /**
+   * Weapon name, e.g. "Longsword".
+   */
+  name: string;
+  /**
+   * Weapon category such as "simple melee" or "martial ranged".
+   */
+  category: string;
+  /**
+   * Damage dice and type, e.g. "1d8 slashing".
+   */
+  damage: string;
+  /**
+   * List of properties from the SRD, e.g. ["versatile", "heavy"].
+   */
+  properties: string[];
+  /**
+   * Weight in pounds.
+   */
+  weight: number;
+  /**
+   * Cost as a string, e.g. "15 gp".
+   */
+  cost: string;
+  /**
+   * Whether the creature wielding the weapon is proficient with it.
+   */
+  proficient: boolean;
+}


### PR DESCRIPTION
## Summary
- add `Weapon` interface with SRD-compliant weapon fields

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9a85ed468832eb5edf78a301607b9