### PR TITLE
Refetch weapons when modal opens

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -6,14 +6,22 @@ import apiFetch from '../../utils/apiFetch';
 
 /**
  * List of weapons with ownership toggles.
- * @param {{ campaign?: string, onChange?: (weapons: Weapon[]) => void, initialWeapons?: Weapon[], characterId?: string }} props
+ * @param {{ campaign?: string, onChange?: (weapons: Weapon[]) => void, initialWeapons?: Weapon[], characterId?: string, show?: boolean }} props
  */
-function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
+function WeaponList({
+  campaign,
+  onChange,
+  initialWeapons = [],
+  characterId,
+  show = true,
+}) {
   const [weapons, setWeapons] =
     useState/** @type {Record<string, Weapon & { owned?: boolean, proficient?: boolean, granted?: boolean, pending?: boolean }> | null} */(null);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (!show) return;
+
     async function fetchWeapons() {
       try {
         const [phb, custom, prof] = await Promise.all([
@@ -103,7 +111,7 @@ function WeaponList({ campaign, onChange, initialWeapons = [], characterId }) {
 
     fetchWeapons();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [campaign, characterId]);
+  }, [campaign, characterId, show]);
 
   if (!weapons) {
     return <div>Loading...</div>;

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -172,3 +172,21 @@ test('reloads allowed and proficient weapons when character changes', async () =
   expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char2');
 });
 
+test('refetches weapons when modal is opened', async () => {
+  apiFetch
+    .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ allowed: [], proficient: {}, granted: [] }),
+    });
+
+  const { rerender } = render(<WeaponList characterId="char1" show={false} />);
+
+  expect(apiFetch).not.toHaveBeenCalled();
+
+  rerender(<WeaponList characterId="char1" show />);
+  expect(await screen.findByText('Dagger')).toBeInTheDocument();
+  expect(apiFetch).toHaveBeenCalledWith('/weapons');
+  expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char1');
+});
+

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -412,6 +412,7 @@ return (
           initialWeapons={form.weapon}
           onChange={handleWeaponsChange}
           characterId={characterId}
+          show={showWeapons}
         />
       </Modal>
     <Armor


### PR DESCRIPTION
## Summary
- allow `WeaponList` to receive a `show` prop and reload data only when the modal is visible
- pass modal visibility from `ZombiesCharacterSheet` to `WeaponList`
- test that weapons are fetched when the modal opens

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68baf8d3efec832e89ebb50917e6c43d