### PR TITLE
style: center list bullets in background modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -43,6 +43,13 @@
   text-align: center;
 }
 
+.centered-list {
+  list-style-position: inside;
+  padding-left: 0;
+  display: inline-block;
+  text-align: left;
+}
+
 .App-logo {
   height: 40vmin;
   pointer-events: none;

--- a/client/src/components/Zombies/attributes/BackgroundModal.js
+++ b/client/src/components/Zombies/attributes/BackgroundModal.js
@@ -24,7 +24,7 @@ export default function BackgroundModal({ show, onHide, background }) {
             <br />
             <p><strong>Skill Proficiencies:</strong></p>
             {skillProficiencies.length ? (
-              <ul>
+              <ul className="centered-list">
                 {skillProficiencies.map((skill) => (
                   <li key={skill}>{skill}</li>
                 ))}
@@ -34,7 +34,7 @@ export default function BackgroundModal({ show, onHide, background }) {
             )}
             <p><strong>Tool Proficiencies:</strong></p>
             {toolProficiencies.length ? (
-              <ul>
+              <ul className="centered-list">
                 {toolProficiencies.map((tool) => (
                   <li key={tool}>{tool}</li>
                 ))}


### PR DESCRIPTION
## Summary
- center background modal lists with centered-list class
- add centered-list styling for inline bullet alignment

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd30d29448323a34b8a78029792f6