### PR TITLE
Refactor weapon list to track owned inventory

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -408,8 +408,8 @@ return (
         centered
       >
         <WeaponList
-          characterId={characterId}
           campaign={form.campaign}
+          initialWeapons={form.weapon}
           onChange={handleWeaponsChange}
         />
       </Modal>

--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -24,7 +24,7 @@ export interface Weapon {
    */
   cost: string;
   /**
-   * Whether the creature wielding the weapon is proficient with it.
+   * Whether the creature currently owns the weapon.
    */
-  proficient: boolean;
+  owned: boolean;
 }


### PR DESCRIPTION
## Summary
- track weapon ownership in WeaponList instead of proficiency
- initialize weapon list from character's inventory
- adjust ZombiesCharacterSheet to pass weapon inventory

## Testing
- `cd client && CI=true npm test 2>&1 | tail -n 20`
- `cd server && npm test >/tmp/server_test.log && tail -n 20 /tmp/server_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b9df2ec964832ea8e2d3339cb11e2a