### PR TITLE
Adjust spellcaster progression calculations

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -61,6 +61,7 @@ export default function CharacterInfo({ form, show, handleClose, onShowBackgroun
                   <Button
                     onClick={onShowBackground}
                     variant="link"
+                    aria-label="Show Background"
                   >
                     <i className="fa-solid fa-eye"></i>
                   </Button>

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -57,6 +57,16 @@ const CANTRIP_TABLE = {
   20: 5,
 };
 
+const SPELLCASTING_CLASSES = {
+  bard: 'full',
+  cleric: 'full',
+  druid: 'full',
+  sorcerer: 'full',
+  wizard: 'full',
+  paladin: 'half',
+  ranger: 'half',
+};
+
 export default function SpellSelector({
   form,
   show,
@@ -80,15 +90,14 @@ export default function SpellSelector({
       .map((o) => {
         const name = o.Name || o.Occupation;
         const level = Number(o.Level) || 0;
-        const casterProgression = o.casterProgression || o.CasterProgression || 'full';
-        const effectiveLevel =
-          casterProgression === 'half'
-            ? level < 2
-              ? 0
-              : Math.ceil(level / 2)
-            : casterProgression === 'full'
-            ? level
-            : 0;
+        const key = (name || '').toLowerCase();
+        const casterProgression = SPELLCASTING_CLASSES[key] || 'none';
+        let effectiveLevel = 0;
+        if (casterProgression === 'full') {
+          effectiveLevel = level;
+        } else if (casterProgression === 'half') {
+          effectiveLevel = level === 1 ? 0 : Math.ceil(level / 2);
+        }
         return { name, level, casterProgression, effectiveLevel };
       })
       .filter((o) => o.effectiveLevel >= 1);
@@ -246,7 +255,9 @@ export default function SpellSelector({
           </Card.Header>
           <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
             {error && <div className="text-danger mb-2">{error}</div>}
-            {classesInfo.length === 1 ? (
+            {classesInfo.length === 0 ? (
+              <div className="text-light">No spellcasting classes available.</div>
+            ) : classesInfo.length === 1 ? (
               (() => {
                 const cls = classesInfo[0].name;
                 return (

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -40,7 +40,10 @@ test('filters spells by level', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => spellsData });
   render(
     <SpellSelector
-      form={{ occupation: [{ Name: 'Wizard', Level: 5 }], spells: [] }}
+      form={{
+        occupation: [{ Name: 'Wizard', Level: 5, casterProgression: 'full' }],
+        spells: [],
+      }}
       show={true}
       handleClose={() => {}}
     />
@@ -58,7 +61,10 @@ test('saves selected spells', async () => {
   const onChange = jest.fn();
   render(
     <SpellSelector
-      form={{ occupation: [{ Name: 'Wizard', Level: 5 }], spells: [] }}
+      form={{
+        occupation: [{ Name: 'Wizard', Level: 5, casterProgression: 'full' }],
+        spells: [],
+      }}
       show={true}
       handleClose={() => {}}
       onSpellsChange={onChange}
@@ -108,7 +114,12 @@ test('uses Occupation when Name is missing', async () => {
   const onChange = jest.fn();
   render(
     <SpellSelector
-      form={{ occupation: [{ Occupation: 'Wizard', Level: 5 }], spells: [] }}
+      form={{
+        occupation: [
+          { Occupation: 'Wizard', Level: 5, casterProgression: 'full' },
+        ],
+        spells: [],
+      }}
       show={true}
       handleClose={() => {}}
       onSpellsChange={onChange}
@@ -156,8 +167,8 @@ test('renders tabs for multiple classes', async () => {
     <SpellSelector
       form={{
         occupation: [
-          { Name: 'Wizard', Level: 5 },
-          { Name: 'Cleric', Level: 5 },
+          { Name: 'Wizard', Level: 5, casterProgression: 'full' },
+          { Name: 'Cleric', Level: 5, casterProgression: 'full' },
         ],
         spells: [],
       }}
@@ -228,4 +239,19 @@ test('level 1 half-caster has no spell slots', async () => {
   await waitFor(() => {
     expect(screen.queryByLabelText('Level')).toBeNull();
   });
+  expect(
+    screen.getByText(/no spellcasting classes available/i)
+  ).toBeInTheDocument();
+});
+
+test('warlock is not treated as a spellcasting class', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => spellsData });
+  render(
+    <SpellSelector
+      form={{ occupation: [{ Name: 'Warlock', Level: 5 }], spells: [] }}
+      show={true}
+      handleClose={() => {}}
+    />
+  );
+  await screen.findByText(/no spellcasting classes available/i);
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -21,6 +21,15 @@ import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
 
 const HEADER_PADDING = 16;
+const SPELLCASTING_CLASSES = {
+  bard: 'full',
+  cleric: 'full',
+  druid: 'full',
+  sorcerer: 'full',
+  wizard: 'full',
+  paladin: 'half',
+  ranger: 'half',
+};
 
 export default function ZombiesCharacterSheet() {
   const params = useParams();
@@ -244,8 +253,10 @@ const featBonuses = (form.feat || []).reduce(
 const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
 const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
 const hasSpellcasting = (form.occupation || []).some((cls) => {
-  const progression = cls.casterProgression || 'none';
+  const name = (cls.Name || cls.Occupation || '').toLowerCase();
+  const progression = SPELLCASTING_CLASSES[name];
   const level = Number(cls.Level) || 0;
+  if (!progression) return false;
   if (progression === 'full') return level >= 1;
   if (progression === 'half') return level >= 2;
   return false;


### PR DESCRIPTION
## Summary
- Default unknown caster progression to `none`
- Count only full and half caster levels toward spell slots and handle level 1 half casters
- Indicate when no spellcasting classes are available
- Label background view button for accessibility
- Detect spellcasting classes by name to show spell icon and ignore Warlocks

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbfaaa32c8323b376c813848fdb43