### PR TITLE
Handle custom weapons in proficiency calculations

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -80,9 +80,6 @@ function WeaponList({
           Array.isArray(prof.allowed) && prof.allowed.length > 0
             ? new Set(prof.allowed)
             : null;
-        if (allowedSet) {
-          Object.keys(customMap).forEach((k) => allowedSet.add(k));
-        }
         const proficientSet = new Set(Object.keys(prof.proficient || {}));
         const grantedSet = new Set(prof.granted || []);
         const keys = allowedSet ? [...allowedSet] : Object.keys(all);

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -59,7 +59,7 @@ test('fetches weapons and toggles ownership', async () => {
   expect(apiFetch).toHaveBeenCalledTimes(3);
 });
 
-test('custom weapons appear even when not in allowed list', async () => {
+test('custom weapons omitted when not in allowed list', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => weaponsData });
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => customData });
   apiFetch.mockResolvedValueOnce({
@@ -70,7 +70,7 @@ test('custom weapons appear even when not in allowed list', async () => {
   render(<WeaponList campaign="Camp1" characterId="char1" />);
 
   expect(await screen.findByLabelText('Club')).toBeInTheDocument();
-  expect(await screen.findByLabelText('Laser Sword')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Laser Sword')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Dagger')).not.toBeInTheDocument();
 });
 

--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -34,7 +34,14 @@ describe('Weapon proficiency routes', () => {
     const findOneAndUpdate = jest.fn();
 
     dbo.mockResolvedValue({
-      collection: () => ({ findOne, findOneAndUpdate })
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne, findOneAndUpdate };
+        }
+        if (name === 'Weapons') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
     });
 
     const res = await request(app)
@@ -63,7 +70,14 @@ describe('Weapon proficiency routes', () => {
     const findOneAndUpdate = jest.fn().mockResolvedValue({ value: updatedDoc });
 
     dbo.mockResolvedValue({
-      collection: () => ({ findOne, findOneAndUpdate })
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne, findOneAndUpdate };
+        }
+        if (name === 'Weapons') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
     });
 
     const res = await request(app)
@@ -84,7 +98,16 @@ describe('Weapon proficiency routes', () => {
     };
 
     const findOne = jest.fn().mockResolvedValue(charDoc);
-    dbo.mockResolvedValue({ collection: () => ({ findOne }) });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Weapons') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
 
     const res = await request(app).get(
       '/weapon-proficiency/507f1f77bcf86cd799439011'
@@ -109,7 +132,16 @@ describe('Weapon proficiency routes', () => {
     };
 
     const findOne = jest.fn().mockResolvedValue(charDoc);
-    dbo.mockResolvedValue({ collection: () => ({ findOne }) });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Weapons') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
 
     const res = await request(app).get(
       '/weapon-proficiency/507f1f77bcf86cd799439011'
@@ -134,7 +166,16 @@ describe('Weapon proficiency routes', () => {
     };
 
     const findOne = jest.fn().mockResolvedValue(charDoc);
-    dbo.mockResolvedValue({ collection: () => ({ findOne }) });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Weapons') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
 
     const res = await request(app).get(
       '/weapon-proficiency/507f1f77bcf86cd799439011'
@@ -156,6 +197,47 @@ describe('Weapon proficiency routes', () => {
         shortbow: true,
         longbow: true,
       })
+    );
+  });
+
+  test('returns custom weapons for allowed categories', async () => {
+    const charDoc = {
+      campaign: 'alpha',
+      occupation: [{ weapons: ['simple'] }],
+      feat: [],
+      race: {},
+      weaponProficiencies: {},
+    };
+
+    const customWeapons = [
+      { name: 'Laser Sword', category: 'simple melee' },
+    ];
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const toArray = jest.fn().mockResolvedValue(customWeapons);
+    const find = jest.fn().mockReturnValue({ toArray });
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Weapons') {
+          return { find };
+        }
+      },
+    });
+
+    const res = await request(app).get(
+      '/weapon-proficiency/507f1f77bcf86cd799439011'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.allowed).toEqual(
+      expect.arrayContaining(['Laser Sword'])
+    );
+    expect(res.body.granted).toEqual(
+      expect.arrayContaining(['Laser Sword'])
     );
   });
 });


### PR DESCRIPTION
## Summary
- expand weapon proficiency logic to include custom campaign weapons
- avoid client-side inclusion of disallowed custom weapons
- test server proficiency logic for custom weapons

## Testing
- `cd server && npm test -- weaponProficiency.test.js`
- `cd client && CI=true npm test src/components/Weapons/WeaponList.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb01b8188c832ea70e2be2aecafc49