### PR TITLE
Count granted skills toward proficiency limits

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -56,29 +56,29 @@ export default function Skills({
   const lockedProficiencies = useMemo(() => {
     return new Set([...raceProficiencies, ...backgroundProficiencies]);
   }, [raceProficiencies, backgroundProficiencies]);
-  const currentProficiencyCount = Object.entries(form.skills || {}).filter(
-    ([key, s]) => s.proficient && !lockedProficiencies.has(key)
+  const currentProficiencyCount = Object.values(form.skills || {}).filter(
+    (s) => s.proficient
   ).length;
   const [proficiencyPointsLeft, setProficiencyPointsLeft] = useState(
     Math.max(0, (form.proficiencyPoints || 0) - currentProficiencyCount)
   );
-  const currentExpertiseCount = Object.entries(form.skills || {}).filter(
-    ([key, s]) => s.expertise && !lockedExpertise.has(key)
+  const currentExpertiseCount = Object.values(form.skills || {}).filter(
+    (s) => s.expertise
   ).length;
   const [expertisePointsLeft, setExpertisePointsLeft] = useState(
     Math.max(0, (form.expertisePoints || 0) - currentExpertiseCount)
   );
 
   useEffect(() => {
-    const count = Object.entries(form.skills || {}).filter(
-      ([key, s]) => s.proficient && !lockedProficiencies.has(key)
+    const count = Object.values(form.skills || {}).filter(
+      (s) => s.proficient
     ).length;
     setSkills(form.skills || {});
     setProficiencyPointsLeft(
       Math.max(0, (form.proficiencyPoints || 0) - count)
     );
-    const expertiseUsed = Object.entries(form.skills || {}).filter(
-      ([key, s]) => s.expertise && !lockedExpertise.has(key)
+    const expertiseUsed = Object.values(form.skills || {}).filter(
+      (s) => s.expertise
     ).length;
     setExpertisePointsLeft(
       Math.max(0, (form.expertisePoints || 0) - expertiseUsed)
@@ -159,8 +159,8 @@ export default function Skills({
           ...prev,
           [skill]: { proficient: data.proficient, expertise: data.expertise },
         };
-        const proficientCount = Object.entries(newSkills).filter(
-          ([key, s]) => s.proficient && !lockedProficiencies.has(key)
+        const proficientCount = Object.values(newSkills).filter(
+          (s) => s.proficient
         ).length;
         setProficiencyPointsLeft(
           Math.max(0, (form.proficiencyPoints || 0) - proficientCount)

--- a/server/__tests__/skills.test.js
+++ b/server/__tests__/skills.test.js
@@ -46,7 +46,7 @@ describe('Skills routes', () => {
     expect(findOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  test('allows two proficiencies in addition to racial proficiency', async () => {
+  test('limits proficiencies including racial proficiency', async () => {
     const charDoc = {
       race: { skills: { perception: { proficient: true } } },
       skills: { perception: { proficient: true } },
@@ -84,11 +84,6 @@ describe('Skills routes', () => {
     res = await request(app)
       .put('/skills/update-skills/507f1f77bcf86cd799439011')
       .send({ skill: 'arcana', proficient: true, expertise: false });
-    expect(res.status).toBe(200);
-
-    res = await request(app)
-      .put('/skills/update-skills/507f1f77bcf86cd799439011')
-      .send({ skill: 'athletics', proficient: true, expertise: false });
     expect(res.status).toBe(400);
     expect(res.body.message).toBe('No proficiency points remaining');
   });

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -97,12 +97,8 @@ module.exports = (router) => {
           .json({ message: 'Cannot remove granted proficiency' });
       }
 
-      const proficientCount = Object.entries(charDoc.skills || {}).filter(
-        ([key, s]) =>
-          s &&
-          s.proficient &&
-          !charDoc.race?.skills?.[key]?.proficient &&
-          !charDoc.background?.skills?.[key]?.proficient
+      const proficientCount = Object.values(charDoc.skills || {}).filter(
+        (s) => s && s.proficient
       ).length;
       const alreadyProficient = charDoc.skills?.[skill]?.proficient;
       if (
@@ -132,13 +128,8 @@ module.exports = (router) => {
           .status(400)
           .json({ message: 'Cannot remove granted expertise' });
       }
-      const expertiseCount = Object.entries(charDoc.skills || {}).filter(
-        ([key, s]) =>
-          s &&
-          s.expertise &&
-          !charDoc.race?.skills?.[key]?.expertise &&
-          !charDoc.background?.skills?.[key]?.expertise &&
-          !charDoc.feat?.some((ft) => ft?.skills?.[key]?.expertise)
+      const expertiseCount = Object.values(charDoc.skills || {}).filter(
+        (s) => s && s.expertise
       ).length;
       const alreadyExpertise = charDoc.skills?.[skill]?.expertise;
       if (


### PR DESCRIPTION
## Summary
- Treat race and background skill grants as spent proficiency and expertise points in the Skills UI
- Ensure server counts granted proficiencies and expertise when validating updates
- Adjust skill route tests for new limit enforcement

## Testing
- `CI=true npm test`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_68bce7197ea48323b7224b44d474e820