### PR TITLE
Guard spellcasting ability modifier derivation

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -226,8 +226,6 @@ export default function ZombiesCharacterSheet() {
     .find((name) => SPELLCASTING_CLASSES[name]);
   const spellAbilityKey =
     spellcastingClass && (SPELLCASTING_ABILITIES[spellcastingClass] || 'cha');
-  const spellAbilityMod = spellcastingClass ? statMods[spellAbilityKey] : null;
-
   const hasSpellcasting = (form?.occupation || []).some((cls) => {
     const name = (cls.Name || cls.Occupation || '').toLowerCase();
     const progression = SPELLCASTING_CLASSES[name];
@@ -237,6 +235,8 @@ export default function ZombiesCharacterSheet() {
     if (progression === 'half') return level >= 2;
     return false;
   });
+
+  const spellAbilityMod = hasSpellcasting ? statMods[spellAbilityKey] : null;
 
   useEffect(() => {
     async function calculateSpellPoints() {
@@ -383,7 +383,7 @@ return (
         ac={featBonuses.ac}
         hpMaxBonus={featBonuses.hpMaxBonus}
         hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
-        {...(spellAbilityMod != null && { spellAbilityMod })}
+        {...(spellAbilityMod !== null && { spellAbilityMod })}
       />
     </div>
     <PlayerTurnActions


### PR DESCRIPTION
## Summary
- compute `spellAbilityMod` only for spellcasting characters
- only pass `spellAbilityMod` to `HealthDefense` when present

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be05dd8540832e9cbf8f3c881752b7