### PR TITLE
Add weapon proficiency toggle endpoint with eligibility checks

### DIFF
--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -1,0 +1,78 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Weapon proficiency routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects removal of granted proficiency', async () => {
+    const charDoc = {
+      race: { weapons: { dagger: { proficient: true } } },
+      weaponProficiencies: { dagger: true },
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const findOneAndUpdate = jest.fn();
+
+    dbo.mockResolvedValue({
+      collection: () => ({ findOne, findOneAndUpdate })
+    });
+
+    const res = await request(app)
+      .put('/weapon-proficiency/507f1f77bcf86cd799439011')
+      .send({ weapon: 'dagger', proficient: false });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Cannot remove granted proficiency');
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('allows toggling weapon proficiency', async () => {
+    const charDoc = {
+      occupation: [{ weapons: { shortbow: { proficient: false } } }],
+      feat: [],
+      race: {},
+      weaponProficiencies: {},
+    };
+
+    const updatedDoc = {
+      ...charDoc,
+      weaponProficiencies: { shortbow: true },
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const findOneAndUpdate = jest.fn().mockResolvedValue({ value: updatedDoc });
+
+    dbo.mockResolvedValue({
+      collection: () => ({ findOne, findOneAndUpdate })
+    });
+
+    const res = await request(app)
+      .put('/weapon-proficiency/507f1f77bcf86cd799439011')
+      .send({ weapon: 'shortbow', proficient: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ weapon: 'shortbow', proficient: true });
+    expect(findOneAndUpdate).toHaveBeenCalled();
+  });
+});
+

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -16,6 +16,7 @@ const equipment = require('./equipment');
 const races = require('./races');
 const spells = require('./spells');
 const weapons = require('./weapons');
+const weaponProficiency = require('./weaponProficiency');
 
 routes.use(async (req, res, next) => {
   try {
@@ -41,5 +42,6 @@ characterHealth(routes);
 skills(routes);
 feats(routes);
 equipment(routes);
+weaponProficiency(routes);
 
 module.exports = routes;

--- a/server/routes/weaponProficiency.js
+++ b/server/routes/weaponProficiency.js
@@ -1,0 +1,86 @@
+const ObjectId = require('mongodb').ObjectId;
+const express = require('express');
+const authenticateToken = require('../middleware/auth');
+
+// Collect allowed and granted weapons from occupation, feat, and race
+function collectWeaponInfo(occupation = [], feat = [], race) {
+  const allowed = new Set();
+  const granted = new Set();
+  const processSource = (src) => {
+    if (!src) return;
+    const weapons = src.weapons || src.weaponProficiencies;
+    if (!weapons) return;
+    if (Array.isArray(weapons)) {
+      weapons.forEach((w) => {
+        allowed.add(w);
+        granted.add(w);
+      });
+    } else if (typeof weapons === 'object') {
+      Object.keys(weapons).forEach((w) => {
+        allowed.add(w);
+        const val = weapons[w];
+        if (val === true || (val && val.proficient)) {
+          granted.add(w);
+        }
+      });
+    }
+  };
+  if (Array.isArray(occupation)) occupation.forEach(processSource);
+  if (Array.isArray(feat)) feat.forEach(processSource);
+  processSource(race);
+  return { allowed: Array.from(allowed), granted: Array.from(granted) };
+}
+
+module.exports = (router) => {
+  const wpRouter = express.Router();
+
+  // authentication for all weapon proficiency routes
+  wpRouter.use(authenticateToken);
+
+  // Toggle weapon proficiency
+  wpRouter.put('/:id', async (req, res, next) => {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
+    const { weapon, proficient = false } = req.body || {};
+    if (typeof weapon !== 'string' || !weapon.trim()) {
+      return res.status(400).json({ message: 'Invalid weapon' });
+    }
+
+    const db = req.db;
+    const id = { _id: ObjectId(req.params.id) };
+
+    try {
+      const charDoc = await db.collection('Characters').findOne(id);
+      if (!charDoc) {
+        return res.status(404).json({ message: 'Character not found' });
+      }
+
+      const { allowed, granted } = collectWeaponInfo(
+        charDoc.occupation,
+        charDoc.feat,
+        charDoc.race
+      );
+
+      if (!allowed.includes(weapon)) {
+        return res.status(400).json({ message: 'Weapon not allowed' });
+      }
+
+      if (!proficient && granted.includes(weapon)) {
+        return res.status(400).json({ message: 'Cannot remove granted proficiency' });
+      }
+
+      const update = { $set: { [`weaponProficiencies.${weapon}`]: proficient } };
+      await db.collection('Characters').findOneAndUpdate(id, update, {
+        returnDocument: 'after',
+      });
+
+      return res.status(200).json({ weapon, proficient });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.use('/weapon-proficiency', wpRouter);
+};
+


### PR DESCRIPTION
## Summary
- add authenticated `PUT /weapon-proficiency/:id` route to toggle character weapon proficiencies with race/class validation
- register weapon proficiency routes in central router
- add tests for weapon proficiency updates

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9afe8ca90832e8a1acdc6b03e1a5e