### PR TITLE
Include caster progression in multiclass updates

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -9,6 +9,7 @@ jest.mock('../db/conn');
 const dbo = require('../db/conn');
 jest.mock('../middleware/auth', () => (req, res, next) => next());
 const charactersRouter = require('../routes');
+const classes = require('../data/classes');
 
 const app = express();
 app.use(express.json());
@@ -645,6 +646,7 @@ describe('Character routes', () => {
     const occ = captured.update.$set.occupation[0];
     expect(occ.Occupation).toBe('Fighter');
     expect(occ.skills.acrobatics).toEqual({ proficient: true, expertise: false });
+    expect(occ.casterProgression).toBe(classes.fighter.casterProgression);
     expect(occ.proficiencyPoints).toBe(0);
     expect(captured.update.$set.allowedSkills).toEqual([
       'acrobatics',
@@ -657,6 +659,7 @@ describe('Character routes', () => {
       'survival',
     ]);
     expect(res.body.occupation[0].Occupation).toBe('Fighter');
+    expect(res.body.occupation[0].casterProgression).toBe(classes.fighter.casterProgression);
     Math.random.mockRestore();
   });
 

--- a/server/utils/multiclass.js
+++ b/server/utils/multiclass.js
@@ -114,6 +114,7 @@ async function applyMulticlass(characterId, newOccupation) {
     weapons: classInfo.proficiencies.weapons,
     tools: classInfo.proficiencies.tools,
     savingThrows: classInfo.proficiencies.savingThrows,
+    casterProgression: classInfo.casterProgression,
     Level: 1,
     skills,
     proficiencyPoints: 0,


### PR DESCRIPTION
## Summary
- Add `casterProgression` field to new occupation entries when applying multiclassing
- Test that multiclassing returns the expected `casterProgression`

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd073caacc83239a21f39e11dd76e4