### PR TITLE
Gate spellcasting modifier and render Spell Save DC conditionally

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -13,7 +13,7 @@ export default function HealthDefense({
   hpMaxBonusPerLevel = 0,
   initiative = 0,
   speed = 0,
-  spellAbilityMod = 0,
+  spellAbilityMod,
 }) {
   const params = useParams();
 //-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
@@ -66,7 +66,8 @@ export default function HealthDefense({
     0
   );
   const profBonus = form.proficiencyBonus ?? proficiencyBonus(totalLevel);
-  const spellSaveDC = 8 + profBonus + spellAbilityMod;
+  const spellSaveDC =
+    spellAbilityMod != null ? 8 + profBonus + spellAbilityMod : null;
 
   // Health
   const maxHealth =
@@ -259,7 +260,9 @@ return (
 
   {/* Second row */}
   <div style={{ display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
-    <div><strong>Spell Save DC:</strong> {spellSaveDC}</div>
+    {spellSaveDC != null && (
+      <div><strong>Spell Save DC:</strong> {spellSaveDC}</div>
+    )}
     <div><strong>Proficiency Bonus:</strong> {profBonus}</div>
   </div>
 </div>

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -15,7 +15,24 @@ const baseForm = {
   speed: 30,
 };
 
-test('renders proficiency bonus based on total level', () => {
+test('renders only proficiency bonus when no spellcasting', () => {
+  render(
+    <HealthDefense
+      form={baseForm}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  expect(screen.queryByText('Spell Save DC:')).toBeNull();
+  expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('3');
+});
+
+test('renders spell save dc and proficiency bonus when spellAbilityMod provided', () => {
   render(
     <HealthDefense
       form={baseForm}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -224,8 +224,9 @@ export default function ZombiesCharacterSheet() {
   const spellcastingClass = (form?.occupation || [])
     .map((cls) => (cls.Name || cls.Occupation || '').toLowerCase())
     .find((name) => SPELLCASTING_CLASSES[name]);
-  const spellAbilityKey = SPELLCASTING_ABILITIES[spellcastingClass] || 'cha';
-  const spellAbilityMod = spellcastingClass ? statMods[spellAbilityKey] : 0;
+  const spellAbilityKey =
+    spellcastingClass && (SPELLCASTING_ABILITIES[spellcastingClass] || 'cha');
+  const spellAbilityMod = spellcastingClass ? statMods[spellAbilityKey] : null;
 
   const hasSpellcasting = (form?.occupation || []).some((cls) => {
     const name = (cls.Name || cls.Occupation || '').toLowerCase();
@@ -382,7 +383,7 @@ return (
         ac={featBonuses.ac}
         hpMaxBonus={featBonuses.hpMaxBonus}
         hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
-        spellAbilityMod={spellAbilityMod}
+        {...(spellAbilityMod != null && { spellAbilityMod })}
       />
     </div>
     <PlayerTurnActions


### PR DESCRIPTION
## Summary
- Set `spellAbilityMod` to null when no spellcasting class and avoid passing it to `HealthDefense`.
- Compute Spell Save DC only when a spellcasting modifier exists and hide the element otherwise.
- Expand unit tests to cover spellcasting and non-spellcasting scenarios.

## Testing
- `CI=true npm test > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68be02ec3724832eb887bea67efaeb55