### PR TITLE
Sanitize initial armor list

### DIFF
--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -79,8 +79,18 @@ function ArmorList({
             }, {})
           : {};
 
+        const initialArmorArray = Array.isArray(initialArmor) ? initialArmor : [];
+        const invalidInitialArmor = initialArmorArray.filter(
+          (a) => typeof a !== 'string' && typeof a?.name !== 'string'
+        );
+        if (invalidInitialArmor.length) {
+          console.warn('Skipping invalid initial armor entries:', invalidInitialArmor);
+        }
         const ownedSet = new Set(
-          initialArmor.map((a) => (a.name || a).toLowerCase())
+          initialArmorArray
+            .map((a) => (typeof a === 'string' ? a : a?.name))
+            .filter((name) => typeof name === 'string')
+            .map((name) => name.toLowerCase())
         );
         const all = { ...phb, ...customMap };
         const proficientSet = new Set(Object.keys(prof.proficient || {}));

--- a/client/src/components/Armor/ArmorList.test.js
+++ b/client/src/components/Armor/ArmorList.test.js
@@ -294,3 +294,22 @@ test('warns when unknown armor names are returned', async () => {
   warn.mockRestore();
 });
 
+test('skips invalid initial armor entries with warning', async () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => armorData });
+
+  render(
+    <ArmorList
+      initialArmor={[armorData['chain mail'], { invalid: true }, 42, null]}
+    />
+  );
+
+  expect(await screen.findByLabelText('Chain Mail')).toBeChecked();
+  expect(warn).toHaveBeenCalledWith('Skipping invalid initial armor entries:', [
+    { invalid: true },
+    42,
+    null,
+  ]);
+  warn.mockRestore();
+});
+


### PR DESCRIPTION
## Summary
- sanitize initial armor list before ownership set creation
- log invalid initial armor entries and test warning

## Testing
- `CI=true npm test --prefix client src/components/Armor/ArmorList.test.js`
- `CI=true npm test --prefix client` *(fails: Unable to find an accessible element with the role "button" and name `/view/i` in Stats.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bb76c0cfb0832e9404cf49858de17a