### PR TITLE
Handle flat and modified damage values

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,0 +1,17 @@
+import { calculateDamage } from './PlayerTurnActions';
+
+describe('calculateDamage parser', () => {
+  const fixedRoll = (count, sides) => Array(count).fill(1);
+
+  test('handles 10d4', () => {
+    expect(calculateDamage('10d4', 0, false, fixedRoll)).toBe(10);
+  });
+
+  test('handles 10d4+1', () => {
+    expect(calculateDamage('10d4+1', 0, false, fixedRoll)).toBe(11);
+  });
+
+  test('handles flat damage 100', () => {
+    expect(calculateDamage('100', 0, false, fixedRoll)).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Add calculateDamage to parse `XdY±Z` or flat damage values, handle ability and crits
- Use new parser for weapon attacks and spells
- Cover flat and dice-based strings in PlayerTurnActions tests

## Testing
- `cd client && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb39d4fdbc832e969552cacbde804e