### PR TITLE
feat: add racial weapon proficiencies

### DIFF
--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -123,5 +123,32 @@ describe('Weapon proficiency routes', () => {
       expect.arrayContaining(['club', 'light-crossbow'])
     );
   });
+
+  test('includes racial weapon proficiencies', async () => {
+    const races = require('../data/races');
+    const charDoc = {
+      occupation: [],
+      feat: [],
+      race: races.elf,
+      weaponProficiencies: {},
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    dbo.mockResolvedValue({ collection: () => ({ findOne }) });
+
+    const res = await request(app).get(
+      '/weapon-proficiency/507f1f77bcf86cd799439011'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.granted).toEqual(
+      expect.arrayContaining([
+        'longsword',
+        'shortsword',
+        'shortbow',
+        'longbow',
+      ])
+    );
+  });
 });
 

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -12,6 +12,12 @@ const races = {
     abilities: { con: 2 },
     skills: {},
     languages: ["Common", "Dwarvish"],
+    weaponProficiencies: [
+      "battleaxe",
+      "handaxe",
+      "light-hammer",
+      "warhammer",
+    ],
   },
   elf: {
     name: "Elf",
@@ -19,6 +25,12 @@ const races = {
     abilities: { dex: 2 },
     skills: { perception: { proficient: true } },
     languages: ["Common", "Elvish"],
+    weaponProficiencies: [
+      "longsword",
+      "shortsword",
+      "shortbow",
+      "longbow",
+    ],
   },
   halfling: {
     name: "Halfling",


### PR DESCRIPTION
## Summary
- add weapon training to dwarf and elf race data
- verify racial proficiencies are returned by weapon-proficiency endpoint

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68ba35a1dd14832e9ff55967f5147ede