### PR TITLE
Allow optional numeric armor fields

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -329,7 +329,9 @@ const [form2, setForm2] = useState({
   }
   
   async function sendToDb3(){
-    const newArmor = { ...form3 };
+    const newArmor = Object.fromEntries(
+      Object.entries(form3).filter(([_, v]) => v !== "")
+    );
     await apiFetch("/equipment/armor/add", {
        method: "POST",
        headers: {

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -178,6 +178,23 @@ describe('Equipment routes', () => {
       expect(res.body).toMatchObject({ _id: 'abc123', ...payload });
     });
 
+    test('blank numeric fields allowed', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ insertOne: async () => ({ insertedId: 'def456' }) })
+      });
+      const res = await request(app)
+        .post('/equipment/armor/add')
+        .send({
+          campaign: 'Camp1',
+          armorName: 'Leather',
+          armorBonus: '',
+          maxDex: '',
+          armorCheckPenalty: '',
+        });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ _id: 'def456', campaign: 'Camp1', armorName: 'Leather' });
+    });
+
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -129,9 +129,9 @@ module.exports = (router) => {
     [
       body('campaign').trim().notEmpty().withMessage('campaign is required'),
       body('armorName').trim().notEmpty().withMessage('armorName is required'),
-      body('armorBonus').optional().isInt().toInt(),
-      body('maxDex').optional().isInt().toInt(),
-      body('armorCheckPenalty').optional().isInt().toInt(),
+      body('armorBonus').optional({ checkFalsy: true }).isInt().toInt(),
+      body('maxDex').optional({ checkFalsy: true }).isInt().toInt(),
+      body('armorCheckPenalty').optional({ checkFalsy: true }).isInt().toInt(),
       body('type').optional().isString().trim().toLowerCase(),
       body('category').optional().isString().trim().toLowerCase(),
       body('strength').optional().isInt().toInt(),


### PR DESCRIPTION
## Summary
- accept falsy armor number fields in server validation
- strip empty armor fields on client before submit
- test armor insertion with blank numeric fields

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb955db920832ebee64ddc65b74325