### PR TITLE
Enable expertise for background-locked skills

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -206,7 +206,7 @@ export default function Skills({
 
   const toggleExpertise = (skill) => {
     const current = skills[skill] || { proficient: false, expertise: false };
-    if (!current.proficient) return;
+    if (!(current.proficient || lockedProficiencies.has(skill))) return;
     if (!selectableExpertise.has(skill)) return;
     if (!current.expertise && expertisePointsLeft <= 0) return;
     const updated = {
@@ -298,7 +298,9 @@ export default function Skills({
                   const penalty = armorPenalty
                     ? armorPenalty * totalCheckPenalty
                     : 0;
-                  const multiplier = expertise ? 2 : proficient ? 1 : 0;
+                  const isProficient =
+                    proficient || lockedProficiencies.has(key);
+                  const multiplier = expertise ? 2 : isProficient ? 1 : 0;
                   const total =
                     modMap[ability] +
                     profBonus * multiplier +
@@ -338,7 +340,7 @@ export default function Skills({
                           type="checkbox"
                           checked={expertise}
                           disabled={
-                            !proficient ||
+                            !isProficient ||
                             !selectableExpertise.has(key) ||
                             lockedExpertise.has(key) ||
                             (!expertise && expertisePointsLeft <= 0)
@@ -349,7 +351,7 @@ export default function Skills({
                       <td>
                         <Button
                           onClick={() =>
-                            handleRoll(key, ability, proficient, expertise)
+                            handleRoll(key, ability, isProficient, expertise)
                           }
                           variant="link"
                           aria-label="roll"

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -1,4 +1,15 @@
-import { rollSkill } from './Skills';
+import React from 'react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Skills, { rollSkill } from './Skills';
+import apiFetch from '../../../utils/apiFetch';
+
+jest.mock('../../../utils/apiFetch');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+}));
 
 describe('rollSkill critical and fumble events', () => {
   afterEach(() => {
@@ -23,5 +34,44 @@ describe('rollSkill critical and fumble events', () => {
     expect(listener).toHaveBeenCalled();
     expect(listener.mock.calls[0][0].detail).toContain('fumble');
     window.removeEventListener('critical-failure', listener);
+  });
+});
+
+describe('Skills expertise toggle', () => {
+  test('enables and toggles expertise for background proficient skill', async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ proficient: false, expertise: true }),
+    });
+
+    render(
+      <Skills
+        form={{
+          background: { skills: { acrobatics: { proficient: true } } },
+          allowedExpertise: ['acrobatics'],
+          expertisePoints: 1,
+          item: [],
+          feat: [],
+          race: {},
+          skills: {},
+        }}
+        showSkill={true}
+        handleCloseSkill={() => {}}
+        totalLevel={1}
+        strMod={0}
+        dexMod={0}
+        conMod={0}
+        intMod={0}
+        chaMod={0}
+        wisMod={0}
+      />
+    );
+
+    const row = await screen.findByText('Acrobatics');
+    const expertiseCheckbox = within(row.closest('tr')).getAllByRole('checkbox')[1];
+    expect(expertiseCheckbox.disabled).toBe(false);
+
+    await userEvent.click(expertiseCheckbox);
+    await waitFor(() => expect(expertiseCheckbox).toBeChecked());
   });
 });


### PR DESCRIPTION
## Summary
- Combine saved proficiency with background/race locks to compute `isProficient`
- Allow expertise toggling when skill proficiency comes from background or race
- Add test ensuring background-proficient skills expose toggleable expertise

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be04105be48323bc4dff5b1f34c5d7