### PR TITLE
Normalize armor data structures for skills and defense

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -18,18 +18,17 @@ export default function HealthDefense({
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
   let atkBonus = 0;
     
-  //Armor AC/MaxDex
-     let armorAcBonus= [];
-     let armorMaxDexBonus= [];
-     form.armor.map((el) => (
-       armorAcBonus.push(el[1])
-     ))
-    let totalArmorAcBonus = armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) + Number(ac);
-     form.armor.map((el) => (
-      armorMaxDexBonus.push(el[2])
-     ))
-     let filteredMaxDexArray = armorMaxDexBonus.filter(e => e !== '0')
-     let armorMaxDexMin = Math.min(...filteredMaxDexArray);
+  // Armor AC/MaxDex
+  const armorItems = (form.armor || []).map((el) =>
+    Array.isArray(el) ? el : [el.name, el.ac, el.maxDex, el.checkPenalty]
+  );
+  const armorAcBonus = armorItems.map((item) => Number(item[1] ?? 0));
+  const armorMaxDexBonus = armorItems.map((item) => Number(item[2] ?? 0));
+  let totalArmorAcBonus =
+    armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) +
+    Number(ac);
+  let filteredMaxDexArray = armorMaxDexBonus.filter((e) => e !== 0);
+  let armorMaxDexMin = Math.min(...filteredMaxDexArray);
     
      let armorMaxDex;
      if (Number(armorMaxDexMin) < Number(dexMod) && Number(armorMaxDexMin > 0)) {

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -50,7 +50,10 @@ export default function Skills({
   }
 
   // Armor Check Penalty
-  const checkPenalty = form.armor.map((el) => el[3]);
+  const armorItems = (form.armor || []).map((el) =>
+    Array.isArray(el) ? el : [el.name, el.ac, el.maxDex, el.checkPenalty]
+  );
+  const checkPenalty = armorItems.map((item) => Number(item[3] ?? 0));
   const totalCheckPenalty = checkPenalty.reduce(
     (sum, a) => Number(sum) + Number(a),
     0


### PR DESCRIPTION
## Summary
- Normalize `form.armor` entries so objects and arrays are handled consistently in HealthDefense and Skills components
- Safely coerce armor values to numbers before calculations

## Testing
- `npm test -- --watchAll=false` *(fails: 1 failed, 15 passed)*
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb79730db0832e817068a7242802d2