### PR TITLE
Consider bonuses for multiclass stat prerequisites

### DIFF
--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -224,6 +224,7 @@ module.exports = (router) => {
       body('feat').optional().isArray(),
       body('race').optional().isObject(),
       body('background').optional().isObject(),
+      body('abilityScoreImprovement').optional().isObject(),
       body('weapon').optional().isArray(),
       body('armor').optional().isArray(),
       body('item').optional().isArray(),
@@ -263,6 +264,10 @@ module.exports = (router) => {
         myobj.race,
         myobj.background
       );
+
+      if (!myobj.abilityScoreImprovement) {
+        myobj.abilityScoreImprovement = {};
+      }
 
       // derive proficiency bonus from total character level
       const totalLevel = Array.isArray(myobj.occupation)

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -45,6 +45,7 @@ module.exports = (router) => {
       body('wis').isInt().toInt(),
       body('cha').isInt().toInt(),
       body('startStatTotal').isInt().toInt(),
+      body('abilityScoreImprovement').optional().isObject(),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -54,7 +55,7 @@ module.exports = (router) => {
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
       const fields = matchedData(req, { locations: ['body'] });
-
+      
       try {
         await db_connect.collection('Characters').updateOne(id, {
           $set: fields,

--- a/server/routes/characters/stats.js
+++ b/server/routes/characters/stats.js
@@ -14,16 +14,18 @@ module.exports = (router) => {
     const id = { _id: ObjectId(req.params.id) };
     const db_connect = req.db;
     try {
-      await db_connect.collection('Characters').updateOne(id, {
-        $set: {
-          str: req.body.str,
-          dex: req.body.dex,
-          con: req.body.con,
-          int: req.body.int,
-          wis: req.body.wis,
-          cha: req.body.cha,
-        },
-      });
+      const update = {
+        str: req.body.str,
+        dex: req.body.dex,
+        con: req.body.con,
+        int: req.body.int,
+        wis: req.body.wis,
+        cha: req.body.cha,
+      };
+      if (req.body.abilityScoreImprovement) {
+        update.abilityScoreImprovement = req.body.abilityScoreImprovement;
+      }
+      await db_connect.collection('Characters').updateOne(id, { $set: update });
       logger.info('character stats updated');
       res.json({ message: 'User updated successfully' });
     } catch (err) {

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -20,12 +20,47 @@ const prereqs = {
   wizard: { all: ['int'], min: 13 },
 };
 
+function getTotalStat(character = {}, stat = '') {
+  let total = Number(character[stat] || 0);
+  if (character?.race?.abilities && character.race.abilities[stat] != null) {
+    total += Number(character.race.abilities[stat] || 0);
+  }
+  if (
+    character?.abilityScoreImprovement
+    && character.abilityScoreImprovement[stat] != null
+  ) {
+    total += Number(character.abilityScoreImprovement[stat] || 0);
+  }
+  if (Array.isArray(character.feat)) {
+    character.feat.forEach((ft) => {
+      if (ft && typeof ft === 'object') total += Number(ft[stat] || 0);
+    });
+  }
+  if (Array.isArray(character.occupation)) {
+    character.occupation.forEach((occ) => {
+      if (occ && typeof occ === 'object') total += Number(occ[stat] || 0);
+    });
+  }
+  if (Array.isArray(character.item)) {
+    const indexMap = { str: 2, dex: 3, con: 4, int: 5, wis: 6, cha: 7 };
+    character.item.forEach((it) => {
+      if (Array.isArray(it)) {
+        const idx = indexMap[stat];
+        if (idx != null) total += Number(it[idx] || 0);
+      } else if (it && typeof it === 'object') {
+        total += Number(it[stat] || 0);
+      }
+    });
+  }
+  return total;
+}
+
 function canMulticlass(character = {}, newOccupation = '') {
   const name = typeof newOccupation === 'string' ? newOccupation.toLowerCase() : '';
   const req = prereqs[name];
   if (!req) return { allowed: true };
   if (req.all) {
-    const ok = req.all.every((stat) => Number(character[stat]) >= req.min);
+    const ok = req.all.every((stat) => getTotalStat(character, stat) >= req.min);
     if (ok) return { allowed: true };
     return {
       allowed: false,
@@ -33,7 +68,7 @@ function canMulticlass(character = {}, newOccupation = '') {
     };
   }
   if (req.any) {
-    const ok = req.any.some((stat) => Number(character[stat]) >= req.min);
+    const ok = req.any.some((stat) => getTotalStat(character, stat) >= req.min);
     if (ok) return { allowed: true };
     return {
       allowed: false,


### PR DESCRIPTION
## Summary
- add `getTotalStat` helper to sum base stat with racial, improvement, feat, class, and item bonuses
- evaluate multiclass prerequisites using total adjusted stats
- store ability score improvements during character creation and stat updates

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_68bcf4872f60832eba7ee0f3450537e8