### PR TITLE
Allow toggling non-granted weapon proficiency

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -174,7 +174,7 @@ function WeaponList({
 
   const handleToggle = (key) => async () => {
     const weapon = weapons[key];
-    if (weapon.granted || weapon.proficient) return;
+    if (weapon.granted || weapon.pending) return;
     const desired = !weapon.proficient;
     const nextWeapons = {
       ...weapons,
@@ -244,13 +244,11 @@ function WeaponList({
                     type="checkbox"
                     className="weapon-checkbox"
                     checked={weapon.proficient}
-                    disabled={
-                      weapon.proficient || weapon.granted || weapon.pending
-                    }
+                    disabled={weapon.granted || weapon.pending}
                     onChange={handleToggle(key)}
                     aria-label={`${weapon.displayName || weapon.name} proficiency`}
                     style={
-                      weapon.proficient || weapon.granted || weapon.pending
+                      weapon.granted || weapon.pending
                         ? { opacity: 0.5 }
                         : undefined
                     }

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -97,7 +97,7 @@ test('marks weapon proficiency', async () => {
   const daggerProf = within(daggerTr).getByLabelText('Dagger proficiency');
   const clubProf = within(clubTr).getByLabelText('Club proficiency');
   expect(daggerProf).toBeChecked();
-  expect(daggerProf).toBeDisabled();
+  expect(daggerProf).not.toBeDisabled();
   expect(clubProf).not.toBeChecked();
 });
 
@@ -121,7 +121,7 @@ test('granted proficiencies render checked and disabled', async () => {
   expect(daggerProf).toBeDisabled();
 });
 
-test('toggling a non-proficient weapon checks and disables it', async () => {
+test('toggling a non-proficient weapon allows checking and unchecking', async () => {
   apiFetch
     .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
     .mockResolvedValueOnce({
@@ -132,6 +132,7 @@ test('toggling a non-proficient weapon checks and disables it', async () => {
         granted: [],
       }),
     })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
   render(<WeaponList characterId="char1" />);
@@ -143,11 +144,12 @@ test('toggling a non-proficient weapon checks and disables it', async () => {
   expect(clubProf).not.toBeChecked();
   await userEvent.click(clubProf);
   await waitFor(() => expect(clubProf).toBeChecked());
-  await waitFor(() => expect(clubProf).toBeDisabled());
+  await waitFor(() => expect(clubProf).not.toBeDisabled());
 
   await userEvent.click(clubProf);
-  expect(clubProf).toBeChecked();
-  expect(apiFetch).toHaveBeenCalledTimes(3);
+  await waitFor(() => expect(clubProf).not.toBeChecked());
+
+  expect(apiFetch).toHaveBeenCalledTimes(4);
 });
 
 test('shows all weapons when allowed list is empty', async () => {


### PR DESCRIPTION
## Summary
- Allow proficiency toggling unless weapon is granted or pending
- Permit non-granted proficiencies to be enabled and disabled
- Update tests for new proficiency toggle behavior

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb34dcee90832eb37c7c156aafd19f