### PR TITLE
Expose damage animation handler for skill rolls

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useImperativeHandle } from 'react';
 import { Button, Modal, Card, Table } from "react-bootstrap";
 import sword from "../../../images/sword.png";
 
@@ -51,7 +51,7 @@ export function calculateDamage(damageString, ability = 0, crit = false, roll = 
   return damageSum + modifier + ability;
 }
 
-export default function PlayerTurnActions ({ form, strMod, atkBonus, dexMod, headerHeight = 0 }) {
+const PlayerTurnActions = React.forwardRef(({ form, strMod, atkBonus, dexMod, headerHeight = 0 }, ref) => {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
@@ -131,6 +131,8 @@ const updateDamageValueWithAnimation = (newValue) => {
   setLoading(true);
   setDamageValue(newValue);
 };
+
+useImperativeHandle(ref, () => ({ updateDamageValueWithAnimation }));
 
 const [pulse, setPulse] = useState(false);
 
@@ -364,4 +366,6 @@ const showSparklesEffect = () => {
       </Modal>
     </div>
   );
-};
+});
+
+export default PlayerTurnActions;

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -20,6 +20,7 @@ export default function Skills({
   chaMod,
   wisMod,
   onSkillsChange,
+  onRollResult,
 }) {
   const params = useParams();
   const [skills, setSkills] = useState(form.skills || {});
@@ -220,6 +221,7 @@ export default function Skills({
     const result = d20 + bonus;
     const label = skill?.label || skillKey;
     notify(`${label}: d20 (${d20}) + bonus (${bonus}) = ${result}`, 'success');
+    onRollResult?.(result);
   };
 
   const handleView = (skill) => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -38,6 +38,8 @@ export default function ZombiesCharacterSheet() {
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showBackground, setShowBackground] = useState(false);
 
+  const playerTurnActionsRef = useRef(null);
+
   const headerRef = useRef(null);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [navHeight, setNavHeight] = useState(0);
@@ -122,6 +124,10 @@ export default function ZombiesCharacterSheet() {
   const handleCloseHelpModal = () => setShowHelpModal(false);
   const handleShowBackground = () => setShowBackground(true);
   const handleCloseBackground = () => setShowBackground(false);
+
+  const handleRollResult = (result) => {
+    playerTurnActionsRef.current?.updateDamageValueWithAnimation(result);
+  };
 
   const handleWeaponsChange = useCallback(
     async (weapons) => {
@@ -309,6 +315,7 @@ return (
       dexMod={statMods.dex}
       strMod={statMods.str}
       headerHeight={headerHeight}
+      ref={playerTurnActionsRef}
     />
     <Navbar
       fixed="bottom"
@@ -441,6 +448,7 @@ return (
       chaMod={statMods.cha}
       wisMod={statMods.wis}
       onSkillsChange={(skills) => setForm((prev) => ({ ...prev, skills }))}
+      onRollResult={handleRollResult}
     />
     <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
     <BackgroundModal


### PR DESCRIPTION
## Summary
- expose `updateDamageValueWithAnimation` from `PlayerTurnActions` using `forwardRef`
- wire handler through `ZombiesCharacterSheet` and into `Skills`
- trigger damage animation when a skill roll resolves

## Testing
- `CI=true npm test` *(fails: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdad949fc883238d07450d7394b6ca