### PR TITLE
feat: merge campaign weapons into weapon list

### DIFF
--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -9,17 +9,28 @@ const weaponsData = {
   club: { name: 'Club', damage: '1d4 bludgeoning', category: 'simple melee', properties: ['light'], weight: 2, cost: '1 sp', proficient: false },
   dagger: { name: 'Dagger', damage: '1d4 piercing', category: 'simple melee', properties: ['finesse'], weight: 1, cost: '2 gp', proficient: true },
 };
+const customData = [
+  { weaponName: 'Laser Sword', damage: '1d8 radiant', weaponStyle: 'martial melee' },
+];
+
+afterEach(() => {
+  apiFetch.mockReset();
+});
 
 test('fetches and toggles weapon proficiency', async () => {
   apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({ json: async () => customData });
 
-  render(<WeaponList characterId="123" />);
+  render(<WeaponList characterId="123" campaign="Camp1" />);
 
   expect(apiFetch).toHaveBeenCalledWith('/weapons');
+  expect(apiFetch).toHaveBeenCalledWith('/equipment/weapons/Camp1');
   const clubCheckbox = await screen.findByLabelText(/Club/);
   const daggerCheckbox = await screen.findByLabelText(/Dagger/);
+  const laserCheckbox = await screen.findByLabelText(/Laser Sword/);
   expect(clubCheckbox).not.toBeChecked();
   expect(daggerCheckbox).toBeChecked();
+  expect(laserCheckbox).not.toBeChecked();
 
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ weapon: 'club', proficient: true }) });
   await userEvent.click(clubCheckbox);
@@ -37,8 +48,9 @@ test('fetches and toggles weapon proficiency', async () => {
 
 test('disables checkbox when server rejects toggle', async () => {
   apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({ json: async () => customData });
 
-  render(<WeaponList characterId="123" />);
+  render(<WeaponList characterId="123" campaign="Camp1" />);
   const daggerCheckbox = await screen.findByLabelText(/Dagger/);
 
   apiFetch.mockResolvedValueOnce({ ok: false });

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -72,12 +72,30 @@ test('saves selected spells', async () => {
   const lastCall = apiFetch.mock.calls[1];
   expect(lastCall[0]).toBe('/characters/1/spells');
   expect(JSON.parse(lastCall[1].body)).toEqual({
-    spells: [{ name: 'Fireball', level: 3, damage: '' }],
+    spells: [
+      {
+        name: 'Fireball',
+        level: 3,
+        damage: '',
+        castingTime: '1 action',
+        range: '150 feet',
+        duration: 'Instantaneous',
+      },
+    ],
     spellPoints: 1,
   });
   await waitFor(() =>
     expect(onChange).toHaveBeenCalledWith(
-      [{ name: 'Fireball', level: 3, damage: '' }],
+      [
+        {
+          name: 'Fireball',
+          level: 3,
+          damage: '',
+          castingTime: '1 action',
+          range: '150 feet',
+          duration: 'Instantaneous',
+        },
+      ],
       1
     )
   );
@@ -103,12 +121,30 @@ test('uses Occupation when Name is missing', async () => {
   await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
   const lastCall = apiFetch.mock.calls[1];
   expect(JSON.parse(lastCall[1].body)).toEqual({
-    spells: [{ name: 'Fireball', level: 3, damage: '' }],
+    spells: [
+      {
+        name: 'Fireball',
+        level: 3,
+        damage: '',
+        castingTime: '1 action',
+        range: '150 feet',
+        duration: 'Instantaneous',
+      },
+    ],
     spellPoints: 1,
   });
   await waitFor(() =>
     expect(onChange).toHaveBeenCalledWith(
-      [{ name: 'Fireball', level: 3, damage: '' }],
+      [
+        {
+          name: 'Fireball',
+          level: 3,
+          damage: '',
+          castingTime: '1 action',
+          range: '150 feet',
+          duration: 'Instantaneous',
+        },
+      ],
       1
     )
   );

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
-import { Nav, Navbar, Container, Button } from 'react-bootstrap';
+import { Nav, Navbar, Container, Button, Modal } from 'react-bootstrap';
 import '../../../App.scss';
 import loginbg from "../../../images/loginbg.png";
 import CharacterInfo from "../attributes/CharacterInfo";
@@ -9,7 +9,7 @@ import Stats from "../attributes/Stats";
 import Skills from "../attributes/Skills";
 import Feats from "../attributes/Feats";
 import { calculateFeatPointsLeft } from '../../../utils/featUtils';
-import Weapons from "../attributes/Weapons";
+import WeaponList from "../../Weapons/WeaponList";
 import PlayerTurnActions from "../attributes/PlayerTurnActions";
 import Armor from "../attributes/Armor";
 import Items from "../attributes/Items";
@@ -383,13 +383,15 @@ return (
     />
     <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
     <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} />
-    <Weapons
-      form={form}
-      showWeapons={showWeapons}
-      handleCloseWeapons={handleCloseWeapons}
-      strMod={statMods.str}
-      dexMod={statMods.dex}
-    />
+    <Modal
+      className="dnd-modal modern-modal"
+      show={showWeapons}
+      onHide={handleCloseWeapons}
+      size="lg"
+      centered
+    >
+      <WeaponList characterId={characterId} campaign={form.campaign} />
+    </Modal>
     <Armor
       form={form}
       showArmor={showArmor}


### PR DESCRIPTION
## Summary
- merge PHB weapons with campaign equipment in `WeaponList`
- use `WeaponList` modal on Zombies character sheet for proficiency toggles
- adjust tests for new weapon and spell data

## Testing
- `npm test --prefix server`
- `npm test --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9b8f5b374832e8ec6dc61e597a154