### PR TITLE
Remove stale skill entries when proficiency cleared

### DIFF
--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -112,7 +112,7 @@ module.exports = (router) => {
       }
 
       const proficiencyAfterUpdate =
-        proficient || alreadyProficient || raceProficient || backgroundProficient;
+        proficient || raceProficient || backgroundProficient;
       if (expertise && !proficiencyAfterUpdate) {
         return res
           .status(400)
@@ -149,12 +149,20 @@ module.exports = (router) => {
 
       const update = {
         $set: {
-          [`skills.${skill}`]: { proficient: proficiencyAfterUpdate, expertise },
           proficiencyBonus: profBonus,
           allowedSkills,
           allowedExpertise,
         },
       };
+
+      if (proficiencyAfterUpdate || expertise) {
+        update.$set[`skills.${skill}`] = {
+          proficient: proficiencyAfterUpdate,
+          expertise,
+        };
+      } else {
+        update.$unset = { [`skills.${skill}`]: '' };
+      }
 
       const result = await db_connect
         .collection('Characters')


### PR DESCRIPTION
## Summary
- avoid keeping skill records when proficiency is removed
- allow proficiency reallocation by unsetting empty skill entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcf518eb3c8323aeeee1e277d71eca