### PR TITLE
Remove footer banner and relocate spell-slot tabs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -147,7 +147,7 @@ label {
 
 .footer-slot-tabs {
   position: fixed;
-  bottom: 56px;
+  bottom: 0;
   left: 0;
   width: 100%;
   display: flex;
@@ -1108,8 +1108,3 @@ h1 {
   background: #545b62;
 }
 
-// Transparent footer styling
-.footer-transparent {
-  background-color: rgba(0, 0, 0, 0.5) !important;
-  color: #fff;
-}

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MDBFooter } from 'mdb-react-ui-kit';
 
 const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
 
@@ -15,16 +14,6 @@ export default function Footer({ spellSlots = {} }) {
           ))
         )}
       </div>
-      <MDBFooter
-        className='fixed-bottom text-center text-lg-start text-white footer-transparent'
-      >
-        <div className='text-center p-4 footer-transparent'>
-          © 2023 Copyright:
-          <a className='mx-1 text-white fw-bold' href='https://github.com/rjo6615/DnD'>
-            DnD
-          </a>
-        </div>
-      </MDBFooter>
     </>
   );
 }

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -99,6 +99,9 @@ return(
                   </thead>
                 </Table>
               </div>
+              <p className="mt-2 small text-light">
+                © 2023 Copyright: <a href="https://github.com/rjo6615/DnD" className="text-light fw-bold">DnD</a>
+              </p>
             </Card.Body>
             <Card.Footer className="modal-footer justify-content-between">
               <Button className="action-btn btn-danger" onClick={handleShowDeleteCharacter}>Delete Character</Button>


### PR DESCRIPTION
## Summary
- drop copyright footer and MDBFooter dependency
- move spell-slot tabs to bottom and clean up footer styles
- add project copyright notice to Help modal

## Testing
- `CI=true npm test` *(fails: Test Suites: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be308575e08323ad8dfa27cad0068b