### PR TITLE
feat: add crit toggle for attacks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -240,7 +240,7 @@ const showSparklesEffect = () => {
           height: `calc(100vh - ${FOOTER_HEIGHT + headerHeight + damageHeight}px)`
         }}
       >
-        <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px', alignItems: 'center' }}>
           {/* Attack Button */}
           <button
             onClick={handleShowAttack}
@@ -255,10 +255,23 @@ const showSparklesEffect = () => {
               cursor: "pointer",
               backgroundColor: 'transparent',
             }}
-            onMouseEnter={(e) => e.currentTarget.style.transform = "scale(1.1)"}
-            onMouseLeave={(e) => e.currentTarget.style.transform = "scale(1)"}
+            onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.1)")}
+            onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
             title="Attack"
           />
+          {/* Critical hit toggle */}
+          <label style={{ marginLeft: '10px', display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={isCritical}
+              onChange={(e) => {
+                setIsCritical(e.target.checked);
+                if (e.target.checked) setIsFumble(false);
+              }}
+              aria-label="Crit"
+            />
+            <span style={{ marginLeft: '4px' }}>Crit</span>
+          </label>
         </div>
         <div
           style={{

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
 import PlayerTurnActions, { calculateDamage } from './PlayerTurnActions';
 
 describe('calculateDamage parser', () => {
@@ -80,5 +80,27 @@ describe('PlayerTurnActions critical events', () => {
     });
     expect(damage.classList.contains('critical-active')).toBe(false);
     expect(damage.classList.contains('critical-failure')).toBe(false);
+  });
+
+  test('crit toggle activates critical class', () => {
+    const { getByLabelText } = render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [] }}
+        strMod={0}
+        atkBonus={0}
+        dexMod={0}
+      />
+    );
+
+    const damage = document.getElementById('damageAmount');
+    const critToggle = getByLabelText('Crit');
+
+    expect(damage.classList.contains('critical-active')).toBe(false);
+
+    act(() => {
+      fireEvent.click(critToggle);
+    });
+
+    expect(damage.classList.contains('critical-active')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add Crit checkbox next to attack control to mark critical hits
- compute damage using critical toggle and reset critical/fumble flags after animations
- test Crit toggle activates critical-active damage state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bddb928bb08323bcae8c968faf4365