### PR TITLE
Limit available backgrounds

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -24,7 +24,7 @@ test('renders background name and calls onShowBackground', () => {
   const form = {
     occupation: [],
     race: { languages: [] },
-    background: { name: 'Sailor' },
+    background: { name: 'Soldier' },
     age: 100,
     sex: 'M',
     height: "6'",
@@ -40,7 +40,7 @@ test('renders background name and calls onShowBackground', () => {
     />
   );
 
-  expect(screen.getByText('Sailor')).toBeInTheDocument();
+  expect(screen.getByText('Soldier')).toBeInTheDocument();
   const button = screen.getByLabelText('Show Background');
   fireEvent.click(button);
   expect(onShowBackground).toHaveBeenCalled();

--- a/server/__tests__/backgrounds.test.js
+++ b/server/__tests__/backgrounds.test.js
@@ -26,13 +26,13 @@ describe('Background API routes', () => {
   });
 
   test('fetches a multi-word background', async () => {
-    const res = await request(app).get('/backgrounds/guildArtisan');
+    const res = await request(app).get('/backgrounds/folkHero');
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      name: 'Guild Artisan',
+      name: 'Folk Hero',
       skills: {
-        insight: { proficient: true },
-        persuasion: { proficient: true },
+        animalHandling: { proficient: true },
+        survival: { proficient: true },
       },
     });
   });

--- a/server/data/backgrounds.js
+++ b/server/data/backgrounds.js
@@ -8,15 +8,6 @@ const backgrounds = {
     toolProficiencies: [],
     description: 'You have spent your life in service to a temple, gaining the Shelter of the Faithful feature.',
   },
-  charlatan: {
-    name: 'Charlatan',
-    skills: {
-      deception: { proficient: true },
-      sleightOfHand: { proficient: true },
-    },
-    toolProficiencies: ['disguise kit', 'forgery kit'],
-    description: 'You create false identities and forge documents with ease.',
-  },
   criminal: {
     name: 'Criminal',
     skills: {
@@ -25,15 +16,6 @@ const backgrounds = {
     },
     toolProficiencies: ["thieves' tools", 'gaming set'],
     description: 'You have a reliable contact in the criminal underworld.',
-  },
-  entertainer: {
-    name: 'Entertainer',
-    skills: {
-      acrobatics: { proficient: true },
-      performance: { proficient: true },
-    },
-    toolProficiencies: ['disguise kit', 'musical instrument'],
-    description: 'Your performances earn you lodging and admiration by popular demand.',
   },
   folkHero: {
     name: 'Folk Hero',
@@ -44,42 +26,6 @@ const backgrounds = {
     toolProficiencies: ['artisan tools', 'vehicles (land)'],
     description: 'People are inclined to trust you thanks to your rustic hospitality.',
   },
-  guildArtisan: {
-    name: 'Guild Artisan',
-    skills: {
-      insight: { proficient: true },
-      persuasion: { proficient: true },
-    },
-    toolProficiencies: ['artisan tools'],
-    description: 'As a member of a guild you can leverage guild membership for support.',
-  },
-  hermit: {
-    name: 'Hermit',
-    skills: {
-      medicine: { proficient: true },
-      religion: { proficient: true },
-    },
-    toolProficiencies: ['herbalism kit'],
-    description: 'Years of solitude have led to a unique discovery.',
-  },
-  noble: {
-    name: 'Noble',
-    skills: {
-      history: { proficient: true },
-      persuasion: { proficient: true },
-    },
-    toolProficiencies: ['gaming set'],
-    description: 'You enjoy a position of privilege among other nobles.',
-  },
-  outlander: {
-    name: 'Outlander',
-    skills: {
-      athletics: { proficient: true },
-      survival: { proficient: true },
-    },
-    toolProficiencies: ['musical instrument'],
-    description: 'You can find safe paths through the wilderness and recall geographical details.',
-  },
   sage: {
     name: 'Sage',
     skills: {
@@ -89,15 +35,6 @@ const backgrounds = {
     toolProficiencies: [],
     description: 'If you do not know a piece of lore, you know where to find it.',
   },
-  sailor: {
-    name: 'Sailor',
-    skills: {
-      athletics: { proficient: true },
-      perception: { proficient: true },
-    },
-    toolProficiencies: ["navigator's tools", 'vehicles (water)'],
-    description: "You can secure free passage on sailing ships using the Ship's Passage feature.",
-  },
   soldier: {
     name: 'Soldier',
     skills: {
@@ -106,15 +43,6 @@ const backgrounds = {
     },
     toolProficiencies: ['gaming set', 'vehicles (land)'],
     description: 'Your military rank allows you to exert influence in armies.',
-  },
-  urchin: {
-    name: 'Urchin',
-    skills: {
-      sleightOfHand: { proficient: true },
-      stealth: { proficient: true },
-    },
-    toolProficiencies: ['disguise kit', "thieves' tools"],
-    description: 'You know the secret patterns of city streets and can move through them quickly.',
   },
 };
 


### PR DESCRIPTION
## Summary
- Trim server background data to only acolyte, criminal, folk hero, sage, and soldier
- Update server and client tests to match remaining backgrounds

## Testing
- `npm --prefix server test`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcf1eb7da083239357c355f168b9af