### PR TITLE
Normalize occupation object in zombies character select

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -190,7 +190,12 @@ function bigMaff() {
   let occupationLength = occupation.length;
   let randomOccupation = Math.round(Math.random() * (occupationLength - 1));
   let newOccupation = occupation[randomOccupation];
-  updateForm({ occupation: [newOccupation] });
+  const normalizedOccupation = {
+    Occupation: newOccupation.name,
+    Health: newOccupation.hitDie,
+    Level: 1,
+  };
+  updateForm({ occupation: [normalizedOccupation] });
 
   // Race Randomizer
   const raceKeys = Object.keys(races);


### PR DESCRIPTION
## Summary
- Wrap randomly selected occupation into normalized object with Occupation, Health, and Level fields
- Pass normalized occupation object to updateForm during random character creation

## Testing
- `cd client && npm test -- --watchAll=false`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba00626028832ebe5ee2d069635865