### PR TITLE
Prune optional character fields

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -347,6 +347,14 @@ useEffect(() => {
     if (newCharacter.race == null) {
       delete newCharacter.race;
     }
+    if (newCharacter.background == null) {
+      delete newCharacter.background;
+    }
+    Object.keys(newCharacter).forEach((key) => {
+      if (newCharacter[key] === "") {
+        delete newCharacter[key];
+      }
+    });
     try {
       const response = await apiFetch("/characters/add", {
         method: "POST",
@@ -504,6 +512,17 @@ const sendManualToDb = useCallback(async (characterData) => {
     ...baseCharacter,
     feat: (baseCharacter.feat || []).filter((feat) => feat?.featName && feat.featName.trim() !== ""),
   };
+  if (newCharacter.race == null) {
+    delete newCharacter.race;
+  }
+  if (newCharacter.background == null) {
+    delete newCharacter.background;
+  }
+  Object.keys(newCharacter).forEach((key) => {
+    if (newCharacter[key] === "") {
+      delete newCharacter[key];
+    }
+  });
   try {
     const response = await apiFetch("/characters/add", {
       method: "POST",


### PR DESCRIPTION
## Summary
- drop null background entries before saving
- remove empty string numeric fields in send functions

## Testing
- `CI=true npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_68bce9457ad8832394fdc309c45f9d35