### PR TITLE
feat: show spell save DC

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -13,6 +13,7 @@ export default function HealthDefense({
   hpMaxBonusPerLevel = 0,
   initiative = 0,
   speed = 0,
+  spellAbilityMod,
 }) {
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
@@ -65,6 +66,8 @@ export default function HealthDefense({
     0
   );
   const profBonus = form.proficiencyBonus ?? proficiencyBonus(totalLevel);
+  const spellSaveDC =
+    spellAbilityMod !== undefined ? 8 + profBonus + spellAbilityMod : undefined;
 
   // Health
   const maxHealth =
@@ -256,8 +259,11 @@ return (
   </div>
 
   {/* Second row */}
-  <div>
-    <strong>Proficiency Bonus:</strong> {profBonus}
+  <div style={{ display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
+    {spellSaveDC !== undefined && (
+      <div><strong>Spell Save DC:</strong> {spellSaveDC}</div>
+    )}
+    <div><strong>Proficiency Bonus:</strong> {profBonus}</div>
   </div>
 </div>
       </div>

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -15,7 +15,7 @@ const baseForm = {
   speed: 30,
 };
 
-test('renders proficiency bonus based on total level', () => {
+test('renders spell save DC when spell ability mod is provided', () => {
   render(
     <HealthDefense
       form={baseForm}
@@ -26,8 +26,10 @@ test('renders proficiency bonus based on total level', () => {
       hpMaxBonusPerLevel={0}
       initiative={0}
       speed={0}
+      spellAbilityMod={2}
     />
   );
+  expect(screen.getByText('Spell Save DC:').parentElement).toHaveTextContent('13');
   expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('3');
 });
 
@@ -43,7 +45,26 @@ test('uses provided proficiency bonus when supplied', () => {
       hpMaxBonusPerLevel={0}
       initiative={0}
       speed={0}
+      spellAbilityMod={2}
     />
   );
+  expect(screen.getByText('Spell Save DC:').parentElement).toHaveTextContent('14');
   expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('4');
+});
+
+test('does not render spell save DC when no spell ability mod', () => {
+  render(
+    <HealthDefense
+      form={baseForm}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  expect(screen.queryByText('Spell Save DC:')).toBeNull();
+  expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('3');
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -216,6 +216,17 @@ export default function ZombiesCharacterSheet() {
     cha: Math.floor((computedStats.cha - 10) / 2),
   };
 
+  const SPELLCASTING_ABILITIES = {
+    cleric: 'wis',
+    druid: 'wis',
+    wizard: 'int',
+  };
+  const spellcastingClass = (form?.occupation || [])
+    .map((cls) => (cls.Name || cls.Occupation || '').toLowerCase())
+    .find((name) => SPELLCASTING_CLASSES[name]);
+  const spellAbilityKey = SPELLCASTING_ABILITIES[spellcastingClass];
+  const spellAbilityMod = spellcastingClass ? statMods[spellAbilityKey] : undefined;
+
   const hasSpellcasting = (form?.occupation || []).some((cls) => {
     const name = (cls.Name || cls.Occupation || '').toLowerCase();
     const progression = SPELLCASTING_CLASSES[name];
@@ -371,6 +382,7 @@ return (
         ac={featBonuses.ac}
         hpMaxBonus={featBonuses.hpMaxBonus}
         hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
+        spellAbilityMod={spellAbilityMod}
       />
     </div>
     <PlayerTurnActions


### PR DESCRIPTION
## Summary
- compute spellcasting ability mod in character sheet and pass to health/defense
- display spell save DC next to proficiency bonus only for spellcasters
- add tests for conditional spell save DC rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdff49ed68832e87388ba1093e83ad