### PR TITLE
Close skill modal after roll

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -134,6 +134,18 @@ const updateDamageValueWithAnimation = (newValue) => {
 
 const [pulse, setPulse] = useState(false);
 
+// Allow other components to display values in the damage circle
+useEffect(() => {
+  const handler = (e) => {
+    const value = Number(e.detail);
+    if (!Number.isNaN(value)) {
+      updateDamageValueWithAnimation(value);
+    }
+  };
+  window.addEventListener('damage-roll', handler);
+  return () => window.removeEventListener('damage-roll', handler);
+}, []);
+
 useEffect(() => {
   if (!loading) {
     setPulse(true);

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -220,6 +220,8 @@ export default function Skills({
     const result = d20 + bonus;
     const label = skill?.label || skillKey;
     notify(`${label}: d20 (${d20}) + bonus (${bonus}) = ${result}`, 'success');
+    window.dispatchEvent(new CustomEvent('damage-roll', { detail: result }));
+    handleCloseSkill?.();
   };
 
   const handleView = (skill) => {


### PR DESCRIPTION
## Summary
- Close Skills modal when a roll finishes
- Show skill roll result in damage display

## Testing
- `CI=true npm test` *(fails: Test Suites: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdad8298e4832383d1e2aa82978562