### PR TITLE
Add class spell list filtering for spells API

### DIFF
--- a/client/src/components/Spells/SpellList.js
+++ b/client/src/components/Spells/SpellList.js
@@ -6,12 +6,14 @@ import apiFetch from '../../utils/apiFetch';
 
 function SpellList() {
   const [spells, setSpells] = useState/** @type {Spell[] | null} */(null);
+  const [selectedClass, setSelectedClass] = useState('');
 
   useEffect(() => {
-    apiFetch('/spells')
+    const query = selectedClass ? `?class=${selectedClass}` : '';
+    apiFetch(`/spells${query}`)
       .then(res => res.json())
       .then(data => setSpells(Object.values(data)));
-  }, []);
+  }, [selectedClass]);
 
   if (!spells) {
     return <div>Loading...</div>;
@@ -20,6 +22,20 @@ function SpellList() {
   return (
     <div>
       <h1>Spells</h1>
+      <label>
+        Class:
+        <select value={selectedClass} onChange={e => setSelectedClass(e.target.value)}>
+          <option value="">All</option>
+          <option value="bard">Bard</option>
+          <option value="cleric">Cleric</option>
+          <option value="druid">Druid</option>
+          <option value="paladin">Paladin</option>
+          <option value="ranger">Ranger</option>
+          <option value="sorcerer">Sorcerer</option>
+          <option value="warlock">Warlock</option>
+          <option value="wizard">Wizard</option>
+        </select>
+      </label>
       <ul>
         {spells.map(spell => (
           <li key={spell.name}>

--- a/server/__tests__/spells.test.js
+++ b/server/__tests__/spells.test.js
@@ -4,6 +4,7 @@ process.env.CLIENT_ORIGINS = 'http://localhost';
 
 const request = require('supertest');
 const express = require('express');
+const classSpellLists = require('../data/classSpellLists');
 
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
@@ -53,5 +54,14 @@ describe('Spells routes', () => {
     const res = await request(app).get('/spells/fireball');
     expect(res.status).toBe(200);
     expect(res.body.damage).toBe('8d6');
+  });
+
+  test('GET /spells?class=bard returns only bard spells', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).get('/spells').query({ class: 'bard' });
+    expect(res.status).toBe(200);
+    const keys = Object.keys(res.body);
+    expect(keys).toEqual(classSpellLists.bard);
+    expect(keys).not.toContain('fireball');
   });
 });

--- a/server/data/classSpellLists.js
+++ b/server/data/classSpellLists.js
@@ -1,0 +1,24 @@
+const spells = require('./spells');
+
+/**
+ * Mapping of class identifiers to the list of spell IDs they can cast.
+ * Generated from the SRD spells data.
+ * @type {Record<string, string[]>}
+ */
+const classSpellLists = {};
+
+for (const [id, spell] of Object.entries(spells)) {
+  if (!Array.isArray(spell.classes)) continue;
+  spell.classes.forEach(cls => {
+    const key = cls.toLowerCase();
+    if (!classSpellLists[key]) classSpellLists[key] = [];
+    classSpellLists[key].push(id);
+  });
+}
+
+// Ensure deterministic order for easier comparisons/tests.
+Object.keys(classSpellLists).forEach(key => {
+  classSpellLists[key].sort();
+});
+
+module.exports = classSpellLists;

--- a/server/routes/spells.js
+++ b/server/routes/spells.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const spells = require('../data/spells');
+const classSpellLists = require('../data/classSpellLists');
 
 // Extract a basic damage dice string (e.g., "8d6" or "1d8+2") from spell descriptions
 function extractDamage(description = '') {
@@ -18,7 +19,15 @@ Object.values(spells).forEach((spell) => {
 module.exports = (router) => {
   const spellRouter = express.Router();
 
-  spellRouter.get('/', (_req, res) => {
+  spellRouter.get('/', (req, res) => {
+    const className = req.query.class?.toLowerCase();
+    if (className && classSpellLists[className]) {
+      const allowed = classSpellLists[className];
+      const filtered = Object.fromEntries(
+        allowed.map(id => [id, spells[id]]).filter(([, spell]) => spell)
+      );
+      return res.json(filtered);
+    }
     res.json(spells);
   });
 


### PR DESCRIPTION
## Summary
- generate mapping of allowed spell IDs per class
- filter `/spells` by class query parameter
- allow selecting a class in the client spell list
- test that bard query returns only bard spells

## Testing
- `npm test` (server)
- `npm test src/components/Spells/SpellList.test.js src/App.test.js` (client)


------
https://chatgpt.com/codex/tasks/task_e_68bcfae0409483238b4c32b8cd77d255