### PR TITLE
test: verify critical roll events

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -143,9 +143,28 @@ useEffect(() => {
     if (!Number.isNaN(value)) {
       updateDamageValueWithAnimation(value);
     }
+    damageRef.current?.classList.remove('critical-active');
+    damageRef.current?.classList.remove('critical-failure');
   };
   window.addEventListener('damage-roll', handler);
   return () => window.removeEventListener('damage-roll', handler);
+}, []);
+
+useEffect(() => {
+  const critHandler = () => {
+    damageRef.current?.classList.add('critical-active');
+    damageRef.current?.classList.remove('critical-failure');
+  };
+  const fumbleHandler = () => {
+    damageRef.current?.classList.add('critical-failure');
+    damageRef.current?.classList.remove('critical-active');
+  };
+  window.addEventListener('critical-hit', critHandler);
+  window.addEventListener('critical-failure', fumbleHandler);
+  return () => {
+    window.removeEventListener('critical-hit', critHandler);
+    window.removeEventListener('critical-failure', fumbleHandler);
+  };
 }, []);
 
 useEffect(() => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,4 +1,6 @@
-import { calculateDamage } from './PlayerTurnActions';
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import PlayerTurnActions, { calculateDamage } from './PlayerTurnActions';
 
 describe('calculateDamage parser', () => {
   const fixedRoll = (count, sides) => Array(count).fill(1);
@@ -35,5 +37,38 @@ describe('calculateDamage parser', () => {
 
   test('flat damage ignores crit flag', () => {
     expect(calculateDamage('100', 0, true, fixedRoll)).toBe(100);
+  });
+});
+
+describe('PlayerTurnActions critical events', () => {
+  test('critical events toggle classes on damageAmount', () => {
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [] }}
+        strMod={0}
+        atkBonus={0}
+        dexMod={0}
+      />
+    );
+
+    const damage = document.getElementById('damageAmount');
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('critical-hit', { detail: 'critical' }));
+    });
+    expect(damage.classList.contains('critical-active')).toBe(true);
+    expect(damage.classList.contains('critical-failure')).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('critical-failure', { detail: 'fumble' }));
+    });
+    expect(damage.classList.contains('critical-active')).toBe(false);
+    expect(damage.classList.contains('critical-failure')).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('damage-roll', { detail: 5 }));
+    });
+    expect(damage.classList.contains('critical-active')).toBe(false);
+    expect(damage.classList.contains('critical-failure')).toBe(false);
   });
 });

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -7,6 +7,16 @@ import { SKILLS } from '../skillSchema';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import SkillInfoModal from './SkillInfoModal';
 
+export function rollSkill(bonus = 0) {
+  const d20 = Math.floor(Math.random() * 20) + 1;
+  if (d20 === 20) {
+    window.dispatchEvent(new CustomEvent('critical-hit', { detail: 'critical' }));
+  } else if (d20 === 1) {
+    window.dispatchEvent(new CustomEvent('critical-failure', { detail: 'fumble' }));
+  }
+  return d20 + bonus;
+}
+
 export default function Skills({
   form,
   showSkill,
@@ -206,7 +216,6 @@ export default function Skills({
   };
 
   const handleRoll = (skillKey, ability, proficient, expertise) => {
-    const d20 = Math.floor(Math.random() * 20) + 1;
     const skill = SKILLS.find((s) => s.key === skillKey);
     const armorPenalty = skill?.armorPenalty || 0;
     const penalty = armorPenalty ? armorPenalty * totalCheckPenalty : 0;
@@ -217,7 +226,7 @@ export default function Skills({
       itemTotals[skillKey] +
       featTotals[skillKey] +
       raceTotals[skillKey];
-    const result = d20 + bonus;
+    const result = rollSkill(bonus);
     window.dispatchEvent(new CustomEvent('damage-roll', { detail: result }));
 
     handleCloseSkill?.();

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -1,0 +1,27 @@
+import { rollSkill } from './Skills';
+
+describe('rollSkill critical and fumble events', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('dispatches critical event on natural 20', () => {
+    const listener = jest.fn();
+    window.addEventListener('critical-hit', listener);
+    jest.spyOn(Math, 'random').mockReturnValue(0.95); // yields 20
+    rollSkill(0);
+    expect(listener).toHaveBeenCalled();
+    expect(listener.mock.calls[0][0].detail).toContain('critical');
+    window.removeEventListener('critical-hit', listener);
+  });
+
+  test('dispatches fumble event on natural 1', () => {
+    const listener = jest.fn();
+    window.addEventListener('critical-failure', listener);
+    jest.spyOn(Math, 'random').mockReturnValue(0); // yields 1
+    rollSkill(0);
+    expect(listener).toHaveBeenCalled();
+    expect(listener.mock.calls[0][0].detail).toContain('fumble');
+    window.removeEventListener('critical-failure', listener);
+  });
+});


### PR DESCRIPTION
## Summary
- dispatch `critical-hit`/`critical-failure` events when skills roll natural 20 or 1
- toggle damage circle classes in PlayerTurnActions on critical events
- add tests for critical and fumble event dispatch and class toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd21ab9888323bd1d8bb83d1d74df