### PR TITLE
Add proficiency bonus helper and show bonus in health stats

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
+import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useParams } from "react-router-dom";
 
@@ -17,6 +18,7 @@ export default function HealthDefense({
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
   let atkBonus = 0;
+  const profBonus = proficiencyBonus(totalLevel);
     
   // Armor AC/MaxDex
   const armorItems = form.armor || [];
@@ -243,6 +245,7 @@ return (
     <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
       <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
       <div><strong>Attack Bonus:</strong> {atkBonus}</div>
+      <div><strong>Proficiency Bonus:</strong> {profBonus}</div>
       <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
       <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
     </div>

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -4,15 +4,7 @@ import { Modal, Card, Table, Button, Form, Alert } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 
 import { SKILLS } from '../skillSchema';
-
-// Compute 5e proficiency bonus from total character level
-function proficiencyBonus(level = 0) {
-  if (level >= 17) return 6;
-  if (level >= 13) return 5;
-  if (level >= 9) return 4;
-  if (level >= 5) return 3;
-  return 2;
-}
+import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 export default function Skills({
   form,

--- a/client/src/utils/proficiencyBonus.js
+++ b/client/src/utils/proficiencyBonus.js
@@ -1,0 +1,7 @@
+export default function proficiencyBonus(level = 0) {
+  if (level >= 17) return 6;
+  if (level >= 13) return 5;
+  if (level >= 9) return 4;
+  if (level >= 5) return 3;
+  return 2;
+}


### PR DESCRIPTION
## Summary
- move 5e proficiency bonus calculation into shared `proficiencyBonus` util
- use helper in Skills and HealthDefense components
- show Proficiency Bonus alongside AC and attack bonus on character sheet

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc64e78a4c832ea725932c611431a4