### PR TITLE
Enable fade animations for feature modals

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -12,7 +12,6 @@ export default function FeatureModal({ show, onHide, feature }) {
       onHide={onHide}
       centered
       className="dnd-modal modern-modal"
-      animation={false}
     >
       <div className="text-center">
         <Card className="modern-card">

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -52,7 +52,6 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
         onHide={handleCloseFeatures}
         size="lg"
         centered
-        animation={false}
       >
         <div className="text-center">
           <Card className="modern-card">


### PR DESCRIPTION
## Summary
- Remove animation override on feature listing modal
- Remove animation override on feature details modal

## Testing
- `CI=true npm test` *(fails: Test Suites: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb93f4008832e8e6b762a83aa60fc