### PR TITLE
Preserve occupation fields when adding characters

### DIFF
--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -151,6 +151,8 @@ module.exports = (router) => {
       body('campaign').trim().notEmpty().withMessage('campaign is required'),
       body('occupation').optional().isArray(),
       body('occupation.*.Level').isInt().toInt(),
+      body('occupation.*.Occupation').optional().trim(),
+      body('occupation.*.Health').optional().isInt().toInt(),
       body('feat').optional().isArray(),
       body('race').optional().isObject(),
       body('weapon').optional().isArray(),


### PR DESCRIPTION
## Summary
- preserve `Occupation` and `Health` fields for character occupations in `/add` route validation

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ba06805b28832ebd461ef74360bd95