### PR TITLE
Fix armor AC bonus handling

### DIFF
--- a/client/src/components/Armor/ArmorDetail.js
+++ b/client/src/components/Armor/ArmorDetail.js
@@ -18,18 +18,37 @@ function ArmorDetail() {
     return <div>Loading...</div>;
   }
 
+  const ac =
+    armor.category === 'shield'
+      ? armor.acBonus
+      : 10 + Number(armor.acBonus);
+
   return (
     <div>
       <h2>{armor.name}</h2>
-      <p><strong>Category:</strong> {armor.category}</p>
-      <p><strong>AC:</strong> {armor.ac}</p>
+      <p>
+        <strong>Category:</strong> {armor.category}
+      </p>
+      <p>
+        <strong>AC:</strong> {ac}
+      </p>
       {armor.maxDex !== null && armor.maxDex !== undefined && (
-        <p><strong>Max Dex:</strong> {armor.maxDex}</p>
+        <p>
+          <strong>Max Dex:</strong> {armor.maxDex}
+        </p>
       )}
-      {armor.strength && <p><strong>Strength:</strong> {armor.strength}</p>}
+      {armor.strength && (
+        <p>
+          <strong>Strength:</strong> {armor.strength}
+        </p>
+      )}
       {armor.stealth && <p><strong>Stealth:</strong> disadvantage</p>}
-      <p><strong>Weight:</strong> {armor.weight}</p>
-      <p><strong>Cost:</strong> {armor.cost}</p>
+      <p>
+        <strong>Weight:</strong> {armor.weight}
+      </p>
+      <p>
+        <strong>Cost:</strong> {armor.cost}
+      </p>
     </div>
   );
 }

--- a/client/src/components/Armor/ArmorDetail.test.js
+++ b/client/src/components/Armor/ArmorDetail.test.js
@@ -10,7 +10,7 @@ test('fetches and displays armor detail', async () => {
     json: async () => ({
       name: 'Chain Mail',
       category: 'heavy',
-      ac: 16,
+      acBonus: 6,
       maxDex: 0,
       strength: 13,
       stealth: true,

--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -68,7 +68,7 @@ function ArmorList({
                 displayName: a.name || a.armorName,
                 type: a.type,
                 category: a.category || 'custom',
-                ac: a.ac ?? a.armorBonus ?? '',
+                acBonus: a.acBonus ?? a.ac ?? a.armorBonus ?? '',
                 maxDex: a.maxDex ?? null,
                 strength: a.strength ?? null,
                 stealth: a.stealth ?? false,
@@ -175,7 +175,7 @@ function ArmorList({
           ({
             name,
             category,
-            ac,
+            acBonus,
             maxDex,
             strength,
             stealth,
@@ -185,7 +185,7 @@ function ArmorList({
           }) => ({
             name,
             category,
-            ac,
+            acBonus,
             maxDex,
             strength,
             stealth,
@@ -278,7 +278,13 @@ function ArmorList({
                   />
                 </td>
                 <td>{piece.displayName || piece.name}</td>
-                <td>{piece.ac}</td>
+                <td>
+                  {piece.category === 'shield'
+                    ? piece.acBonus
+                    : piece.acBonus !== '' && piece.acBonus !== null && piece.acBonus !== undefined
+                    ? 10 + Number(piece.acBonus)
+                    : ''}
+                </td>
                 <td>
                   {piece.maxDex === null || piece.maxDex === undefined
                     ? '—'

--- a/client/src/components/Armor/ArmorList.test.js
+++ b/client/src/components/Armor/ArmorList.test.js
@@ -9,7 +9,7 @@ const armorData = {
   leather: {
     name: 'Leather Armor',
     category: 'light',
-    ac: 11,
+    acBonus: 1,
     maxDex: null,
     strength: null,
     stealth: false,
@@ -19,7 +19,7 @@ const armorData = {
   'chain mail': {
     name: 'Chain Mail',
     category: 'heavy',
-    ac: 16,
+    acBonus: 6,
     maxDex: 0,
     strength: 13,
     stealth: true,
@@ -31,7 +31,7 @@ const customData = [
   {
     name: 'Force Shield',
     category: 'special',
-    ac: 18,
+    acBonus: 8,
     maxDex: null,
     strength: null,
     stealth: false,

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -20,9 +20,14 @@ export default function HealthDefense({
     
   // Armor AC/MaxDex
   const armorItems = (form.armor || []).map((el) =>
-    Array.isArray(el) ? el : [el.name, el.ac, el.maxDex, el.checkPenalty]
+    Array.isArray(el)
+      ? el
+      : [el.name, el.acBonus ?? el.ac ?? el.armorBonus, el.maxDex, el.checkPenalty]
   );
-  const armorAcBonus = armorItems.map((item) => Number(item[1] ?? 0));
+  const armorAcBonus = armorItems.map((item) => {
+    const value = Number(item[1] ?? 0);
+    return value > 10 ? value - 10 : value;
+  });
   const armorMaxDexBonus = armorItems.map((item) => Number(item[2] ?? 0));
   let totalArmorAcBonus =
     armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) +

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -51,7 +51,9 @@ export default function Skills({
 
   // Armor Check Penalty
   const armorItems = (form.armor || []).map((el) =>
-    Array.isArray(el) ? el : [el.name, el.ac, el.maxDex, el.checkPenalty]
+    Array.isArray(el)
+      ? el
+      : [el.name, el.acBonus ?? el.ac ?? el.armorBonus, el.maxDex, el.checkPenalty]
   );
   const checkPenalty = armorItems.map((item) => Number(item[3] ?? 0));
   const totalCheckPenalty = checkPenalty.reduce(

--- a/server/__tests__/armor.test.js
+++ b/server/__tests__/armor.test.js
@@ -37,7 +37,7 @@ describe('Armor API routes', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
       name: 'Chain Mail',
-      ac: 16,
+      acBonus: 6,
       strength: 13,
       stealth: true,
     });

--- a/server/data/armor.js
+++ b/server/data/armor.js
@@ -8,7 +8,7 @@ const armors = {
   padded: {
     name: "Padded",
     category: "light",
-    ac: 11,
+    acBonus: 1,
     maxDex: null,
     strength: null,
     stealth: true,
@@ -19,7 +19,7 @@ const armors = {
   leather: {
     name: "Leather",
     category: "light",
-    ac: 11,
+    acBonus: 1,
     maxDex: null,
     strength: null,
     stealth: false,
@@ -30,7 +30,7 @@ const armors = {
   "studded-leather": {
     name: "Studded Leather",
     category: "light",
-    ac: 12,
+    acBonus: 2,
     maxDex: null,
     strength: null,
     stealth: false,
@@ -41,7 +41,7 @@ const armors = {
   hide: {
     name: "Hide",
     category: "medium",
-    ac: 12,
+    acBonus: 2,
     maxDex: 2,
     strength: null,
     stealth: false,
@@ -52,7 +52,7 @@ const armors = {
   "chain-shirt": {
     name: "Chain Shirt",
     category: "medium",
-    ac: 13,
+    acBonus: 3,
     maxDex: 2,
     strength: null,
     stealth: false,
@@ -63,7 +63,7 @@ const armors = {
   "scale-mail": {
     name: "Scale Mail",
     category: "medium",
-    ac: 14,
+    acBonus: 4,
     maxDex: 2,
     strength: null,
     stealth: true,
@@ -74,7 +74,7 @@ const armors = {
   breastplate: {
     name: "Breastplate",
     category: "medium",
-    ac: 14,
+    acBonus: 4,
     maxDex: 2,
     strength: null,
     stealth: false,
@@ -85,7 +85,7 @@ const armors = {
   "half-plate": {
     name: "Half Plate",
     category: "medium",
-    ac: 15,
+    acBonus: 5,
     maxDex: 2,
     strength: null,
     stealth: true,
@@ -96,7 +96,7 @@ const armors = {
   "ring-mail": {
     name: "Ring Mail",
     category: "heavy",
-    ac: 14,
+    acBonus: 4,
     maxDex: 0,
     strength: null,
     stealth: true,
@@ -107,7 +107,7 @@ const armors = {
   "chain-mail": {
     name: "Chain Mail",
     category: "heavy",
-    ac: 16,
+    acBonus: 6,
     maxDex: 0,
     strength: 13,
     stealth: true,
@@ -118,7 +118,7 @@ const armors = {
   splint: {
     name: "Splint",
     category: "heavy",
-    ac: 17,
+    acBonus: 7,
     maxDex: 0,
     strength: 15,
     stealth: true,
@@ -129,7 +129,7 @@ const armors = {
   plate: {
     name: "Plate",
     category: "heavy",
-    ac: 18,
+    acBonus: 8,
     maxDex: 0,
     strength: 15,
     stealth: true,
@@ -140,7 +140,7 @@ const armors = {
   shield: {
     name: "Shield",
     category: "shield",
-    ac: 2,
+    acBonus: 2,
     maxDex: null,
     strength: null,
     stealth: false,

--- a/types/armor.d.ts
+++ b/types/armor.d.ts
@@ -12,9 +12,9 @@ export interface Armor {
    */
   category: string;
   /**
-   * Base armor class provided by the armor.
+   * Armor class bonus provided by the armor (base AC minus 10).
    */
-  ac: number;
+  acBonus: number;
   /**
    * Maximum Dexterity modifier allowed, or null for no limit.
    */


### PR DESCRIPTION
## Summary
- compute armor AC bonus by subtracting base 10 when needed
- display AC using new `acBonus` values across client components
- store armor `acBonus` on the server to avoid future ambiguity

## Testing
- `npm test --prefix server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68bb7c07e394832e82357e5227b916a4