### PR TITLE
Allow local API in Helmet CSP during development

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -39,12 +39,19 @@ app.use(cors({
 app.use(express.json());
 app.use(cookieParser());
 const apiHost = process.env.API_ORIGIN || 'https://realmtracker.org';
+const connectSrc = ["'self'", apiHost];
+if (!isProd) {
+  const devApiHost = process.env.API_ORIGIN_DEV || 'http://localhost:5000';
+  if (!connectSrc.includes(devApiHost)) {
+    connectSrc.push(devApiHost);
+  }
+}
 app.use(
   helmet({
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        connectSrc: ["'self'", apiHost],
+        connectSrc,
       },
     },
   })


### PR DESCRIPTION
## Summary
- allow local API (`http://localhost:5000`) to connect when `NODE_ENV` is not production

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba294eb938832e9a75c1334815d208