### PR TITLE
Remove unused Link import from Navbar component

### DIFF
--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -3,7 +3,6 @@ import Container from 'react-bootstrap/Container';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
-import { Link } from 'react-router-dom';
 import logoLight from "../../images/logo-light.png";
 import apiFetch from "../../utils/apiFetch";
 


### PR DESCRIPTION
## Summary
- remove unused Link import from Navbar component

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc40a1c710832ea1809ec603109a73