### PR TITLE
Handle missing feature details in modal

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Modal, Card, Button } from 'react-bootstrap';
 
 export default function FeatureModal({ show, onHide, feature }) {
-  if (!feature) return null;
+  if (!show || !feature) return null;
   return (
     <Modal
       show={show}
@@ -17,7 +17,7 @@ export default function FeatureModal({ show, onHide, feature }) {
             <Card.Title className="modal-title">{feature.name}</Card.Title>
           </Card.Header>
           <Card.Body>
-            <p>{feature.description}</p>
+            <p>{feature.description || 'Feature details unavailable'}</p>
           </Card.Body>
           <Card.Footer className="modal-footer">
             <Button className="action-btn close-btn" onClick={onHide}>


### PR DESCRIPTION
## Summary
- Render `FeatureModal` only when both `show` and `feature` are truthy
- Display fallback message when a feature lacks a description

## Testing
- `CI=true npm test` *(fails: Test Suites: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda0d68014832ea8ba335b18be0b73