### PR TITLE
Ignore empty weapon proficiency allow list

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -43,7 +43,10 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
 
         const ownedSet = new Set(initialWeapons.map((w) => w.name || w));
         const all = { ...phb, ...customMap };
-        const allowedSet = prof.allowed ? new Set(prof.allowed) : null;
+        const allowedSet =
+          Array.isArray(prof.allowed) && prof.allowed.length > 0
+            ? new Set(prof.allowed)
+            : null;
         const proficientSet = new Set(prof.proficient || []);
         const grantedSet = new Set(prof.granted || []);
         const keys = allowedSet

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -20,14 +20,23 @@ afterEach(() => {
 test('fetches weapons and toggles ownership', async () => {
   apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce({ json: async () => customData });
+  apiFetch.mockResolvedValueOnce({
+    json: async () => ({ allowed: null, proficient: [], granted: [] }),
+  });
   const onChange = jest.fn();
 
   render(
-    <WeaponList campaign="Camp1" initialWeapons={[weaponsData.dagger]} onChange={onChange} />
+    <WeaponList
+      campaign="Camp1"
+      initialWeapons={[weaponsData.dagger]}
+      onChange={onChange}
+      characterId="char1"
+    />
   );
 
   expect(apiFetch).toHaveBeenCalledWith('/weapons');
   expect(apiFetch).toHaveBeenCalledWith('/equipment/weapons/Camp1');
+  expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char1');
   const clubCheckbox = await screen.findByLabelText('Club');
   const daggerCheckbox = await screen.findByLabelText('Dagger');
   const laserCheckbox = await screen.findByLabelText('Laser Sword');
@@ -46,7 +55,7 @@ test('fetches weapons and toggles ownership', async () => {
       ])
     )
   );
-  expect(apiFetch).toHaveBeenCalledTimes(2);
+  expect(apiFetch).toHaveBeenCalledTimes(3);
 });
 
 test('marks weapon proficiency', async () => {
@@ -73,5 +82,17 @@ test('marks weapon proficiency', async () => {
   expect(daggerProf).toBeChecked();
   expect(daggerProf).toBeDisabled();
   expect(clubProf).not.toBeChecked();
+});
+
+test('shows all weapons when allowed list is empty', async () => {
+  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({
+    json: async () => ({ allowed: [], proficient: [], granted: [] }),
+  });
+
+  render(<WeaponList characterId="char1" />);
+
+  expect(await screen.findByText('Club')).toBeInTheDocument();
+  expect(await screen.findByText('Dagger')).toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary
- Treat empty `allowed` arrays for weapon proficiency as unrestricted
- Cover empty proficiency allowances with new test and adjust existing tests

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9ef9d7f9c832e8a802c271a8ecf61