### PR TITLE
Fix sendToDb response handling and modal closing

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -348,20 +348,25 @@ useEffect(() => {
       delete newCharacter.race;
     }
     try {
-      await apiFetch("/characters/add", {
+      const response = await apiFetch("/characters/add", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(newCharacter),
       });
+      if (!response.ok) {
+        notify(`An error occurred: ${response.statusText}`);
+        return;
+      }
+      const { insertedId } = await response.json();
+      handleClose();
+      setRecords((prev) => [...prev, { ...newCharacter, _id: insertedId }]);
+      setForm(createDefaultForm(params.campaign));
     } catch (error) {
       notify(error.toString());
-      return;
-    };
-   setForm(createDefaultForm(params.campaign));
-  navigate(0);
-}, [form, setForm, navigate, createDefaultForm, params.campaign]);
+    }
+}, [form, params.campaign, handleClose, setRecords, setForm, createDefaultForm]);
 
 //--------------------------------------------Create Character (Manual)---------------------
 const [show5, setShow5] = useState(false);


### PR DESCRIPTION
## Summary
- Handle POST response in `sendToDb`, append new character to state, and close modal
- Align random character creation with manual path by reusing response handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc30bf8ec83239d28e729f3af144c