### PR TITLE
feat: improve background display

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -2,9 +2,8 @@ import React, { useState } from "react";
 import { Card, Table, Modal, Button } from "react-bootstrap";
 import levelup from "../../../images/levelup.png";
 import LevelUp from "./LevelUp"; // Import LevelUp component
-import { SKILLS } from "../skillSchema";
 
-export default function CharacterInfo({ form, show, handleClose }) {
+export default function CharacterInfo({ form, show, handleClose, onShowBackground }) {
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
 
@@ -19,19 +18,6 @@ export default function CharacterInfo({ form, show, handleClose }) {
   const raceLanguages = (form.race?.languages || [])
     .filter((language) => language && !language.includes("Choice"))
     .join(", ");
-
-  const skillLabelMap = SKILLS.reduce((acc, { key, label }) => {
-    acc[key] = label;
-    return acc;
-  }, {});
-
-  const backgroundSkills = Object.entries(form.background?.skills || {})
-    .filter(([, v]) => v?.proficient)
-    .map(([k]) => skillLabelMap[k] || k)
-    .join(", ");
-
-  const backgroundDescription =
-    form.background?.description?.trim() || "No description available";
 
   return (
     <Modal
@@ -70,15 +56,16 @@ export default function CharacterInfo({ form, show, handleClose }) {
               </tr>
               <tr>
                 <th>Background</th>
-                <td>{form.background?.name || ''}</td>
-              </tr>
-              <tr>
-                <th>Description</th>
-                <td>{backgroundDescription}</td>
-              </tr>
-              <tr>
-                <th>Skills</th>
-                <td>{backgroundSkills}</td>
+                <td>
+                  {form.background?.name || ''}
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="ms-2 fas fa-eye"
+                    aria-label="Show Background"
+                    onClick={onShowBackground}
+                  ></Button>
+                </td>
               </tr>
               <tr>
                 <th>Languages</th>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import CharacterInfo from './CharacterInfo';
 
 jest.mock('./LevelUp', () => () => <div />);
@@ -14,47 +14,35 @@ test('renders race languages', () => {
     weight: 180,
   };
 
-  render(<CharacterInfo form={form} show={true} handleClose={() => {}} />);
+  render(<CharacterInfo form={form} show={true} handleClose={() => {}} onShowBackground={() => {}} />);
 
   expect(screen.getByText('Common, Elvish')).toBeInTheDocument();
 });
 
-test('renders proficient background skills', () => {
+test('renders background name and calls onShowBackground', () => {
+  const onShowBackground = jest.fn();
   const form = {
     occupation: [],
     race: { languages: [] },
-    background: {
-      name: 'Sailor',
-      skills: {
-        athletics: { proficient: true },
-        stealth: { proficient: false },
-        perception: { proficient: true },
-      },
-    },
+    background: { name: 'Sailor' },
     age: 100,
     sex: 'M',
     height: "6'",
     weight: 180,
   };
 
-  render(<CharacterInfo form={form} show={true} handleClose={() => {}} />);
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={onShowBackground}
+    />
+  );
 
-  expect(screen.getByText('Athletics, Perception')).toBeInTheDocument();
-});
-
-test('shows default background description when missing', () => {
-  const form = {
-    occupation: [],
-    race: { languages: [] },
-    background: { name: 'Sailor', description: '' },
-    age: 100,
-    sex: 'M',
-    height: "6'",
-    weight: 180,
-  };
-
-  render(<CharacterInfo form={form} show={true} handleClose={() => {}} />);
-
-  expect(screen.getByText('No description available')).toBeInTheDocument();
+  expect(screen.getByText('Sailor')).toBeInTheDocument();
+  const button = screen.getByLabelText('Show Background');
+  fireEvent.click(button);
+  expect(onShowBackground).toHaveBeenCalled();
 });
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -323,12 +323,6 @@ return (
             variant="secondary"
           ></Button>
           <Button
-            onClick={handleShowBackground}
-            style={{ color: "black", padding: "8px", marginTop: "10px" }}
-            className="mx-1 fas fa-eye"
-            variant="secondary"
-          ></Button>
-          <Button
             onClick={handleShowStats}
             style={{
               color: "black",
@@ -418,6 +412,7 @@ return (
       form={form}
       show={showCharacterInfo}
       handleClose={handleCloseCharacterInfo}
+      onShowBackground={handleShowBackground}
     />
     <Skills
       form={form}


### PR DESCRIPTION
## Summary
- remove description/skills from Character Info and add eye icon button for background modal
- drop background eye from bottom navbar and pass handler via CharacterInfo props
- update CharacterInfo tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc5d5c7d88323bb368ff3d2051dd1