### PR TITLE
Refactor weapon change handling and memoize sheet callback

### DIFF
--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -33,11 +33,7 @@ test('fetches and toggles weapon proficiency', async () => {
   expect(daggerCheckbox).toBeChecked();
   expect(laserCheckbox).not.toBeChecked();
 
-  await waitFor(() =>
-    expect(onChange).toHaveBeenCalledWith([
-      expect.objectContaining({ name: 'Dagger', proficient: true }),
-    ])
-  );
+  expect(onChange).not.toHaveBeenCalled();
   onChange.mockClear();
 
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ weapon: 'club', proficient: true }) });
@@ -53,7 +49,7 @@ test('fetches and toggles weapon proficiency', async () => {
   );
   await waitFor(() => expect(clubCheckbox).toBeChecked());
   await waitFor(() =>
-    expect(onChange).toHaveBeenCalledWith(
+    expect(onChange).toHaveBeenLastCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ name: 'Club', proficient: true }),
         expect.objectContaining({ name: 'Dagger', proficient: true }),

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button, Modal } from 'react-bootstrap';
@@ -110,19 +110,22 @@ export default function ZombiesCharacterSheet() {
   const handleShowHelpModal = () => setShowHelpModal(true);
   const handleCloseHelpModal = () => setShowHelpModal(false);
 
-  const handleWeaponsChange = async (weapons) => {
-    setForm((prev) => ({ ...prev, weapon: weapons }));
-    try {
-      await apiFetch(`/equipment/update-weapon/${characterId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ weapon: weapons }),
-      });
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-    }
-  };
+  const handleWeaponsChange = useCallback(
+    async (weapons) => {
+      setForm((prev) => ({ ...prev, weapon: weapons }));
+      try {
+        await apiFetch(`/equipment/update-weapon/${characterId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ weapon: weapons }),
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      }
+    },
+    [characterId]
+  );
 
   if (!form) {
     return <div style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${loginbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", minHeight: "100vh"}}>Loading...</div>;


### PR DESCRIPTION
## Summary
- call `onChange` directly within `WeaponList` toggles and remove dependency on effect
- memoize `ZombiesCharacterSheet` weapon change handler with `useCallback`
- update tests for new weapon change behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest client/src/components/Weapons/WeaponList.test.js` *(fails: 403 Forbidden from registry)*
- `npm install jest` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db16a754832ebc2500ef8336f981