### PR TITLE
Use icon-only button for weapon deletion

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -594,9 +594,10 @@ const [form2, setForm2] = useState({
                       <td>{w.weight}</td>
                       <td>{w.cost}</td>
                       <td>
-                        <Button size="sm" variant="danger" onClick={() => deleteWeapon(w._id)}>
-                          Delete
-                        </Button>
+                        <Button
+                          className="btn-danger action-btn fa-solid fa-trash"
+                          onClick={() => deleteWeapon(w._id)}
+                        />
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- Replace text delete button with icon-styled Button for weapon removal

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bb5d36b8fc832eab73274de22244bb