### PR TITLE
Handle armorBonus fallback across armor components

### DIFF
--- a/client/src/components/Armor/ArmorDetail.js
+++ b/client/src/components/Armor/ArmorDetail.js
@@ -18,7 +18,7 @@ function ArmorDetail() {
     return <div>Loading...</div>;
   }
 
-  const acBonus = Number(armor.acBonus);
+  const acBonus = Number(armor.acBonus ?? armor.armorBonus ?? armor.ac ?? 0);
 
   return (
     <div>

--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -68,7 +68,7 @@ function ArmorList({
                 displayName: a.name || a.armorName,
                 type: a.type,
                 category: a.category || 'custom',
-                acBonus: a.acBonus ?? a.ac ?? '',
+                acBonus: a.acBonus ?? a.armorBonus ?? a.ac ?? '',
                 maxDex: a.maxDex ?? null,
                 strength: a.strength ?? null,
                 stealth: a.stealth ?? false,

--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -183,7 +183,12 @@ return(
          type="text">
           <option value="" disabled>Select your armor</option>
           {armor.armor.map((el) => (
-          <option key={el.armorName} value={[el.armorName, el.acBonus, el.maxDex, el.armorCheckPenalty]}>{el.armorName}</option>
+          <option
+            key={el.armorName}
+            value={[el.armorName, el.acBonus || el.armorBonus, el.maxDex, el.armorCheckPenalty]}
+          >
+            {el.armorName}
+          </option>
           ))}
         </Form.Select>
       </Form.Group>

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -25,7 +25,7 @@ export default function HealthDefense({
       const value = Number(item[1] ?? 0);
       return value > 10 ? value - 10 : value;
     }
-    return Number(item.acBonus ?? 0);
+    return Number(item.acBonus ?? item.armorBonus ?? item.ac ?? 0);
   });
   const armorMaxDexBonus = armorItems.map((item) =>
     Array.isArray(item) ? Number(item[2] ?? 0) : Number(item.maxDex ?? 0)

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -53,7 +53,7 @@ export default function Skills({
   const armorItems = (form.armor || []).map((el) =>
     Array.isArray(el)
       ? el
-      : [el.name, el.acBonus ?? el.ac, el.maxDex, el.checkPenalty]
+      : [el.name, el.acBonus ?? el.armorBonus ?? el.ac, el.maxDex, el.checkPenalty]
   );
   const checkPenalty = armorItems.map((item) => Number(item[3] ?? 0));
   const totalCheckPenalty = checkPenalty.reduce(

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -783,7 +783,7 @@ const [form2, setForm2] = useState({
               <td>{a.armorName ?? a.name}</td>
               <td>{a.type}</td>
               <td>{a.category}</td>
-              <td>{a.armorBonus ?? a.acBonus}</td>
+              <td>{a.armorBonus ?? a.acBonus ?? a.ac}</td>
               <td>{a.maxDex}</td>
               <td>{a.armorCheckPenalty}</td>
               <td>


### PR DESCRIPTION
## Summary
- Treat custom armor objects' AC bonus as `acBonus ?? armorBonus ?? ac`
- Use `acBonus || armorBonus` when selecting armor for Zombies
- Include armorBonus fallback in armor details, health/defense, skill checks, and DM page display

## Testing
- `CI=true npm test --silent -- --watchAll=false` in `client`
- `npm test --silent` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68bba2d38e5c832e806b4cbbeff2958d