### PR TITLE
Expose armor AC bonuses

### DIFF
--- a/client/src/components/Armor/ArmorDetail.js
+++ b/client/src/components/Armor/ArmorDetail.js
@@ -18,10 +18,7 @@ function ArmorDetail() {
     return <div>Loading...</div>;
   }
 
-  const ac =
-    armor.category === 'shield'
-      ? armor.acBonus
-      : 10 + Number(armor.acBonus);
+  const acBonus = Number(armor.acBonus);
 
   return (
     <div>
@@ -30,7 +27,7 @@ function ArmorDetail() {
         <strong>Category:</strong> {armor.category}
       </p>
       <p>
-        <strong>AC:</strong> {ac}
+        <strong>AC Bonus:</strong> {acBonus}
       </p>
       {armor.maxDex !== null && armor.maxDex !== undefined && (
         <p>

--- a/client/src/components/Armor/ArmorDetail.test.js
+++ b/client/src/components/Armor/ArmorDetail.test.js
@@ -31,6 +31,6 @@ test('fetches and displays armor detail', async () => {
   expect(apiFetch).toHaveBeenCalledWith('/armor/chain-mail');
   await waitFor(() => expect(screen.getByText('Chain Mail')).toBeInTheDocument());
   expect(screen.getByText(/heavy/)).toBeInTheDocument();
-  expect(screen.getByText(/16/)).toBeInTheDocument();
+  expect(screen.getByText(/6/)).toBeInTheDocument();
 });
 

--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -242,7 +242,7 @@ function ArmorList({
               <th>Owned</th>
               <th>Proficient</th>
               <th>Name</th>
-              <th>AC</th>
+              <th>AC Bonus</th>
               <th>Max Dex</th>
               <th>Strength</th>
               <th>Stealth</th>
@@ -279,10 +279,8 @@ function ArmorList({
                 </td>
                 <td>{piece.displayName || piece.name}</td>
                 <td>
-                  {piece.category === 'shield'
+                  {piece.acBonus !== '' && piece.acBonus !== null && piece.acBonus !== undefined
                     ? piece.acBonus
-                    : piece.acBonus !== '' && piece.acBonus !== null && piece.acBonus !== undefined
-                    ? 10 + Number(piece.acBonus)
                     : ''}
                 </td>
                 <td>

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -19,16 +19,17 @@ export default function HealthDefense({
   let atkBonus = 0;
     
   // Armor AC/MaxDex
-  const armorItems = (form.armor || []).map((el) =>
-    Array.isArray(el)
-      ? el
-      : [el.name, el.acBonus ?? el.ac ?? el.armorBonus, el.maxDex, el.checkPenalty]
-  );
+  const armorItems = form.armor || [];
   const armorAcBonus = armorItems.map((item) => {
-    const value = Number(item[1] ?? 0);
-    return value > 10 ? value - 10 : value;
+    if (Array.isArray(item)) {
+      const value = Number(item[1] ?? 0);
+      return value > 10 ? value - 10 : value;
+    }
+    return Number(item.acBonus ?? 0);
   });
-  const armorMaxDexBonus = armorItems.map((item) => Number(item[2] ?? 0));
+  const armorMaxDexBonus = armorItems.map((item) =>
+    Array.isArray(item) ? Number(item[2] ?? 0) : Number(item.maxDex ?? 0)
+  );
   let totalArmorAcBonus =
     armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) +
     Number(ac);

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -122,6 +122,7 @@ export default function Stats({ form, showStats, handleCloseStats }) {
                           <Button
                             onClick={() => handleView(key)}
                             variant="link"
+                            aria-label="view"
                           >
                             <i className="fa-solid fa-eye"></i>
                           </Button>

--- a/server/data/armor.js
+++ b/server/data/armor.js
@@ -8,7 +8,7 @@ const armors = {
   padded: {
     name: "Padded",
     category: "light",
-    acBonus: 1,
+    ac: 11,
     maxDex: null,
     strength: null,
     stealth: true,
@@ -19,7 +19,7 @@ const armors = {
   leather: {
     name: "Leather",
     category: "light",
-    acBonus: 1,
+    ac: 11,
     maxDex: null,
     strength: null,
     stealth: false,
@@ -30,7 +30,7 @@ const armors = {
   "studded-leather": {
     name: "Studded Leather",
     category: "light",
-    acBonus: 2,
+    ac: 12,
     maxDex: null,
     strength: null,
     stealth: false,
@@ -41,7 +41,7 @@ const armors = {
   hide: {
     name: "Hide",
     category: "medium",
-    acBonus: 2,
+    ac: 12,
     maxDex: 2,
     strength: null,
     stealth: false,
@@ -52,7 +52,7 @@ const armors = {
   "chain-shirt": {
     name: "Chain Shirt",
     category: "medium",
-    acBonus: 3,
+    ac: 13,
     maxDex: 2,
     strength: null,
     stealth: false,
@@ -63,7 +63,7 @@ const armors = {
   "scale-mail": {
     name: "Scale Mail",
     category: "medium",
-    acBonus: 4,
+    ac: 14,
     maxDex: 2,
     strength: null,
     stealth: true,
@@ -74,7 +74,7 @@ const armors = {
   breastplate: {
     name: "Breastplate",
     category: "medium",
-    acBonus: 4,
+    ac: 14,
     maxDex: 2,
     strength: null,
     stealth: false,
@@ -85,7 +85,7 @@ const armors = {
   "half-plate": {
     name: "Half Plate",
     category: "medium",
-    acBonus: 5,
+    ac: 15,
     maxDex: 2,
     strength: null,
     stealth: true,
@@ -96,7 +96,7 @@ const armors = {
   "ring-mail": {
     name: "Ring Mail",
     category: "heavy",
-    acBonus: 4,
+    ac: 14,
     maxDex: 0,
     strength: null,
     stealth: true,
@@ -107,7 +107,7 @@ const armors = {
   "chain-mail": {
     name: "Chain Mail",
     category: "heavy",
-    acBonus: 6,
+    ac: 16,
     maxDex: 0,
     strength: 13,
     stealth: true,
@@ -118,7 +118,7 @@ const armors = {
   splint: {
     name: "Splint",
     category: "heavy",
-    acBonus: 7,
+    ac: 17,
     maxDex: 0,
     strength: 15,
     stealth: true,
@@ -129,7 +129,7 @@ const armors = {
   plate: {
     name: "Plate",
     category: "heavy",
-    acBonus: 8,
+    ac: 18,
     maxDex: 0,
     strength: 15,
     stealth: true,
@@ -140,7 +140,7 @@ const armors = {
   shield: {
     name: "Shield",
     category: "shield",
-    acBonus: 2,
+    ac: 12,
     maxDex: null,
     strength: null,
     stealth: false,
@@ -153,6 +153,7 @@ const armors = {
 // Default the type of each armor to its key for canonical mapping
 for (const [key, armor] of Object.entries(armors)) {
   armor.type = armor.type || key;
+  armor.acBonus = armor.ac - 10;
 }
 // Derive canonical option lists for client consumption
 const types = Object.keys(armors);

--- a/types/armor.d.ts
+++ b/types/armor.d.ts
@@ -12,6 +12,10 @@ export interface Armor {
    */
   category: string;
   /**
+   * Total armor class provided by the armor before additional bonuses.
+   */
+  ac: number;
+  /**
    * Armor class bonus provided by the armor (base AC minus 10).
    */
   acBonus: number;


### PR DESCRIPTION
## Summary
- derive `acBonus` from base `ac` for all armor and expose to clients
- use armor `acBonus` when summing defenses and list armor by bonus instead of total AC
- show armor AC bonus in detail view and fix stats view button accessibility

## Testing
- `npm test` (server)
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_68bb866bad98832e953214f0aabdc914