### PR TITLE
Center BackgroundModal title

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -976,6 +976,8 @@ h1 {
 .modal-title {
   font-size: 1.4rem;
   font-weight: bold;
+  text-align: center;
+  width: 100%;
 }
 
 /* Points Section */

--- a/client/src/components/Zombies/attributes/BackgroundModal.js
+++ b/client/src/components/Zombies/attributes/BackgroundModal.js
@@ -26,7 +26,7 @@ export default function BackgroundModal({ show, onHide, background }) {
       <div className="text-center">
         <Card className="modern-card">
           <Card.Header className="modal-header">
-            <Card.Title className="modal-title">
+            <Card.Title className="modal-title text-center">
               {background.name || "Background"}
             </Card.Title>
           </Card.Header>


### PR DESCRIPTION
## Summary
- center background name in `BackgroundModal` Card title
- ensure modal titles are centered by extending `.modal-title` styles

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcda4b761c8323a54554064f3bb3f6