### PR TITLE
Expose expertise slots after multiclassing

### DIFF
--- a/server/routes/characters/occupations.js
+++ b/server/routes/characters/occupations.js
@@ -49,7 +49,15 @@ module.exports = (router) => {
         return res.status(400).json({ message: result.message });
       }
       logger.info('Character multiclass applied');
-      res.json(result);
+      res.json({
+        allowed: true,
+        occupation: result.occupation,
+        health: result.health,
+        allowedSkills: result.allowedSkills,
+        allowedExpertise: result.allowedExpertise,
+        proficiencyPoints: result.proficiencyPoints,
+        expertisePoints: result.expertisePoints,
+      });
     } catch (error) {
       logger.error(error);
       next(error);


### PR DESCRIPTION
## Summary
- compute allowed expertise and skill point totals when multiclassing
- return new expertise and proficiency data from multiclass route
- test multiclassed rogue/bard expertise selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0dbcdf1c8323b4afe08f425af15c