### PR TITLE
Enhance skill checkbox styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8,6 +8,33 @@
   border-color: var(--bs-primary);
 }
 
+.skill-checkbox .form-check-input {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-width: 2px;
+}
+
+.skill-checkbox .form-check-input:not(:disabled) {
+  cursor: pointer;
+  border-color: var(--bs-dark);
+}
+
+.skill-checkbox .form-check-input:checked:not(:disabled) {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+}
+
+.skill-checkbox .form-check-input:disabled {
+  cursor: not-allowed;
+  background-color: #e9ecef;
+  border-color: #adb5bd;
+}
+
+.skill-checkbox .form-check-input:disabled:checked {
+  background-color: rgba(var(--bs-primary-rgb), 0.5);
+  border-color: rgba(var(--bs-primary-rgb), 0.5);
+}
+
 .App {
   text-align: center;
 }

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -29,16 +29,22 @@ export default function Skills({
 }) {
   const params = useParams();
   const [skills, setSkills] = useState(form.skills || {});
-  const currentProficiencyCount = Object.values(form.skills || {}).filter(
-    (s) => s.proficient
+  const raceProficiencies = new Set(
+    Object.entries(form.race?.skills || {})
+      .filter(([, s]) => s?.proficient)
+      .map(([key]) => key)
+  );
+  const currentProficiencyCount = Object.entries(form.skills || {}).filter(
+    ([key, s]) => s.proficient && !raceProficiencies.has(key)
   ).length;
   const [proficiencyPointsLeft, setProficiencyPointsLeft] = useState(
     Math.max(0, (form.proficiencyPoints || 0) - currentProficiencyCount)
   );
 
   useEffect(() => {
-    const count = Object.values(form.skills || {}).filter((s) => s.proficient)
-      .length;
+    const count = Object.entries(form.skills || {}).filter(
+      ([key, s]) => s.proficient && !raceProficiencies.has(key)
+    ).length;
     setSkills(form.skills || {});
     setProficiencyPointsLeft(
       Math.max(0, (form.proficiencyPoints || 0) - count)
@@ -94,11 +100,6 @@ export default function Skills({
   const profBonus = proficiencyBonus(totalLevel);
 
   const selectableSkills = new Set(form.allowedSkills || []);
-  const raceProficiencies = new Set(
-    Object.entries(form.race?.skills || {})
-      .filter(([, s]) => s?.proficient)
-      .map(([key]) => key)
-  );
 
   async function updateSkill(skill, updated) {
     try {
@@ -116,8 +117,8 @@ export default function Skills({
           ...prev,
           [skill]: { proficient: data.proficient, expertise: data.expertise },
         };
-        const proficientCount = Object.values(newSkills).filter(
-          (s) => s.proficient
+        const proficientCount = Object.entries(newSkills).filter(
+          ([key, s]) => s.proficient && !raceProficiencies.has(key)
         ).length;
         setProficiencyPointsLeft(
           Math.max(0, (form.proficiencyPoints || 0) - proficientCount)
@@ -214,6 +215,7 @@ export default function Skills({
                     <td>{modMap[ability]}</td>
                     <td>
                       <Form.Check
+                        className="skill-checkbox"
                         type="checkbox"
                         checked={proficient}
                         disabled={!isSelectable || isRaceSkill}
@@ -222,6 +224,7 @@ export default function Skills({
                     </td>
                     <td>
                       <Form.Check
+                        className="skill-checkbox"
                         type="checkbox"
                         checked={expertise}
                         disabled={!proficient}


### PR DESCRIPTION
## Summary
- add `skill-checkbox` class to proficiency and expertise controls
- style `skill-checkbox` inputs to increase size, use high-contrast colors, dim disabled boxes, and tint locked selections blue
- grey out disabled skill checkboxes and show not-allowed cursor for better distinction
- darken borders for selectable skill checkboxes
- exclude racial skill bonuses from proficiency-point tracking so players can spend all points

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbaeb727d4832e8f0700857de60da8