### PR TITLE
feat: centralize proficiency bonus and surface in defense

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
 import { Button } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useParams } from "react-router-dom";
+import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 export default function HealthDefense({
   form,
@@ -59,6 +60,8 @@ export default function HealthDefense({
       }
     }
   }
+
+  const profBonus = proficiencyBonus(form.proficiencyBonus ?? totalLevel);
 
   // Health
   const maxHealth =
@@ -240,14 +243,16 @@ return (
     }}
   >
     {/* Core Stats */}
-    <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
-      <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
-      <div><strong>Attack Bonus:</strong> {atkBonus}</div>
-      <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
-      <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
-    </div>
+      <div style={{ color: "#FFFFFF", display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
+        <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
+        <div><strong>Attack Bonus:</strong> {atkBonus}</div>
+        <div><strong>Proficiency Bonus:</strong> {profBonus}</div>
+        <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
+        <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
+      </div>
 
+      </div>
     </div>
-  </div>
-)
+  );
 }
+

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HealthDefense from './HealthDefense';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+}));
+
+const form = {
+  armor: [],
+  occupation: [],
+  health: 10,
+  tempHealth: 5,
+  speed: 30,
+};
+
+test('renders proficiency bonus', () => {
+  render(
+    <HealthDefense
+      form={form}
+      totalLevel={5}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('3');
+});

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -4,15 +4,7 @@ import { Modal, Card, Table, Button, Form, Alert } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 
 import { SKILLS } from '../skillSchema';
-
-// Compute 5e proficiency bonus from total character level
-function proficiencyBonus(level = 0) {
-  if (level >= 17) return 6;
-  if (level >= 13) return 5;
-  if (level >= 9) return 4;
-  if (level >= 5) return 3;
-  return 2;
-}
+import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 export default function Skills({
   form,

--- a/client/src/utils/proficiencyBonus.js
+++ b/client/src/utils/proficiencyBonus.js
@@ -1,0 +1,7 @@
+export default function proficiencyBonus(level = 0) {
+  if (level >= 17) return 6;
+  if (level >= 13) return 5;
+  if (level >= 9) return 4;
+  if (level >= 5) return 3;
+  return 2;
+}


### PR DESCRIPTION
## Summary
- add shared proficiency bonus helper
- use utility in Skills and HealthDefense components
- show proficiency bonus in HealthDefense and test rendering

## Testing
- `npm test -- --runTestsByPath src/components/Zombies/attributes/HealthDefense.test.js --watchAll=false`
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc69f68ae8832eb0192180cfaad99f