### PR TITLE
feat: expand armor creation fields

### DIFF
--- a/client/src/components/Armor/ArmorDetail.test.js
+++ b/client/src/components/Armor/ArmorDetail.test.js
@@ -32,5 +32,9 @@ test('fetches and displays armor detail', async () => {
   await waitFor(() => expect(screen.getByText('Chain Mail')).toBeInTheDocument());
   expect(screen.getByText(/heavy/)).toBeInTheDocument();
   expect(screen.getByText(/6/)).toBeInTheDocument();
+  expect(screen.getByText(/Strength:/)).toBeInTheDocument();
+  expect(screen.getByText(/disadvantage/)).toBeInTheDocument();
+  expect(screen.getByText(/55/)).toBeInTheDocument();
+  expect(screen.getByText(/75 gp/)).toBeInTheDocument();
 });
 

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -282,6 +282,10 @@ const [form2, setForm2] = useState({
     armorBonus: "",
     maxDex: "",
     armorCheckPenalty: "",
+    strength: "",
+    stealth: "",
+    weight: "",
+    cost: "",
   });
   
   function updateForm3(value) {
@@ -346,6 +350,10 @@ const [form2, setForm2] = useState({
     armorBonus: "",
     maxDex: "",
     armorCheckPenalty: "",
+    strength: "",
+    stealth: "",
+    weight: "",
+    cost: "",
   });
    fetchArmor();
    setIsCreatingArmor(false);
@@ -715,6 +723,22 @@ const [form2, setForm2] = useState({
 
           <Form.Label className="text-light">Armor Check Penalty</Form.Label>
           <Form.Control className="mb-2" onChange={(e) => updateForm3({ armorCheckPenalty: e.target.value })} type="text" placeholder="Enter Armor Check Penalty" />
+
+          <Form.Label className="text-light">Strength Requirement</Form.Label>
+          <Form.Control className="mb-2" onChange={(e) => updateForm3({ strength: e.target.value })} type="text" placeholder="Enter Strength Requirement" />
+
+          <Form.Label className="text-light">Stealth</Form.Label>
+          <Form.Select className="mb-2" value={form3.stealth} onChange={(e) => updateForm3({ stealth: e.target.value })}>
+            <option value="">Select option</option>
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </Form.Select>
+
+          <Form.Label className="text-light">Weight</Form.Label>
+          <Form.Control className="mb-2" onChange={(e) => updateForm3({ weight: e.target.value })} type="text" placeholder="Enter Weight" />
+
+          <Form.Label className="text-light">Cost</Form.Label>
+          <Form.Control className="mb-2" onChange={(e) => updateForm3({ cost: e.target.value })} type="text" placeholder="Enter Cost" />
         </Form.Group>
         <div className="text-center">
           <Button variant="primary" type="submit">

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -486,13 +486,14 @@ describe('Character routes', () => {
 
   test('add armor success', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+      collection: () => ({ insertOne: async () => ({ insertedId: 'abc123' }) })
     });
+    const payload = { campaign: 'Camp1', armorName: 'Plate' };
     const res = await request(app)
       .post('/equipment/armor/add')
-      .send({ campaign: 'Camp1', armorName: 'Plate' });
+      .send(payload);
     expect(res.status).toBe(200);
-    expect(res.body.acknowledged).toBe(true);
+    expect(res.body).toMatchObject({ _id: 'abc123', ...payload });
   });
 
   test('add armor failure', async () => {

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -159,20 +159,37 @@ describe('Equipment routes', () => {
 
     test('insert success', async () => {
       dbo.mockResolvedValue({
-        collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+        collection: () => ({ insertOne: async () => ({ insertedId: 'abc123' }) })
       });
+      const payload = {
+        campaign: 'Camp1',
+        armorName: 'Plate',
+        type: 'heavy',
+        category: 'martial',
+        strength: 15,
+        stealth: true,
+        weight: 65,
+        cost: '1500 gp',
+      };
       const res = await request(app)
         .post('/equipment/armor/add')
-        .send({ campaign: 'Camp1', armorName: 'Plate' });
+        .send(payload);
       expect(res.status).toBe(200);
-      expect(res.body.acknowledged).toBe(true);
+      expect(res.body).toMatchObject({ _id: 'abc123', ...payload });
     });
 
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
         .post('/equipment/armor/add')
-        .send({ campaign: 'Camp1', armorName: 'Plate', armorBonus: 'bad' });
+        .send({
+          campaign: 'Camp1',
+          armorName: 'Plate',
+          armorBonus: 'bad',
+          strength: 'bad',
+          stealth: 'maybe',
+          weight: 'bad',
+        });
       expect(res.status).toBe(400);
     });
   });

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -132,6 +132,12 @@ module.exports = (router) => {
       body('armorBonus').optional().isInt().toInt(),
       body('maxDex').optional().isInt().toInt(),
       body('armorCheckPenalty').optional().isInt().toInt(),
+      body('type').optional().isString().trim().toLowerCase(),
+      body('category').optional().isString().trim().toLowerCase(),
+      body('strength').optional().isInt().toInt(),
+      body('stealth').optional().isBoolean().toBoolean(),
+      body('weight').optional().isFloat().toFloat(),
+      body('cost').optional().isString().trim(),
     ],
     handleValidationErrors,
     async (req, response, next) => {
@@ -139,7 +145,8 @@ module.exports = (router) => {
       const myobj = matchedData(req, { locations: ['body'], includeOptionals: true });
       try {
         const result = await db_connect.collection('Armor').insertOne(myobj);
-        response.json(result);
+        const armor = { _id: result.insertedId, ...myobj };
+        response.json(armor);
       } catch (err) {
         next(err);
       }


### PR DESCRIPTION
## Summary
- accept extra armor fields on POST /equipment/armor/add
- show new armor fields in DM form and return created record
- cover new armor properties in server and client tests

## Testing
- `cd server && npm test`
- `cd client && CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68bb900fad50832ea3adca0b71b3adcb