### PR TITLE
Render zombie feature descriptions from multiple sources

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -3,6 +3,9 @@ import { Modal, Card, Button } from 'react-bootstrap';
 
 export default function FeatureModal({ show, onHide, feature }) {
   if (!show || !feature) return null;
+  const description = Array.isArray(feature.desc)
+    ? feature.desc.join('\n')
+    : (feature.description || feature.desc);
   return (
     <Modal
       show={show}
@@ -17,7 +20,7 @@ export default function FeatureModal({ show, onHide, feature }) {
             <Card.Title className="modal-title">{feature.name}</Card.Title>
           </Card.Header>
           <Card.Body>
-            <p>{feature.description || 'Feature details unavailable'}</p>
+            <p>{description || 'Feature details unavailable'}</p>
           </Card.Body>
           <Card.Footer className="modal-footer">
             <Button className="action-btn close-btn" onClick={onHide}>


### PR DESCRIPTION
## Summary
- Map `feature.desc` and `feature.description` into a single `description` variable
- Display the unified `description` in the feature modal

## Testing
- `CI=true npm test` *(fails: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1d9987c832eb34633f4cea2b0ed