### PR TITLE
Handle API errors in WeaponList

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -17,12 +17,36 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
     async function fetchWeapons() {
       try {
         const [phb, custom, prof] = await Promise.all([
-          apiFetch('/weapons').then((res) => res.json()),
+          apiFetch('/weapons').then((res) => {
+            if (!res.ok) {
+              const error = new Error(`${res.status} ${res.statusText}`);
+              error.status = res.status;
+              error.statusText = res.statusText;
+              throw error;
+            }
+            return res.json();
+          }),
           campaign
-            ? apiFetch(`/equipment/weapons/${campaign}`).then((res) => res.json())
+            ? apiFetch(`/equipment/weapons/${campaign}`).then((res) => {
+                if (!res.ok) {
+                  const error = new Error(`${res.status} ${res.statusText}`);
+                  error.status = res.status;
+                  error.statusText = res.statusText;
+                  throw error;
+                }
+                return res.json();
+              })
             : Promise.resolve([]),
           characterId
-            ? apiFetch(`/weapon-proficiency/${characterId}`).then((res) => res.json())
+            ? apiFetch(`/weapon-proficiency/${characterId}`).then((res) => {
+                if (!res.ok) {
+                  const error = new Error(`${res.status} ${res.statusText}`);
+                  error.status = res.status;
+                  error.statusText = res.statusText;
+                  throw error;
+                }
+                return res.json();
+              })
             : Promise.resolve({ allowed: null, granted: [], proficient: {} }),
         ]);
 
@@ -66,9 +90,13 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
 
         setWeapons(withOwnership);
         setError(null);
-      } catch {
+      } catch (err) {
         setWeapons({});
-        setError('Failed to load weapons. Please check that the server is available.');
+        if (err && err.status) {
+          setError(`Failed to load weapons: ${err.status} ${err.statusText}`);
+        } else {
+          setError('Failed to load weapons. Please check that the server is available.');
+        }
       }
     }
 

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -18,9 +18,10 @@ afterEach(() => {
 });
 
 test('fetches weapons and toggles ownership', async () => {
-  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
-  apiFetch.mockResolvedValueOnce({ json: async () => customData });
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => customData });
   apiFetch.mockResolvedValueOnce({
+    ok: true,
     json: async () => ({ allowed: null, proficient: [], granted: [] }),
   });
   const onChange = jest.fn();
@@ -59,9 +60,10 @@ test('fetches weapons and toggles ownership', async () => {
 });
 
 test('marks weapon proficiency', async () => {
-  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce(
     {
+      ok: true,
       json: async () => ({
         allowed: ['club', 'dagger'],
         proficient: ['dagger'],
@@ -85,8 +87,9 @@ test('marks weapon proficiency', async () => {
 });
 
 test('shows all weapons when allowed list is empty', async () => {
-  apiFetch.mockResolvedValueOnce({ json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce({
+    ok: true,
     json: async () => ({ allowed: [], proficient: [], granted: [] }),
   });
 
@@ -98,12 +101,14 @@ test('shows all weapons when allowed list is empty', async () => {
 
 test('reloads allowed and proficient weapons when character changes', async () => {
   apiFetch
-    .mockResolvedValueOnce({ json: async () => weaponsData })
+    .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
     .mockResolvedValueOnce({
+      ok: true,
       json: async () => ({ allowed: ['club'], proficient: ['club'], granted: [] }),
     })
-    .mockResolvedValueOnce({ json: async () => weaponsData })
+    .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
     .mockResolvedValueOnce({
+      ok: true,
       json: async () => ({ allowed: ['dagger'], proficient: ['dagger'], granted: [] }),
     });
 


### PR DESCRIPTION
## Summary
- check WeaponList API responses for HTTP errors before parsing JSON
- surface HTTP error codes in UI by throwing Error with status and statusText
- adapt WeaponList tests for new response handling

## Testing
- `CI=true npm test --prefix client -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ba294e5f7c832e804d25805cb37a33