### PR TITLE
Add weapon deletion endpoint and tests

### DIFF
--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -140,11 +140,11 @@ describe('Equipment routes', () => {
   describe('delete weapon', () => {
     test('delete success', async () => {
       dbo.mockResolvedValue({
-        collection: () => ({ deleteOne: async () => ({ deletedCount: 1 }) })
+        collection: () => ({ deleteOne: async () => ({ acknowledged: true, deletedCount: 1 }) })
       });
       const res = await request(app).delete('/equipment/weapon/507f1f77bcf86cd799439011');
       expect(res.status).toBe(200);
-      expect(res.body.message).toBe('Weapon deleted');
+      expect(res.body).toEqual({ acknowledged: true });
     });
 
     test('delete weapon invalid id', async () => {
@@ -155,7 +155,7 @@ describe('Equipment routes', () => {
 
     test('delete weapon not found', async () => {
       dbo.mockResolvedValue({
-        collection: () => ({ deleteOne: async () => ({ deletedCount: 0 }) })
+        collection: () => ({ deleteOne: async () => ({ acknowledged: true, deletedCount: 0 }) })
       });
       const res = await request(app).delete('/equipment/weapon/507f1f77bcf86cd799439011');
       expect(res.status).toBe(404);

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -90,17 +90,19 @@ module.exports = (router) => {
 
   // This section will delete a weapon.
   equipmentRouter.route('/weapon/:id').delete(async (req, res, next) => {
-    if (!ObjectId.isValid(req.params.id)) {
+    const { id } = req.params;
+    if (!ObjectId.isValid(id)) {
       return res.status(400).json({ message: 'Invalid ID' });
     }
-    const myquery = { _id: ObjectId(req.params.id) };
     const db_connect = req.db;
     try {
-      const result = await db_connect.collection('Weapons').deleteOne(myquery);
+      const result = await db_connect
+        .collection('Weapons')
+        .deleteOne({ _id: ObjectId(id) });
       if (result.deletedCount === 0) {
         return res.status(404).json({ message: 'Weapon not found' });
       }
-      res.json({ message: 'Weapon deleted' });
+      res.json({ acknowledged: true });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary
- return `{ acknowledged: true }` when deleting a weapon and validate IDs
- adjust weapon deletion tests for new behavior and invalid ID handling

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf4821e68832eacc15cac952e6c96