### PR TITLE
Fix manual character save handler

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -494,7 +494,7 @@ const onSubmitManual = async (e) => {
     setForm(updatedForm);
     return;
   }
-  await sendToDb(updatedForm);
+  await sendManualToDb(updatedForm);
 };
 
 const handleAbilitySkillConfirm = () => {
@@ -530,7 +530,11 @@ const handleAbilitySkillConfirm = () => {
   setShowAbilitySkillModal(false);
   setAbilitySelections([]);
   setSkillSelections([]);
-  sendToDb(updatedForm);
+  if (show5) {
+    sendManualToDb(updatedForm);
+  } else {
+    sendToDb(updatedForm);
+  }
 };
 
 const getAvailableAbilityOptions = (index) => {


### PR DESCRIPTION
## Summary
- Use `sendManualToDb` when submitting manual character forms
- Route ability/skill confirmation to the manual save handler when manual creation is active

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc40bc6360832e94d7e34ccdd1716b