### PR TITLE
Remove armor check penalty field

### DIFF
--- a/client/src/components/Zombies/attributes/Armor.js
+++ b/client/src/components/Zombies/attributes/Armor.js
@@ -64,13 +64,13 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
     return result;
   };
   let newArmor;
-  if (JSON.stringify(form.armor) === JSON.stringify([["","","",""]])) {
+  if (JSON.stringify(form.armor) === JSON.stringify([["","",""]])) {
     let newArmorArr = addArmor.armor.split(',');
-    const armorArrChunks = splitArmorArr(newArmorArr, 4);
+    const armorArrChunks = splitArmorArr(newArmorArr, 3);
     newArmor = armorArrChunks;
   } else {
     let newArmorArr = (form.armor + "," + addArmor.armor).split(',');
-    const armorArrChunks = splitArmorArr(newArmorArr, 4);
+    const armorArrChunks = splitArmorArr(newArmorArr, 3);
     newArmor = armorArrChunks;
   }
   async function addArmorToDb(e){
@@ -97,11 +97,11 @@ export default function Armor({form, showArmor, handleCloseArmor, dexMod}) {
     updateArmor(form.armor);
     addDeleteArmorToDb();
   }
-  const showDeleteArmorBtn = JSON.stringify(form.armor) !== JSON.stringify([["","","",""]]);
+  const showDeleteArmorBtn = JSON.stringify(form.armor) !== JSON.stringify([["","",""]]);
   async function addDeleteArmorToDb(){
     let newArmorForm = form.armor;
     if (JSON.stringify(form.armor) === JSON.stringify([])){
-      newArmorForm = [["","","",""]];
+      newArmorForm = [["","",""]];
       await apiFetch(`/equipment/update-armor/${params.id}`, {
         method: "PUT",
         headers: {
@@ -156,7 +156,6 @@ return(
               <th>Armor Name</th>
               <th>Ac Bns</th>
               <th>Max Dex Bns</th>
-              <th>Check Penalty</th>
               <th>Delete</th>
             </tr>
           </thead>
@@ -166,7 +165,6 @@ return(
               <td>{el[0]}</td>
               <td>{el[1]}</td>
               <td>{el[2]}</td>
-              <td>{el[3]}</td>
               <td><Button size="sm" className="btn-danger action-btn fa-solid fa-trash" hidden={!showDeleteArmorBtn} onClick={() => {deleteArmors(el);}}></Button></td>
             </tr>
             ))}
@@ -185,7 +183,7 @@ return(
           {armor.armor.map((el) => (
           <option
             key={el.armorName}
-            value={[el.armorName, el.acBonus || el.armorBonus, el.maxDex, el.armorCheckPenalty]}
+            value={[el.armorName, el.acBonus || el.armorBonus, el.maxDex]}
           >
             {el.armorName}
           </option>

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -294,7 +294,6 @@ const [form2, setForm2] = useState({
     category: "",
     armorBonus: "",
     maxDex: "",
-    armorCheckPenalty: "",
     strength: "",
     stealth: "",
     weight: "",
@@ -342,7 +341,7 @@ const [form2, setForm2] = useState({
   }
   
   async function sendToDb3(){
-    const numericFields = ['armorBonus', 'maxDex', 'armorCheckPenalty', 'strength', 'weight'];
+    const numericFields = ['armorBonus', 'maxDex', 'strength', 'weight'];
     const newArmor = Object.fromEntries(
       Object.entries(form3)
         .filter(([_, v]) => v !== "")
@@ -370,7 +369,6 @@ const [form2, setForm2] = useState({
     category: "",
     armorBonus: "",
     maxDex: "",
-    armorCheckPenalty: "",
     strength: "",
     stealth: "",
     weight: "",
@@ -741,9 +739,6 @@ const [form2, setForm2] = useState({
           <Form.Label className="text-light">Max Dex Bonus</Form.Label>
           <Form.Control className="mb-2" onChange={(e) => updateForm3({ maxDex: e.target.value })} type="text" placeholder="Enter Max Dex Bonus" />
 
-          <Form.Label className="text-light">Armor Check Penalty</Form.Label>
-          <Form.Control className="mb-2" onChange={(e) => updateForm3({ armorCheckPenalty: e.target.value })} type="text" placeholder="Enter Armor Check Penalty" />
-
           <Form.Label className="text-light">Strength Requirement</Form.Label>
           <Form.Control className="mb-2" onChange={(e) => updateForm3({ strength: e.target.value })} type="text" placeholder="Enter Strength Requirement" />
 
@@ -779,7 +774,6 @@ const [form2, setForm2] = useState({
             <th>Category</th>
             <th>AC Bonus</th>
             <th>Max Dex</th>
-            <th>Check Penalty</th>
             <th>Delete</th>
           </tr>
         </thead>
@@ -791,7 +785,6 @@ const [form2, setForm2] = useState({
               <td>{a.category}</td>
               <td>{a.armorBonus ?? a.acBonus ?? a.ac}</td>
               <td>{a.maxDex}</td>
-              <td>{a.armorCheckPenalty}</td>
               <td>
                 <Button className="btn-danger action-btn fa-solid fa-trash" onClick={() => deleteArmor(a._id)} />
               </td>

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -189,7 +189,6 @@ describe('Equipment routes', () => {
           armorName: 'Leather',
           armorBonus: '',
           maxDex: '',
-          armorCheckPenalty: '',
         });
       expect(res.status).toBe(200);
       expect(res.body).toMatchObject({ _id: 'def456', campaign: 'Camp1', armorName: 'Leather' });

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -131,7 +131,6 @@ module.exports = (router) => {
       body('armorName').trim().notEmpty().withMessage('armorName is required'),
       body('armorBonus').optional({ checkFalsy: true }).isInt().toInt(),
       body('maxDex').optional({ checkFalsy: true }).isInt().toInt(),
-      body('armorCheckPenalty').optional({ checkFalsy: true }).isInt().toInt(),
       body('type').optional().isString().trim().toLowerCase(),
       body('category').optional().isString().trim().toLowerCase(),
       body('strength').optional().isInt().toInt(),


### PR DESCRIPTION
## Summary
- drop armor check penalty from DM armor form and table
- streamline armor selection component to use only name, AC bonus and max Dex
- simplify server armor route/tests to remove armor check penalty validation

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4a8e6578832ea140f67b51d9a1db