### PR TITLE
Fix crit damage rolling and spell crit toggle

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -14,4 +14,18 @@ describe('calculateDamage parser', () => {
   test('handles flat damage 100', () => {
     expect(calculateDamage('100', 0, false, fixedRoll)).toBe(100);
   });
+
+  test('crit rolls extra dice but adds modifiers once', () => {
+    let calls = 0;
+    const critRoll = (count, sides) => {
+      calls++;
+      return Array(count).fill(1);
+    };
+    expect(calculateDamage('1d4+2', 4, true, critRoll)).toBe(8);
+    expect(calls).toBe(2);
+  });
+
+  test('flat damage ignores crit flag', () => {
+    expect(calculateDamage('100', 0, true, fixedRoll)).toBe(100);
+  });
 });


### PR DESCRIPTION
## Summary
- Roll an additional set of dice on critical hits instead of doubling the total
- Allow spell attacks to benefit from critical hits via the crit toggle
- Test critical and flat damage calculations

## Testing
- `CI=true npm test --prefix client -- PlayerTurnActions.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb49affa1c832ebf1523905e8fd5df