### PR TITLE
Wrap handleClose5 with useCallback

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -347,7 +347,7 @@ useEffect(() => {
 
 //--------------------------------------------Create Character (Manual)---------------------
 const [show5, setShow5] = useState(false);
-const handleClose5 = () => setShow5(false);
+const handleClose5 = useCallback(() => setShow5(false), []);
 const handleShow5 = () => setShow5(true);
 
 const [selectedOccupation, setSelectedOccupation] = useState(null);


### PR DESCRIPTION
## Summary
- stabilize `handleClose5` using `useCallback`
- ensure `sendManualToDb` depends on the stable `handleClose5`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc40b43b08832e9dca6f100c1ce7e1