### PR TITLE
Capitalize weapon names in attack modal

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -293,7 +293,7 @@ const showSparklesEffect = () => {
                   {Array.isArray(form.weapon) &&
                     form.weapon.map((weapon) => (
                       <tr key={weapon.name}>
-                        <td>{weapon.name}</td>
+                        <td className="text-capitalize">{weapon.name}</td>
                         <td>{getAttackBonus(weapon)}</td>
                         <td>{getDamageString(weapon)}</td>
                         <td>


### PR DESCRIPTION
## Summary
- Display weapon names with initial capital letters in the player attack modal table.

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bb56f5da34832ea2d545b72a20790d