### PR TITLE
feat: add classes dataset and routes

### DIFF
--- a/server/data/classes.js
+++ b/server/data/classes.js
@@ -1,0 +1,209 @@
+/**
+ * Core D&D 5e classes.
+ * Simplified for API consumption.
+ */
+/** @typedef {import('../../types/class').Class} Class */
+/** @type {Record<string, Class>} */
+const classes = {
+  barbarian: {
+    name: 'Barbarian',
+    hitDie: 12,
+    proficiencies: {
+      armor: ['light', 'medium', 'shields'],
+      weapons: ['simple', 'martial'],
+      tools: [],
+      savingThrows: ['str', 'con'],
+      skills: {
+        count: 2,
+        options: ['animalHandling', 'athletics', 'intimidation', 'nature', 'perception', 'survival'],
+      },
+    },
+    spellcasting: false,
+  },
+  bard: {
+    name: 'Bard',
+    hitDie: 8,
+    proficiencies: {
+      armor: ['light'],
+      weapons: ['simple', 'handCrossbows', 'longswords', 'rapiers', 'shortswords'],
+      tools: ['three musical instruments'],
+      savingThrows: ['dex', 'cha'],
+      skills: {
+        count: 3,
+        options: [
+          'acrobatics',
+          'animalHandling',
+          'arcana',
+          'athletics',
+          'deception',
+          'history',
+          'insight',
+          'intimidation',
+          'investigation',
+          'medicine',
+          'nature',
+          'perception',
+          'performance',
+          'persuasion',
+          'religion',
+          'sleightOfHand',
+          'stealth',
+          'survival',
+        ],
+      },
+    },
+    spellcasting: true,
+  },
+  cleric: {
+    name: 'Cleric',
+    hitDie: 8,
+    proficiencies: {
+      armor: ['light', 'medium', 'shields'],
+      weapons: ['simple'],
+      tools: [],
+      savingThrows: ['wis', 'cha'],
+      skills: {
+        count: 2,
+        options: ['history', 'insight', 'medicine', 'persuasion', 'religion'],
+      },
+    },
+    spellcasting: true,
+  },
+  druid: {
+    name: 'Druid',
+    hitDie: 8,
+    proficiencies: {
+      armor: ['light (non-metal)', 'medium (non-metal)', 'shields (non-metal)'],
+      weapons: ['clubs', 'daggers', 'darts', 'javelins', 'maces', 'quarterstaffs', 'scimitars', 'sickles', 'slings', 'spears'],
+      tools: ['herbalism kit'],
+      savingThrows: ['int', 'wis'],
+      skills: {
+        count: 2,
+        options: ['arcana', 'animalHandling', 'insight', 'medicine', 'nature', 'perception', 'religion', 'survival'],
+      },
+    },
+    spellcasting: true,
+  },
+  fighter: {
+    name: 'Fighter',
+    hitDie: 10,
+    proficiencies: {
+      armor: ['all armor', 'shields'],
+      weapons: ['simple', 'martial'],
+      tools: [],
+      savingThrows: ['str', 'con'],
+      skills: {
+        count: 2,
+        options: ['acrobatics', 'animalHandling', 'athletics', 'history', 'insight', 'intimidation', 'perception', 'survival'],
+      },
+    },
+    spellcasting: false,
+  },
+  monk: {
+    name: 'Monk',
+    hitDie: 8,
+    proficiencies: {
+      armor: [],
+      weapons: ['simple', 'shortswords'],
+      tools: ['one type of artisan tools or instrument'],
+      savingThrows: ['str', 'dex'],
+      skills: {
+        count: 2,
+        options: ['acrobatics', 'athletics', 'history', 'insight', 'religion', 'stealth'],
+      },
+    },
+    spellcasting: false,
+  },
+  paladin: {
+    name: 'Paladin',
+    hitDie: 10,
+    proficiencies: {
+      armor: ['all armor', 'shields'],
+      weapons: ['simple', 'martial'],
+      tools: [],
+      savingThrows: ['wis', 'cha'],
+      skills: {
+        count: 2,
+        options: ['athletics', 'insight', 'intimidation', 'medicine', 'persuasion', 'religion'],
+      },
+    },
+    spellcasting: true,
+  },
+  ranger: {
+    name: 'Ranger',
+    hitDie: 10,
+    proficiencies: {
+      armor: ['light', 'medium', 'shields'],
+      weapons: ['simple', 'martial'],
+      tools: [],
+      savingThrows: ['str', 'dex'],
+      skills: {
+        count: 3,
+        options: ['animalHandling', 'athletics', 'insight', 'investigation', 'nature', 'perception', 'stealth', 'survival'],
+      },
+    },
+    spellcasting: true,
+  },
+  rogue: {
+    name: 'Rogue',
+    hitDie: 8,
+    proficiencies: {
+      armor: ['light'],
+      weapons: ['simple', 'handCrossbows', 'longswords', 'rapiers', 'shortswords'],
+      tools: ['thieves tools'],
+      savingThrows: ['dex', 'int'],
+      skills: {
+        count: 4,
+        options: ['acrobatics', 'athletics', 'deception', 'insight', 'intimidation', 'investigation', 'perception', 'performance', 'persuasion', 'sleightOfHand', 'stealth'],
+      },
+    },
+    spellcasting: false,
+  },
+  sorcerer: {
+    name: 'Sorcerer',
+    hitDie: 6,
+    proficiencies: {
+      armor: [],
+      weapons: ['daggers', 'darts', 'slings', 'quarterstaffs', 'light crossbows'],
+      tools: [],
+      savingThrows: ['con', 'cha'],
+      skills: {
+        count: 2,
+        options: ['arcana', 'deception', 'insight', 'intimidation', 'persuasion', 'religion'],
+      },
+    },
+    spellcasting: true,
+  },
+  warlock: {
+    name: 'Warlock',
+    hitDie: 8,
+    proficiencies: {
+      armor: ['light'],
+      weapons: ['simple'],
+      tools: [],
+      savingThrows: ['wis', 'cha'],
+      skills: {
+        count: 2,
+        options: ['arcana', 'deception', 'history', 'intimidation', 'investigation', 'nature', 'religion'],
+      },
+    },
+    spellcasting: true,
+  },
+  wizard: {
+    name: 'Wizard',
+    hitDie: 6,
+    proficiencies: {
+      armor: [],
+      weapons: ['daggers', 'darts', 'slings', 'quarterstaffs', 'light crossbows'],
+      tools: [],
+      savingThrows: ['int', 'wis'],
+      skills: {
+        count: 2,
+        options: ['arcana', 'history', 'insight', 'investigation', 'medicine', 'religion'],
+      },
+    },
+    spellcasting: true,
+  },
+};
+
+module.exports = classes;

--- a/server/routes/classes.js
+++ b/server/routes/classes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const classes = require('../data/classes');
+
+module.exports = (router) => {
+  const classRouter = express.Router();
+
+  classRouter.get('/', (_req, res) => {
+    res.json(classes);
+  });
+
+  classRouter.get('/:name', (req, res) => {
+    const cls = classes[req.params.name.toLowerCase()];
+    if (!cls) {
+      return res.status(404).json({ message: 'Class not found' });
+    }
+    res.json(cls);
+  });
+
+  router.use('/classes', classRouter);
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -13,6 +13,7 @@ const characterHealth = require('./characters/health');
 const skills = require('./skills');
 const feats = require('./feats');
 const equipment = require('./equipment');
+const classes = require('./classes');
 const races = require('./races');
 const spells = require('./spells');
 const weapons = require('./weapons');
@@ -30,6 +31,7 @@ routes.use(async (req, res, next) => {
 auth(routes);
 users(routes);
 campaigns(routes);
+classes(routes);
 races(routes);
 spells(routes);
 weapons(routes);

--- a/types/class.d.ts
+++ b/types/class.d.ts
@@ -1,0 +1,32 @@
+export interface Class {
+  /**
+   * Class name, e.g. "Wizard".
+   */
+  name: string;
+  /**
+   * Hit die value, e.g. 8 for a d8.
+   */
+  hitDie: number;
+  /**
+   * Proficiency details for the class.
+   */
+  proficiencies: {
+    /** Armor types the class is proficient with. */
+    armor: string[];
+    /** Weapon types the class is proficient with. */
+    weapons: string[];
+    /** Tool proficiencies granted by the class. */
+    tools: string[];
+    /** Saving throws the class is proficient in. */
+    savingThrows: string[];
+    /** Skill choices available at 1st level. */
+    skills: {
+      count: number;
+      options: string[];
+    };
+  };
+  /**
+   * Whether the class grants spellcasting at 1st level.
+   */
+  spellcasting: boolean;
+}


### PR DESCRIPTION
## Summary
- add core class data with hit dice, proficiencies and spellcasting flag
- expose `/classes` and `/classes/:name` routes and register them
- define `Class` TypeScript interface

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f530c988832eba0444b25046b9b7