### PR TITLE
Handle weapon proficiency toggles with optimistic pending state

### DIFF
--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -62,7 +62,7 @@ test('fetches and toggles weapon proficiency', async () => {
   );
 });
 
-test('disables checkbox when server rejects toggle', async () => {
+test('reverts checkbox when server rejects toggle', async () => {
   apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce({ json: async () => customData });
 
@@ -71,6 +71,10 @@ test('disables checkbox when server rejects toggle', async () => {
 
   apiFetch.mockResolvedValueOnce({ ok: false });
   await userEvent.click(daggerCheckbox);
-  await waitFor(() => expect(daggerCheckbox).toBeDisabled());
+
+  await waitFor(() => {
+    expect(daggerCheckbox).toBeChecked();
+    expect(daggerCheckbox).not.toBeDisabled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add per-weapon `pending` flags and optimistic update handling
- prevent disabling toggles permanently on failed requests
- adjust tests for new pending behavior and rollback

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b9d69871e4832ea59a014629cabfd3