### PR TITLE
feat: add CRUD endpoints for equipment items

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -508,13 +508,13 @@ describe('Character routes', () => {
 
   test('add item success', async () => {
     dbo.mockResolvedValue({
-      collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+      collection: () => ({ insertOne: async () => ({ insertedId: '507f1f77bcf86cd799439011' }) })
     });
     const res = await request(app)
-      .post('/equipment/item/add')
-      .send({ campaign: 'Camp1', itemName: 'Potion' });
+      .post('/equipment/items')
+      .send({ campaign: 'Camp1', name: 'Potion', category: 'gear', weight: 1, cost: '5 gp' });
     expect(res.status).toBe(200);
-    expect(res.body.acknowledged).toBe(true);
+    expect(res.body._id).toBeDefined();
   });
 
   test('add item failure', async () => {
@@ -522,8 +522,8 @@ describe('Character routes', () => {
       collection: () => ({ insertOne: async () => { throw new Error('db error'); } })
     });
     const res = await request(app)
-      .post('/equipment/item/add')
-      .send({ campaign: 'Camp1', itemName: 'Potion' });
+      .post('/equipment/items')
+      .send({ campaign: 'Camp1', name: 'Potion', category: 'gear', weight: 1, cost: '5 gp' });
     expect(res.status).toBe(500);
   });
 

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -314,30 +314,30 @@ describe('Equipment routes', () => {
     });
   });
 
-  describe('/item/add', () => {
+  describe('/items', () => {
     test('validation failure', async () => {
       dbo.mockResolvedValue({});
-      const res = await request(app).post('/equipment/item/add').send({});
+      const res = await request(app).post('/equipment/items').send({});
       expect(res.status).toBe(400);
       expect(res.body.errors).toBeDefined();
     });
 
     test('insert success', async () => {
       dbo.mockResolvedValue({
-        collection: () => ({ insertOne: async () => ({ acknowledged: true }) })
+        collection: () => ({ insertOne: async () => ({ insertedId: '507f1f77bcf86cd799439011' }) })
       });
       const res = await request(app)
-        .post('/equipment/item/add')
-        .send({ campaign: 'Camp1', itemName: 'Potion' });
+        .post('/equipment/items')
+        .send({ campaign: 'Camp1', name: 'Potion', category: 'gear', weight: 1, cost: '5 gp' });
       expect(res.status).toBe(200);
-      expect(res.body.acknowledged).toBe(true);
+      expect(res.body._id).toBeDefined();
     });
 
     test('numeric validation failure', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
-        .post('/equipment/item/add')
-        .send({ campaign: 'Camp1', itemName: 'Potion', str: 'bad' });
+        .post('/equipment/items')
+        .send({ campaign: 'Camp1', name: 'Potion', category: 'gear', weight: 'bad', cost: '5 gp' });
       expect(res.status).toBe(400);
     });
   });


### PR DESCRIPTION
## Summary
- add `GET/POST/PUT/DELETE` handlers for `/equipment/items`
- validate item name, category, weight, and cost
- extend tests for new equipment items endpoints

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0fb21424832e8664ecfdca2224c3