### PR TITLE
Highlight skill and feat buttons when points remain

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -416,7 +416,7 @@ return (
               marginTop: "10px",
               backgroundColor: skillsGold,
             }}
-            className="mx-1 fas fa-book-open"
+            className={`mx-1 fas fa-book-open ${skillPointsLeft > 0 ? 'points-glow' : ''}`}
             variant="secondary"
           ></Button>
           <Button
@@ -427,7 +427,7 @@ return (
               marginTop: "10px",
               backgroundColor: featsGold,
             }}
-            className="mx-1 fas fa-hand-fist"
+            className={`mx-1 fas fa-hand-fist ${featPointsLeft > 0 ? 'points-glow' : ''}`}
             variant="secondary"
           ></Button>
           <Button

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -121,3 +121,59 @@ test('warlock character renders spells button', async () => {
   const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
   expect(spellButton).toBeInTheDocument();
 });
+
+test('skills button includes points-glow when skill points available', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Fighter', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 1,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const skillButton = buttons.find((btn) => btn.classList.contains('fa-book-open'));
+  await waitFor(() => expect(skillButton).toHaveClass('points-glow'));
+});
+
+test('feats button includes points-glow when feat points available', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Fighter', Level: 4 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const featButton = buttons.find((btn) => btn.classList.contains('fa-hand-fist'));
+  await waitFor(() => expect(featButton).toHaveClass('points-glow'));
+});


### PR DESCRIPTION
## Summary
- Glow skill and feat buttons when unspent points remain
- Test that skill and feat buttons gain `points-glow` class when points are available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfb98d00c83239db3f094a5cff3b8