### PR TITLE
Fix weapon modal table overflow

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -586,7 +586,7 @@ const [form2, setForm2] = useState({
             <Card.Header className="modal-header">
               <Card.Title className="modal-title">{isCreatingWeapon ? "Create Weapon" : "Weapons"}</Card.Title>
             </Card.Header>
-          <Card.Body>
+          <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
           <div className="text-center">
             {isCreatingWeapon ? (
               <Form onSubmit={onSubmit2} className="px-5">
@@ -659,7 +659,7 @@ const [form2, setForm2] = useState({
             </Form>
             ) : (
               <>
-              <Table striped bordered hover size="sm" className="modern-table mt-3">
+              <Table responsive striped bordered hover size="sm" className="modern-table mt-3">
                 <thead>
                   <tr>
                    <th>Name</th>


### PR DESCRIPTION
## Summary
- keep weapon list table within DM page modal by making modal body scrollable
- make weapon list table responsive to prevent horizontal overflow

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbac20847c832eace4fee735c5aad8