### PR TITLE
Rename armorBonus to acBonus across server and client

### DIFF
--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -68,7 +68,7 @@ function ArmorList({
                 displayName: a.name || a.armorName,
                 type: a.type,
                 category: a.category || 'custom',
-                acBonus: a.acBonus ?? a.ac ?? a.armorBonus ?? '',
+                acBonus: a.acBonus ?? a.ac ?? '',
                 maxDex: a.maxDex ?? null,
                 strength: a.strength ?? null,
                 stealth: a.stealth ?? false,

--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -183,7 +183,7 @@ return(
          type="text">
           <option value="" disabled>Select your armor</option>
           {armor.armor.map((el) => (
-          <option key={el.armorName} value={[el.armorName, el.armorBonus, el.maxDex, el.armorCheckPenalty]}>{el.armorName}</option>
+          <option key={el.armorName} value={[el.armorName, el.acBonus, el.maxDex, el.armorCheckPenalty]}>{el.armorName}</option>
           ))}
         </Form.Select>
       </Form.Group>

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -53,7 +53,7 @@ export default function Skills({
   const armorItems = (form.armor || []).map((el) =>
     Array.isArray(el)
       ? el
-      : [el.name, el.acBonus ?? el.ac ?? el.armorBonus, el.maxDex, el.checkPenalty]
+      : [el.name, el.acBonus ?? el.ac, el.maxDex, el.checkPenalty]
   );
   const checkPenalty = armorItems.map((item) => Number(item[3] ?? 0));
   const totalCheckPenalty = checkPenalty.reduce(

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -279,7 +279,7 @@ const [form2, setForm2] = useState({
     name: "",
     type: "",
     category: "",
-    armorBonus: "",
+    acBonus: "",
     maxDex: "",
     armorCheckPenalty: "",
     strength: "",
@@ -349,7 +349,7 @@ const [form2, setForm2] = useState({
     name: "",
     type: "",
     category: "",
-    armorBonus: "",
+    acBonus: "",
     maxDex: "",
     armorCheckPenalty: "",
     strength: "",
@@ -717,8 +717,8 @@ const [form2, setForm2] = useState({
             ))}
           </Form.Select>
 
-          <Form.Label className="text-light">Armor Bonus</Form.Label>
-          <Form.Control className="mb-2" onChange={(e) => updateForm3({ armorBonus: e.target.value })} type="text" placeholder="Enter Armor Bonus" />
+          <Form.Label className="text-light">AC Bonus</Form.Label>
+          <Form.Control className="mb-2" onChange={(e) => updateForm3({ acBonus: e.target.value })} type="text" placeholder="Enter AC Bonus" />
 
           <Form.Label className="text-light">Max Dex Bonus</Form.Label>
           <Form.Control className="mb-2" onChange={(e) => updateForm3({ maxDex: e.target.value })} type="text" placeholder="Enter Max Dex Bonus" />
@@ -759,7 +759,7 @@ const [form2, setForm2] = useState({
             <th>Name</th>
             <th>Type</th>
             <th>Category</th>
-            <th>Armor Bonus</th>
+            <th>AC Bonus</th>
             <th>Max Dex</th>
             <th>Check Penalty</th>
             <th>Delete</th>
@@ -771,7 +771,7 @@ const [form2, setForm2] = useState({
               <td>{a.name}</td>
               <td>{a.type}</td>
               <td>{a.category}</td>
-              <td>{a.armorBonus}</td>
+              <td>{a.acBonus}</td>
               <td>{a.maxDex}</td>
               <td>{a.armorCheckPenalty}</td>
               <td>

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -187,7 +187,7 @@ describe('Equipment routes', () => {
         .send({
           campaign: 'Camp1',
           armorName: 'Leather',
-          armorBonus: '',
+          acBonus: '',
           maxDex: '',
           armorCheckPenalty: '',
         });
@@ -202,7 +202,7 @@ describe('Equipment routes', () => {
         .send({
           campaign: 'Camp1',
           armorName: 'Plate',
-          armorBonus: 'bad',
+          acBonus: 'bad',
           strength: 'bad',
           stealth: 'maybe',
           weight: 'bad',

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -129,7 +129,7 @@ module.exports = (router) => {
     [
       body('campaign').trim().notEmpty().withMessage('campaign is required'),
       body('armorName').trim().notEmpty().withMessage('armorName is required'),
-      body('armorBonus').optional({ checkFalsy: true }).isInt().toInt(),
+      body('acBonus').optional({ checkFalsy: true }).isInt().toInt(),
       body('maxDex').optional({ checkFalsy: true }).isInt().toInt(),
       body('armorCheckPenalty').optional({ checkFalsy: true }).isInt().toInt(),
       body('type').optional().isString().trim().toLowerCase(),


### PR DESCRIPTION
## Summary
- standardize armor creation validator to expect `acBonus`
- switch Zombies DM armor form and table to use `acBonus`
- update client components and server tests to remove `armorBonus`

## Testing
- `cd server && npm test`
- `cd client && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb962e50d8832e8b7994d761ecd20b