### PR TITLE
Add Occupation property to multiclass entries

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -631,9 +631,11 @@ describe('Character routes', () => {
     expect(res.status).toBe(200);
     expect(captured.update.$set.health).toBe(11);
     const occ = captured.update.$set.occupation[0];
+    expect(occ.Occupation).toBe('Fighter');
     expect(occ.skills.acrobatics).toEqual({ proficient: true, expertise: false });
     expect(occ.proficiencyPoints).toBe(0);
     expect(captured.update.$set.allowedSkills).toEqual(['acrobatics']);
+    expect(res.body.occupation[0].Occupation).toBe('Fighter');
     Math.random.mockRestore();
   });
 

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -87,7 +87,7 @@ async function applyMulticlass(characterId, newOccupation) {
   });
 
   const occEntry = {
-    Name: classInfo.name,
+    Occupation: classInfo.name,
     Health: classInfo.hitDie,
     armor: classInfo.proficiencies.armor,
     weapons: classInfo.proficiencies.weapons,


### PR DESCRIPTION
## Summary
- include `Occupation` field in multiclass class entries
- verify `Occupation` is present in multiclass API response

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68ba17bbcaa4832ea03b2536e6f39842