### PR TITLE
Compute remaining spell capacity in character sheet

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
 jest.mock('../../../utils/apiFetch');
@@ -27,6 +27,10 @@ jest.mock('../attributes/Features', () => () => null);
 jest.mock('../attributes/SpellSelector', () => () => null);
 jest.mock('../attributes/HealthDefense', () => () => null);
 
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
 test('spells button includes points-glow when spell points available', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,
@@ -53,5 +57,38 @@ test('spells button includes points-glow when spell points available', async () 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
   const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
-  expect(spellButton).toHaveClass('points-glow');
+  await waitFor(() => expect(spellButton).toHaveClass('points-glow'));
+});
+
+test('spells button glows when spellPoints absent but spells remain', async () => {
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        occupation: [{ Name: 'Wizard', Level: 1 }],
+        spells: [],
+        str: 10,
+        dex: 10,
+        con: 10,
+        int: 10,
+        wis: 10,
+        cha: 10,
+        startStatTotal: 60,
+        proficiencyPoints: 0,
+        skills: {},
+        item: [],
+        feat: [],
+        weapon: [],
+        armor: [],
+      }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ spellsKnown: 1 }),
+    });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  await waitFor(() => expect(spellButton).toHaveClass('points-glow'));
 });


### PR DESCRIPTION
## Summary
- derive spellPointsLeft from class data when character lacks a stored value
- use spellPointsLeft to color and glow the spells button
- test that characters without spellPoints but with available spells still glow the button

## Testing
- `CI=true npm --prefix client test -- client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bdf4a392f883239bb23fcad760b8e0