### PR TITLE
feat: expose weapon proficiency info

### DIFF
--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import WeaponList from './WeaponList';
 import apiFetch from '../../utils/apiFetch';
@@ -47,5 +47,22 @@ test('fetches weapons and toggles ownership', async () => {
     )
   );
   expect(apiFetch).toHaveBeenCalledTimes(2);
+});
+
+test('marks weapon proficiency', async () => {
+  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce(
+    { json: async () => ({ allowed: ['club', 'dagger'], proficient: ['dagger'] }) }
+  );
+
+  render(<WeaponList characterId="char1" />);
+
+  const daggerRow = await screen.findByText('Dagger');
+  expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char1');
+
+  const daggerTr = daggerRow.closest('tr');
+  const clubTr = screen.getByText('Club').closest('tr');
+  expect(within(daggerTr).getByText('Yes')).toBeInTheDocument();
+  expect(within(clubTr).getByText('No')).toBeInTheDocument();
 });
 

--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -74,5 +74,29 @@ describe('Weapon proficiency routes', () => {
     expect(res.body).toEqual({ weapon: 'shortbow', proficient: true });
     expect(findOneAndUpdate).toHaveBeenCalled();
   });
+
+  test('returns allowed and proficient weapons', async () => {
+    const charDoc = {
+      occupation: [{ weapons: { club: false } }],
+      feat: [],
+      race: { weapons: { dagger: { proficient: true } } },
+      weaponProficiencies: { club: true },
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    dbo.mockResolvedValue({ collection: () => ({ findOne }) });
+
+    const res = await request(app).get(
+      '/weapon-proficiency/507f1f77bcf86cd799439011'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.allowed).toEqual(
+      expect.arrayContaining(['club', 'dagger'])
+    );
+    expect(res.body.proficient).toEqual(
+      expect.arrayContaining(['club', 'dagger'])
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- add GET `/weapon-proficiency/:id` to return allowed and proficient weapons
- annotate weapons with proficiency info in WeaponList and show new column
- test weapon proficiency retrieval on server and client

## Testing
- `npm test` (server)
- `CI=true npm test -- --watchAll=false` (client)


------
https://chatgpt.com/codex/tasks/task_e_68b9e3415e7c832e937e04329755fd95