### PR TITLE
Close skill modal after roll

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -220,6 +220,7 @@ export default function Skills({
     const result = d20 + bonus;
     const label = skill?.label || skillKey;
     notify(`${label}: d20 (${d20}) + bonus (${bonus}) = ${result}`, 'success');
+    handleCloseSkill?.();
   };
 
   const handleView = (skill) => {


### PR DESCRIPTION
## Summary
- Close Skills modal when a roll finishes

## Testing
- `CI=true npm test` *(fails: Test Suites: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdad8298e4832383d1e2aa82978562