### PR TITLE
Add colored pulse animations for critical and fumble damage

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -934,12 +934,52 @@ h1 {
   }
 }
 
+@keyframes pulseGold {
+  0% {
+    background-color: rgba(255, 215, 0, 0.8);
+    transform: scale(1);
+  }
+  50% {
+    background-color: rgba(255, 215, 0, 0.4);
+    transform: scale(1.1);
+  }
+  100% {
+    background-color: rgba(255, 215, 0, 0.8);
+    transform: scale(1);
+  }
+}
+
+@keyframes pulseRed {
+  0% {
+    background-color: rgba(255, 0, 0, 0.8);
+    transform: scale(1);
+  }
+  50% {
+    background-color: rgba(255, 0, 0, 0.4);
+    transform: scale(1.1);
+  }
+  100% {
+    background-color: rgba(255, 0, 0, 0.8);
+    transform: scale(1);
+  }
+}
+
 #damageAmount {
   transition: background-color 0.5s ease, transform 0.5s ease;
 }
 
 .pulse {
   animation: pulseOnce 2s 1; /* Run the animation once over 2 seconds */
+}
+
+.pulse-gold {
+  animation: pulseGold 2s 1;
+  box-shadow: 0 0 10px #FFD700;
+}
+
+.pulse-red {
+  animation: pulseRed 2s 1;
+  box-shadow: 0 0 10px #FF0000;
 }
 
 .hidden {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -113,8 +113,6 @@ useEffect(() => {
   if (loading) {
     const timer = setTimeout(() => {
       setLoading(false);
-      setIsCritical(false);
-      setIsFumble(false);
     }, 1000); // 1 second delay
     return () => clearTimeout(timer);
   }
@@ -122,12 +120,13 @@ useEffect(() => {
 
 const updateDamageValueWithAnimation = (newValue) => {
   setLoading(true);
+  setPulseClass('');
   setDamageValue(newValue);
 };
 
 useImperativeHandle(ref, () => ({ updateDamageValueWithAnimation }));
 
-const [pulse, setPulse] = useState(false);
+const [pulseClass, setPulseClass] = useState('');
 
 // Allow other components to display values in the damage circle
 useEffect(() => {
@@ -146,9 +145,14 @@ useEffect(() => {
 
 useEffect(() => {
   if (!loading) {
-    setPulse(true);
-    const timer = setTimeout(() => setPulse(false), 2000); // Remove the pulse class after the animation
-    return () => clearTimeout(timer); // Cleanup the timer on unmount or when loading changes
+    const cls = isCritical ? 'pulse-gold' : isFumble ? 'pulse-red' : 'pulse';
+    setPulseClass(cls);
+    const timer = setTimeout(() => {
+      setPulseClass('');
+      setIsCritical(false);
+      setIsFumble(false);
+    }, 2000);
+    return () => clearTimeout(timer);
   }
 }, [loading]);
 //-------------------------------------------D20 Dice Roller--------------------------------------------------------------------------
@@ -224,7 +228,7 @@ const showSparklesEffect = () => {
       <div
         id="damageAmount"
         ref={damageRef}
-        className={`mt-3 ${loading ? 'loading' : ''} ${pulse ? 'pulse' : ''} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
+        className={`mt-3 ${loading ? 'loading' : ''} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
         style={{ margin: "0 auto" }}
       >
         <span id="damageValue" className={loading ? 'hidden' : ''}>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -42,6 +42,8 @@ describe('calculateDamage parser', () => {
 
 describe('PlayerTurnActions critical events', () => {
   test('damage-roll event toggles classes on damageAmount', () => {
+    jest.useFakeTimers();
+
     render(
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [] }}
@@ -60,8 +62,12 @@ describe('PlayerTurnActions critical events', () => {
         })
       );
     });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     expect(damage.classList.contains('critical-active')).toBe(true);
     expect(damage.classList.contains('critical-failure')).toBe(false);
+    expect(damage.classList.contains('pulse-gold')).toBe(true);
 
     act(() => {
       window.dispatchEvent(
@@ -70,16 +76,24 @@ describe('PlayerTurnActions critical events', () => {
         })
       );
     });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     expect(damage.classList.contains('critical-active')).toBe(false);
     expect(damage.classList.contains('critical-failure')).toBe(true);
+    expect(damage.classList.contains('pulse-red')).toBe(true);
 
     act(() => {
       window.dispatchEvent(
         new CustomEvent('damage-roll', { detail: { value: 1 } })
       );
     });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     expect(damage.classList.contains('critical-active')).toBe(false);
     expect(damage.classList.contains('critical-failure')).toBe(false);
+    expect(damage.classList.contains('pulse')).toBe(true);
   });
 
   test('crit toggle activates critical class', () => {


### PR DESCRIPTION
## Summary
- Add gold and red pulse animations for critical hits and fumbles
- Update damage circle to apply pulse color based on roll outcome
- Test critical and fumble events for correct pulse animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bddd365c548323aba157988acfb52c