### PR TITLE
Expand allowed skill list from class, feat, and race options

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -647,7 +647,16 @@ describe('Character routes', () => {
     expect(occ.Occupation).toBe('Fighter');
     expect(occ.skills.acrobatics).toEqual({ proficient: true, expertise: false });
     expect(occ.proficiencyPoints).toBe(0);
-    expect(captured.update.$set.allowedSkills).toEqual(['acrobatics']);
+    expect(captured.update.$set.allowedSkills).toEqual([
+      'acrobatics',
+      'animalHandling',
+      'athletics',
+      'history',
+      'insight',
+      'intimidation',
+      'perception',
+      'survival',
+    ]);
     expect(res.body.occupation[0].Occupation).toBe('Fighter');
     Math.random.mockRestore();
   });

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -6,40 +6,7 @@ const handleValidationErrors = require('../../middleware/validation');
 const logger = require('../../utils/logger');
 const { numericFields, skillFields, skillNames } = require('../fieldConstants');
 const proficiencyBonus = require('../../utils/proficiency');
-
-const collectAllowedSkills = (occupation = [], feat = [], race) => {
-  const allowed = new Set();
-  if (Array.isArray(occupation)) {
-    occupation.forEach((occ) => {
-      if (occ && occ.skills && typeof occ.skills === 'object') {
-        Object.keys(occ.skills).forEach((skill) => {
-          if (occ.skills[skill] && occ.skills[skill].proficient) {
-            allowed.add(skill);
-          }
-        });
-      }
-    });
-  }
-  if (Array.isArray(feat)) {
-    feat.forEach((ft) => {
-      if (ft && ft.skills && typeof ft.skills === 'object') {
-        Object.keys(ft.skills).forEach((skill) => {
-          if (ft.skills[skill] && ft.skills[skill].proficient) {
-            allowed.add(skill);
-          }
-        });
-      }
-    });
-  }
-  if (race && race.skills && typeof race.skills === 'object') {
-    Object.keys(race.skills).forEach((skill) => {
-      if (race.skills[skill] && race.skills[skill].proficient) {
-        allowed.add(skill);
-      }
-    });
-  }
-  return Array.from(allowed);
-};
+const collectAllowedSkills = require('../../utils/collectAllowedSkills');
 
 const countFeatProficiencies = (feat = []) => {
   const profs = new Set();

--- a/server/routes/feats.js
+++ b/server/routes/feats.js
@@ -5,6 +5,7 @@ const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 const { skillNames } = require('./fieldConstants');
 const logger = require('../utils/logger');
+const collectAllowedSkills = require('../utils/collectAllowedSkills');
 
 module.exports = (router) => {
   const featRouter = express.Router();
@@ -22,33 +23,6 @@ module.exports = (router) => {
     'hpMaxBonus',
     'hpMaxBonusPerLevel',
   ];
-
-  const collectAllowedSkills = (occupation = [], feat = []) => {
-    const allowed = new Set();
-    if (Array.isArray(occupation)) {
-      occupation.forEach((occ) => {
-        if (occ && occ.skills && typeof occ.skills === 'object') {
-          Object.keys(occ.skills).forEach((skill) => {
-            if (occ.skills[skill] && occ.skills[skill].proficient) {
-              allowed.add(skill);
-            }
-          });
-        }
-      });
-    }
-    if (Array.isArray(feat)) {
-      feat.forEach((ft) => {
-        if (ft && ft.skills && typeof ft.skills === 'object') {
-          Object.keys(ft.skills).forEach((skill) => {
-            if (ft.skills[skill] && ft.skills[skill].proficient) {
-              allowed.add(skill);
-            }
-          });
-        }
-      });
-    }
-    return Array.from(allowed);
-  };
 
   const extractFeatSkills = (feats = []) => {
     const skills = {};

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -3,40 +3,7 @@ const express = require('express');
 const authenticateToken = require('../middleware/auth');
 const proficiencyBonus = require('../utils/proficiency');
 
-// Helper to determine allowed skills from occupations and feats when not precomputed
-const collectAllowedSkills = (occupation = [], feat = [], race) => {
-  const allowed = new Set();
-  if (Array.isArray(occupation)) {
-    occupation.forEach((occ) => {
-      if (occ && occ.skills && typeof occ.skills === 'object') {
-        Object.keys(occ.skills).forEach((sk) => {
-          if (occ.skills[sk] && occ.skills[sk].proficient) {
-            allowed.add(sk);
-          }
-        });
-      }
-    });
-  }
-  if (Array.isArray(feat)) {
-    feat.forEach((ft) => {
-      if (ft && ft.skills && typeof ft.skills === 'object') {
-        Object.keys(ft.skills).forEach((sk) => {
-          if (ft.skills[sk] && ft.skills[sk].proficient) {
-            allowed.add(sk);
-          }
-        });
-      }
-    });
-  }
-  if (race && race.skills && typeof race.skills === 'object') {
-    Object.keys(race.skills).forEach((sk) => {
-      if (race.skills[sk] && race.skills[sk].proficient) {
-        allowed.add(sk);
-      }
-    });
-  }
-  return Array.from(allowed);
-};
+const collectAllowedSkills = require('../utils/collectAllowedSkills');
 
 // Map each skill to its associated ability score
 const skillAbilityMap = {

--- a/server/utils/collectAllowedSkills.js
+++ b/server/utils/collectAllowedSkills.js
@@ -1,0 +1,64 @@
+const classes = require('../data/classes');
+
+/**
+ * Collect allowed skill names based on a character's occupations, feats, and race.
+ * Includes all skill options provided by class proficiencies, feat skillOptions,
+ * and race skillChoices, plus any explicit skills marked proficient.
+ * @param {Array} occupation
+ * @param {Array} feat
+ * @param {Object} race
+ * @returns {string[]}
+ */
+function collectAllowedSkills(occupation = [], feat = [], race) {
+  const allowed = new Set();
+
+  // From class proficiencies
+  if (Array.isArray(occupation)) {
+    occupation.forEach((occ) => {
+      const key = typeof occ.Occupation === 'string'
+        ? occ.Occupation.toLowerCase()
+        : typeof occ.Name === 'string'
+        ? occ.Name.toLowerCase()
+        : '';
+      const classInfo = classes[key];
+      if (classInfo?.proficiencies?.skills?.options) {
+        classInfo.proficiencies.skills.options.forEach((sk) => allowed.add(sk));
+      }
+      if (occ?.skills && typeof occ.skills === 'object') {
+        Object.keys(occ.skills).forEach((sk) => {
+          if (occ.skills[sk]?.proficient) allowed.add(sk);
+        });
+      }
+    });
+  }
+
+  // From feats
+  if (Array.isArray(feat)) {
+    feat.forEach((ft) => {
+      if (Array.isArray(ft?.skillOptions)) {
+        ft.skillOptions.forEach((sk) => allowed.add(sk));
+      }
+      if (ft?.skills && typeof ft.skills === 'object') {
+        Object.keys(ft.skills).forEach((sk) => {
+          if (ft.skills[sk]?.proficient) allowed.add(sk);
+        });
+      }
+    });
+  }
+
+  // From race
+  if (race && typeof race === 'object') {
+    if (race.skills && typeof race.skills === 'object') {
+      Object.keys(race.skills).forEach((sk) => {
+        if (race.skills[sk]?.proficient) allowed.add(sk);
+      });
+    }
+    if (Array.isArray(race.skillChoices?.options)) {
+      race.skillChoices.options.forEach((sk) => allowed.add(sk));
+    }
+  }
+
+  return Array.from(allowed);
+}
+
+module.exports = collectAllowedSkills;

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -3,6 +3,7 @@ const dbo = require('../db/conn');
 const { skillNames } = require('../routes/fieldConstants');
 const multiclassProficiencies = require('../data/multiclassProficiencies');
 const classes = require('../data/classes');
+const collectAllowedSkills = require('./collectAllowedSkills');
 
 const prereqs = {
   barbarian: { all: ['str'], min: 13 },
@@ -40,21 +41,6 @@ function canMulticlass(character = {}, newOccupation = '') {
     };
   }
   return { allowed: true };
-}
-
-function collectAllowedSkills(occupation = []) {
-  if (!Array.isArray(occupation)) return [];
-  const allowed = new Set();
-  occupation.forEach((occ) => {
-    if (occ && occ.skills && typeof occ.skills === 'object') {
-      Object.keys(occ.skills).forEach((skill) => {
-        if (occ.skills[skill] && occ.skills[skill].proficient) {
-          allowed.add(skill);
-        }
-      });
-    }
-  });
-  return Array.from(allowed);
 }
 
 async function applyMulticlass(characterId, newOccupation) {


### PR DESCRIPTION
## Summary
- centralize allowed skill calculation in `collectAllowedSkills`
- use shared helper across skill, feat, character, and multiclass routes
- update multiclass test for expanded skill options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbbdb7906c832ebc0e2d09d67f77bf