### PR TITLE
Enable warlock spellcasting button

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -27,6 +27,7 @@ const SPELLCASTING_CLASSES = {
   druid: 'full',
   sorcerer: 'full',
   wizard: 'full',
+  warlock: 'full',
   paladin: 'half',
   ranger: 'half',
 };

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -92,3 +92,32 @@ test('spells button glows when spellPoints absent but spells remain', async () =
   const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
   await waitFor(() => expect(spellButton).toHaveClass('points-glow'));
 });
+
+test('warlock character renders spells button', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Warlock', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  expect(spellButton).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- Treat warlocks as full spellcasters so spell button shows on sheet
- Test that warlock characters render spell button

## Testing
- `CI=true npm --prefix client test client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdfad47388832ea1e7fc9213af45e6