### PR TITLE
Highlight spells button when spell points remain

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -982,6 +982,23 @@ h1 {
   box-shadow: 0 0 10px #FF0000;
 }
 
+@keyframes pointsGlow {
+  0% {
+    box-shadow: 0 0 6px #FFD700;
+  }
+  50% {
+    box-shadow: 0 0 12px #FFD700;
+  }
+  100% {
+    box-shadow: 0 0 6px #FFD700;
+  }
+}
+
+.points-glow {
+  animation: pointsGlow 2s infinite;
+  box-shadow: 0 0 6px #FFD700;
+}
+
 .hidden {
   display: none;
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -405,7 +405,7 @@ return (
                 marginTop: '10px',
                 backgroundColor: spellsGold,
               }}
-              className="mx-1 fas fa-hat-wizard"
+              className={`mx-1 fas fa-hat-wizard ${(form.spellPoints || 0) > 0 ? 'points-glow' : ''}`}
               variant="secondary"
             ></Button>
           )}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ZombiesCharacterSheet from './ZombiesCharacterSheet';
+
+jest.mock('../../../utils/apiFetch');
+import apiFetch from '../../../utils/apiFetch';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+}));
+
+jest.mock('../attributes/CharacterInfo', () => () => null);
+jest.mock('../attributes/Stats', () => () => null);
+jest.mock('../attributes/Skills', () => () => null);
+jest.mock('../attributes/Feats', () => () => null);
+jest.mock('../../Weapons/WeaponList', () => () => null);
+jest.mock('../attributes/PlayerTurnActions', () => {
+  const React = require('react');
+  return React.forwardRef(() => null);
+});
+jest.mock('../../Armor/ArmorList', () => () => null);
+jest.mock('../attributes/Items', () => () => null);
+jest.mock('../attributes/Help', () => () => null);
+jest.mock('../attributes/BackgroundModal', () => () => null);
+jest.mock('../attributes/Features', () => () => null);
+jest.mock('../attributes/SpellSelector', () => () => null);
+jest.mock('../attributes/HealthDefense', () => () => null);
+
+test('spells button includes points-glow when spell points available', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 1,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  expect(spellButton).toHaveClass('points-glow');
+});


### PR DESCRIPTION
## Summary
- add `points-glow` styling for spells button when unspent spell points exist
- define pulsing gold `points-glow` animation in App.scss
- test that ZombiesCharacterSheet shows glowing spells button with points

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdef0cae6c8323b0b2c87647c33b40