### PR TITLE
refactor: use new classes endpoint

### DIFF
--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -123,7 +123,7 @@ export default function LevelUp({ show, handleClose, form }) {
   useEffect(() => {
     if (!user) return;
     async function fetchData() {
-      const response = await apiFetch('/characters/occupations');
+      const response = await apiFetch('/classes');
 
       if (!response.ok) {
         const message = `An error has occurred: ${response.statusText}`;
@@ -137,7 +137,7 @@ export default function LevelUp({ show, handleClose, form }) {
         navigate("/");
         return;
       }
-      setGetOccupation(record);
+      setGetOccupation(Object.values(record));
     }
     fetchData();
     return;
@@ -204,12 +204,12 @@ export default function LevelUp({ show, handleClose, form }) {
                           <option value="" disabled>Select your class</option>
                           {getOccupation.map((occupation, i) => {
                             const isOccupationSelected = form.occupation.some(
-                              (item) => item.Occupation === occupation.Occupation
+                              (item) => item.Occupation === occupation.name
                             );
 
                             return (
                               <option key={i} disabled={isOccupationSelected}>
-                                {occupation.Occupation}
+                                {occupation.name}
                               </option>
                             );
                           })}

--- a/client/src/components/Zombies/attributes/LevelUp.test.js
+++ b/client/src/components/Zombies/attributes/LevelUp.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import LevelUp from './LevelUp';
+
+jest.mock('../../../utils/apiFetch');
+import apiFetch from '../../../utils/apiFetch';
+
+jest.mock('../../../hooks/useUser', () => jest.fn());
+import useUser from '../../../hooks/useUser';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+  useNavigate: () => jest.fn(),
+}));
+
+test('fetches classes on mount', async () => {
+  useUser.mockReturnValue({ username: 'tester' });
+  apiFetch.mockResolvedValue({ ok: true, json: async () => ({ wizard: { name: 'Wizard' } }) });
+
+  render(<LevelUp show={true} handleClose={() => {}} form={{ occupation: [] }} />);
+
+  await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/classes'));
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -99,7 +99,7 @@ const [skillSelections, setSkillSelections] = useState([]);
 useEffect(() => {
   if (!user) return;
   async function fetchData() {
-    const response = await apiFetch(`/characters/occupations`);
+    const response = await apiFetch(`/classes`);
 
     if (!response.ok) {
       const message = `An error has occurred: ${response.statusText}`;
@@ -114,8 +114,9 @@ useEffect(() => {
       return;
     }
 
-    setOccupation(record);
-    setGetOccupation(record);
+    const classes = Object.values(record);
+    setOccupation(classes);
+    setGetOccupation(classes);
   }
   fetchData();
   return;
@@ -363,19 +364,19 @@ const handleConfirmOccupation = useCallback(() => {
   if (selectedOccupation && !isOccupationConfirmed) {
     const selectedAddOccupation = selectedAddOccupationRef.current.value;
     const occupationExists = form.occupation.some(
-      (occupation) => occupation.Occupation === selectedOccupation.Occupation
+      (occupation) => occupation.Occupation === selectedOccupation.name
     );
     const selectedAddOccupationObject = getOccupation.find(
-      (occupation) => occupation.Occupation === selectedAddOccupation
+      (occupation) => occupation.name === selectedAddOccupation
     );
 
     if (!occupationExists && selectedAddOccupationObject) {
-      const addOccupationStr = Number(selectedAddOccupationObject.str) + Number(form.str);
-      const addOccupationDex = Number(selectedAddOccupationObject.dex) + Number(form.dex);
-      const addOccupationCon = Number(selectedAddOccupationObject.con) + Number(form.con);
-      const addOccupationInt = Number(selectedAddOccupationObject.int) + Number(form.int);
-      const addOccupationWis = Number(selectedAddOccupationObject.wis) + Number(form.wis);
-      const addOccupationCha = Number(selectedAddOccupationObject.cha) + Number(form.cha);
+      const addOccupationStr = Number(selectedAddOccupationObject.str || 0) + Number(form.str);
+      const addOccupationDex = Number(selectedAddOccupationObject.dex || 0) + Number(form.dex);
+      const addOccupationCon = Number(selectedAddOccupationObject.con || 0) + Number(form.con);
+      const addOccupationInt = Number(selectedAddOccupationObject.int || 0) + Number(form.int);
+      const addOccupationWis = Number(selectedAddOccupationObject.wis || 0) + Number(form.wis);
+      const addOccupationCha = Number(selectedAddOccupationObject.cha || 0) + Number(form.cha);
 
       const totalNewStats =
         addOccupationStr +
@@ -387,7 +388,7 @@ const handleConfirmOccupation = useCallback(() => {
 
       const updatedForm = {
         ...form,
-        occupation: [selectedOccupation],
+        occupation: [{ ...selectedOccupation, Occupation: selectedOccupation.name }],
         startStatTotal: totalNewStats,
         str: addOccupationStr,
         dex: addOccupationDex,
@@ -612,7 +613,7 @@ const getAvailableSkillOptions = (index) => {
             >
               <option value="" disabled>Select your class</option>
               {getOccupation.map((occupation, i) => (
-                <option key={i}>{occupation.Occupation}</option>
+                <option key={i}>{occupation.name}</option>
               ))}
             </Form.Select>
         <Form.Label className="text-light">Race</Form.Label>


### PR DESCRIPTION
## Summary
- replace outdated occupation fetches with `/classes` in LevelUp and character select
- adapt state to new class data shape
- add LevelUp test mocking the `/classes` endpoint

## Testing
- `cd client && npm test -- --watchAll=false`
- `cd client && npm test -- LevelUp.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6a372f4832ea4c361fc2cec30d8