### PR TITLE
style: standardize footer button sizing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1154,3 +1154,11 @@ h1 {
   background-color: rgba(0, 0, 0, 0.5) !important;
   color: #fff;
 }
+
+.footer-btn {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -405,52 +405,48 @@ return (
         >
           <Button
             onClick={handleShowCharacterInfo}
-            style={{ color: "black", padding: "8px", marginTop: "10px" }}
-            className="mx-1 fas fa-image-portrait"
+            style={{ color: "black", marginTop: "10px" }}
+            className="footer-btn mx-1 fas fa-image-portrait"
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowStats}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: statPointsLeft > 0 ? "gold" : "#6C757D",
             }}
-            className="mx-1 fas fa-scroll"
+            className="footer-btn mx-1 fas fa-scroll"
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowSkill}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: skillsGold,
             }}
-            className={`mx-1 fas fa-book-open ${skillPointsLeft > 0 ? 'points-glow' : ''}`}
+            className={`footer-btn mx-1 fas fa-book-open ${skillPointsLeft > 0 ? 'points-glow' : ''}`}
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowFeats}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: featsGold,
             }}
-            className={`mx-1 fas fa-hand-fist ${featPointsLeft > 0 ? 'points-glow' : ''}`}
+            className={`footer-btn mx-1 fas fa-hand-fist ${featPointsLeft > 0 ? 'points-glow' : ''}`}
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowFeatures}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: "#6C757D",
             }}
-            className="mx-1 fas fa-star"
+            className="footer-btn mx-1 fas fa-star"
             variant="secondary"
           ></Button>
           {hasSpellcasting && (
@@ -458,11 +454,10 @@ return (
               onClick={handleShowSpells}
               style={{
                 color: 'black',
-                padding: '8px',
                 marginTop: '10px',
                 backgroundColor: spellsGold,
               }}
-              className={`mx-1 fas fa-hat-wizard ${spellPointsLeft > 0 ? 'points-glow' : ''}`}
+              className={`footer-btn mx-1 fas fa-hat-wizard ${spellPointsLeft > 0 ? 'points-glow' : ''}`}
               variant="secondary"
             ></Button>
           )}
@@ -470,39 +465,36 @@ return (
             onClick={handleShowWeapons}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: "#6C757D",
             }}
-            className="mx-1 fas fa-wand-sparkles"
+            className="footer-btn mx-1 fas fa-wand-sparkles"
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowArmor}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: "#6C757D",
             }}
-            className="mx-1 fas fa-shield"
+            className="footer-btn mx-1 fas fa-shield"
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowItems}
             style={{
               color: "black",
-              padding: "8px",
               marginTop: "10px",
               backgroundColor: "#6C757D",
             }}
-            className="mx-1 fas fa-briefcase"
+            className="footer-btn mx-1 fas fa-briefcase"
             variant="secondary"
           ></Button>
           <Button
             onClick={handleShowHelpModal}
-            style={{ color: "white", padding: "8px", marginTop: "10px" }}
-            className="mx-1 fas fa-info"
+            style={{ color: "white", marginTop: "10px" }}
+            className="footer-btn mx-1 fas fa-info"
             variant="primary"
           ></Button>
         </Nav>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -177,3 +177,31 @@ test('feats button includes points-glow when feat points available', async () =>
   const featButton = buttons.find((btn) => btn.classList.contains('fa-hand-fist'));
   await waitFor(() => expect(featButton).toHaveClass('points-glow'));
 });
+
+test('all footer buttons have footer-btn class', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  buttons.forEach((btn) => expect(btn).toHaveClass('footer-btn'));
+});


### PR DESCRIPTION
## Summary
- add shared `.footer-btn` class for consistent square sizing
- apply `footer-btn` to Zombies character sheet footer buttons and remove inline padding
- verify in tests that all footer buttons use the shared class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0083226483239c6b00c68cf7d2f5