### PR TITLE
Include granted weapons in proficiency payload

### DIFF
--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -97,7 +97,7 @@ describe('Weapon proficiency routes', () => {
     expect(res.body.granted).toEqual(
       expect.arrayContaining(['dagger'])
     );
-    expect(res.body.proficient).toEqual({ club: true });
+    expect(res.body.proficient).toEqual({ dagger: true, club: true });
   });
 
   test('expands category weapon proficiencies', async () => {
@@ -148,6 +148,14 @@ describe('Weapon proficiency routes', () => {
         'shortbow',
         'longbow',
       ])
+    );
+    expect(res.body.proficient).toEqual(
+      expect.objectContaining({
+        longsword: true,
+        shortsword: true,
+        shortbow: true,
+        longbow: true,
+      })
     );
   });
 });

--- a/server/routes/weaponProficiency.js
+++ b/server/routes/weaponProficiency.js
@@ -96,7 +96,10 @@ module.exports = (router) => {
         charDoc.feat,
         charDoc.race
       );
-      const proficient = charDoc.weaponProficiencies || {};
+      const proficient = Object.assign(
+        Object.fromEntries(granted.map((w) => [w, true])),
+        charDoc.weaponProficiencies || {}
+      );
 
       return res.status(200).json({
         allowed,


### PR DESCRIPTION
## Summary
- Merge granted weapons with stored proficiencies so clients receive a unified `proficient` map
- Ensure tests cover granted weapon inclusion in proficiency payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba36360270832ebb62399d576a4bf1