### PR TITLE
Add close buttons to Zombies character equipment modals

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -438,6 +438,11 @@ return (
           characterId={characterId}
           show={showWeapons}
         />
+        <div className="modal-footer">
+          <Button className="action-btn close-btn" onClick={handleCloseWeapons}>
+            Close
+          </Button>
+        </div>
       </Modal>
       <Modal
         className="dnd-modal modern-modal"
@@ -453,6 +458,11 @@ return (
           characterId={characterId}
           show={showArmor}
         />
+        <div className="modal-footer">
+          <Button className="action-btn close-btn" onClick={handleCloseArmor}>
+            Close
+          </Button>
+        </div>
       </Modal>
     <Items
       form={form}


### PR DESCRIPTION
## Summary
- Add footer close button to weapon modal
- Add footer close button to armor modal

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc46af3ce0832ea6ac16c3c2f51d44