### PR TITLE
Add class features module and UI with feature modal

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Modal, Card, Button } from 'react-bootstrap';
+
+export default function FeatureModal({ show, onHide, feature }) {
+  if (!feature) return null;
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      centered
+      className="dnd-modal modern-modal"
+      animation={false}
+    >
+      <div className="text-center">
+        <Card className="modern-card">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">{feature.name}</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <p>{feature.description}</p>
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={onHide}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Card, Table, Button } from 'react-bootstrap';
+import apiFetch from '../../../utils/apiFetch';
+import FeatureModal from './FeatureModal';
+
+export default function Features({ form, showFeatures, handleCloseFeatures }) {
+  const [features, setFeatures] = useState([]);
+  const [modalFeature, setModalFeature] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    if (!showFeatures) return;
+    async function fetchFeatures() {
+      const allFeatures = [];
+      try {
+        for (const occ of form.occupation || []) {
+          const res = await apiFetch(
+            `/classes/${occ.Name.toLowerCase()}/features/${occ.Level}`
+          );
+          if (!res.ok) continue;
+          const data = await res.json();
+          (data.features || []).forEach((f) =>
+            allFeatures.push({ ...f, class: occ.Name })
+          );
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      }
+      setFeatures(allFeatures);
+    }
+    fetchFeatures();
+  }, [form.occupation, showFeatures]);
+
+  return (
+    <>
+      <Modal
+        className="dnd-modal modern-modal"
+        show={showFeatures}
+        onHide={handleCloseFeatures}
+        size="lg"
+        centered
+        animation={false}
+      >
+        <div className="text-center">
+          <Card className="modern-card">
+            <Card.Header className="modal-header">
+              <Card.Title className="modal-title">Features</Card.Title>
+            </Card.Header>
+            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+              <Table striped bordered hover size="sm" className="modern-table">
+                <thead>
+                  <tr>
+                    <th>Class</th>
+                    <th>Feature</th>
+                    <th>View</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {features.map((feat, idx) => (
+                    <tr key={`${feat.class}-${idx}`}>
+                      <td>{feat.class}</td>
+                      <td>{feat.name}</td>
+                      <td>
+                        <Button
+                          size="sm"
+                          className="action-btn fa-regular fa-eye"
+                          aria-label="view feature"
+                          onClick={() => {
+                            setModalFeature(feat);
+                            setShowModal(true);
+                          }}
+                        ></Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Card.Body>
+          </Card>
+        </div>
+      </Modal>
+      <FeatureModal
+        show={showModal}
+        onHide={() => setShowModal(false)}
+        feature={modalFeature}
+      />
+    </>
+  );
+}

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Features from './Features';
+
+jest.mock('../../../utils/apiFetch');
+import apiFetch from '../../../utils/apiFetch';
+
+test('renders features and opens modal with description', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      features: [
+        { name: 'Action Surge', description: 'You can take one additional action.' }
+      ]
+    })
+  });
+
+  const form = { occupation: [{ Name: 'Fighter', Level: 2 }] };
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+    />
+  );
+
+  expect(await screen.findByText('Action Surge')).toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(
+      screen.getByRole('button', { name: /view feature/i })
+    );
+  });
+
+  expect(
+    await screen.findByText('You can take one additional action.')
+  ).toBeInTheDocument();
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -18,6 +18,7 @@ import { SKILLS } from "../skillSchema";
 import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import BackgroundModal from "../attributes/BackgroundModal";
+import Features from "../attributes/Features";
 
 const HEADER_PADDING = 16;
 
@@ -29,6 +30,7 @@ export default function ZombiesCharacterSheet() {
   const [showStats, setShowStats] = useState(false);
   const [showSkill, setShowSkill] = useState(false); // State for skills modal
   const [showFeats, setShowFeats] = useState(false);
+  const [showFeatures, setShowFeatures] = useState(false);
   const [showWeapons, setShowWeapons] = useState(false);
   const [showArmor, setShowArmor] = useState(false);
   const [showItems, setShowItems] = useState(false);
@@ -106,6 +108,8 @@ export default function ZombiesCharacterSheet() {
   const handleCloseSkill = () => setShowSkill(false); // Handler to close skills modal
   const handleShowFeats = () => setShowFeats(true);
   const handleCloseFeats = () => setShowFeats(false);
+  const handleShowFeatures = () => setShowFeatures(true);
+  const handleCloseFeatures = () => setShowFeatures(false);
   const handleShowWeapons = () => setShowWeapons(true);
   const handleCloseWeapons = () => setShowWeapons(false); 
   const handleShowArmor = () => setShowArmor(true);
@@ -355,6 +359,17 @@ return (
             className="mx-1 fas fa-hand-fist"
             variant="secondary"
           ></Button>
+          <Button
+            onClick={handleShowFeatures}
+            style={{
+              color: "black",
+              padding: "8px",
+              marginTop: "10px",
+              backgroundColor: "#6C757D",
+            }}
+            className="mx-1 fas fa-star"
+            variant="secondary"
+          ></Button>
                     <Button
             onClick={handleShowSpells}
             style={{
@@ -434,6 +449,11 @@ return (
       background={form.background}
     />
     <Feats form={form} showFeats={showFeats} handleCloseFeats={handleCloseFeats} />
+    <Features
+      form={form}
+      showFeatures={showFeatures}
+      handleCloseFeatures={handleCloseFeatures}
+    />
       <Modal
         className="dnd-modal modern-modal"
         show={showWeapons}

--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -1,0 +1,58 @@
+// Mapping of class names to their features and spell progression.
+// Each class maps to an object with `featuresByLevel` and optional
+// `spellSlots` and `spellsKnown` mappings keyed by level.
+
+/**
+ * @typedef {{ name: string, description: string }} Feature
+ * @typedef {{ featuresByLevel: Record<number, Feature[]>, spellSlots?: Record<number, Record<number, number>>, spellsKnown?: Record<number, number> }} ClassFeatures
+ * @type {Record<string, ClassFeatures>}
+ */
+const classFeatures = {
+  fighter: {
+    featuresByLevel: {
+      1: [
+        {
+          name: 'Fighting Style',
+          description: 'You adopt a particular style of fighting as your specialty.'
+        },
+        {
+          name: 'Second Wind',
+          description: 'You have a limited well of stamina that you can draw on to protect yourself.'
+        }
+      ],
+      2: [
+        {
+          name: 'Action Surge',
+          description: 'You can push yourself beyond your normal limits for a moment.'
+        }
+      ],
+      3: [
+        {
+          name: 'Martial Archetype',
+          description: 'You choose an archetype that you strive to emulate in your combat styles and techniques.'
+        }
+      ]
+    }
+  },
+  wizard: {
+    featuresByLevel: {
+      1: [
+        { name: 'Spellcasting', description: 'You have learned to cast spells through rigorous study.' },
+        { name: 'Arcane Recovery', description: 'You have learned to regain some of your magical energy by studying your spellbook.' }
+      ],
+      2: [
+        { name: 'Arcane Tradition', description: 'You choose an arcane tradition, shaping your practice of magic.' }
+      ]
+    },
+    spellSlots: {
+      1: { 1: 2 }, // level 1: two 1st-level spell slots
+      2: { 1: 3 }
+    },
+    spellsKnown: {
+      1: 6,
+      2: 7
+    }
+  }
+};
+
+module.exports = classFeatures;

--- a/server/routes/classes.js
+++ b/server/routes/classes.js
@@ -1,11 +1,27 @@
 const express = require('express');
 const classes = require('../data/classes');
+const classFeatures = require('../data/classFeatures');
 
 module.exports = (router) => {
   const classRouter = express.Router();
 
   classRouter.get('/', (_req, res) => {
     res.json(classes);
+  });
+
+  classRouter.get('/:name/features/:level', (req, res) => {
+    const cls = classFeatures[req.params.name.toLowerCase()];
+    if (!cls) {
+      return res.status(404).json({ message: 'Class not found' });
+    }
+    const level = Number(req.params.level);
+    const features = cls.featuresByLevel?.[level];
+    const spellSlots = cls.spellSlots?.[level];
+    const spellsKnown = cls.spellsKnown?.[level];
+    if (!features && !spellSlots && spellsKnown == null) {
+      return res.status(404).json({ message: 'Level not found' });
+    }
+    res.json({ features: features || [], spellSlots, spellsKnown });
   });
 
   classRouter.get('/:name', (req, res) => {

--- a/types/class.d.ts
+++ b/types/class.d.ts
@@ -1,3 +1,10 @@
+export interface Feature {
+  /** Feature name */
+  name: string;
+  /** Detailed description of the feature */
+  description: string;
+}
+
 export interface Class {
   /**
    * Class name, e.g. "Wizard".
@@ -29,6 +36,10 @@ export interface Class {
    * Spell slot progression for the class.
    * 'full' for full casters, 'half' for half casters.
    * Undefined for non-spellcasting classes.
-   */
+  */
   casterProgression?: 'full' | 'half';
+  /**
+   * Features available to the class keyed by character level.
+   */
+  featuresByLevel?: Record<number, Feature[]>;
 }


### PR DESCRIPTION
## Summary
- add class features dataset with fighter and wizard example data
- expose `/classes/:name/features/:level` endpoint returning features and spell data
- implement Features UI with modal to view descriptions and navigation button
- add tests for feature display

## Testing
- `npm test`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0d89309c83238cff22d0d1c8934b