### PR TITLE
Toggle critical hits via damage circle

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -98,6 +98,11 @@ const handleSpellsButtonClick = (spell, crit = false) => {
   updateDamageValueWithAnimation(damageValue);
 };
 
+const handleDamageClick = () => {
+  setIsCritical((prev) => !prev);
+  setIsFumble(false);
+};
+
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const opacity = 0.85;
 // Calculate RGBA color with opacity
@@ -230,6 +235,7 @@ const showSparklesEffect = () => {
         ref={damageRef}
         className={`mt-3 ${loading ? 'loading' : ''} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
         style={{ margin: "0 auto" }}
+        onClick={handleDamageClick}
       >
         <span id="damageValue" className={loading ? 'hidden' : ''}>
           {damageValue}
@@ -263,19 +269,6 @@ const showSparklesEffect = () => {
             onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
             title="Attack"
           />
-          {/* Critical hit toggle */}
-          <label style={{ marginLeft: '10px', display: 'flex', alignItems: 'center' }}>
-            <input
-              type="checkbox"
-              checked={isCritical}
-              onChange={(e) => {
-                setIsCritical(e.target.checked);
-                if (e.target.checked) setIsFumble(false);
-              }}
-              aria-label="Crit"
-            />
-            <span style={{ marginLeft: '4px' }}>Crit</span>
-          </label>
         </div>
         <div
           style={{

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -96,8 +96,8 @@ describe('PlayerTurnActions critical events', () => {
     expect(damage.classList.contains('pulse')).toBe(true);
   });
 
-  test('crit toggle activates critical class', () => {
-    const { getByLabelText } = render(
+  test('clicking damageAmount toggles critical class', () => {
+    render(
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [] }}
         strMod={0}
@@ -107,14 +107,19 @@ describe('PlayerTurnActions critical events', () => {
     );
 
     const damage = document.getElementById('damageAmount');
-    const critToggle = getByLabelText('Crit');
 
     expect(damage.classList.contains('critical-active')).toBe(false);
 
     act(() => {
-      fireEvent.click(critToggle);
+      fireEvent.click(damage);
     });
 
     expect(damage.classList.contains('critical-active')).toBe(true);
+
+    act(() => {
+      fireEvent.click(damage);
+    });
+
+    expect(damage.classList.contains('critical-active')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- remove Crit checkbox and allow critical toggling by clicking the damage circle
- add handler to clear fumbles when the damage circle is clicked
- update tests for new critical toggle behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bddf98be208323a80f88e7bba20387