### PR TITLE
Recompute allowed skills on update

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -373,15 +373,14 @@ describe('Character routes', () => {
     dbo.mockResolvedValue({
       collection: () => ({
         findOne: async () => ({
-          occupation: [{ Level: 1 }],
-          allowedSkills: ['acrobatics'],
+          occupation: [{ Level: 1, Occupation: 'Rogue' }],
           skills: {},
           proficiencyPoints: 1,
         }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
-            occupation: [{ Level: 1 }],
+            occupation: [{ Level: 1, Occupation: 'Rogue' }],
             skills: { acrobatics: { proficient: true, expertise: false } },
           },
         }),
@@ -404,15 +403,14 @@ describe('Character routes', () => {
     dbo.mockResolvedValue({
       collection: () => ({
         findOne: async () => ({
-          occupation: [{ Level: 1 }],
-          allowedSkills: ['acrobatics'],
+          occupation: [{ Level: 1, Occupation: 'Rogue' }],
           skills: {},
           proficiencyPoints: 1,
         }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
-            occupation: [{ Level: 1 }],
+            occupation: [{ Level: 1, Occupation: 'Rogue' }],
             skills: { acrobatics: { proficient: true, expertise: true } },
           },
         }),
@@ -435,8 +433,7 @@ describe('Character routes', () => {
     dbo.mockResolvedValue({
       collection: () => ({
         findOne: async () => ({
-          occupation: [{ Level: 1 }],
-          allowedSkills: ['acrobatics'],
+          occupation: [{ Level: 1, Occupation: 'Rogue' }],
           skills: {},
           proficiencyPoints: 1,
         }),

--- a/server/__tests__/skills.test.js
+++ b/server/__tests__/skills.test.js
@@ -27,8 +27,7 @@ describe('Skills routes', () => {
   test('rejects removal of racial proficiency', async () => {
     const charDoc = {
       race: { skills: { perception: { proficient: true } } },
-      skills: { perception: { proficient: true } },
-      allowedSkills: ['perception']
+      skills: { perception: { proficient: true } }
     };
 
     const findOne = jest.fn().mockResolvedValue(charDoc);
@@ -52,7 +51,10 @@ describe('Skills routes', () => {
       race: { skills: { perception: { proficient: true } } },
       skills: { perception: { proficient: true } },
       proficiencyPoints: 2,
-      allowedSkills: ['perception', 'stealth', 'arcana', 'athletics'],
+      occupation: [
+        { Level: 1, Occupation: 'Rogue' },
+        { Level: 1, Occupation: 'Wizard' }
+      ],
       dex: 10,
       int: 10
     };

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -62,9 +62,11 @@ module.exports = (router) => {
         charDoc.race?.skills?.[skill]?.proficient
       );
 
-      const allowedSkills =
-        charDoc.allowedSkills ||
-        collectAllowedSkills(charDoc.occupation, charDoc.feat, charDoc.race);
+      const allowedSkills = collectAllowedSkills(
+        charDoc.occupation,
+        charDoc.feat,
+        charDoc.race
+      );
       if (!allowedSkills.includes(skill)) {
         return res.status(400).json({ message: 'Skill not allowed' });
       }
@@ -101,6 +103,7 @@ module.exports = (router) => {
         $set: {
           [`skills.${skill}`]: { proficient, expertise },
           proficiencyBonus: profBonus,
+          allowedSkills,
         },
       };
 


### PR DESCRIPTION
## Summary
- Recalculate allowed skills on each update rather than relying on cached data
- Persist the recalculated skills array when updating proficiency
- Adjust tests to derive allowed skills from class data

## Testing
- `cd server && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b943b0832ebfe6e6a31a35a7b6