### PR TITLE
Handle non-object occupation entries in feature loading

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -17,14 +17,18 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
       setError(null);
       const allFeatures = [];
       try {
-        for (const occ of form.occupation || []) {
+        for (const occ of Array.isArray(form.occupation) ? form.occupation : []) {
+          if (typeof occ !== 'object' || occ === null) continue;
+          const displayName = occ.Name || occ.Occupation || occ.name || '';
+          const className = displayName.toLowerCase();
+          if (!className) continue;
           const res = await apiFetch(
-            `/classes/${occ.Name.toLowerCase()}/features/${occ.Level}`
+            `/classes/${className}/features/${occ.Level || 1}`
           );
           if (!res.ok) continue;
           const data = await res.json();
           (data.features || []).forEach((f) =>
-            allFeatures.push({ ...f, class: occ.Name })
+            allFeatures.push({ ...f, class: displayName })
           );
         }
       } catch (err) {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -52,7 +52,7 @@ const createDefaultForm = useCallback((campaign) => {
     token: "",
     characterName: "",
     campaign: campaign.toString(),
-    occupation: [""],
+    occupation: [],
     race: null,
     background: null,
     feat: [],


### PR DESCRIPTION
## Summary
- Skip non-object occupation entries and support multiple name keys when loading class features
- Initialize Zombies character occupation as an empty array

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda456529c832eb27bdea6928e1da9