### PR TITLE
Fix ZombiesCharacterSelect health dice effect dependencies

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -317,7 +317,7 @@ useEffect(() => {
   };
   rollHealthDice();
   return;
-}, [ form.occupation ]);
+}, [normalizedOccState.Health, normalizedOccState.Level]);
 
  // Sends form data to database
    const sendToDb = useCallback(async (characterData) => {


### PR DESCRIPTION
## Summary
- ensure health dice rolling effect reruns when occupation health or level changes

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc40b33dbc832e954229ba16b2b407