### PR TITLE
Add modal for inspecting character background details

### DIFF
--- a/client/src/components/Zombies/attributes/BackgroundModal.js
+++ b/client/src/components/Zombies/attributes/BackgroundModal.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { Modal, Card, Button } from "react-bootstrap";
+
+export default function BackgroundModal({ show, onHide, background }) {
+  if (!background) return null;
+
+  const skillProficiencies = Object.entries(background.skills || {})
+    .filter(([, value]) => value?.proficient)
+    .map(([key]) => key);
+
+  const toolProficiencies = background.toolProficiencies || [];
+
+  return (
+    <Modal show={show} onHide={onHide} centered className="dnd-modal modern-modal">
+      <div className="text-center">
+        <Card className="modern-card">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">
+              {background.name || "Background"}
+            </Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <p>{background.description}</p>
+            <br />
+            <p><strong>Skill Proficiencies:</strong></p>
+            {skillProficiencies.length ? (
+              <ul>
+                {skillProficiencies.map((skill) => (
+                  <li key={skill}>{skill}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>None</p>
+            )}
+            <p><strong>Tool Proficiencies:</strong></p>
+            {toolProficiencies.length ? (
+              <ul>
+                {toolProficiencies.map((tool) => (
+                  <li key={tool}>{tool}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>None</p>
+            )}
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={onHide}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </div>
+    </Modal>
+  );
+}
+

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -17,6 +17,7 @@ import Help from "../attributes/Help";
 import { SKILLS } from "../skillSchema";
 import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
+import BackgroundModal from "../attributes/BackgroundModal";
 
 const HEADER_PADDING = 16;
 
@@ -33,6 +34,7 @@ export default function ZombiesCharacterSheet() {
   const [showItems, setShowItems] = useState(false);
   const [showSpells, setShowSpells] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
+  const [showBackground, setShowBackground] = useState(false);
 
   const headerRef = useRef(null);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -114,6 +116,8 @@ export default function ZombiesCharacterSheet() {
   const handleCloseSpells = () => setShowSpells(false);
   const handleShowHelpModal = () => setShowHelpModal(true);
   const handleCloseHelpModal = () => setShowHelpModal(false);
+  const handleShowBackground = () => setShowBackground(true);
+  const handleCloseBackground = () => setShowBackground(false);
 
   const handleWeaponsChange = useCallback(
     async (weapons) => {
@@ -319,6 +323,12 @@ return (
             variant="secondary"
           ></Button>
           <Button
+            onClick={handleShowBackground}
+            style={{ color: "black", padding: "8px", marginTop: "10px" }}
+            className="mx-1 fas fa-eye"
+            variant="secondary"
+          ></Button>
+          <Button
             onClick={handleShowStats}
             style={{
               color: "black",
@@ -423,6 +433,11 @@ return (
       onSkillsChange={(skills) => setForm((prev) => ({ ...prev, skills }))}
     />
     <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
+    <BackgroundModal
+      show={showBackground}
+      onHide={handleCloseBackground}
+      background={form.background}
+    />
     <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} />
       <Modal
         className="dnd-modal modern-modal"


### PR DESCRIPTION
## Summary
- Add BackgroundModal component to show description, skill, and tool proficiencies
- Add eye button and state on character sheet to open background modal

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc0c30d08832398d1c1ae5e6d4206