### PR TITLE
Ensure HealthDefense uses supplied proficiency bonus

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -6,7 +6,6 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 export default function HealthDefense({
   form,
-  totalLevel,
   conMod,
   dexMod,
   ac = 0,
@@ -61,7 +60,11 @@ export default function HealthDefense({
     }
   }
 
-  const profBonus = proficiencyBonus(form.proficiencyBonus ?? totalLevel);
+  const totalLevel = occupations.reduce(
+    (total, o) => total + Number(o.Level),
+    0
+  );
+  const profBonus = form.proficiencyBonus ?? proficiencyBonus(totalLevel);
 
   // Health
   const maxHealth =

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -7,19 +7,18 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ id: '1' }),
 }));
 
-const form = {
+const baseForm = {
   armor: [],
-  occupation: [],
+  occupation: [{ Level: 3 }, { Level: 2 }],
   health: 10,
   tempHealth: 5,
   speed: 30,
 };
 
-test('renders proficiency bonus', () => {
+test('renders proficiency bonus based on total level', () => {
   render(
     <HealthDefense
-      form={form}
-      totalLevel={5}
+      form={baseForm}
       conMod={0}
       dexMod={0}
       ac={0}
@@ -30,4 +29,21 @@ test('renders proficiency bonus', () => {
     />
   );
   expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('3');
+});
+
+test('uses provided proficiency bonus when supplied', () => {
+  const formWithProf = { ...baseForm, proficiencyBonus: 4 };
+  render(
+    <HealthDefense
+      form={formWithProf}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('4');
 });


### PR DESCRIPTION
## Summary
- Compute total level from all occupations in HealthDefense
- Allow form.proficiencyBonus to override computed value
- Add tests for multiclass total level and explicit proficiency bonus

## Testing
- `cd client && npm test src/components/Zombies/attributes/HealthDefense.test.js -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc6d09c90c832eb7875197dfb68fbb