### PR TITLE
Remove spells and weapons links from navbar

### DIFF
--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -20,9 +20,8 @@ function NavbarComponent() {
           <img src={logoLight} alt="" width="60px" height="60px" className="d-inline-block align-text-top" />
         </Navbar.Brand>
           <Nav className="ml-auto">
-            <Nav.Link as={Link} to="/spells">Spells</Nav.Link>
-            {/* Link to weapon list */}
-            <Nav.Link as={Link} to="/weapons">Weapons</Nav.Link>
+            {/* <Nav.Link as={Link} to="/spells">Spells</Nav.Link> */}
+            {/* <Nav.Link as={Link} to="/weapons">Weapons</Nav.Link> */}
             <Nav.Link>
               <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={handleLogout}>
                 Logout


### PR DESCRIPTION
## Summary
- comment out spells and weapons links in navbar leaving only logout

## Testing
- `npm test -- --watchAll=false` *(fails: Test Suites: 1 failed, 11 passed, 12 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8d489f0832ebf83e9c2cdaafaa0