### PR TITLE
Handle optional armor numeric fields

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -279,7 +279,7 @@ const [form2, setForm2] = useState({
     name: "",
     type: "",
     category: "",
-    acBonus: "",
+    armorBonus: "",
     maxDex: "",
     armorCheckPenalty: "",
     strength: "",
@@ -329,8 +329,14 @@ const [form2, setForm2] = useState({
   }
   
   async function sendToDb3(){
+    const numericFields = ['armorBonus', 'maxDex', 'armorCheckPenalty', 'strength', 'weight'];
     const newArmor = Object.fromEntries(
-      Object.entries(form3).filter(([_, v]) => v !== "")
+      Object.entries(form3)
+        .filter(([_, v]) => v !== "")
+        .map(([key, value]) => [
+          key,
+          numericFields.includes(key) ? Number(value) : value,
+        ])
     );
     await apiFetch("/equipment/armor/add", {
        method: "POST",
@@ -349,7 +355,7 @@ const [form2, setForm2] = useState({
     name: "",
     type: "",
     category: "",
-    acBonus: "",
+    armorBonus: "",
     maxDex: "",
     armorCheckPenalty: "",
     strength: "",
@@ -718,7 +724,7 @@ const [form2, setForm2] = useState({
           </Form.Select>
 
           <Form.Label className="text-light">AC Bonus</Form.Label>
-          <Form.Control className="mb-2" onChange={(e) => updateForm3({ acBonus: e.target.value })} type="text" placeholder="Enter AC Bonus" />
+          <Form.Control className="mb-2" onChange={(e) => updateForm3({ armorBonus: e.target.value })} type="text" placeholder="Enter AC Bonus" />
 
           <Form.Label className="text-light">Max Dex Bonus</Form.Label>
           <Form.Control className="mb-2" onChange={(e) => updateForm3({ maxDex: e.target.value })} type="text" placeholder="Enter Max Dex Bonus" />
@@ -771,7 +777,7 @@ const [form2, setForm2] = useState({
               <td>{a.name}</td>
               <td>{a.type}</td>
               <td>{a.category}</td>
-              <td>{a.acBonus}</td>
+              <td>{a.armorBonus ?? a.acBonus}</td>
               <td>{a.maxDex}</td>
               <td>{a.armorCheckPenalty}</td>
               <td>

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -187,7 +187,7 @@ describe('Equipment routes', () => {
         .send({
           campaign: 'Camp1',
           armorName: 'Leather',
-          acBonus: '',
+          armorBonus: '',
           maxDex: '',
           armorCheckPenalty: '',
         });
@@ -202,7 +202,7 @@ describe('Equipment routes', () => {
         .send({
           campaign: 'Camp1',
           armorName: 'Plate',
-          acBonus: 'bad',
+          armorBonus: 'bad',
           strength: 'bad',
           stealth: 'maybe',
           weight: 'bad',

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -129,7 +129,7 @@ module.exports = (router) => {
     [
       body('campaign').trim().notEmpty().withMessage('campaign is required'),
       body('armorName').trim().notEmpty().withMessage('armorName is required'),
-      body('acBonus').optional({ checkFalsy: true }).isInt().toInt(),
+      body('armorBonus').optional({ checkFalsy: true }).isInt().toInt(),
       body('maxDex').optional({ checkFalsy: true }).isInt().toInt(),
       body('armorCheckPenalty').optional({ checkFalsy: true }).isInt().toInt(),
       body('type').optional().isString().trim().toLowerCase(),


### PR DESCRIPTION
## Summary
- ensure `/equipment/armor/add` accepts optional numeric fields `armorBonus`, `maxDex`, and `armorCheckPenalty`
- sanitize armor form on Zombies DM page by dropping blanks and casting numeric inputs
- cover blank numeric fields scenario in tests

## Testing
- `npm test`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9906cc3c832eb727afc8156da954