### PR TITLE
Reload weapons when character changes

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -74,7 +74,7 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
 
     fetchWeapons();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [campaign]);
+  }, [campaign, characterId]);
 
   if (!weapons) {
     return <div>Loading...</div>;

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -96,3 +96,25 @@ test('shows all weapons when allowed list is empty', async () => {
   expect(await screen.findByText('Dagger')).toBeInTheDocument();
 });
 
+test('reloads allowed and proficient weapons when character changes', async () => {
+  apiFetch
+    .mockResolvedValueOnce({ json: async () => weaponsData })
+    .mockResolvedValueOnce({
+      json: async () => ({ allowed: ['club'], proficient: ['club'], granted: [] }),
+    })
+    .mockResolvedValueOnce({ json: async () => weaponsData })
+    .mockResolvedValueOnce({
+      json: async () => ({ allowed: ['dagger'], proficient: ['dagger'], granted: [] }),
+    });
+
+  const { rerender } = render(<WeaponList characterId="char1" />);
+
+  expect(await screen.findByText('Club')).toBeInTheDocument();
+  expect(screen.queryByText('Dagger')).not.toBeInTheDocument();
+
+  rerender(<WeaponList characterId="char2" />);
+  expect(await screen.findByText('Dagger')).toBeInTheDocument();
+  expect(screen.queryByText('Club')).not.toBeInTheDocument();
+  expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char2');
+});
+


### PR DESCRIPTION
## Summary
- Re-fetch weapon data when the character changes by adding `characterId` to the WeaponList `useEffect` dependencies
- Add test verifying that switching characters reloads allowed and proficient weapons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ba1c12a834832ea774eaaf1af9bf57