### PR TITLE
feat(types): add owned field to Item interface

### DIFF
--- a/types/item.d.ts
+++ b/types/item.d.ts
@@ -23,4 +23,8 @@ export interface Item {
    * Optional list of SRD properties, may be empty.
    */
   properties?: string[];
+  /**
+   * Whether the creature currently owns the item.
+   */
+  owned: boolean;
 }


### PR DESCRIPTION
## Summary
- add owned boolean property to Item type for shared client/server usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be0eb850dc832eb0063727626a1d78