### PR TITLE
feat: add paladin spells known helper

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -139,6 +139,20 @@ export default function SpellSelector({
   const [viewSpell, setViewSpell] = useState(null);
   const [spellsKnown, setSpellsKnown] = useState({});
 
+  const chaMod = useMemo(() => {
+    const itemBonus = (form.item || []).reduce(
+      (sum, el) => sum + Number(el[7] || 0),
+      0
+    );
+    const featBonus = (form.feat || []).reduce(
+      (sum, el) => sum + Number(el.cha || 0),
+      0
+    );
+    const raceBonus = form.race?.abilities?.cha || 0;
+    const computed = (form.cha || 0) + itemBonus + featBonus + raceBonus;
+    return Math.floor((computed - 10) / 2);
+  }, [form.cha, form.item, form.feat, form.race]);
+
   useEffect(() => {
     apiFetch('/spells')
       .then((res) => res.json())
@@ -164,7 +178,7 @@ export default function SpellSelector({
         classesInfo.map(async ({ name, level }) => {
           try {
             const res = await apiFetch(
-              `/classes/${name.toLowerCase()}/features/${level}`
+              `/classes/${name.toLowerCase()}/features/${level}?chaMod=${chaMod}`
             );
             if (res.ok) {
               const data = await res.json();
@@ -180,7 +194,7 @@ export default function SpellSelector({
       setSpellsKnown(result);
     };
     fetchSpellsKnown();
-  }, [classesInfo]);
+  }, [classesInfo, chaMod]);
 
   function spellsForClass(cls) {
     return Object.values(allSpells).filter(

--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -7,7 +7,9 @@
  * @typedef {{
  *   featuresByLevel: Record<number, Feature[]>,
  *   spellSlots?: Record<number, Record<number, number>>,
- *   spellsKnown?: Record<number, number>,
+ *   spellsKnown?:
+ *     | Record<number, number>
+ *     | ((level: number, chaMod: number) => number),
  *   pactMagic?: Record<number, Record<number, number>>
  * }} ClassFeatures
  * @type {Record<string, ClassFeatures>}
@@ -87,10 +89,13 @@ const pactMagic = {
  17: { 5: 4 },
  18: { 5: 4 },
  19: { 5: 4 },
- 20: { 5: 4 }
+  20: { 5: 4 }
 };
 
 // Spells known tables
+function paladinSpellsKnown(level, chaMod) {
+  return Math.max(1, Math.floor(level / 2) + chaMod);
+}
 const bardSpellsKnown = {
   1: 4,
   2: 5,
@@ -1464,7 +1469,8 @@ const classFeatures = {
   monk: { featuresByLevel: monkFeatures },
   paladin: {
     featuresByLevel: paladinFeatures,
-    spellSlots: halfCasterSlots
+    spellSlots: halfCasterSlots,
+    spellsKnown: paladinSpellsKnown
   },
   ranger: {
     featuresByLevel: rangerFeatures,

--- a/server/routes/classes.js
+++ b/server/routes/classes.js
@@ -17,7 +17,13 @@ module.exports = (router) => {
     const level = Number(req.params.level);
     const features = cls.featuresByLevel?.[level];
     const spellSlots = cls.spellSlots?.[level];
-    const spellsKnown = cls.spellsKnown?.[level];
+    let spellsKnown;
+    if (typeof cls.spellsKnown === 'function') {
+      const chaMod = Number(req.query.chaMod) || 0;
+      spellsKnown = cls.spellsKnown(level, chaMod);
+    } else {
+      spellsKnown = cls.spellsKnown?.[level];
+    }
     const pactMagic = cls.pactMagic?.[level];
     if (!features && !spellSlots && spellsKnown == null && !pactMagic) {
       return res.status(404).json({ message: 'Level not found' });


### PR DESCRIPTION
## Summary
- add dynamic paladin spells known helper and expose in class features
- extend class features typing and server route to handle functions
- calculate Charisma modifier and pass to API when fetching spells known

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd6be7de0832e9838c41b9f8c96df