### PR TITLE
Remove notify call from zombie skills

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -6,7 +6,6 @@ import { useParams } from 'react-router-dom';
 import { SKILLS } from '../skillSchema';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import SkillInfoModal from './SkillInfoModal';
-import { notify } from '../../../utils/notification';
 
 export default function Skills({
   form,
@@ -219,8 +218,6 @@ export default function Skills({
       featTotals[skillKey] +
       raceTotals[skillKey];
     const result = d20 + bonus;
-    const label = skill?.label || skillKey;
-    notify(`${label}: d20 (${d20}) + bonus (${bonus}) = ${result}`, 'success');
     window.dispatchEvent(new CustomEvent('damage-roll', { detail: result }));
 
     handleCloseSkill?.();


### PR DESCRIPTION
## Summary
- remove unused notification import and call in zombie skills roll handler

## Testing
- `CI=true npm test` *(fails: npm not found; attempted apt-get update but repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb58b6a988323896c6efa7e74024a