### PR TITLE
Normalize occupation fields in Zombies character select

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -393,7 +393,14 @@ const handleConfirmOccupation = useCallback(() => {
 
       const updatedForm = {
         ...form,
-        occupation: [{ ...selectedOccupation, Occupation: selectedOccupation.name }],
+        occupation: [
+          {
+            ...selectedOccupation,
+            Occupation: selectedOccupation.name,
+            Health: selectedOccupation.hitDie,
+            Level: form.occupation?.[0]?.Level || 1,
+          },
+        ],
         startStatTotal: totalNewStats,
         str: addOccupationStr,
         dex: addOccupationDex,


### PR DESCRIPTION
## Summary
- Normalize occupation data when confirming class selection
- Include Occupation name, hit die Health, and Level defaulting to 1

## Testing
- `CI=true npm --prefix client test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ba04de1eb0832e897f86785968a1d0