### PR TITLE
style weapon proficiency checkbox with primary accent

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3,6 +3,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
 
+.weapon-checkbox .form-check-input:checked {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+}
+
 .App {
   text-align: center;
 }

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -105,6 +105,7 @@ function WeaponList({ characterId, campaign }) {
                 <td>
                   <Form.Check
                     type="checkbox"
+                    className="weapon-checkbox"
                     checked={weapon.proficient}
                     disabled={weapon.disabled}
                     onChange={handleToggle(key)}


### PR DESCRIPTION
## Summary
- add `weapon-checkbox` class to weapon list checkbox
- style checked weapon proficiency checkbox with primary blue accent

## Testing
- `cd client && CI=true npm test -- src/components/Weapons/WeaponList.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9d1a841a8832e99c974259140a865