### PR TITLE
Handle object weapon proficiency responses in WeaponList

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -72,7 +72,7 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
           Array.isArray(prof.allowed) && prof.allowed.length > 0
             ? new Set(prof.allowed)
             : null;
-        const proficientSet = new Set(prof.proficient || []);
+        const proficientSet = new Set(Object.keys(prof.proficient || {}));
         const grantedSet = new Set(prof.granted || []);
         const keys = allowedSet
           ? Object.keys(all).filter((k) => allowedSet.has(k))

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -22,7 +22,7 @@ test('fetches weapons and toggles ownership', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => customData });
   apiFetch.mockResolvedValueOnce({
     ok: true,
-    json: async () => ({ allowed: null, proficient: [], granted: [] }),
+    json: async () => ({ allowed: null, proficient: {}, granted: [] }),
   });
   const onChange = jest.fn();
 
@@ -66,7 +66,7 @@ test('marks weapon proficiency', async () => {
       ok: true,
       json: async () => ({
         allowed: ['club', 'dagger'],
-        proficient: ['dagger'],
+        proficient: { dagger: true },
         granted: ['dagger'],
       }),
     }
@@ -90,7 +90,7 @@ test('shows all weapons when allowed list is empty', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce({
     ok: true,
-    json: async () => ({ allowed: [], proficient: [], granted: [] }),
+    json: async () => ({ allowed: [], proficient: {}, granted: [] }),
   });
 
   render(<WeaponList characterId="char1" />);
@@ -104,12 +104,12 @@ test('reloads allowed and proficient weapons when character changes', async () =
     .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ allowed: ['club'], proficient: ['club'], granted: [] }),
+      json: async () => ({ allowed: ['club'], proficient: { club: true }, granted: [] }),
     })
     .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ allowed: ['dagger'], proficient: ['dagger'], granted: [] }),
+      json: async () => ({ allowed: ['dagger'], proficient: { dagger: true }, granted: [] }),
     });
 
   const { rerender } = render(<WeaponList characterId="char1" />);


### PR DESCRIPTION
## Summary
- Support object-based weapon proficiency API responses by building proficiency set from keys
- Update WeaponList tests to mock object proficiency data

## Testing
- `cd client && npm test -- --runTestsByPath src/components/Weapons/WeaponList.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba2bd147b8832ea13955829a3927e5