### PR TITLE
Include custom weapons in allowed list

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -80,11 +80,12 @@ function WeaponList({
           Array.isArray(prof.allowed) && prof.allowed.length > 0
             ? new Set(prof.allowed)
             : null;
+        if (allowedSet) {
+          Object.keys(customMap).forEach((k) => allowedSet.add(k));
+        }
         const proficientSet = new Set(Object.keys(prof.proficient || {}));
         const grantedSet = new Set(prof.granted || []);
-        const keys = allowedSet
-          ? Object.keys(all).filter((k) => allowedSet.has(k))
-          : Object.keys(all);
+        const keys = allowedSet ? [...allowedSet] : Object.keys(all);
         const withOwnership = keys.reduce((acc, key) => {
           acc[key] = {
             ...all[key],

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -59,6 +59,21 @@ test('fetches weapons and toggles ownership', async () => {
   expect(apiFetch).toHaveBeenCalledTimes(3);
 });
 
+test('custom weapons appear even when not in allowed list', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => customData });
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ allowed: ['club'], proficient: {}, granted: [] }),
+  });
+
+  render(<WeaponList campaign="Camp1" characterId="char1" />);
+
+  expect(await screen.findByLabelText('Club')).toBeInTheDocument();
+  expect(await screen.findByLabelText('Laser Sword')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Dagger')).not.toBeInTheDocument();
+});
+
 test('marks weapon proficiency', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
- ensure custom weapons are merged into allowed set
- test that custom weapons show up even when not in allowed list

## Testing
- `cd client && CI=true npm test -- src/components/Weapons/WeaponList.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bafcd4534c832e8c9ac6888e187961