### PR TITLE
Expose weapon proficiency details and update weapon list

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -10,7 +10,7 @@ import apiFetch from '../../utils/apiFetch';
  */
 function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
   const [weapons, setWeapons] =
-    useState/** @type {Record<string, Weapon & { owned?: boolean, proficient?: boolean }> | null} */(null);
+    useState/** @type {Record<string, Weapon & { owned?: boolean, granted?: boolean, proficient?: boolean }> | null} */(null);
 
   useEffect(() => {
     async function fetchWeapons() {
@@ -22,7 +22,7 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
             : Promise.resolve([]),
           characterId
             ? apiFetch(`/weapon-proficiency/${characterId}`).then((res) => res.json())
-            : Promise.resolve({ allowed: null, proficient: [] }),
+            : Promise.resolve({ allowed: null, granted: [], proficient: {} }),
         ]);
 
         const customMap = Array.isArray(custom)
@@ -44,7 +44,8 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
         const ownedSet = new Set(initialWeapons.map((w) => w.name || w));
         const all = { ...phb, ...customMap };
         const allowedSet = prof.allowed ? new Set(prof.allowed) : null;
-        const proficientSet = new Set(prof.proficient || []);
+        const granted = prof.granted || [];
+        const proficient = prof.proficient || {};
         const keys = allowedSet
           ? Object.keys(all).filter((k) => allowedSet.has(k))
           : Object.keys(all);
@@ -52,7 +53,8 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
           acc[key] = {
             ...all[key],
             owned: ownedSet.has(all[key].name),
-            proficient: proficientSet.has(key),
+            granted: granted.includes(key),
+            proficient: Boolean(proficient[key]),
           };
           return acc;
         }, {});
@@ -115,7 +117,7 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
                     aria-label={weapon.name}
                   />
                 </td>
-                <td>{weapon.proficient ? 'Yes' : 'No'}</td>
+                <td>{weapon.granted || weapon.proficient ? 'Yes' : 'No'}</td>
                 <td>{weapon.name}</td>
                 <td>{weapon.damage}</td>
                 <td>{weapon.category}</td>

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -52,7 +52,13 @@ test('fetches weapons and toggles ownership', async () => {
 test('marks weapon proficiency', async () => {
   apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce(
-    { json: async () => ({ allowed: ['club', 'dagger'], proficient: ['dagger'] }) }
+    {
+      json: async () => ({
+        allowed: ['club', 'dagger'],
+        granted: ['dagger'],
+        proficient: {},
+      }),
+    }
   );
 
   render(<WeaponList characterId="char1" />);

--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -75,7 +75,7 @@ describe('Weapon proficiency routes', () => {
     expect(findOneAndUpdate).toHaveBeenCalled();
   });
 
-  test('returns allowed and proficient weapons', async () => {
+  test('returns allowed, granted, and manual proficiencies', async () => {
     const charDoc = {
       occupation: [{ weapons: { club: false } }],
       feat: [],
@@ -94,9 +94,10 @@ describe('Weapon proficiency routes', () => {
     expect(res.body.allowed).toEqual(
       expect.arrayContaining(['club', 'dagger'])
     );
-    expect(res.body.proficient).toEqual(
-      expect.arrayContaining(['club', 'dagger'])
+    expect(res.body.granted).toEqual(
+      expect.arrayContaining(['dagger'])
     );
+    expect(res.body.proficient).toEqual({ club: true });
   });
 });
 

--- a/server/routes/weaponProficiency.js
+++ b/server/routes/weaponProficiency.js
@@ -57,20 +57,12 @@ module.exports = (router) => {
         charDoc.feat,
         charDoc.race
       );
-
-      const proficient = new Set(granted);
-      const manual = charDoc.weaponProficiencies || {};
-      Object.keys(manual).forEach((w) => {
-        if (manual[w]) {
-          proficient.add(w);
-        } else {
-          proficient.delete(w);
-        }
-      });
+      const proficient = charDoc.weaponProficiencies || {};
 
       return res.status(200).json({
         allowed,
-        proficient: Array.from(proficient),
+        granted,
+        proficient,
       });
     } catch (err) {
       next(err);


### PR DESCRIPTION
## Summary
- expand weapon proficiency API to include allowed, granted, and manual flags
- load new proficiency data in weapon list and mark granted weapons
- adjust tests for new API response

## Testing
- `cd server && npm test --silent`
- `cd client && CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b9e9f69e9c832e8902fa3673e80ecc