### PR TITLE
Refactor weapon list with bootstrap card and table

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Card, Table, Form } from 'react-bootstrap';
 import apiFetch from '../../utils/apiFetch';
 
 /** @typedef {import('../../../../types/weapon').Weapon} Weapon */
@@ -81,29 +82,47 @@ function WeaponList({ characterId, campaign }) {
   };
 
   return (
-    <div>
-      <h1>Weapons</h1>
-      <ul>
-        {Object.entries(weapons).map(([key, weapon]) => (
-          <li key={key}>
-            <label>
-              <input
-                type="checkbox"
-                checked={weapon.proficient}
-                disabled={weapon.disabled}
-                onChange={handleToggle(key)}
-              />{' '}
-              {weapon.name} - {weapon.damage} ({weapon.category})
-            </label>
-            <div>
-              <small>
-                {weapon.properties.join(', ') || 'No properties'} | Weight: {weapon.weight} | Cost: {weapon.cost}
-              </small>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Card className="modern-card">
+      <Card.Header className="modal-header">
+        <Card.Title className="modal-title">Weapons</Card.Title>
+      </Card.Header>
+      <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+        <Table striped bordered hover size="sm" className="modern-table">
+          <thead>
+            <tr>
+              <th>Prof</th>
+              <th>Name</th>
+              <th>Damage</th>
+              <th>Category</th>
+              <th>Properties</th>
+              <th>Weight</th>
+              <th>Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(weapons).map(([key, weapon]) => (
+              <tr key={key}>
+                <td>
+                  <Form.Check
+                    type="checkbox"
+                    checked={weapon.proficient}
+                    disabled={weapon.disabled}
+                    onChange={handleToggle(key)}
+                    aria-label={weapon.name}
+                  />
+                </td>
+                <td>{weapon.name}</td>
+                <td>{weapon.damage}</td>
+                <td>{weapon.category}</td>
+                <td>{weapon.properties.join(', ') || 'No properties'}</td>
+                <td>{weapon.weight}</td>
+                <td>{weapon.cost}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- Revamp `WeaponList` to use React-Bootstrap `Card`, `Table`, and `Form.Check`
- Present weapons in a modern table layout with proficiency toggles and details

## Testing
- `cd client && npm test -- WeaponList.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9cee4f38c832e8c7f777a747c99f1