### PR TITLE
feat: enforce expertise selection

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -406,12 +406,14 @@ describe('Character routes', () => {
           occupation: [{ Level: 1, Occupation: 'Rogue' }],
           skills: {},
           proficiencyPoints: 1,
+          expertisePoints: 2,
         }),
         findOneAndUpdate: async () => ({
           value: {
             dex: 12,
             occupation: [{ Level: 1, Occupation: 'Rogue' }],
             skills: { acrobatics: { proficient: true, expertise: true } },
+            expertisePoints: 2,
           },
         }),
       }),

--- a/server/__tests__/skills.test.js
+++ b/server/__tests__/skills.test.js
@@ -92,5 +92,60 @@ describe('Skills routes', () => {
     expect(res.status).toBe(400);
     expect(res.body.message).toBe('No proficiency points remaining');
   });
+
+  test('rejects expertise without proficiency', async () => {
+    const charDoc = {
+      occupation: [{ Level: 1, Occupation: 'Rogue' }],
+      skills: {},
+      expertisePoints: 2,
+    };
+
+    const findOne = jest.fn().mockResolvedValue(charDoc);
+    const findOneAndUpdate = jest.fn();
+
+    dbo.mockResolvedValue({
+      collection: () => ({ findOne, findOneAndUpdate })
+    });
+
+    const res = await request(app)
+      .put('/skills/update-skills/507f1f77bcf86cd799439011')
+      .send({ skill: 'stealth', proficient: false, expertise: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Expertise requires proficiency');
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('allows expertise when class grants slots', async () => {
+    const charDoc = {
+      occupation: [{ Level: 1, Occupation: 'Rogue' }],
+      skills: { stealth: { proficient: true, expertise: false } },
+      expertisePoints: 2,
+      dex: 10,
+    };
+
+    const findOne = jest.fn().mockImplementation(() => Promise.resolve({ ...charDoc }));
+    const findOneAndUpdate = jest.fn().mockImplementation((id, update) => {
+      Object.entries(update.$set || {}).forEach(([key, value]) => {
+        if (key.startsWith('skills.')) {
+          const skillKey = key.split('.')[1];
+          charDoc.skills[skillKey] = value;
+        } else {
+          charDoc[key] = value;
+        }
+      });
+      return Promise.resolve({ value: { ...charDoc } });
+    });
+
+    dbo.mockResolvedValue({
+      collection: () => ({ findOne, findOneAndUpdate })
+    });
+
+    const res = await request(app)
+      .put('/skills/update-skills/507f1f77bcf86cd799439011')
+      .send({ skill: 'stealth', proficient: true, expertise: true });
+    expect(res.status).toBe(200);
+    expect(res.body.expertise).toBe(true);
+  });
 });
 

--- a/server/utils/collectAllowedExpertise.js
+++ b/server/utils/collectAllowedExpertise.js
@@ -1,0 +1,87 @@
+const { skillNames } = require('../routes/fieldConstants');
+const collectAllowedSkills = require('./collectAllowedSkills');
+
+/**
+ * Collect allowed skills for applying expertise based on class features,
+ * feats, race, and background. If a class grants expertise slots (e.g.,
+ * Rogue or Bard), all skills become eligible. Otherwise only explicit
+ * expertise grants or options from feats/race/background are included.
+ *
+ * @param {Array} occupation
+ * @param {Array} feat
+ * @param {Object} race
+ * @param {Object} background
+ * @returns {string[]}
+ */
+function collectAllowedExpertise(occupation = [], feat = [], race, background) {
+  const allowed = new Set();
+  let classGrantsExpertise = false;
+
+  if (Array.isArray(occupation)) {
+    occupation.forEach((occ) => {
+      const name = (
+        typeof occ.Occupation === 'string'
+          ? occ.Occupation
+          : typeof occ.Name === 'string'
+          ? occ.Name
+          : ''
+      ).toLowerCase();
+      const level = occ.Level || occ.level || 0;
+      if (name === 'rogue' && level >= 1) classGrantsExpertise = true;
+      if (name === 'bard' && level >= 3) classGrantsExpertise = true;
+      if (occ?.skills && typeof occ.skills === 'object') {
+        Object.keys(occ.skills).forEach((sk) => {
+          if (occ.skills[sk]?.expertise) allowed.add(sk);
+        });
+      }
+    });
+  }
+
+  if (Array.isArray(feat)) {
+    feat.forEach((ft) => {
+      if (Array.isArray(ft?.expertiseOptions)) {
+        ft.expertiseOptions.forEach((sk) => allowed.add(sk));
+      }
+      if (ft?.skills && typeof ft.skills === 'object') {
+        Object.keys(ft.skills).forEach((sk) => {
+          if (ft.skills[sk]?.expertise) allowed.add(sk);
+        });
+      }
+    });
+  }
+
+  if (race && typeof race === 'object') {
+    if (race.skills && typeof race.skills === 'object') {
+      Object.keys(race.skills).forEach((sk) => {
+        if (race.skills[sk]?.expertise) allowed.add(sk);
+      });
+    }
+    if (Array.isArray(race.expertiseChoices?.options)) {
+      race.expertiseChoices.options.forEach((sk) => allowed.add(sk));
+    }
+  }
+
+  if (background && typeof background === 'object') {
+    if (background.skills && typeof background.skills === 'object') {
+      Object.keys(background.skills).forEach((sk) => {
+        if (background.skills[sk]?.expertise) allowed.add(sk);
+      });
+    }
+    if (Array.isArray(background.expertiseChoices)) {
+      background.expertiseChoices.forEach((sk) => allowed.add(sk));
+    }
+  }
+
+  if (classGrantsExpertise) {
+    skillNames.forEach((sk) => allowed.add(sk));
+  }
+
+  // ensure any skill already allowed for proficiency is also considered
+  collectAllowedSkills(occupation, feat, race, background).forEach((sk) =>
+    allowed.add(sk)
+  );
+
+  return Array.from(allowed);
+}
+
+module.exports = collectAllowedExpertise;

--- a/server/utils/collectAllowedSkills.js
+++ b/server/utils/collectAllowedSkills.js
@@ -3,7 +3,9 @@ const classes = require('../data/classes');
 /**
  * Collect allowed skill names based on a character's occupations, feats, and race.
  * Includes all skill options provided by class proficiencies, feat skillOptions,
- * and race skillChoices, plus any explicit skills marked proficient.
+ * and race skillChoices, plus any explicit skills marked proficient or granting
+ * expertise. Expertise implies proficiency, so any explicit expertise grants
+ * are also considered allowed skills.
  * @param {Array} occupation
  * @param {Array} feat
  * @param {Object} race
@@ -26,7 +28,8 @@ function collectAllowedSkills(occupation = [], feat = [], race, background) {
       }
       if (occ?.skills && typeof occ.skills === 'object') {
         Object.keys(occ.skills).forEach((sk) => {
-          if (occ.skills[sk]?.proficient) allowed.add(sk);
+          const info = occ.skills[sk];
+          if (info?.proficient || info?.expertise) allowed.add(sk);
         });
       }
     });
@@ -38,9 +41,13 @@ function collectAllowedSkills(occupation = [], feat = [], race, background) {
       if (Array.isArray(ft?.skillOptions)) {
         ft.skillOptions.forEach((sk) => allowed.add(sk));
       }
+      if (Array.isArray(ft?.expertiseOptions)) {
+        ft.expertiseOptions.forEach((sk) => allowed.add(sk));
+      }
       if (ft?.skills && typeof ft.skills === 'object') {
         Object.keys(ft.skills).forEach((sk) => {
-          if (ft.skills[sk]?.proficient) allowed.add(sk);
+          const info = ft.skills[sk];
+          if (info?.proficient || info?.expertise) allowed.add(sk);
         });
       }
     });
@@ -50,11 +57,15 @@ function collectAllowedSkills(occupation = [], feat = [], race, background) {
   if (race && typeof race === 'object') {
     if (race.skills && typeof race.skills === 'object') {
       Object.keys(race.skills).forEach((sk) => {
-        if (race.skills[sk]?.proficient) allowed.add(sk);
+        const info = race.skills[sk];
+        if (info?.proficient || info?.expertise) allowed.add(sk);
       });
     }
     if (Array.isArray(race.skillChoices?.options)) {
       race.skillChoices.options.forEach((sk) => allowed.add(sk));
+    }
+    if (Array.isArray(race.expertiseChoices?.options)) {
+      race.expertiseChoices.options.forEach((sk) => allowed.add(sk));
     }
   }
 
@@ -62,11 +73,15 @@ function collectAllowedSkills(occupation = [], feat = [], race, background) {
   if (background && typeof background === 'object') {
     if (background.skills && typeof background.skills === 'object') {
       Object.keys(background.skills).forEach((sk) => {
-        if (background.skills[sk]?.proficient) allowed.add(sk);
+        const info = background.skills[sk];
+        if (info?.proficient || info?.expertise) allowed.add(sk);
       });
     }
     if (Array.isArray(background.toolProficiencies)) {
       background.toolProficiencies.forEach((tool) => allowed.add(tool));
+    }
+    if (Array.isArray(background.expertiseChoices)) {
+      background.expertiseChoices.forEach((sk) => allowed.add(sk));
     }
   }
 


### PR DESCRIPTION
## Summary
- track available expertise slots on characters and expose allowed expertise
- enforce expertise prerequisites and slots in skill updates
- display remaining expertise on client and disable disallowed toggles

## Testing
- `npm --prefix server test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb9e73c548323bc70d8ab45588cc1