### PR TITLE
Display granted weapon proficiencies as checked

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -81,7 +81,7 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
           acc[key] = {
             ...all[key],
             owned: ownedSet.has(all[key].name),
-            proficient: proficientSet.has(key),
+            proficient: grantedSet.has(key) || proficientSet.has(key),
             granted: grantedSet.has(key),
             pending: false,
           };

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -86,6 +86,26 @@ test('marks weapon proficiency', async () => {
   expect(clubProf).not.toBeChecked();
 });
 
+test('granted proficiencies render checked and disabled', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      allowed: ['club', 'dagger'],
+      proficient: {},
+      granted: ['dagger'],
+    }),
+  });
+
+  render(<WeaponList characterId="char1" />);
+
+  const daggerRow = await screen.findByText('Dagger');
+  const daggerTr = daggerRow.closest('tr');
+  const daggerProf = within(daggerTr).getByLabelText('Dagger proficiency');
+  expect(daggerProf).toBeChecked();
+  expect(daggerProf).toBeDisabled();
+});
+
 test('toggling a non-proficient weapon checks and disables it', async () => {
   apiFetch
     .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })


### PR DESCRIPTION
## Summary
- Treat granted proficiencies as already proficient when building weapon list
- Test that granted weapon proficiencies render checked and disabled

## Testing
- `cd client && CI=true npm test -- src/components/Weapons/WeaponList.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba3489f3a4832e962ae7d5dd67aad6