### PR TITLE
Exclude racial skills from proficiency count

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -203,7 +203,9 @@ export default function ZombiesCharacterSheet() {
 
   const skillPointsLeft =
     (form.proficiencyPoints || 0) -
-    Object.values(form.skills || {}).filter((s) => s.proficient).length;
+    Object.entries(form.skills || {}).filter(
+      ([key, s]) => s.proficient && !form.race?.skills?.[key]?.proficient
+    ).length;
   const skillsGold = skillPointsLeft > 0 ? 'gold' : '#6C757D';
 
 // ---------------------------------------Feats and bonuses----------------------------------------------


### PR DESCRIPTION
## Summary
- ignore racial skill proficiencies when calculating remaining skill points

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbbacd636c832e90de1be1a47a253e