### PR TITLE
Show full weapon catalog and adjust proficiency

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -81,21 +81,26 @@ function WeaponList({
           initialWeapons.map((w) => (w.name || w).toLowerCase())
         );
         const all = { ...phb, ...customMap };
-        const allowedSet =
-          Array.isArray(prof.allowed) && prof.allowed.length > 0
-            ? new Set(prof.allowed)
-            : null;
         const proficientSet = new Set(Object.keys(prof.proficient || {}));
         const grantedSet = new Set(prof.granted || []);
-        const keys = allowedSet ? [...allowedSet] : Object.keys(all);
+        const keys = Object.keys(all);
         const unknown = [];
+
+        [
+          prof.allowed || [],
+          prof.granted || [],
+          Object.keys(prof.proficient || {}),
+        ].forEach((arr) =>
+          arr.forEach((name) => {
+            if (!all[name]) {
+              console.warn('Unrecognized weapon from server:', name);
+              unknown.push(name);
+            }
+          })
+        );
+
         const withOwnership = keys.reduce((acc, key) => {
           const base = all[key];
-          if (!base) {
-            console.warn('Unrecognized weapon from server:', key);
-            unknown.push(key);
-            return acc;
-          }
           acc[key] = {
             ...base,
             name: key,


### PR DESCRIPTION
## Summary
- show all PHB and custom weapons without allowed filtering
- keep server granted and proficient sets for auto-checked boxes
- warn about unknown weapon names returned by the server

## Testing
- `CI=true npm --prefix client test src/components/Weapons/WeaponList.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb309cfe8c832e9c4dd1e4076a9309