### PR TITLE
Handle trailing text in damage strings

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -19,7 +19,8 @@ function rollDice(numberOfDiceValue, sidesOfDiceValue) {
 }
 
 export function calculateDamage(damageString, ability = 0, crit = false, roll = rollDice) {
-  const match = damageString.match(/^(\d+)(?:d(\d+)([+-]\d+)?)?$/);
+  const cleanString = damageString.split(' ')[0];
+  const match = cleanString.match(/^(\d+)(?:d(\d+)([+-]\d+)?)?$/);
   if (!match) {
     // eslint-disable-next-line no-console
     console.error('Invalid damage string');
@@ -87,7 +88,8 @@ const handleToggleAfterDamage = () => {
 
   const getDamageString = (weapon) => {
     const ability = abilityForWeapon(weapon);
-    return `${weapon.damage}+${ability}`;
+    const dice = weapon.damage.split(' ')[0];
+    return `${dice}+${ability}`;
   };
 
   const handleWeaponAttack = (weapon) => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -11,6 +11,14 @@ describe('calculateDamage parser', () => {
     expect(calculateDamage('10d4+1', 0, false, fixedRoll)).toBe(11);
   });
 
+  test('handles 1d8 slashing', () => {
+    expect(calculateDamage('1d8 slashing', 0, false, fixedRoll)).toBe(1);
+  });
+
+  test('handles 2d6 fire', () => {
+    expect(calculateDamage('2d6 fire', 0, false, fixedRoll)).toBe(2);
+  });
+
   test('handles flat damage 100', () => {
     expect(calculateDamage('100', 0, false, fixedRoll)).toBe(100);
   });


### PR DESCRIPTION
## Summary
- Strip trailing text before parsing damage to support strings like `1d8 slashing`
- Show only dice portion plus ability bonus when rendering damage strings
- Add tests for calculating damage with extra text

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bbaaaffcfc832e832a24c093438f4e