### PR TITLE
refactor: use static class data for multiclass

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -357,22 +357,14 @@ describe('Character routes', () => {
   });
 
   test('get occupations success', async () => {
-    dbo.mockResolvedValue({
-      collection: () => ({
-        find: () => ({ toArray: async () => [{ name: 'Soldier' }] })
-      })
-    });
+    dbo.mockResolvedValue({});
     const res = await request(app).get('/characters/occupations');
     expect(res.status).toBe(200);
-    expect(res.body[0].name).toBe('Soldier');
+    expect(res.body.some((c) => c.name === 'Fighter')).toBe(true);
   });
 
   test('get occupations failure', async () => {
-    dbo.mockResolvedValue({
-      collection: () => ({
-        find: () => ({ toArray: async () => { throw new Error('db error'); } })
-      })
-    });
+    dbo.mockRejectedValue(new Error('db error'));
     const res = await request(app).get('/characters/occupations');
     expect(res.status).toBe(500);
   });
@@ -629,9 +621,7 @@ describe('Character routes', () => {
             },
           };
         }
-        return {
-          findOne: async () => ({ Occupation: 'Fighter', Health: 10, acrobatics: 1 }),
-        };
+        throw new Error(`Unexpected collection ${name}`);
       },
     });
     jest.spyOn(Math, 'random').mockReturnValue(0);
@@ -656,9 +646,7 @@ describe('Character routes', () => {
             findOne: async () => character,
           };
         }
-        return {
-          findOne: async () => ({ Occupation: 'Fighter', Health: 10 }),
-        };
+        throw new Error(`Unexpected collection ${name}`);
       },
     });
     const res = await request(app)

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -2,6 +2,7 @@ const ObjectId = require('mongodb').ObjectId;
 const dbo = require('../db/conn');
 const { skillNames } = require('../routes/fieldConstants');
 const multiclassProficiencies = require('../data/multiclassProficiencies');
+const classes = require('../data/classes');
 
 const prereqs = {
   barbarian: { all: ['str'], min: 13 },
@@ -59,7 +60,6 @@ function collectAllowedSkills(occupation = []) {
 async function applyMulticlass(characterId, newOccupation) {
   const db = await dbo();
   const characters = db.collection('Characters');
-  const occupations = db.collection('Occupations');
   const _id = new ObjectId(characterId);
   const character = await characters.findOne({ _id });
   if (!character) throw new Error('Character not found');
@@ -73,28 +73,31 @@ async function applyMulticlass(characterId, newOccupation) {
   const validation = canMulticlass(character, newOccupation);
   if (!validation.allowed) return validation;
 
-  const occDoc = await occupations.findOne({ Occupation: newOccupation });
-  if (!occDoc) throw new Error('Occupation not found');
+  const key = newOccupation.toLowerCase();
+  const classInfo = classes[key];
+  if (!classInfo) throw new Error('Occupation not found');
 
-  const granted = multiclassProficiencies[newOccupation.toLowerCase()] || [];
+  const granted = multiclassProficiencies[key] || [];
   const skills = {};
   skillNames.forEach((skill) => {
     skills[skill] = {
       proficient: granted.includes(skill),
       expertise: false,
     };
-    delete occDoc[skill];
   });
-  delete occDoc.skillMod;
-  delete occDoc.proficiencyPoints;
 
   const occEntry = {
-    ...occDoc,
+    Name: classInfo.name,
+    Health: classInfo.hitDie,
+    armor: classInfo.proficiencies.armor,
+    weapons: classInfo.proficiencies.weapons,
+    tools: classInfo.proficiencies.tools,
+    savingThrows: classInfo.proficiencies.savingThrows,
     Level: 1,
     skills,
     proficiencyPoints: 0,
   };
-  const hpGain = Math.floor(Math.random() * occDoc.Health) + 1;
+  const hpGain = Math.floor(Math.random() * classInfo.hitDie) + 1;
   const newHealth = (character.health || 0) + hpGain;
 
   const updatedOccupation = Array.isArray(character.occupation)


### PR DESCRIPTION
## Summary
- refactor multiclass logic to use static class data instead of Occupations collection
- serve class list from in-memory data
- update unit tests for new class data source

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f84120f0832e9923f47786b3c71d