### PR TITLE
Add armor data and API routes

### DIFF
--- a/server/__tests__/armor.test.js
+++ b/server/__tests__/armor.test.js
@@ -1,0 +1,46 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Armor API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbo.mockResolvedValue({});
+  });
+
+  test('lists all armor', async () => {
+    const res = await request(app).get('/armor');
+    expect(res.status).toBe(200);
+    expect(res.body.padded).toBeDefined();
+    expect(res.body.leather).toBeDefined();
+  });
+
+  test('fetches a single armor', async () => {
+    const res = await request(app).get('/armor/chain-mail');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ name: 'Chain Mail', ac: '16' });
+  });
+
+  test('returns 404 for unknown armor', async () => {
+    const res = await request(app).get('/armor/unknown');
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Armor not found');
+  });
+});

--- a/server/data/armor.js
+++ b/server/data/armor.js
@@ -1,0 +1,140 @@
+/**
+ * Player's Handbook armor.
+ * Generated for proficiency checks.
+ */
+/** @typedef {import('../../types/armor').Armor} Armor */
+/** @type {Record<string, Armor>} */
+const armors = {
+  padded: {
+    name: "Padded",
+    category: "light",
+    ac: "11 + Dex modifier",
+    properties: ["stealth disadvantage"],
+    weight: 8,
+    cost: "5 gp",
+    proficient: false,
+  },
+  leather: {
+    name: "Leather",
+    category: "light",
+    ac: "11 + Dex modifier",
+    properties: [],
+    weight: 10,
+    cost: "10 gp",
+    proficient: false,
+  },
+  "studded-leather": {
+    name: "Studded Leather",
+    category: "light",
+    ac: "12 + Dex modifier",
+    properties: [],
+    weight: 13,
+    cost: "45 gp",
+    proficient: false,
+  },
+  hide: {
+    name: "Hide",
+    category: "medium",
+    ac: "12 + Dex modifier (max 2)",
+    properties: [],
+    weight: 12,
+    cost: "10 gp",
+    proficient: false,
+  },
+  "chain-shirt": {
+    name: "Chain Shirt",
+    category: "medium",
+    ac: "13 + Dex modifier (max 2)",
+    properties: [],
+    weight: 20,
+    cost: "50 gp",
+    proficient: false,
+  },
+  "scale-mail": {
+    name: "Scale Mail",
+    category: "medium",
+    ac: "14 + Dex modifier (max 2)",
+    properties: ["stealth disadvantage"],
+    weight: 45,
+    cost: "50 gp",
+    proficient: false,
+  },
+  breastplate: {
+    name: "Breastplate",
+    category: "medium",
+    ac: "14 + Dex modifier (max 2)",
+    properties: [],
+    weight: 20,
+    cost: "400 gp",
+    proficient: false,
+  },
+  "half-plate": {
+    name: "Half Plate",
+    category: "medium",
+    ac: "15 + Dex modifier (max 2)",
+    properties: ["stealth disadvantage"],
+    weight: 40,
+    cost: "750 gp",
+    proficient: false,
+  },
+  "ring-mail": {
+    name: "Ring Mail",
+    category: "heavy",
+    ac: "14",
+    properties: ["stealth disadvantage"],
+    weight: 40,
+    cost: "30 gp",
+    proficient: false,
+  },
+  "chain-mail": {
+    name: "Chain Mail",
+    category: "heavy",
+    ac: "16",
+    properties: ["strength 13", "stealth disadvantage"],
+    weight: 55,
+    cost: "75 gp",
+    proficient: false,
+  },
+  splint: {
+    name: "Splint",
+    category: "heavy",
+    ac: "17",
+    properties: ["strength 15", "stealth disadvantage"],
+    weight: 60,
+    cost: "200 gp",
+    proficient: false,
+  },
+  plate: {
+    name: "Plate",
+    category: "heavy",
+    ac: "18",
+    properties: ["strength 15", "stealth disadvantage"],
+    weight: 65,
+    cost: "1500 gp",
+    proficient: false,
+  },
+  shield: {
+    name: "Shield",
+    category: "shield",
+    ac: "+2",
+    properties: [],
+    weight: 6,
+    cost: "10 gp",
+    proficient: false,
+  },
+};
+
+// Default the type of each armor to its key for canonical mapping
+for (const [key, armor] of Object.entries(armors)) {
+  armor.type = armor.type || key;
+}
+// Derive canonical option lists for client consumption
+const types = Object.keys(armors);
+const categories = [
+  ...new Set(Object.values(armors).map((a) => a.category)),
+];
+const properties = [
+  ...new Set(Object.values(armors).flatMap((a) => a.properties)),
+];
+
+module.exports = { armors, types, categories, properties };

--- a/server/routes/armor.js
+++ b/server/routes/armor.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const {
+  armors,
+  types,
+  categories,
+  properties,
+} = require('../data/armor');
+
+module.exports = (router) => {
+  const armorRouter = express.Router();
+
+  armorRouter.get('/', (_req, res) => {
+    res.json(armors);
+  });
+
+  armorRouter.get('/options', (_req, res) => {
+    res.json({ types, categories, properties });
+  });
+
+  armorRouter.get('/:name', (req, res) => {
+    const armor = armors[req.params.name.toLowerCase()];
+    if (!armor) {
+      return res.status(404).json({ message: 'Armor not found' });
+    }
+    res.json(armor);
+  });
+
+  router.use('/armor', armorRouter);
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,6 +17,7 @@ const classes = require('./classes');
 const races = require('./races');
 const spells = require('./spells');
 const weapons = require('./weapons');
+const armor = require('./armor');
 const weaponProficiency = require('./weaponProficiency');
 
 routes.use(async (req, res, next) => {
@@ -35,6 +36,7 @@ classes(routes);
 races(routes);
 spells(routes);
 weapons(routes);
+armor(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.
 characterOccupations(routes);

--- a/types/armor.d.ts
+++ b/types/armor.d.ts
@@ -1,0 +1,34 @@
+export interface Armor {
+  /**
+   * Armor name, e.g. "Chain Mail".
+   */
+  name: string;
+  /**
+   * Canonical armor key used for proficiency mapping.
+   */
+  type?: string;
+  /**
+   * Armor category such as "light", "medium", "heavy", or "shield".
+   */
+  category: string;
+  /**
+   * Armor class description, e.g. "16" or "12 + Dex modifier".
+   */
+  ac: string;
+  /**
+   * List of properties from the SRD, e.g. ["stealth disadvantage"].
+   */
+  properties: string[];
+  /**
+   * Weight in pounds.
+   */
+  weight: number;
+  /**
+   * Cost as a string, e.g. "50 gp".
+   */
+  cost: string;
+  /**
+   * Whether the creature currently owns the armor.
+   */
+  owned: boolean;
+}


### PR DESCRIPTION
## Summary
- add SRD armor dataset with derived option arrays
- expose new `/armor` API with list, options, and detail endpoints
- register armor route and provide tests

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6b79da94832e8fc3ee24345f1f19