### PR TITLE
feat: manage campaign weapons

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -151,6 +151,25 @@ const [form2, setForm2] = useState({
   const [show2, setShow2] = useState(false);
   const handleClose2 = () => setShow2(false);
   const handleShow2 = () => setShow2(true);
+
+  const [weapons, setWeapons] = useState([]);
+
+  const fetchWeapons = async () => {
+    const response = await apiFetch(`/equipment/weapons/${currentCampaign}`);
+    if (!response.ok) {
+      const message = `An error has occurred: ${response.statusText}`;
+      setStatus({ type: 'danger', message });
+      return;
+    }
+    const data = await response.json();
+    setWeapons(data);
+  };
+
+  useEffect(() => {
+    if (show2) {
+      fetchWeapons();
+    }
+  }, [show2, currentCampaign]);
   
   function updateForm2(value) {
     return setForm2((prev) => {
@@ -205,8 +224,22 @@ const [form2, setForm2] = useState({
       cost: "",
       proficient: false,
     });
-     navigate(0);
+     fetchWeapons();
    }
+
+  async function deleteWeapon(id) {
+    try {
+      const response = await apiFetch(`/equipment/weapon/${id}`, { method: 'DELETE' });
+      if (!response.ok) {
+        const message = `An error has occurred: ${response.statusText}`;
+        setStatus({ type: 'danger', message });
+        return;
+      }
+      setWeapons((prev) => prev.filter((w) => w._id !== id));
+    } catch (error) {
+      setStatus({ type: 'danger', message: error.toString() });
+    }
+  }
    //  ------------------------------------Armor-----------------------------------
   
   const [show3, setShow3] = useState(false);
@@ -489,12 +522,42 @@ const [form2, setForm2] = useState({
               Close
             </Button>
             </div>
-       </Form>
-       </div>
-       </Card.Body>
-       </Card>  
-       </div>      
-        </Modal>
+      </Form>
+      <Table striped bordered condensed="true" className="mt-3">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Category</th>
+            <th>Damage</th>
+            <th>Properties</th>
+            <th>Weight</th>
+            <th>Cost</th>
+            <th>Delete</th>
+          </tr>
+        </thead>
+        <tbody>
+          {weapons.map((w) => (
+            <tr key={w._id}>
+              <td>{w.weaponName || w.name}</td>
+              <td>{w.weaponStyle || w.category}</td>
+              <td>{w.damage}</td>
+              <td>{Array.isArray(w.properties) ? w.properties.join(', ') : ''}</td>
+              <td>{w.weight}</td>
+              <td>{w.cost}</td>
+              <td>
+                <Button size="sm" variant="danger" onClick={() => deleteWeapon(w._id)}>
+                  Delete
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+      </div>
+      </Card.Body>
+      </Card>
+      </div>
+       </Modal>
   {/* --------------------------------------- Armor Modal --------------------------------- */}
   <Modal className="dnd-modal" centered show={show3} onHide={handleClose3}>
   <div className="text-center">

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -108,6 +108,23 @@ describe('Equipment routes', () => {
     });
   });
 
+  describe('delete weapon', () => {
+    test('delete success', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ deleteOne: async () => ({ deletedCount: 1 }) })
+      });
+      const res = await request(app).delete('/equipment/weapon/507f1f77bcf86cd799439011');
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Weapon deleted');
+    });
+
+    test('delete weapon invalid id', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app).delete('/equipment/weapon/123');
+      expect(res.status).toBe(400);
+    });
+  });
+
   describe('/armor/add', () => {
     test('validation failure', async () => {
       dbo.mockResolvedValue({});

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -86,6 +86,24 @@ module.exports = (router) => {
     }
   );
 
+  // This section will delete a weapon.
+  equipmentRouter.route('/weapon/:id').delete(async (req, res, next) => {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
+    const myquery = { _id: ObjectId(req.params.id) };
+    const db_connect = req.db;
+    try {
+      const result = await db_connect.collection('Weapons').deleteOne(myquery);
+      if (result.deletedCount === 0) {
+        return res.status(404).json({ message: 'Weapon not found' });
+      }
+      res.json({ message: 'Weapon deleted' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // Armor Section
 
   // This section will get a list of all the armor.


### PR DESCRIPTION
## Summary
- load campaign weapons when DM opens weapon modal
- display weapons with delete option
- add endpoint and tests for deleting campaign weapons

## Testing
- `cd server && npm test`
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bae7848dcc832ea94d8ba32e661159