### PR TITLE
Add skill descriptions and info modal for skills

### DIFF
--- a/client/src/components/Zombies/attributes/SkillInfoModal.js
+++ b/client/src/components/Zombies/attributes/SkillInfoModal.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { Modal, Card, Button } from "react-bootstrap";
+import { SKILLS } from "../skillSchema";
+
+export default function SkillInfoModal({ show, onHide, skillKey }) {
+  if (!skillKey) return null;
+
+  const skillInfo = SKILLS.find((s) => s.key === skillKey) || {};
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      centered
+      className="dnd-modal modern-modal"
+    >
+      <div className="text-center">
+        <Card className="modern-card">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">{skillInfo.label}</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <p>{skillInfo.description}</p>
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={onHide}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 
 import { SKILLS } from '../skillSchema';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
+import SkillInfoModal from './SkillInfoModal';
 
 export default function Skills({
   form,
@@ -22,6 +23,8 @@ export default function Skills({
   const params = useParams();
   const [skills, setSkills] = useState(form.skills || {});
   const [error, setError] = useState('');
+  const [showSkillInfo, setShowSkillInfo] = useState(false);
+  const [selectedSkill, setSelectedSkill] = useState(null);
   const raceProficiencies = useMemo(() => {
     return new Set(
       Object.entries(form.race?.skills || {})
@@ -201,108 +204,134 @@ export default function Skills({
     updateSkill(skill, updated);
   };
 
+  const handleView = (skill) => {
+    setSelectedSkill(skill);
+    setShowSkillInfo(true);
+  };
+
+  const handleCloseSkillInfo = () => {
+    setShowSkillInfo(false);
+  };
+
   return (
-    <Modal
-      className="dnd-modal modern-modal"
-      show={showSkill}
-      onHide={handleCloseSkill}
-      size="lg"
-      scrollable
-      centered
-    >
-      <Card className="modern-card text-center">
-        <Card.Header className="modal-header">
-          <Card.Title className="modal-title">Skills</Card.Title>
-        </Card.Header>
-        <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-          {error && (
-            <Alert variant="danger" onClose={() => setError('')} dismissible>
-              {error}
-            </Alert>
-          )}
-          <div className="points-container" style={{ display: 'flex' }}>
-            <span className="points-label text-light">Points Left:</span>
-            <span className="points-value">{proficiencyPointsLeft}</span>
-          </div>
-          <div className="points-container" style={{ display: 'flex' }}>
-            <span className="points-label text-light">Expertise Left:</span>
-            <span className="points-value">{expertisePointsLeft}</span>
-          </div>
-          <Table striped bordered hover size="sm" className="modern-table">
-            <thead>
-              <tr>
-                <th>Skill</th>
-                <th>Total</th>
-                <th>Mod</th>
-                <th>Prof</th>
-                <th>Exp</th>
-              </tr>
-            </thead>
-            <tbody>
-              {SKILLS.map(({
-                key,
-                label,
-                ability,
-                armorPenalty = 0,
-              }) => {
-                const { proficient = false, expertise = false } =
-                  skills[key] || {};
-                const penalty = armorPenalty
-                  ? armorPenalty * totalCheckPenalty
-                  : 0;
-                const multiplier = expertise ? 2 : proficient ? 1 : 0;
-                const total =
-                  modMap[ability] +
-                  profBonus * multiplier +
-                  penalty +
-                  itemTotals[key] +
-                  featTotals[key] +
-                  raceTotals[key];
-                const isSelectable = selectableSkills.has(key);
-                const isRaceSkill = raceProficiencies.has(key);
-                const isBackgroundSkill = backgroundProficiencies.has(key);
-                return (
-                  <tr key={key}>
-                    <td>{label}</td>
-                    <td>{total}</td>
-                    <td>{modMap[ability]}</td>
-                    <td>
-                      <Form.Check
-                        className="skill-checkbox"
-                        type="checkbox"
-                        checked={proficient}
-                        disabled={!isSelectable || isRaceSkill || isBackgroundSkill}
-                        onChange={() => toggleProficient(key)}
-                      />
-                    </td>
-                    <td>
-                      <Form.Check
-                        className="skill-checkbox"
-                        type="checkbox"
-                        checked={expertise}
-                        disabled={
-                          !proficient ||
-                          !selectableExpertise.has(key) ||
-                          lockedExpertise.has(key) ||
-                          (!expertise && expertisePointsLeft <= 0)
-                        }
-                        onChange={() => toggleExpertise(key)}
-                      />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </Table>
-        </Card.Body>
-        <Card.Footer className="modal-footer d-flex">
-          <Button
-            onClick={() => handleCloseSkill()}
-            className="action-btn close-btn flex-fill"
-          >Close</Button>
-        </Card.Footer>
-      </Card>
-    </Modal>
+    <>
+      <Modal
+        className="dnd-modal modern-modal"
+        show={showSkill}
+        onHide={handleCloseSkill}
+        size="lg"
+        scrollable
+        centered
+      >
+        <Card className="modern-card text-center">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Skills</Card.Title>
+          </Card.Header>
+          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+            {error && (
+              <Alert variant="danger" onClose={() => setError('')} dismissible>
+                {error}
+              </Alert>
+            )}
+            <div className="points-container" style={{ display: 'flex' }}>
+              <span className="points-label text-light">Points Left:</span>
+              <span className="points-value">{proficiencyPointsLeft}</span>
+            </div>
+            <div className="points-container" style={{ display: 'flex' }}>
+              <span className="points-label text-light">Expertise Left:</span>
+              <span className="points-value">{expertisePointsLeft}</span>
+            </div>
+            <Table striped bordered hover size="sm" className="modern-table">
+              <thead>
+                <tr>
+                  <th>Skill</th>
+                  <th>View</th>
+                  <th>Total</th>
+                  <th>Mod</th>
+                  <th>Prof</th>
+                  <th>Exp</th>
+                </tr>
+              </thead>
+              <tbody>
+                {SKILLS.map(({
+                  key,
+                  label,
+                  ability,
+                  armorPenalty = 0,
+                }) => {
+                  const { proficient = false, expertise = false } =
+                    skills[key] || {};
+                  const penalty = armorPenalty
+                    ? armorPenalty * totalCheckPenalty
+                    : 0;
+                  const multiplier = expertise ? 2 : proficient ? 1 : 0;
+                  const total =
+                    modMap[ability] +
+                    profBonus * multiplier +
+                    penalty +
+                    itemTotals[key] +
+                    featTotals[key] +
+                    raceTotals[key];
+                  const isSelectable = selectableSkills.has(key);
+                  const isRaceSkill = raceProficiencies.has(key);
+                  const isBackgroundSkill = backgroundProficiencies.has(key);
+                  return (
+                    <tr key={key}>
+                      <td>{label}</td>
+                      <td>
+                        <Button
+                          onClick={() => handleView(key)}
+                          variant="link"
+                          aria-label="view"
+                        >
+                          <i className="fa-solid fa-eye"></i>
+                        </Button>
+                      </td>
+                      <td>{total}</td>
+                      <td>{modMap[ability]}</td>
+                      <td>
+                        <Form.Check
+                          className="skill-checkbox"
+                          type="checkbox"
+                          checked={proficient}
+                          disabled={!isSelectable || isRaceSkill || isBackgroundSkill}
+                          onChange={() => toggleProficient(key)}
+                        />
+                      </td>
+                      <td>
+                        <Form.Check
+                          className="skill-checkbox"
+                          type="checkbox"
+                          checked={expertise}
+                          disabled={
+                            !proficient ||
+                            !selectableExpertise.has(key) ||
+                            lockedExpertise.has(key) ||
+                            (!expertise && expertisePointsLeft <= 0)
+                          }
+                          onChange={() => toggleExpertise(key)}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </Table>
+          </Card.Body>
+          <Card.Footer className="modal-footer d-flex">
+            <Button
+              onClick={() => handleCloseSkill()}
+              className="action-btn close-btn flex-fill"
+            >Close</Button>
+          </Card.Footer>
+        </Card>
+      </Modal>
+      <SkillInfoModal
+        show={showSkillInfo}
+        onHide={handleCloseSkillInfo}
+        skillKey={selectedSkill}
+      />
+    </>
   );
 }
 

--- a/client/src/components/Zombies/skillSchema.js
+++ b/client/src/components/Zombies/skillSchema.js
@@ -1,22 +1,170 @@
 export const SKILLS = [
-  { key: 'acrobatics', label: 'Acrobatics', ability: 'dex', itemBonusIndex: 8, armorPenalty: 1, proficient: false, expertise: false },
-  { key: 'animalHandling', label: 'Animal Handling', ability: 'wis', itemBonusIndex: 9, proficient: false, expertise: false },
-  { key: 'arcana', label: 'Arcana', ability: 'int', itemBonusIndex: 10, proficient: false, expertise: false },
-  { key: 'athletics', label: 'Athletics', ability: 'str', itemBonusIndex: 11, armorPenalty: 1, proficient: false, expertise: false },
-  { key: 'deception', label: 'Deception', ability: 'cha', itemBonusIndex: 12, proficient: false, expertise: false },
-  { key: 'history', label: 'History', ability: 'int', itemBonusIndex: 13, proficient: false, expertise: false },
-  { key: 'insight', label: 'Insight', ability: 'wis', itemBonusIndex: 14, proficient: false, expertise: false },
-  { key: 'intimidation', label: 'Intimidation', ability: 'cha', itemBonusIndex: 15, proficient: false, expertise: false },
-  { key: 'investigation', label: 'Investigation', ability: 'int', itemBonusIndex: 16, proficient: false, expertise: false },
-  { key: 'medicine', label: 'Medicine', ability: 'wis', itemBonusIndex: 17, proficient: false, expertise: false },
-  { key: 'nature', label: 'Nature', ability: 'int', itemBonusIndex: 18, proficient: false, expertise: false },
-  { key: 'perception', label: 'Perception', ability: 'wis', itemBonusIndex: 19, proficient: false, expertise: false },
-  { key: 'performance', label: 'Performance', ability: 'cha', itemBonusIndex: 20, proficient: false, expertise: false },
-  { key: 'persuasion', label: 'Persuasion', ability: 'cha', itemBonusIndex: 21, proficient: false, expertise: false },
-  { key: 'religion', label: 'Religion', ability: 'int', itemBonusIndex: 22, proficient: false, expertise: false },
-  { key: 'sleightOfHand', label: 'Sleight of Hand', ability: 'dex', itemBonusIndex: 23, armorPenalty: 1, proficient: false, expertise: false },
-  { key: 'stealth', label: 'Stealth', ability: 'dex', itemBonusIndex: 24, armorPenalty: 1, proficient: false, expertise: false },
-  { key: 'survival', label: 'Survival', ability: 'wis', itemBonusIndex: 25, proficient: false, expertise: false },
+  {
+    key: 'acrobatics',
+    label: 'Acrobatics',
+    ability: 'dex',
+    itemBonusIndex: 8,
+    armorPenalty: 1,
+    proficient: false,
+    expertise: false,
+    description: 'Performing acrobatic stunts, maintaining balance, and escaping bonds.'
+  },
+  {
+    key: 'animalHandling',
+    label: 'Animal Handling',
+    ability: 'wis',
+    itemBonusIndex: 9,
+    proficient: false,
+    expertise: false,
+    description: 'Calming animals, intuiting their intentions, and training them.'
+  },
+  {
+    key: 'arcana',
+    label: 'Arcana',
+    ability: 'int',
+    itemBonusIndex: 10,
+    proficient: false,
+    expertise: false,
+    description: 'Knowledge about magical lore, spells, and artifacts.'
+  },
+  {
+    key: 'athletics',
+    label: 'Athletics',
+    ability: 'str',
+    itemBonusIndex: 11,
+    armorPenalty: 1,
+    proficient: false,
+    expertise: false,
+    description: 'Physical feats of strength such as climbing, jumping, or swimming.'
+  },
+  {
+    key: 'deception',
+    label: 'Deception',
+    ability: 'cha',
+    itemBonusIndex: 12,
+    proficient: false,
+    expertise: false,
+    description: 'Concealing the truth through lies, feints, and trickery.'
+  },
+  {
+    key: 'history',
+    label: 'History',
+    ability: 'int',
+    itemBonusIndex: 13,
+    proficient: false,
+    expertise: false,
+    description: 'Recall of historical events, legendary people, and ancient civilizations.'
+  },
+  {
+    key: 'insight',
+    label: 'Insight',
+    ability: 'wis',
+    itemBonusIndex: 14,
+    proficient: false,
+    expertise: false,
+    description: 'Reading body language, motives, and intentions.'
+  },
+  {
+    key: 'intimidation',
+    label: 'Intimidation',
+    ability: 'cha',
+    itemBonusIndex: 15,
+    proficient: false,
+    expertise: false,
+    description: 'Influencing others through threats, hostile actions, and fear.'
+  },
+  {
+    key: 'investigation',
+    label: 'Investigation',
+    ability: 'int',
+    itemBonusIndex: 16,
+    proficient: false,
+    expertise: false,
+    description: 'Searching for clues and making deductions.'
+  },
+  {
+    key: 'medicine',
+    label: 'Medicine',
+    ability: 'wis',
+    itemBonusIndex: 17,
+    proficient: false,
+    expertise: false,
+    description: 'Stabilizing the dying, diagnosing illnesses, and treating wounds.'
+  },
+  {
+    key: 'nature',
+    label: 'Nature',
+    ability: 'int',
+    itemBonusIndex: 18,
+    proficient: false,
+    expertise: false,
+    description: 'Knowledge of terrain, plants, animals, weather, and natural cycles.'
+  },
+  {
+    key: 'perception',
+    label: 'Perception',
+    ability: 'wis',
+    itemBonusIndex: 19,
+    proficient: false,
+    expertise: false,
+    description: 'Noticing clues, spotting hidden objects, and detecting danger.'
+  },
+  {
+    key: 'performance',
+    label: 'Performance',
+    ability: 'cha',
+    itemBonusIndex: 20,
+    proficient: false,
+    expertise: false,
+    description: 'Entertaining audiences through music, dance, or acting.'
+  },
+  {
+    key: 'persuasion',
+    label: 'Persuasion',
+    ability: 'cha',
+    itemBonusIndex: 21,
+    proficient: false,
+    expertise: false,
+    description: 'Influencing others with tact, diplomacy, and social grace.'
+  },
+  {
+    key: 'religion',
+    label: 'Religion',
+    ability: 'int',
+    itemBonusIndex: 22,
+    proficient: false,
+    expertise: false,
+    description: 'Knowledge of deities, rites, prayers, and religious hierarchies.'
+  },
+  {
+    key: 'sleightOfHand',
+    label: 'Sleight of Hand',
+    ability: 'dex',
+    itemBonusIndex: 23,
+    armorPenalty: 1,
+    proficient: false,
+    expertise: false,
+    description: 'Picking pockets, palming objects, and performing delicate tricks.'
+  },
+  {
+    key: 'stealth',
+    label: 'Stealth',
+    ability: 'dex',
+    itemBonusIndex: 24,
+    armorPenalty: 1,
+    proficient: false,
+    expertise: false,
+    description: 'Concealing yourself from enemies and moving silently.'
+  },
+  {
+    key: 'survival',
+    label: 'Survival',
+    ability: 'wis',
+    itemBonusIndex: 25,
+    proficient: false,
+    expertise: false,
+    description: 'Tracking, hunting, and navigating the wilderness.'
+  }
 ];
 
 export default SKILLS;


### PR DESCRIPTION
## Summary
- document each skill with description metadata
- add SkillInfoModal to show details for a selected skill
- wire up Skills table with view column and modal state

## Testing
- `npm --prefix client test` *(fails: Feats test not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_e_68bda7485abc8323a4bcd1fb34cea58a