### PR TITLE
feat: add armor proficiency route

### DIFF
--- a/server/__tests__/armorProficiency.test.js
+++ b/server/__tests__/armorProficiency.test.js
@@ -1,0 +1,150 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Armor proficiency routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects removal of granted proficiency', async () => {
+    const charDoc = {
+      race: { armor: { leather: { proficient: true } } },
+      armorProficiencies: { leather: true },
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const findOneAndUpdate = jest.fn();
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne, findOneAndUpdate };
+        }
+        if (name === 'Armor') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
+
+    const res = await request(app)
+      .put('/armor-proficiency/507f1f77bcf86cd799439011')
+      .send({ armor: 'leather', proficient: false });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Cannot remove granted proficiency');
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('allows toggling armor proficiency', async () => {
+    const charDoc = {
+      occupation: [{ armor: { shield: { proficient: false } } }],
+      feat: [],
+      race: {},
+      armorProficiencies: {},
+    };
+
+    const updatedDoc = {
+      ...charDoc,
+      armorProficiencies: { shield: true },
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const findOneAndUpdate = jest.fn().mockResolvedValue({ value: updatedDoc });
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne, findOneAndUpdate };
+        }
+        if (name === 'Armor') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
+
+    const res = await request(app)
+      .put('/armor-proficiency/507f1f77bcf86cd799439011')
+      .send({ armor: 'shield', proficient: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ armor: 'shield', proficient: true });
+    expect(findOneAndUpdate).toHaveBeenCalled();
+  });
+
+  test('returns allowed, granted, and manual proficiencies', async () => {
+    const charDoc = {
+      occupation: [{ armor: { padded: false } }],
+      feat: [],
+      race: { armor: { leather: { proficient: true } } },
+      armorProficiencies: { padded: true },
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Armor') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
+
+    const res = await request(app).get(
+      '/armor-proficiency/507f1f77bcf86cd799439011'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.allowed).toEqual(expect.arrayContaining(['padded', 'leather']));
+    expect(res.body.granted).toEqual(expect.arrayContaining(['leather']));
+    expect(res.body.proficient).toEqual({ leather: true, padded: true });
+  });
+
+  test('expands armor categories', async () => {
+    const charDoc = {
+      race: { armor: ['light'] },
+      armorProficiencies: {},
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return { findOne };
+        }
+        if (name === 'Armor') {
+          return { find: () => ({ toArray: jest.fn().mockResolvedValue([]) }) };
+        }
+      },
+    });
+
+    const res = await request(app).get(
+      '/armor-proficiency/507f1f77bcf86cd799439011'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.granted).toEqual(
+      expect.arrayContaining(['padded', 'leather', 'studded-leather'])
+    );
+  });
+});
+

--- a/server/routes/armorProficiency.js
+++ b/server/routes/armorProficiency.js
@@ -1,0 +1,212 @@
+const ObjectId = require('mongodb').ObjectId;
+const express = require('express');
+const authenticateToken = require('../middleware/auth');
+const { armors: armorData } = require('../data/armor');
+
+// Collect allowed and granted armor from occupation, feat, and race
+function collectArmorInfo(occupation = [], feat = [], race, customArmors = []) {
+  const allowed = new Set();
+  const granted = new Set();
+
+  const canonicalize = (name) => {
+    const lower = String(name).toLowerCase();
+    if (armorData[lower]) return lower;
+    if (lower.endsWith('s')) {
+      const singular = lower.slice(0, -1);
+      if (armorData[singular]) return singular;
+    }
+    return lower;
+  };
+
+  const typeMap = Array.isArray(customArmors)
+    ? customArmors.reduce((acc, a) => {
+        const type = String(a.type || a.name).toLowerCase();
+        const nameKey = canonicalize(a.name);
+        (acc[type] ||= []).push(nameKey);
+        return acc;
+      }, {})
+    : {};
+
+  const addArmor = (canonical, isGranted = true) => {
+    allowed.add(canonical);
+    if (isGranted) granted.add(canonical);
+    const extra = typeMap[canonical];
+    if (extra) {
+      extra.forEach((name) => {
+        allowed.add(name);
+        if (isGranted) granted.add(name);
+      });
+    }
+  };
+
+  const expandCategory = (term) => {
+    const lower = String(term).toLowerCase();
+    const standard = Object.keys(armorData).filter((key) =>
+      armorData[key].category.toLowerCase().startsWith(lower)
+    );
+    const custom = Array.isArray(customArmors)
+      ? customArmors
+          .filter(
+            (a) => a.category && a.category.toLowerCase().startsWith(lower)
+          )
+          .map((a) => a.name)
+      : [];
+    return [...standard, ...custom];
+  };
+
+  const processArray = (arr) => {
+    arr.forEach((a) => {
+      if (typeof a === 'string') {
+        const expanded = expandCategory(a);
+        if (expanded.length) {
+          expanded.forEach((key) => {
+            const canonical = canonicalize(key);
+            addArmor(canonical);
+          });
+        } else {
+          const canonical = canonicalize(a);
+          addArmor(canonical);
+        }
+      } else {
+        addArmor(a);
+      }
+    });
+  };
+
+  const processObject = (obj) => {
+    Object.keys(obj).forEach((a) => {
+      const val = obj[a];
+      const expanded = expandCategory(a);
+      const isGranted = val === true || (val && val.proficient);
+      if (expanded.length) {
+        expanded.forEach((key) => {
+          const canonical = canonicalize(key);
+          addArmor(canonical, isGranted);
+        });
+      } else {
+        const canonical = canonicalize(a);
+        addArmor(canonical, isGranted);
+      }
+    });
+  };
+
+  const processSource = (src) => {
+    if (!src) return;
+    const armor = src.armor || src.armorProficiencies;
+    if (!armor) return;
+    if (Array.isArray(armor)) {
+      processArray(armor);
+    } else if (typeof armor === 'object') {
+      processObject(armor);
+    }
+  };
+
+  if (Array.isArray(occupation)) occupation.forEach(processSource);
+  if (Array.isArray(feat)) feat.forEach(processSource);
+  processSource(race);
+
+  return { allowed: Array.from(allowed), granted: Array.from(granted) };
+}
+
+module.exports = (router) => {
+  const apRouter = express.Router();
+
+  // authentication for all armor proficiency routes
+  apRouter.use(authenticateToken);
+
+  // Get allowed and proficient armor for a character
+  apRouter.get('/:id', async (req, res, next) => {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
+
+    const db = req.db;
+    const id = { _id: ObjectId(req.params.id) };
+
+    try {
+      const charDoc = await db.collection('Characters').findOne(id);
+      if (!charDoc) {
+        return res.status(404).json({ message: 'Character not found' });
+      }
+
+      const customArmors = await db
+        .collection('Armor')
+        .find({ campaign: charDoc.campaign })
+        .toArray();
+
+      const { allowed, granted } = collectArmorInfo(
+        charDoc.occupation,
+        charDoc.feat,
+        charDoc.race,
+        customArmors
+      );
+      const proficient = Object.assign(
+        Object.fromEntries(granted.map((a) => [a, true])),
+        charDoc.armorProficiencies || {}
+      );
+
+      return res.status(200).json({
+        allowed,
+        granted,
+        proficient,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Toggle armor proficiency
+  apRouter.put('/:id', async (req, res, next) => {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
+    const { armor, proficient = false } = req.body || {};
+    if (typeof armor !== 'string' || !armor.trim()) {
+      return res.status(400).json({ message: 'Invalid armor' });
+    }
+
+    const db = req.db;
+    const id = { _id: ObjectId(req.params.id) };
+
+    try {
+      const charDoc = await db.collection('Characters').findOne(id);
+      if (!charDoc) {
+        return res.status(404).json({ message: 'Character not found' });
+      }
+
+      const customArmors = await db
+        .collection('Armor')
+        .find({ campaign: charDoc.campaign })
+        .toArray();
+
+      const { allowed, granted } = collectArmorInfo(
+        charDoc.occupation,
+        charDoc.feat,
+        charDoc.race,
+        customArmors
+      );
+
+      if (!allowed.includes(armor)) {
+        return res.status(400).json({ message: 'Armor not allowed' });
+      }
+
+      if (!proficient && granted.includes(armor)) {
+        return res
+          .status(400)
+          .json({ message: 'Cannot remove granted proficiency' });
+      }
+
+      const update = { $set: { [`armorProficiencies.${armor}`]: proficient } };
+      await db.collection('Characters').findOneAndUpdate(id, update, {
+        returnDocument: 'after',
+      });
+
+      return res.status(200).json({ armor, proficient });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.use('/armor-proficiency', apRouter);
+};
+

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -19,6 +19,7 @@ const spells = require('./spells');
 const weapons = require('./weapons');
 const armor = require('./armor');
 const weaponProficiency = require('./weaponProficiency');
+const armorProficiency = require('./armorProficiency');
 
 routes.use(async (req, res, next) => {
   try {
@@ -47,5 +48,6 @@ skills(routes);
 feats(routes);
 equipment(routes);
 weaponProficiency(routes);
+armorProficiency(routes);
 
 module.exports = routes;


### PR DESCRIPTION
## Summary
- add armor proficiency route with canonicalization and category expansion
- register armor proficiency route
- cover armor proficiency routes with tests

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68bb6c442894832e81598fc5fa2aaa21