### PR TITLE
Remove weapon proficient flag

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -145,7 +145,6 @@ const [form2, setForm2] = useState({
     properties: "",
     weight: "",
     cost: "",
-    proficient: false,
   });
   
   const [show2, setShow2] = useState(false);
@@ -195,7 +194,6 @@ const [form2, setForm2] = useState({
       properties: propertiesArray,
       weight: weightNumber,
       cost: form2.cost,
-      proficient: form2.proficient ?? false,
     };
     Object.keys(newWeapon).forEach((key) => {
       if (newWeapon[key] === "" || newWeapon[key] === undefined) {
@@ -222,7 +220,6 @@ const [form2, setForm2] = useState({
       properties: "",
       weight: "",
       cost: "",
-      proficient: false,
     });
      fetchWeapons();
    }
@@ -506,14 +503,7 @@ const [form2, setForm2] = useState({
          <Form.Control className="mb-2" onChange={(e) => updateForm2({ cost: e.target.value })}
           type="text" placeholder="Enter cost" />
 
-         <Form.Check
-           className="mb-2 text-light"
-           type="checkbox"
-           label="Proficient"
-           onChange={(e) => updateForm2({ proficient: e.target.checked })}
-         />
-
-       </Form.Group>
+      </Form.Group>
        <div className="text-center">
        <Button variant="primary" onClick={handleClose2} type="submit">
               Create

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -42,7 +42,6 @@ describe('Equipment routes', () => {
         properties: ['versatile'],
         weight: 6,
         cost: '10 gp',
-        proficient: true,
       };
       dbo.mockResolvedValue({
         collection: () => ({ insertOne: async () => ({ insertedId }) })
@@ -78,20 +77,6 @@ describe('Equipment routes', () => {
           category: 'Martial',
           damage: '1d8',
           weight: 'heavy',
-        });
-      expect(res.status).toBe(400);
-    });
-
-    test('invalid proficient type', async () => {
-      dbo.mockResolvedValue({});
-      const res = await request(app)
-        .post('/equipment/weapon/add')
-        .send({
-          campaign: 'Camp1',
-          name: 'Sword',
-          category: 'Martial',
-          damage: '1d8',
-          proficient: 'yes',
         });
       expect(res.status).toBe(400);
     });

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -72,7 +72,6 @@ module.exports = (router) => {
       body('properties').optional().isArray(),
       body('weight').optional().isFloat().toFloat(),
       body('cost').optional().isString().trim(),
-      body('proficient').optional().isBoolean().toBoolean(),
     ],
     handleValidationErrors,
     async (req, response, next) => {


### PR DESCRIPTION
## Summary
- stop sending weapon proficiency from Zombies DM weapon form
- drop server-side weapon proficient validation and persistence
- adjust equipment route tests for removed field

## Testing
- `npm test` (server)
- `CI=true npm test -- --watchAll=false` (client)


------
https://chatgpt.com/codex/tasks/task_e_68bb01bde5f8832ebe97c351c2d27fb6