### PR TITLE
Normalize weapon names in class proficiencies

### DIFF
--- a/server/data/classes.js
+++ b/server/data/classes.js
@@ -25,7 +25,7 @@ const classes = {
     hitDie: 8,
     proficiencies: {
       armor: ['light'],
-      weapons: ['simple', 'handCrossbows', 'longswords', 'rapiers', 'shortswords'],
+      weapons: ['simple', 'hand-crossbow', 'longsword', 'rapier', 'shortsword'],
       tools: ['three musical instruments'],
       savingThrows: ['dex', 'cha'],
       skills: {
@@ -74,7 +74,7 @@ const classes = {
     hitDie: 8,
     proficiencies: {
       armor: ['light (non-metal)', 'medium (non-metal)', 'shields (non-metal)'],
-      weapons: ['clubs', 'daggers', 'darts', 'javelins', 'maces', 'quarterstaffs', 'scimitars', 'sickles', 'slings', 'spears'],
+      weapons: ['club', 'dagger', 'dart', 'javelin', 'mace', 'quarterstaff', 'scimitar', 'sickle', 'sling', 'spear'],
       tools: ['herbalism kit'],
       savingThrows: ['int', 'wis'],
       skills: {
@@ -104,7 +104,7 @@ const classes = {
     hitDie: 8,
     proficiencies: {
       armor: [],
-      weapons: ['simple', 'shortswords'],
+      weapons: ['simple', 'shortsword'],
       tools: ['one type of artisan tools or instrument'],
       savingThrows: ['str', 'dex'],
       skills: {
@@ -149,7 +149,7 @@ const classes = {
     hitDie: 8,
     proficiencies: {
       armor: ['light'],
-      weapons: ['simple', 'handCrossbows', 'longswords', 'rapiers', 'shortswords'],
+      weapons: ['simple', 'hand-crossbow', 'longsword', 'rapier', 'shortsword'],
       tools: ['thieves tools'],
       savingThrows: ['dex', 'int'],
       skills: {
@@ -164,7 +164,7 @@ const classes = {
     hitDie: 6,
     proficiencies: {
       armor: [],
-      weapons: ['daggers', 'darts', 'slings', 'quarterstaffs', 'light crossbows'],
+      weapons: ['dagger', 'dart', 'sling', 'quarterstaff', 'light-crossbow'],
       tools: [],
       savingThrows: ['con', 'cha'],
       skills: {
@@ -194,7 +194,7 @@ const classes = {
     hitDie: 6,
     proficiencies: {
       armor: [],
-      weapons: ['daggers', 'darts', 'slings', 'quarterstaffs', 'light crossbows'],
+      weapons: ['dagger', 'dart', 'sling', 'quarterstaff', 'light-crossbow'],
       tools: [],
       savingThrows: ['int', 'wis'],
       skills: {


### PR DESCRIPTION
## Summary
- align weapon proficiency names for Bard, Druid, Monk, Rogue, Sorcerer, and Wizard with canonical weapon keys
- ensure /weapon-proficiency returns valid entries and weapons modal renders correctly

## Testing
- `node - <<'NODE'
const classes = require('./server/data/classes');
const weapons = require('./server/data/weapons');
const check = ['druid','bard','monk','rogue','sorcerer','wizard'];
check.forEach(c=>{
 const arr = classes[c].proficiencies.weapons;
 const invalid = arr.filter(w=>!['simple','martial'].includes(w) && !weapons[w]);
 console.log(c, 'invalid:', invalid);
});
NODE`
- `cd server && npm test`
- `cd client && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb05996b0c832ea5af1510d6fcaf81