### PR TITLE
Add default background description fallback

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -30,6 +30,9 @@ export default function CharacterInfo({ form, show, handleClose }) {
     .map(([k]) => skillLabelMap[k] || k)
     .join(", ");
 
+  const backgroundDescription =
+    form.background?.description?.trim() || "No description available";
+
   return (
     <Modal
       className="dnd-modal modern-modal"
@@ -68,6 +71,10 @@ export default function CharacterInfo({ form, show, handleClose }) {
               <tr>
                 <th>Background</th>
                 <td>{form.background?.name || ''}</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td>{backgroundDescription}</td>
               </tr>
               <tr>
                 <th>Skills</th>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -42,3 +42,19 @@ test('renders proficient background skills', () => {
   expect(screen.getByText('Athletics, Perception')).toBeInTheDocument();
 });
 
+test('shows default background description when missing', () => {
+  const form = {
+    occupation: [],
+    race: { languages: [] },
+    background: { name: 'Sailor', description: '' },
+    age: 100,
+    sex: 'M',
+    height: "6'",
+    weight: 180,
+  };
+
+  render(<CharacterInfo form={form} show={true} handleClose={() => {}} />);
+
+  expect(screen.getByText('No description available')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- show "No description available" when background lacks a description
- cover background description fallback with unit test

## Testing
- `cd client && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb5304aa883239def622bd9ea8341