### PR TITLE
feat: add armor deletion endpoint

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -359,6 +359,7 @@ const [form2, setForm2] = useState({
         setStatus({ type: 'danger', message });
         return;
       }
+      await response.json();
       setArmor((prev) => prev.filter((a) => a._id !== id));
     } catch (error) {
       setStatus({ type: 'danger', message: error.toString() });

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -217,6 +217,32 @@ describe('Equipment routes', () => {
     });
   });
 
+  describe('delete armor', () => {
+    test('delete success', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ deleteOne: async () => ({ acknowledged: true, deletedCount: 1 }) })
+      });
+      const res = await request(app).delete('/equipment/armor/507f1f77bcf86cd799439011');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ acknowledged: true });
+    });
+
+    test('delete armor invalid id', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app).delete('/equipment/armor/123');
+      expect(res.status).toBe(400);
+    });
+
+    test('delete armor not found', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ deleteOne: async () => ({ acknowledged: true, deletedCount: 0 }) })
+      });
+      const res = await request(app).delete('/equipment/armor/507f1f77bcf86cd799439011');
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Armor not found');
+    });
+  });
+
   describe('/item/add', () => {
     test('validation failure', async () => {
       dbo.mockResolvedValue({});

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -171,6 +171,26 @@ module.exports = (router) => {
     }
   );
 
+  // This section will delete an armor.
+  equipmentRouter.route('/armor/:id').delete(async (req, res, next) => {
+    const { id } = req.params;
+    if (!ObjectId.isValid(id)) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
+    const db_connect = req.db;
+    try {
+      const result = await db_connect
+        .collection('Armor')
+        .deleteOne({ _id: ObjectId(id) });
+      if (result.deletedCount === 0) {
+        return res.status(404).json({ message: 'Armor not found' });
+      }
+      res.json({ acknowledged: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // Item Section
 
   // This section will get a list of all the items.


### PR DESCRIPTION
## Summary
- add DELETE /equipment/armor/:id route
- test armor deletion
- update ZombiesDM deleteArmor to use new endpoint

## Testing
- `npm test --prefix server`
- `CI=true npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68bb8f1f4f40832eac4e033077d5ae48