### PR TITLE
Filter CharacterInfo skills by proficiency

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Card, Table, Modal, Button } from "react-bootstrap";
 import levelup from "../../../images/levelup.png";
 import LevelUp from "./LevelUp"; // Import LevelUp component
+import { SKILLS } from "../skillSchema";
 
 export default function CharacterInfo({ form, show, handleClose }) {
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
@@ -17,6 +18,16 @@ export default function CharacterInfo({ form, show, handleClose }) {
 
   const raceLanguages = (form.race?.languages || [])
     .filter((language) => language && !language.includes("Choice"))
+    .join(", ");
+
+  const skillLabelMap = SKILLS.reduce((acc, { key, label }) => {
+    acc[key] = label;
+    return acc;
+  }, {});
+
+  const backgroundSkills = Object.entries(form.background?.skills || {})
+    .filter(([, v]) => v?.proficient)
+    .map(([k]) => skillLabelMap[k] || k)
     .join(", ");
 
   return (
@@ -57,6 +68,10 @@ export default function CharacterInfo({ form, show, handleClose }) {
               <tr>
                 <th>Background</th>
                 <td>{form.background?.name || ''}</td>
+              </tr>
+              <tr>
+                <th>Skills</th>
+                <td>{backgroundSkills}</td>
               </tr>
               <tr>
                 <th>Languages</th>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -19,3 +19,26 @@ test('renders race languages', () => {
   expect(screen.getByText('Common, Elvish')).toBeInTheDocument();
 });
 
+test('renders proficient background skills', () => {
+  const form = {
+    occupation: [],
+    race: { languages: [] },
+    background: {
+      name: 'Sailor',
+      skills: {
+        athletics: { proficient: true },
+        stealth: { proficient: false },
+        perception: { proficient: true },
+      },
+    },
+    age: 100,
+    sex: 'M',
+    height: "6'",
+    weight: 180,
+  };
+
+  render(<CharacterInfo form={form} show={true} handleClose={() => {}} />);
+
+  expect(screen.getByText('Athletics, Perception')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- display only proficient background skills in CharacterInfo
- test background skills are filtered and joined with commas

## Testing
- `CI=true npm test -- CharacterInfo.test.js`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb3b5fbe48323ad3ff9950aae5823