### PR TITLE
style: center background lists and capitalize proficiencies

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -43,6 +43,13 @@
   text-align: center;
 }
 
+.centered-list {
+  list-style-position: inside;
+  padding-left: 0;
+  display: inline-block;
+  text-align: left;
+}
+
 .App-logo {
   height: 40vmin;
   pointer-events: none;

--- a/client/src/components/Zombies/attributes/BackgroundModal.js
+++ b/client/src/components/Zombies/attributes/BackgroundModal.js
@@ -8,6 +8,17 @@ export default function BackgroundModal({ show, onHide, background }) {
     .filter(([, value]) => value?.proficient)
     .map(([key]) => key);
 
+  const formatLabel = (text) =>
+    text
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .split(" ")
+      .map((word) =>
+        word.charAt(0) === "("
+          ? "(" + word.charAt(1).toUpperCase() + word.slice(2)
+          : word.charAt(0).toUpperCase() + word.slice(1)
+      )
+      .join(" ");
+
   const toolProficiencies = background.toolProficiencies || [];
 
   return (
@@ -24,9 +35,9 @@ export default function BackgroundModal({ show, onHide, background }) {
             <br />
             <p><strong>Skill Proficiencies:</strong></p>
             {skillProficiencies.length ? (
-              <ul>
+              <ul className="centered-list">
                 {skillProficiencies.map((skill) => (
-                  <li key={skill}>{skill}</li>
+                  <li key={skill}>{formatLabel(skill)}</li>
                 ))}
               </ul>
             ) : (
@@ -34,9 +45,9 @@ export default function BackgroundModal({ show, onHide, background }) {
             )}
             <p><strong>Tool Proficiencies:</strong></p>
             {toolProficiencies.length ? (
-              <ul>
+              <ul className="centered-list">
                 {toolProficiencies.map((tool) => (
-                  <li key={tool}>{tool}</li>
+                  <li key={tool}>{formatLabel(tool)}</li>
                 ))}
               </ul>
             ) : (


### PR DESCRIPTION
## Summary
- center background modal lists with centered-list class
- add centered-list styling for inline bullet alignment
- title-case background skill and tool proficiencies

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd30d29448323a34b8a78029792f6