### PR TITLE
feat: add weapon list and detail components

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,8 @@ import Login from "./components/Login/Login";
 import Notifications from "./components/Notifications";
 import SpellList from "./components/Spells/SpellList";
 import SpellDetail from "./components/Spells/SpellDetail";
+import WeaponList from "./components/Weapons/WeaponList";
+import WeaponDetail from "./components/Weapons/WeaponDetail";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import "./App.scss";
@@ -37,12 +39,12 @@ function App() {
 
   return (
     <Router>
-      <AppRoutes />
+      <AppRoutes user={user} />
     </Router>
   );
 }
 
-function AppRoutes() {
+function AppRoutes({ user }) {
   const location = useLocation();
   const hideNavbarRoutes = []; // Add routes here to hide the navbar when needed
 
@@ -54,6 +56,8 @@ function AppRoutes() {
         <Route path="/" element={<Zombies />} />
         <Route path="/spells" element={<SpellList />} />
         <Route path="/spells/:name" element={<SpellDetail />} />
+        <Route path="/weapons" element={<WeaponList characterId={user?._id} />} />
+        <Route path="/weapons/:name" element={<WeaponDetail />} />
         <Route path="/zombies-character-select/:campaign" element={<ZombiesCharacterSelect />} />
         <Route path="/zombies-character-sheet/:id" element={<ZombiesCharacterSheet />} />
         <Route path="/zombies-dm/:campaign" element={<ZombiesDM />} />

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -21,6 +21,7 @@ function NavbarComponent() {
         </Navbar.Brand>
           <Nav className="ml-auto">
             <Nav.Link as={Link} to="/spells">Spells</Nav.Link>
+            <Nav.Link as={Link} to="/weapons">Weapons</Nav.Link>
             <Nav.Link>
               <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={handleLogout}>
                 Logout

--- a/client/src/components/Weapons/WeaponDetail.js
+++ b/client/src/components/Weapons/WeaponDetail.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import apiFetch from '../../utils/apiFetch';
+
+/** @typedef {import('../../../../types/weapon').Weapon} Weapon */
+
+function WeaponDetail() {
+  const { name } = useParams();
+  const [weapon, setWeapon] = useState/** @type {Weapon | null} */(null);
+
+  useEffect(() => {
+    apiFetch(`/weapons/${name}`)
+      .then((res) => res.json())
+      .then(setWeapon);
+  }, [name]);
+
+  if (!weapon) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>{weapon.name}</h2>
+      <p><strong>Category:</strong> {weapon.category}</p>
+      <p><strong>Damage:</strong> {weapon.damage}</p>
+      <p><strong>Properties:</strong> {weapon.properties.join(', ') || 'None'}</p>
+      <p><strong>Weight:</strong> {weapon.weight}</p>
+      <p><strong>Cost:</strong> {weapon.cost}</p>
+    </div>
+  );
+}
+
+export default WeaponDetail;
+

--- a/client/src/components/Weapons/WeaponDetail.test.js
+++ b/client/src/components/Weapons/WeaponDetail.test.js
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import WeaponDetail from './WeaponDetail';
+import apiFetch from '../../utils/apiFetch';
+
+jest.mock('../../utils/apiFetch');
+
+test('fetches and displays weapon detail', async () => {
+  apiFetch.mockResolvedValueOnce({
+    json: async () => ({
+      name: 'Club',
+      category: 'simple melee',
+      damage: '1d4 bludgeoning',
+      properties: ['light'],
+      weight: 2,
+      cost: '1 sp',
+      proficient: false,
+    }),
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/weapons/club']}>
+      <Routes>
+        <Route path="/weapons/:name" element={<WeaponDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  expect(apiFetch).toHaveBeenCalledWith('/weapons/club');
+  await waitFor(() => expect(screen.getByText('Club')).toBeInTheDocument());
+  expect(screen.getByText(/simple melee/)).toBeInTheDocument();
+  expect(screen.getByText(/1d4 bludgeoning/)).toBeInTheDocument();
+});
+

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import apiFetch from '../../utils/apiFetch';
+
+/** @typedef {import('../../../../types/weapon').Weapon} Weapon */
+
+/**
+ * List of weapons with proficiency toggles.
+ * @param {{ characterId: string }} props
+ */
+function WeaponList({ characterId }) {
+  const [weapons, setWeapons] = useState/** @type {Record<string, Weapon & {disabled?: boolean}> | null} */(null);
+
+  useEffect(() => {
+    apiFetch('/weapons')
+      .then((res) => res.json())
+      .then((data) => setWeapons(data));
+  }, []);
+
+  if (!weapons) {
+    return <div>Loading...</div>;
+  }
+
+  const handleToggle = (key) => async () => {
+    const weapon = weapons[key];
+    const newProficient = !weapon.proficient;
+    try {
+      const res = await apiFetch(`/weapon-proficiency/${characterId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ weapon: key, proficient: newProficient }),
+      });
+      if (res.ok) {
+        setWeapons((prev) => ({
+          ...prev,
+          [key]: { ...prev[key], proficient: newProficient, disabled: false },
+        }));
+      } else {
+        setWeapons((prev) => ({ ...prev, [key]: { ...prev[key], disabled: true } }));
+      }
+    } catch (err) {
+      setWeapons((prev) => ({ ...prev, [key]: { ...prev[key], disabled: true } }));
+    }
+  };
+
+  return (
+    <div>
+      <h1>Weapons</h1>
+      <ul>
+        {Object.entries(weapons).map(([key, weapon]) => (
+          <li key={key}>
+            <label>
+              <input
+                type="checkbox"
+                checked={weapon.proficient}
+                disabled={weapon.disabled}
+                onChange={handleToggle(key)}
+              />{' '}
+              {weapon.name} - {weapon.damage} ({weapon.category})
+            </label>
+            <div>
+              <small>
+                {weapon.properties.join(', ') || 'No properties'} | Weight: {weapon.weight} | Cost: {weapon.cost}
+              </small>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default WeaponList;
+

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WeaponList from './WeaponList';
+import apiFetch from '../../utils/apiFetch';
+
+jest.mock('../../utils/apiFetch');
+
+const weaponsData = {
+  club: { name: 'Club', damage: '1d4 bludgeoning', category: 'simple melee', properties: ['light'], weight: 2, cost: '1 sp', proficient: false },
+  dagger: { name: 'Dagger', damage: '1d4 piercing', category: 'simple melee', properties: ['finesse'], weight: 1, cost: '2 gp', proficient: true },
+};
+
+test('fetches and toggles weapon proficiency', async () => {
+  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+
+  render(<WeaponList characterId="123" />);
+
+  expect(apiFetch).toHaveBeenCalledWith('/weapons');
+  const clubCheckbox = await screen.findByLabelText(/Club/);
+  expect(clubCheckbox).not.toBeChecked();
+
+  apiFetch.mockResolvedValueOnce({ ok: true });
+  await userEvent.click(clubCheckbox);
+  await waitFor(() => expect(apiFetch).toHaveBeenLastCalledWith(
+    '/weapon-proficiency/123',
+    expect.objectContaining({
+      method: 'PUT',
+      body: JSON.stringify({ weapon: 'club', proficient: true }),
+    })
+  ));
+  await waitFor(() => expect(clubCheckbox).toBeChecked());
+});
+
+test('disables checkbox when server rejects toggle', async () => {
+  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+
+  render(<WeaponList characterId="123" />);
+  const daggerCheckbox = await screen.findByLabelText(/Dagger/);
+
+  apiFetch.mockResolvedValueOnce({ ok: false });
+  await userEvent.click(daggerCheckbox);
+  await waitFor(() => expect(daggerCheckbox).toBeDisabled());
+});
+


### PR DESCRIPTION
## Summary
- add Weapons pages with proficiency toggles
- expose weapon details view
- link weapons in navigation and routes

## Testing
- `npm test` (server)
- `npm test src/components/Weapons/WeaponList.test.js src/components/Weapons/WeaponDetail.test.js` (client)
- `npm test` (client) *(fails: SpellSelector.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b14f8130832e956b9bd74d80a8ae