### PR TITLE
Add critical failure styling for damage indicator

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -320,6 +320,12 @@ $rotateX: -$angle;
   box-shadow: 0 0 10px #FFD700;
 }
 
+#damageAmount.critical-failure {
+  border: 2px solid #FF0000;
+  color: #FF0000;
+  box-shadow: 0 0 10px #FF0000;
+}
+
 #damageValue {
   padding-top: 5px;
   display: inline-block; /* Make the text an inline block */

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -137,7 +137,7 @@ useEffect(() => {
     if (!Number.isNaN(num)) {
       updateDamageValueWithAnimation(num);
     }
-    setIsCritical(!!critical);
+    setIsCritical(!!critical && !fumble);
     setIsFumble(!!fumble);
   };
   window.addEventListener('damage-roll', handler);


### PR DESCRIPTION
## Summary
- add red glow style for fumbled damage results
- ensure PlayerTurnActions applies the `critical-failure` class when fumble occurs

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdd922f5f88323b221bc5984037b2a