### PR TITLE
refactor: centralize proficiency bonus helper

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
+import { proficiencyBonus } from '../../../utils/dnd';
 import { Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useParams } from "react-router-dom";
 
@@ -17,6 +18,7 @@ export default function HealthDefense({
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
   let atkBonus = 0;
+  const profBonus = proficiencyBonus(totalLevel);
     
   // Armor AC/MaxDex
   const armorItems = form.armor || [];
@@ -243,6 +245,7 @@ return (
     <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
       <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
       <div><strong>Attack Bonus:</strong> {atkBonus}</div>
+      <div><strong>Proficiency Bonus:</strong> {profBonus}</div>
       <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
       <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
     </div>

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -1,18 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import apiFetch from '../../../utils/apiFetch';
+import { proficiencyBonus } from '../../../utils/dnd';
 import { Modal, Card, Table, Button, Form, Alert } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 
 import { SKILLS } from '../skillSchema';
-
-// Compute 5e proficiency bonus from total character level
-function proficiencyBonus(level = 0) {
-  if (level >= 17) return 6;
-  if (level >= 13) return 5;
-  if (level >= 9) return 4;
-  if (level >= 5) return 3;
-  return 2;
-}
 
 export default function Skills({
   form,

--- a/client/src/utils/dnd.js
+++ b/client/src/utils/dnd.js
@@ -1,0 +1,7 @@
+export function proficiencyBonus(level = 0) {
+  if (level >= 17) return 6;
+  if (level >= 13) return 5;
+  if (level >= 9) return 4;
+  if (level >= 5) return 3;
+  return 2;
+}

--- a/client/src/utils/dnd.test.js
+++ b/client/src/utils/dnd.test.js
@@ -1,0 +1,28 @@
+import { proficiencyBonus } from './dnd';
+
+describe('proficiencyBonus', () => {
+  it('returns 2 for levels 1-4', () => {
+    expect(proficiencyBonus(1)).toBe(2);
+    expect(proficiencyBonus(4)).toBe(2);
+  });
+
+  it('returns 3 for levels 5-8', () => {
+    expect(proficiencyBonus(5)).toBe(3);
+    expect(proficiencyBonus(8)).toBe(3);
+  });
+
+  it('returns 4 for levels 9-12', () => {
+    expect(proficiencyBonus(9)).toBe(4);
+    expect(proficiencyBonus(12)).toBe(4);
+  });
+
+  it('returns 5 for levels 13-16', () => {
+    expect(proficiencyBonus(13)).toBe(5);
+    expect(proficiencyBonus(16)).toBe(5);
+  });
+
+  it('returns 6 for levels 17 and above', () => {
+    expect(proficiencyBonus(17)).toBe(6);
+    expect(proficiencyBonus(20)).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary
- move proficiency bonus calculation into shared `client/src/utils/dnd.js`
- reuse helper in Skills and HealthDefense components
- add tests for proficiency bonus utility

## Testing
- `CI=true npm test --silent`
- `npm test --silent` (server)


------
https://chatgpt.com/codex/tasks/task_e_68bc64f0a22c832e816e602c0f0f8383