### PR TITLE
feat: toggle weapon creation view in ZombiesDM

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -149,7 +149,11 @@ const [form2, setForm2] = useState({
   });
   
   const [show2, setShow2] = useState(false);
-  const handleClose2 = () => setShow2(false);
+  const [isCreatingWeapon, setIsCreatingWeapon] = useState(false);
+  const handleClose2 = () => {
+    setShow2(false);
+    setIsCreatingWeapon(false);
+  };
   const handleShow2 = () => setShow2(true);
 
   const [weapons, setWeapons] = useState([]);
@@ -490,114 +494,125 @@ const [form2, setForm2] = useState({
           <Modal className="dnd-modal" centered show={show2} onHide={handleClose2}>
           <div className="text-center">
           <Card className="dnd-background">
-            <Card.Title>Create Weapon</Card.Title>         
-          <Card.Body>   
+            <Card.Title>{isCreatingWeapon ? "Create Weapon" : "Weapons"}</Card.Title>
+          <Card.Body>
           <div className="text-center">
-        <Form onSubmit={onSubmit2} className="px-5">
-         <Form.Group className="mb-3 pt-3" >
+            {isCreatingWeapon ? (
+              <Form onSubmit={onSubmit2} className="px-5">
+               <Form.Group className="mb-3 pt-3" >
 
-         <Form.Label className="text-light">Name</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm2({ name: e.target.value })}
-          type="text" placeholder="Enter weapon name" />
+               <Form.Label className="text-light">Name</Form.Label>
+               <Form.Control className="mb-2" onChange={(e) => updateForm2({ name: e.target.value })}
+                type="text" placeholder="Enter weapon name" />
 
-         <Form.Label className="text-light">Type</Form.Label>
-         <Form.Select
-          className="mb-2"
-          value={form2.type}
-          onChange={(e) => updateForm2({ type: e.target.value })}
-        >
-          <option value="">Select type</option>
-          {weaponOptions.types.map((t) => (
-            <option key={t} value={t}>{t}</option>
-          ))}
-        </Form.Select>
+               <Form.Label className="text-light">Type</Form.Label>
+               <Form.Select
+                className="mb-2"
+                value={form2.type}
+                onChange={(e) => updateForm2({ type: e.target.value })}
+              >
+                <option value="">Select type</option>
+                {weaponOptions.types.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </Form.Select>
 
-         <Form.Label className="text-light">Category</Form.Label>
-         <Form.Select
-          className="mb-2"
-          value={form2.category}
-          onChange={(e) => updateForm2({ category: e.target.value })}
-        >
-          <option value="">Select category</option>
-          {weaponOptions.categories.map((c) => (
-            <option key={c} value={c}>{c}</option>
-          ))}
-        </Form.Select>
+               <Form.Label className="text-light">Category</Form.Label>
+               <Form.Select
+                className="mb-2"
+                value={form2.category}
+                onChange={(e) => updateForm2({ category: e.target.value })}
+              >
+                <option value="">Select category</option>
+                {weaponOptions.categories.map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </Form.Select>
 
-         <Form.Label className="text-light">Damage</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm2({ damage: e.target.value })}
-          type="text" placeholder="Enter damage" />
+               <Form.Label className="text-light">Damage</Form.Label>
+               <Form.Control className="mb-2" onChange={(e) => updateForm2({ damage: e.target.value })}
+                type="text" placeholder="Enter damage" />
 
-         <Form.Label className="text-light">Properties</Form.Label>
-         <Form.Select
-          multiple
-          className="mb-2"
-          value={form2.properties}
-          onChange={(e) => {
-            const selected = Array.from(e.target.selectedOptions, (opt) => opt.value);
-            updateForm2({ properties: selected });
-          }}
-        >
-          {weaponOptions.properties.map((p) => (
-            <option key={p} value={p}>{p}</option>
-          ))}
-        </Form.Select>
+               <Form.Label className="text-light">Properties</Form.Label>
+               <Form.Select
+                multiple
+                className="mb-2"
+                value={form2.properties}
+                onChange={(e) => {
+                  const selected = Array.from(e.target.selectedOptions, (opt) => opt.value);
+                  updateForm2({ properties: selected });
+                }}
+              >
+                {weaponOptions.properties.map((p) => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </Form.Select>
 
-         <Form.Label className="text-light">Weight</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm2({ weight: e.target.value })}
-          type="text" placeholder="Enter weight" />
+               <Form.Label className="text-light">Weight</Form.Label>
+               <Form.Control className="mb-2" onChange={(e) => updateForm2({ weight: e.target.value })}
+                type="text" placeholder="Enter weight" />
 
-         <Form.Label className="text-light">Cost</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm2({ cost: e.target.value })}
-          type="text" placeholder="Enter cost" />
+               <Form.Label className="text-light">Cost</Form.Label>
+               <Form.Control className="mb-2" onChange={(e) => updateForm2({ cost: e.target.value })}
+                type="text" placeholder="Enter cost" />
 
-      </Form.Group>
-       <div className="text-center">
-       <Button variant="primary" onClick={handleClose2} type="submit">
-              Create
-            </Button>
-            <Button className="ms-4" variant="secondary" onClick={handleClose2}>
-              Close
-            </Button>
-            </div>
-      </Form>
-      <Table striped bordered condensed="true" className="mt-3">
-        <thead>
-          <tr>
-           <th>Name</th>
-            <th>Type</th>
-            <th>Category</th>
-            <th>Damage</th>
-            <th>Properties</th>
-            <th>Weight</th>
-            <th>Cost</th>
-            <th>Delete</th>
-          </tr>
-        </thead>
-        <tbody>
-          {weapons.map((w) => (
-            <tr key={w._id}>
-              <td>{w.name}</td>
-              <td>{w.type}</td>
-              <td>{w.category}</td>
-              <td>{w.damage}</td>
-              <td>{w.properties?.join(', ')}</td>
-              <td>{w.weight}</td>
-              <td>{w.cost}</td>
-              <td>
-                <Button size="sm" variant="danger" onClick={() => deleteWeapon(w._id)}>
-                  Delete
-                </Button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-      </div>
-      </Card.Body>
-      </Card>
-      </div>
-       </Modal>
+            </Form.Group>
+             <div className="text-center">
+             <Button variant="primary" onClick={handleClose2} type="submit">
+                    Create
+                  </Button>
+                  <Button className="ms-4" variant="secondary" onClick={() => setIsCreatingWeapon(false)}>
+                    Cancel
+                  </Button>
+                  </div>
+            </Form>
+            ) : (
+              <>
+              <Table striped bordered condensed="true" className="mt-3">
+                <thead>
+                  <tr>
+                   <th>Name</th>
+                    <th>Type</th>
+                    <th>Category</th>
+                    <th>Damage</th>
+                    <th>Properties</th>
+                    <th>Weight</th>
+                    <th>Cost</th>
+                    <th>Delete</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {weapons.map((w) => (
+                    <tr key={w._id}>
+                      <td>{w.name}</td>
+                      <td>{w.type}</td>
+                      <td>{w.category}</td>
+                      <td>{w.damage}</td>
+                      <td>{w.properties?.join(', ')}</td>
+                      <td>{w.weight}</td>
+                      <td>{w.cost}</td>
+                      <td>
+                        <Button size="sm" variant="danger" onClick={() => deleteWeapon(w._id)}>
+                          Delete
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+              <Button variant="primary" onClick={() => setIsCreatingWeapon(true)}>
+                Create Weapon
+              </Button>
+              <Button className="ms-4" variant="secondary" onClick={handleClose2}>
+                Close
+              </Button>
+              </>
+            )}
+          </div>
+          </Card.Body>
+          </Card>
+          </div>
+           </Modal>
   {/* --------------------------------------- Armor Modal --------------------------------- */}
   <Modal className="dnd-modal" centered show={show3} onHide={handleClose3}>
   <div className="text-center">


### PR DESCRIPTION
## Summary
- add `isCreatingWeapon` flag to manage weapon creation flow
- show existing weapon table with a button to create new weapons
- render creation form only when creating, with a cancel option

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5b11de9c832ea9d77cfda78f29d7