### PR TITLE
feat: randomize zombie backgrounds in character generator

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -265,6 +265,15 @@ function bigMaff() {
         updateForm({ skills: { ...(form.skills || {}), ...chosenRace.skills } });
       }
   }
+  // Background Randomizer
+  const backgroundKeys = Object.keys(backgrounds);
+  if (backgroundKeys.length) {
+    const bg = JSON.parse(JSON.stringify(
+      backgrounds[backgroundKeys[Math.floor(Math.random() * backgroundKeys.length)]]
+    ));
+    const updatedSkills = { ...(form.skills || {}), ...(bg.skills || {}) };
+    updateForm({ background: bg, skills: updatedSkills });
+  }
 
   // Age Randomizer
   let newAge = Math.round(Math.random() * (50 - 19)) + 19;


### PR DESCRIPTION
## Summary
- Randomly select and clone a background during character generation
- Merge background skills into existing skills and store chosen background for submission

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, unable to install npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bced41a47c8323b3a265e6c0dc0da1