### PR TITLE
Add expertise points glow to skills button

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -295,7 +295,16 @@ export default function ZombiesCharacterSheet() {
     Object.entries(form.skills || {}).filter(
       ([key, s]) => s.proficient && !form.race?.skills?.[key]?.proficient
     ).length;
-  const skillsGold = skillPointsLeft > 0 ? 'gold' : '#6C757D';
+  const expertisePointsLeft =
+    (form.expertisePoints || 0) -
+    Object.entries(form.skills || {}).filter(
+      ([key, s]) =>
+        s.expertise &&
+        !form.race?.skills?.[key]?.expertise &&
+        !form.background?.skills?.[key]?.expertise
+    ).length;
+  const skillsGold =
+    skillPointsLeft > 0 || expertisePointsLeft > 0 ? 'gold' : '#6C757D';
 
 // ---------------------------------------Feats and bonuses----------------------------------------------
 const featBonuses = (form.feat || []).reduce(
@@ -427,7 +436,9 @@ return (
               marginTop: "10px",
               backgroundColor: skillsGold,
             }}
-            className={`footer-btn mx-1 fas fa-book-open ${skillPointsLeft > 0 ? 'points-glow' : ''}`}
+            className={`footer-btn mx-1 fas fa-book-open ${
+              skillPointsLeft > 0 || expertisePointsLeft > 0 ? 'points-glow' : ''
+            }`}
             variant="secondary"
           ></Button>
           <Button

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -150,6 +150,35 @@ test('skills button includes points-glow when skill points available', async () 
   await waitFor(() => expect(skillButton).toHaveClass('points-glow'));
 });
 
+test('skills button includes points-glow when expertise points available', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Fighter', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      expertisePoints: 1,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const skillButton = buttons.find((btn) => btn.classList.contains('fa-book-open'));
+  await waitFor(() => expect(skillButton).toHaveClass('points-glow'));
+});
+
 test('feats button includes points-glow when feat points available', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- calculate remaining expertise points on character sheet, excluding racial or background expertise
- highlight skill button when any skill or expertise points are unspent
- test that skill button glows when expertise points remain

## Testing
- `npm test -- client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68be0ff1c5a88323b9ea9c0e51f01e9a