### PR TITLE
Add spell slot tabs for spellcasting classes

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -145,6 +145,35 @@ label {
   background-color: #a00000; /* Darker red color on hover */
 }
 
+// Spell slot tabs
+.spell-slot-tabs {
+  position: absolute;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.spell-slot-tab {
+  padding: 2px 6px;
+  margin: 0 2px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  text-align: center;
+  background-color: #e9ecef;
+  color: #000;
+}
+
+.spell-slot-tab.available {
+  background-color: #198754;
+  color: #fff;
+}
+
+.spell-slot-tab.zero {
+  background-color: #6c757d;
+  color: #fff;
+}
 // Dice Roller----------------------------------------------------------------------------------------------
 $transitionDuration: 0.5s;
 $animationDuration:  3s;

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -2,35 +2,12 @@ import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Button, Form, Tabs, Tab, Table } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
+import { SLOT_TABLE, SPELLCASTING_CLASSES } from './spellUtils';
 
 /**
  * Modal component allowing users to select spells for their character.
  * Spells are fetched from the server and filtered by class and level.
  */
-// Full-caster spell slot table indexed by class level then spell level
-const SLOT_TABLE = {
-  0: Array(10).fill(0),
-  1: [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
-  2: [0, 3, 0, 0, 0, 0, 0, 0, 0, 0],
-  3: [0, 4, 2, 0, 0, 0, 0, 0, 0, 0],
-  4: [0, 4, 3, 0, 0, 0, 0, 0, 0, 0],
-  5: [0, 4, 3, 2, 0, 0, 0, 0, 0, 0],
-  6: [0, 4, 3, 3, 0, 0, 0, 0, 0, 0],
-  7: [0, 4, 3, 3, 1, 0, 0, 0, 0, 0],
-  8: [0, 4, 3, 3, 2, 0, 0, 0, 0, 0],
-  9: [0, 4, 3, 3, 3, 1, 0, 0, 0, 0],
-  10: [0, 4, 3, 3, 3, 2, 0, 0, 0, 0],
-  11: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
-  12: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
-  13: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
-  14: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
-  15: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
-  16: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
-  17: [0, 4, 3, 3, 3, 2, 1, 1, 1, 1],
-  18: [0, 4, 3, 3, 3, 3, 1, 1, 1, 1],
-  19: [0, 4, 3, 3, 3, 3, 2, 1, 1, 1],
-  20: [0, 4, 3, 3, 3, 3, 2, 2, 1, 1],
-};
 
 // Number of cantrips known by class level
 const CANTRIP_TABLE = {
@@ -57,16 +34,6 @@ const CANTRIP_TABLE = {
   20: 5,
 };
 
-const SPELLCASTING_CLASSES = {
-  bard: 'full',
-  cleric: 'full',
-  druid: 'full',
-  sorcerer: 'full',
-  warlock: 'full',
-  wizard: 'full',
-  paladin: 'half',
-  ranger: 'half',
-};
 
 export default function SpellSelector({
   form,

--- a/client/src/components/Zombies/attributes/SpellSlotTabs.js
+++ b/client/src/components/Zombies/attributes/SpellSlotTabs.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import getSpellSlots from './spellUtils';
+
+export default function SpellSlotTabs({ occupation, usedSlots = {}, setUsedSlots }) {
+  const slots = getSpellSlots(occupation);
+  const remaining = slots.map((total, lvl) => total - (usedSlots[lvl] || 0));
+  const totalRemaining = remaining.reduce((sum, n) => sum + n, 0);
+
+  return (
+    <div className="spell-slot-tabs" data-testid="spell-slot-tabs">
+      <div className="spell-slot-tab" data-testid="slot-total">Total {totalRemaining}</div>
+      {remaining.map((count, lvl) =>
+        lvl > 0 && slots[lvl] > 0 ? (
+          <div
+            key={lvl}
+            className={`spell-slot-tab ${count <= 0 ? 'zero' : 'available'}`}
+            data-testid={`slot-level-${lvl}`}
+          >
+            {`${lvl}:${count}`}
+          </div>
+        ) : null
+      )}
+    </div>
+  );
+}

--- a/client/src/components/Zombies/attributes/spellUtils.js
+++ b/client/src/components/Zombies/attributes/spellUtils.js
@@ -1,0 +1,49 @@
+export const SLOT_TABLE = {
+  0: Array(10).fill(0),
+  1: [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+  2: [0, 3, 0, 0, 0, 0, 0, 0, 0, 0],
+  3: [0, 4, 2, 0, 0, 0, 0, 0, 0, 0],
+  4: [0, 4, 3, 0, 0, 0, 0, 0, 0, 0],
+  5: [0, 4, 3, 2, 0, 0, 0, 0, 0, 0],
+  6: [0, 4, 3, 3, 0, 0, 0, 0, 0, 0],
+  7: [0, 4, 3, 3, 1, 0, 0, 0, 0, 0],
+  8: [0, 4, 3, 3, 2, 0, 0, 0, 0, 0],
+  9: [0, 4, 3, 3, 3, 1, 0, 0, 0, 0],
+  10: [0, 4, 3, 3, 3, 2, 0, 0, 0, 0],
+  11: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
+  12: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
+  13: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
+  14: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
+  15: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
+  16: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
+  17: [0, 4, 3, 3, 3, 2, 1, 1, 1, 1],
+  18: [0, 4, 3, 3, 3, 3, 1, 1, 1, 1],
+  19: [0, 4, 3, 3, 3, 3, 2, 1, 1, 1],
+  20: [0, 4, 3, 3, 3, 3, 2, 2, 1, 1],
+};
+
+export const SPELLCASTING_CLASSES = {
+  bard: 'full',
+  cleric: 'full',
+  druid: 'full',
+  sorcerer: 'full',
+  warlock: 'full',
+  wizard: 'full',
+  paladin: 'half',
+  ranger: 'half',
+};
+
+export function getSpellSlots(occupation = []) {
+  const effectiveLevel = (occupation || []).reduce((sum, o) => {
+    const name = (o.Name || o.Occupation || '').toLowerCase();
+    const level = Number(o.Level) || 0;
+    const progression = SPELLCASTING_CLASSES[name];
+    if (progression === 'full') return sum + level;
+    if (progression === 'half') return sum + (level === 1 ? 0 : Math.ceil(level / 2));
+    return sum;
+  }, 0);
+
+  return SLOT_TABLE[effectiveLevel] || Array(10).fill(0);
+}
+
+export default getSpellSlots;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -19,18 +19,10 @@ import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
+import SpellSlotTabs from "../attributes/SpellSlotTabs";
+import { SPELLCASTING_CLASSES } from "../attributes/spellUtils";
 
 const HEADER_PADDING = 16;
-const SPELLCASTING_CLASSES = {
-  bard: 'full',
-  cleric: 'full',
-  druid: 'full',
-  sorcerer: 'full',
-  wizard: 'full',
-  warlock: 'full',
-  paladin: 'half',
-  ranger: 'half',
-};
 
 export default function ZombiesCharacterSheet() {
   const params = useParams();
@@ -48,6 +40,7 @@ export default function ZombiesCharacterSheet() {
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showBackground, setShowBackground] = useState(false);
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
+  const [spellSlotsUsed, setSpellSlotsUsed] = useState({});
 
   const playerTurnActionsRef = useRef(null);
 
@@ -421,6 +414,13 @@ return (
       headerHeight={headerHeight}
       ref={playerTurnActionsRef}
     />
+    {hasSpellcasting && (
+      <SpellSlotTabs
+        occupation={form?.occupation}
+        usedSlots={spellSlotsUsed}
+        setUsedSlots={setSpellSlotsUsed}
+      />
+    )}
     <Navbar
       fixed="bottom"
       data-bs-theme="dark"

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -26,6 +26,7 @@ jest.mock('../attributes/BackgroundModal', () => () => null);
 jest.mock('../attributes/Features', () => () => null);
 jest.mock('../attributes/SpellSelector', () => () => null);
 jest.mock('../attributes/HealthDefense', () => () => null);
+jest.mock('../attributes/SpellSlotTabs', () => jest.requireActual('../attributes/SpellSlotTabs'));
 
 beforeEach(() => {
   apiFetch.mockReset();
@@ -233,4 +234,62 @@ test('all footer buttons have footer-btn class', async () => {
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
   buttons.forEach((btn) => expect(btn).toHaveClass('footer-btn'));
+});
+
+test('renders spell slot tabs for caster', async () => {
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        occupation: [{ Name: 'Wizard', Level: 3 }],
+        spells: [],
+        str: 10,
+        dex: 10,
+        con: 10,
+        int: 10,
+        wis: 10,
+        cha: 10,
+        startStatTotal: 60,
+        proficiencyPoints: 0,
+        skills: {},
+        item: [],
+        feat: [],
+        weapon: [],
+        armor: [],
+      }),
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+  render(<ZombiesCharacterSheet />);
+
+  const total = await screen.findByTestId('slot-total');
+  expect(total).toHaveTextContent('Total 6');
+  expect(screen.getByTestId('slot-level-1')).toHaveTextContent('1:4');
+  expect(screen.getByTestId('slot-level-2')).toHaveTextContent('2:2');
+});
+
+test('non-caster does not render spell slot tabs', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Fighter', Level: 3 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  await waitFor(() => expect(screen.queryByTestId('spell-slot-tabs')).toBeNull());
 });


### PR DESCRIPTION
## Summary
- centralize spell slot data in `spellUtils` with helper `getSpellSlots`
- display remaining spell slots via new `SpellSlotTabs` component and styling
- render slot tabs on character sheet when applicable and cover with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be14cfee9883238cd1aa931e7facbe