### PR TITLE
Handle missing class ability modifiers in zombie character creation

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -282,14 +282,9 @@ function bigMaff() {
     let randomCha = sumArray[5] + Number(newOccupation.cha || 0) + (raceAbilities.cha || 0);
     updateForm({ cha: randomCha });
 
-  let startStatTotal =
-    randomStr +
-    randomDex +
-    randomCon +
-    randomInt +
-    randomWis +
-    randomCha;
-  updateForm({ startStatTotal: startStatTotal });
+  const stats = [randomStr, randomDex, randomCon, randomInt, randomWis, randomCha];
+  const startStatTotal = stats.reduce((sum, stat) => sum + (Number(stat) || 0), 0);
+  updateForm({ startStatTotal });
 
   const conModValue = Math.floor((randomCon - 10) / 2);
   const newHealth = Number(normalizedOcc.Health);


### PR DESCRIPTION
## Summary
- Default class ability modifiers to 0 in ZombiesCharacterSelect `bigMaff`
- Recalculate `startStatTotal` after stat generation to avoid NaN

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba14593090832ebd7a414754d4a248