### PR TITLE
Enhance skill checkbox styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8,6 +8,21 @@
   border-color: var(--bs-primary);
 }
 
+.skill-checkbox .form-check-input {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-width: 2px;
+}
+
+.skill-checkbox .form-check-input:checked:not(:disabled) {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+}
+
+.skill-checkbox .form-check-input:disabled {
+  opacity: 0.5;
+}
+
 .App {
   text-align: center;
 }

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -214,6 +214,7 @@ export default function Skills({
                     <td>{modMap[ability]}</td>
                     <td>
                       <Form.Check
+                        className="skill-checkbox"
                         type="checkbox"
                         checked={proficient}
                         disabled={!isSelectable || isRaceSkill}
@@ -222,6 +223,7 @@ export default function Skills({
                     </td>
                     <td>
                       <Form.Check
+                        className="skill-checkbox"
                         type="checkbox"
                         checked={expertise}
                         disabled={!proficient}


### PR DESCRIPTION
## Summary
- add `skill-checkbox` class to proficiency and expertise controls
- style `skill-checkbox` inputs to increase size, use high-contrast colors, and dim disabled boxes

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bbaeb727d4832e8f0700857de60da8