### PR TITLE
Preserve feat and race skills when multiclassing

### DIFF
--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -89,7 +89,11 @@ async function applyMulticlass(characterId, newOccupation) {
   const updatedOccupation = Array.isArray(character.occupation)
     ? [...character.occupation, occEntry]
     : [occEntry];
-  const allowedSkills = collectAllowedSkills(updatedOccupation);
+  const allowedSkills = collectAllowedSkills(
+    updatedOccupation,
+    character.feat,
+    character.race,
+  );
 
   await characters.updateOne(
     { _id },


### PR DESCRIPTION
## Summary
- ensure `collectAllowedSkills` accounts for feat and race when multiclassing
- persist recomputed `allowedSkills` back to the character record

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbbfab4004832eaf77fc22f23f0406