### PR TITLE
Restrict cantrip options to full casters

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -75,10 +75,14 @@ export default function SpellSelector({
 }) {
   const params = useParams();
 
-  const getAvailableLevels = useCallback((effectiveLevel) => {
+  const getAvailableLevels = useCallback((effectiveLevel, casterProgression) => {
     const slotRow = SLOT_TABLE[effectiveLevel] || [];
     const options = [];
-    if ((CANTRIP_TABLE[effectiveLevel] || 0) > 0) options.push(0);
+    if (
+      casterProgression === 'full' &&
+      (CANTRIP_TABLE[effectiveLevel] || 0) > 0
+    )
+      options.push(0);
     slotRow.forEach((slots, lvl) => {
       if (lvl > 0 && slots > 0) options.push(lvl);
     });
@@ -105,8 +109,8 @@ export default function SpellSelector({
 
   const levelOptions = useMemo(
     () =>
-      classesInfo.reduce((acc, { name, effectiveLevel }) => {
-        acc[name] = getAvailableLevels(effectiveLevel);
+      classesInfo.reduce((acc, { name, effectiveLevel, casterProgression }) => {
+        acc[name] = getAvailableLevels(effectiveLevel, casterProgression);
         return acc;
       }, {}),
     [classesInfo, getAvailableLevels]

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -205,7 +205,7 @@ test('renders tabs for multiple classes', async () => {
 });
 
 test.each(['Paladin', 'Ranger'])(
-  '5th-level %s gains 2nd-level slots',
+  '5th-level %s gains 2nd-level slots without cantrips',
   async (cls) => {
     apiFetch.mockResolvedValueOnce({ ok: true, json: async () => spellsData });
     render(
@@ -221,8 +221,26 @@ test.each(['Paladin', 'Ranger'])(
     const select = await screen.findByLabelText('Level');
     const options = Array.from(select.options).map((o) => o.value);
     expect(options).toContain('2');
+    expect(options).not.toContain('0');
   }
 );
+
+test('full casters include level 0 options', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => spellsData });
+  render(
+    <SpellSelector
+      form={{
+        occupation: [{ Name: 'Wizard', Level: 5, casterProgression: 'full' }],
+        spells: [],
+      }}
+      show={true}
+      handleClose={() => {}}
+    />
+  );
+  const select = await screen.findByLabelText('Level');
+  const options = Array.from(select.options).map((o) => o.value);
+  expect(options).toContain('0');
+});
 
 test('level 1 half-caster has no spell slots', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => spellsData });


### PR DESCRIPTION
## Summary
- adjust spell level availability to consider each class's caster progression
- ensure only full casters receive cantrip (level 0) options
- add tests validating cantrip availability for full and half casters

## Testing
- `CI=true npm test -- client/src/components/Zombies/attributes/SpellSelector.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bdc98c503c8323b4a042a50d5f85cc