### PR TITLE
Add weapons API routes

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,6 +15,7 @@ const feats = require('./feats');
 const equipment = require('./equipment');
 const races = require('./races');
 const spells = require('./spells');
+const weapons = require('./weapons');
 
 routes.use(async (req, res, next) => {
   try {
@@ -30,6 +31,7 @@ users(routes);
 campaigns(routes);
 races(routes);
 spells(routes);
+weapons(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.
 characterOccupations(routes);

--- a/server/routes/weapons.js
+++ b/server/routes/weapons.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const weapons = require('../data/weapons');
+
+module.exports = (router) => {
+  const weaponRouter = express.Router();
+
+  weaponRouter.get('/', (_req, res) => {
+    res.json(weapons);
+  });
+
+  weaponRouter.get('/:name', (req, res) => {
+    const weapon = weapons[req.params.name.toLowerCase()];
+    if (!weapon) {
+      return res.status(404).json({ message: 'Weapon not found' });
+    }
+    res.json(weapon);
+  });
+
+  router.use('/weapons', weaponRouter);
+};


### PR DESCRIPTION
## Summary
- add weapons router with endpoints to list weapons and fetch individual entries
- register weapons routes with main Express router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9af0073c0832e9927ea6019ec8abb