### PR TITLE
feat: support custom weapon base types

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -66,6 +66,7 @@ function WeaponList({
               acc[key] = {
                 name: key,
                 displayName: w.name,
+                type: w.type,
                 category: w.category || 'custom',
                 damage: w.damage || '',
                 properties: w.properties || [],
@@ -153,13 +154,14 @@ function WeaponList({
     if (typeof onChange === 'function') {
       const ownedWeapons = Object.values(nextWeapons)
         .filter((w) => w.owned)
-        .map(({ name, category, damage, properties, weight, cost }) => ({
+        .map(({ name, category, damage, properties, weight, cost, type }) => ({
           name,
           category,
           damage,
           properties,
           weight,
           cost,
+          type,
         }));
       onChange(ownedWeapons);
     }

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -140,6 +140,7 @@ async function sendNewPlayersToDb() {
 const [form2, setForm2] = useState({
     campaign: currentCampaign,
     name: "",
+    type: "",
     category: "",
     damage: "",
     properties: "",
@@ -189,6 +190,7 @@ const [form2, setForm2] = useState({
     const newWeapon = {
       campaign: currentCampaign,
       name: form2.name,
+      type: form2.type,
       category: form2.category,
       damage: form2.damage,
       properties: propertiesArray,
@@ -213,8 +215,9 @@ const [form2, setForm2] = useState({
      });
 
      setForm2({
-      campaign: currentCampaign,
-      name: "",
+     campaign: currentCampaign,
+     name: "",
+      type: "",
       category: "",
       damage: "",
       properties: "",
@@ -483,6 +486,10 @@ const [form2, setForm2] = useState({
          <Form.Control className="mb-2" onChange={(e) => updateForm2({ name: e.target.value })}
           type="text" placeholder="Enter weapon name" />
 
+         <Form.Label className="text-light">Type</Form.Label>
+         <Form.Control className="mb-2" onChange={(e) => updateForm2({ type: e.target.value })}
+          type="text" placeholder="Enter base weapon type" />
+
          <Form.Label className="text-light">Category</Form.Label>
          <Form.Control className="mb-2" onChange={(e) => updateForm2({ category: e.target.value })}
           type="text" placeholder="Enter weapon category" />
@@ -516,7 +523,8 @@ const [form2, setForm2] = useState({
       <Table striped bordered condensed="true" className="mt-3">
         <thead>
           <tr>
-            <th>Name</th>
+           <th>Name</th>
+            <th>Type</th>
             <th>Category</th>
             <th>Damage</th>
             <th>Properties</th>
@@ -529,6 +537,7 @@ const [form2, setForm2] = useState({
           {weapons.map((w) => (
             <tr key={w._id}>
               <td>{w.name}</td>
+              <td>{w.type}</td>
               <td>{w.category}</td>
               <td>{w.damage}</td>
               <td>{Array.isArray(w.properties) ? w.properties.join(', ') : ''}</td>

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -37,6 +37,7 @@ describe('Equipment routes', () => {
       const payload = {
         campaign: 'Camp1',
         name: 'Sword',
+        type: 'quarterstaff',
         category: 'Martial',
         damage: '1d8',
         properties: ['versatile'],
@@ -48,7 +49,7 @@ describe('Equipment routes', () => {
       });
       const res = await request(app)
         .post('/equipment/weapon/add')
-        .send(payload);
+        .send({ ...payload, type: 'Quarterstaff' });
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ _id: insertedId, ...payload });
     });

--- a/server/__tests__/weaponProficiency.test.js
+++ b/server/__tests__/weaponProficiency.test.js
@@ -271,5 +271,47 @@ describe('Weapon proficiency routes', () => {
       expect.arrayContaining(['laser sword'])
     );
   });
+
+  test('maps custom weapon types to class proficiencies', async () => {
+    const classes = require('../data/classes');
+    const charDoc = {
+      campaign: 'alpha',
+      occupation: [{ weapons: classes.druid.proficiencies.weapons }],
+      feat: [],
+      race: {},
+      weaponProficiencies: {},
+    };
+
+    const customWeapons = [
+      { name: 'Carved Stick', category: 'simple melee', type: 'quarterstaff' },
+    ];
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const toArray = jest.fn().mockResolvedValue(customWeapons);
+    const find = jest.fn().mockReturnValue({ toArray });
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Weapons') {
+          return { find };
+        }
+      },
+    });
+
+    const res = await request(app).get(
+      '/weapon-proficiency/507f1f77bcf86cd799439011'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.allowed).toEqual(
+      expect.arrayContaining(['quarterstaff', 'carved stick'])
+    );
+    expect(res.body.granted).toEqual(
+      expect.arrayContaining(['quarterstaff', 'carved stick'])
+    );
+  });
 });
 

--- a/server/data/weapons.js
+++ b/server/data/weapons.js
@@ -340,4 +340,9 @@ const weapons = {
   },
 };
 
+// Default the type of each weapon to its key for canonical mapping
+for (const [key, weapon] of Object.entries(weapons)) {
+  weapon.type = weapon.type || key;
+}
+
 module.exports = weapons;

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -67,6 +67,7 @@ module.exports = (router) => {
     [
       body('campaign').trim().notEmpty().withMessage('campaign is required'),
       body('name').trim().notEmpty().withMessage('name is required'),
+      body('type').optional().isString().trim().toLowerCase(),
       body('category').trim().notEmpty().withMessage('category is required'),
       body('damage').trim().notEmpty().withMessage('damage is required'),
       body('properties').optional().isArray(),

--- a/server/routes/weaponProficiency.js
+++ b/server/routes/weaponProficiency.js
@@ -18,6 +18,27 @@ function collectWeaponInfo(occupation = [], feat = [], race, customWeapons = [])
     return lower;
   };
 
+  const typeMap = Array.isArray(customWeapons)
+    ? customWeapons.reduce((acc, w) => {
+        const type = String(w.type || w.name).toLowerCase();
+        const nameKey = canonicalize(w.name);
+        (acc[type] ||= []).push(nameKey);
+        return acc;
+      }, {})
+    : {};
+
+  const addWeapon = (canonical, isGranted = true) => {
+    allowed.add(canonical);
+    if (isGranted) granted.add(canonical);
+    const extra = typeMap[canonical];
+    if (extra) {
+      extra.forEach((name) => {
+        allowed.add(name);
+        if (isGranted) granted.add(name);
+      });
+    }
+  };
+
   const expandCategory = (term) => {
     const lower = String(term).toLowerCase();
     const standard = Object.keys(weaponData).filter((key) =>
@@ -40,17 +61,14 @@ function collectWeaponInfo(occupation = [], feat = [], race, customWeapons = [])
         if (expanded.length) {
           expanded.forEach((key) => {
             const canonical = canonicalize(key);
-            allowed.add(canonical);
-            granted.add(canonical);
+            addWeapon(canonical);
           });
         } else {
           const canonical = canonicalize(w);
-          allowed.add(canonical);
-          granted.add(canonical);
+          addWeapon(canonical);
         }
       } else {
-        allowed.add(w);
-        granted.add(w);
+        addWeapon(w);
       }
     });
   };
@@ -63,13 +81,11 @@ function collectWeaponInfo(occupation = [], feat = [], race, customWeapons = [])
       if (expanded.length) {
         expanded.forEach((key) => {
           const canonical = canonicalize(key);
-          allowed.add(canonical);
-          if (isGranted) granted.add(canonical);
+          addWeapon(canonical, isGranted);
         });
       } else {
         const canonical = canonicalize(w);
-        allowed.add(canonical);
-        if (isGranted) granted.add(canonical);
+        addWeapon(canonical, isGranted);
       }
     });
   };

--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -4,6 +4,10 @@ export interface Weapon {
    */
   name: string;
   /**
+   * Canonical weapon key used for proficiency mapping.
+   */
+  type?: string;
+  /**
    * Weapon category such as "simple melee" or "martial ranged".
    */
   category: string;


### PR DESCRIPTION
## Summary
- allow weapons to include a canonical base type
- map custom weapon types to class proficiencies
- extend equipment routes and client UI for base type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb22b7fb28832e85fd72e8008a3f96