### PR TITLE
feat: support case-sensitive background keys

### DIFF
--- a/server/__tests__/backgrounds.test.js
+++ b/server/__tests__/backgrounds.test.js
@@ -1,0 +1,45 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Background API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbo.mockResolvedValue({});
+  });
+
+  test('fetches a multi-word background', async () => {
+    const res = await request(app).get('/backgrounds/guildArtisan');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      name: 'Guild Artisan',
+      skills: {
+        insight: { proficient: true },
+        persuasion: { proficient: true },
+      },
+    });
+  });
+
+  test('returns 404 for unknown background', async () => {
+    const res = await request(app).get('/backgrounds/unknown');
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Background not found');
+  });
+});

--- a/server/routes/backgrounds.js
+++ b/server/routes/backgrounds.js
@@ -9,7 +9,7 @@ module.exports = (router) => {
   });
 
   backgroundRouter.get('/:name', (req, res) => {
-    const bg = backgrounds[req.params.name.toLowerCase()];
+    const bg = backgrounds[req.params.name];
     if (!bg) {
       return res.status(404).json({ message: 'Background not found' });
     }


### PR DESCRIPTION
## Summary
- handle background lookup without lowercasing keys
- add tests for multi-word background keys like `guildArtisan`

## Testing
- `npm test --prefix server`
- `CI=true npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1bc637083238db4ff55f9c726ca