### PR TITLE
Add tests for weapons routes and checkboxes

### DIFF
--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -17,9 +17,11 @@ test('fetches and toggles weapon proficiency', async () => {
 
   expect(apiFetch).toHaveBeenCalledWith('/weapons');
   const clubCheckbox = await screen.findByLabelText(/Club/);
+  const daggerCheckbox = await screen.findByLabelText(/Dagger/);
   expect(clubCheckbox).not.toBeChecked();
+  expect(daggerCheckbox).toBeChecked();
 
-  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ weapon: 'club', proficient: false }) });
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ weapon: 'club', proficient: true }) });
   await userEvent.click(clubCheckbox);
   await waitFor(() =>
     expect(apiFetch).toHaveBeenLastCalledWith(
@@ -30,7 +32,7 @@ test('fetches and toggles weapon proficiency', async () => {
       })
     )
   );
-  await waitFor(() => expect(clubCheckbox).not.toBeChecked());
+  await waitFor(() => expect(clubCheckbox).toBeChecked());
 });
 
 test('disables checkbox when server rejects toggle', async () => {

--- a/server/__tests__/weapons.test.js
+++ b/server/__tests__/weapons.test.js
@@ -1,0 +1,47 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Weapons API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbo.mockResolvedValue({});
+  });
+
+  test('lists all weapons', async () => {
+    const res = await request(app).get('/weapons');
+    expect(res.status).toBe(200);
+    expect(res.body.club).toBeDefined();
+    expect(res.body.dagger).toBeDefined();
+  });
+
+  test('fetches a single weapon', async () => {
+    const res = await request(app).get('/weapons/club');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ name: 'Club', damage: '1d4 bludgeoning' });
+  });
+
+  test('returns 404 for unknown weapon', async () => {
+    const res = await request(app).get('/weapons/unknown');
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Weapon not found');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for weapons API routes including 404 case
- verify WeaponList checkboxes render and toggle in component tests

## Testing
- `npm test` (server)
- `CI=true npm test src/components/Weapons/WeaponList.test.js` (client)
- `CI=true npm test` (client) *(fails: SpellSelector and Feats tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b5046440832e93701a204348aab8