### PR TITLE
Add skill descriptions with view modal

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -3,7 +3,7 @@ import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Form } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 
-import { SKILLS } from "../skillSchema";
+import { SKILLS, SKILL_DESCRIPTIONS } from "../skillSchema";
 export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, strMod, dexMod, conMod, intMod, chaMod, wisMod}) {
   const params = useParams();
   const navigate = useNavigate();
@@ -17,7 +17,7 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
       setChosenSkill(e.target.value);
   }
   
-  const [addSkillForm, setAddSkillForm] = useState({ 
+  const [addSkillForm, setAddSkillForm] = useState({
     newSkill: "",
   });
   function updateAddSkill(value) {
@@ -25,7 +25,7 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
       return { ...prev, ...value };
     });
   }
-  const [newSkill, setNewSkill] = useState({ 
+  const [newSkill, setNewSkill] = useState({
     skill: "",
   });
   function updateNewSkill(value) {
@@ -33,6 +33,16 @@ export default function Skills({ form, showSkill, handleCloseSkill, totalLevel, 
       return { ...prev, ...value };
     });
   }
+
+  const [showDescription, setShowDescription] = useState(false);
+  const [descriptionContent, setDescriptionContent] = useState("");
+  const [descriptionTitle, setDescriptionTitle] = useState("");
+
+  const handleViewDescription = (key, label) => {
+    setDescriptionContent(SKILL_DESCRIPTIONS[key] || "No description available.");
+    setDescriptionTitle(label);
+    setShowDescription(true);
+  };
   
   if (!form) {
     return <div>Loading...</div>;
@@ -246,6 +256,7 @@ let firstLevelSkill =
                 <tr>
                   <th></th>
                   <th>Skill</th>
+                  <th>View</th>
                   <th>Total</th>
                   <th>Rank</th>
                   <th>Mod</th>
@@ -266,6 +277,13 @@ let firstLevelSkill =
                         ></Button>
                       </td>
                       <td>{label}</td>
+                      <td>
+                        <Button
+                          size="sm"
+                          onClick={() => handleViewDescription(key, label)}
+                          className="action-btn fa-solid fa-circle-info"
+                        ></Button>
+                      </td>
                       <td>
                         <span id={totalId}>{skillTotalForm[key]} </span>
                       </td>
@@ -298,6 +316,13 @@ let firstLevelSkill =
                       ></Button>
                     </td>
                     <td>{el[0]}</td>
+                    <td>
+                      <Button
+                        size="sm"
+                        onClick={() => handleViewDescription(el[0], el[0])}
+                        className="action-btn fa-solid fa-circle-info"
+                      ></Button>
+                    </td>
                     <td>
                       <span id={el[0] + "total"}>{Number(el[1]) + intMod}</span>
                     </td>
@@ -391,6 +416,25 @@ let firstLevelSkill =
                 form="addSkillForm"
               >
                 Create
+              </Button>
+            </Card.Footer>
+          </Card>
+        </Modal>
+        <Modal className="modern-modal" show={showDescription} onHide={() => setShowDescription(false)} centered>
+          <Card className="modern-card text-center">
+            <Card.Header className="modal-header">
+              <Card.Title className="modal-title">{descriptionTitle}</Card.Title>
+            </Card.Header>
+            <Card.Body>
+              <p>{descriptionContent}</p>
+            </Card.Body>
+            <Card.Footer className="modal-footer">
+              <Button
+                className="action-btn close-btn"
+                variant="secondary"
+                onClick={() => setShowDescription(false)}
+              >
+                Close
               </Button>
             </Card.Footer>
           </Card>

--- a/client/src/components/Zombies/skillSchema.js
+++ b/client/src/components/Zombies/skillSchema.js
@@ -31,4 +31,37 @@ export const SKILLS = [
   { key: 'useRope', label: 'Use Rope', mod: 'dex', featIndex: 31, itemIndex: 37 },
 ];
 
+export const SKILL_DESCRIPTIONS = {
+  appraise: 'Estimate the value of items and objects.',
+  balance: 'Keep your footing on narrow or slippery surfaces.',
+  bluff: 'Convince others of falsehoods or feign actions.',
+  climb: 'Ascend, descend, or traverse vertical surfaces.',
+  concentration: 'Maintain focus despite distractions.',
+  decipherScript: 'Understand unfamiliar or ancient writings.',
+  diplomacy: 'Negotiate or influence through tact and charm.',
+  disableDevice: 'Disarm traps or sabotage mechanical devices.',
+  disguise: 'Alter appearance to hide identity.',
+  escapeArtist: 'Slip bonds or squeeze through tight spaces.',
+  forgery: 'Create or detect counterfeit documents.',
+  gatherInfo: 'Collect rumors and useful local information.',
+  handleAnimal: 'Train, handle, or calm animals.',
+  heal: 'Treat wounds and ailments with first aid.',
+  hide: 'Conceal yourself from sight.',
+  intimidate: 'Influence others through threats or force.',
+  jump: 'Leap over obstacles or across distances.',
+  listen: 'Detect faint sounds or approaching creatures.',
+  moveSilently: 'Sneak quietly without being heard.',
+  openLock: 'Pick mechanical locks without a key.',
+  ride: 'Guide and control mounts.',
+  search: 'Find hidden objects, compartments, or clues.',
+  senseMotive: 'Discern intentions and detect lies.',
+  sleightOfHand: 'Perform tricks or steal small objects unnoticed.',
+  spot: 'Notice fine details or hidden creatures.',
+  survival: 'Live off the land and track creatures.',
+  swim: 'Move and stay afloat in water.',
+  tumble: 'Dodge attacks and move acrobatically.',
+  useTech: 'Operate or repair technological devices.',
+  useRope: 'Tie knots and use ropes effectively.',
+};
+
 export default SKILLS;


### PR DESCRIPTION
## Summary
- show skill description via new View column and modal
- document skill details in `SKILL_DESCRIPTIONS`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bda2b1c9a48323a5b9b391519177d0