### PR TITLE
feat: show spell slots above module navbar

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import apiFetch from './utils/apiFetch';
 import { BrowserRouter as Router, Route, Routes, Navigate, useLocation } from "react-router-dom";
 import Navbar from "./components/Navbar/Navbar";
-// import Footer from "./components/Footer/Footer";
+import Footer from "./components/Footer/Footer";
 import Zombies from "./components/Zombies/pages/Zombies";
 import ZombiesCharacterSheet from "./components/Zombies/pages/ZombiesCharacterSheet";
 import ZombiesCharacterSelect from "./components/Zombies/pages/ZombiesCharacterSelect";
@@ -49,6 +49,7 @@ function App() {
 function AppRoutes({ user }) {
   const location = useLocation();
   const hideNavbarRoutes = []; // Add routes here to hide the navbar when needed
+  const [spellSlots, setSpellSlots] = useState({});
 
   return (
     <>
@@ -65,11 +66,11 @@ function AppRoutes({ user }) {
         <Route path="/armor" element={<ArmorList characterId={user?._id} strength={20} />} />
         <Route path="/armor/:name" element={<ArmorDetail />} />
         <Route path="/zombies-character-select/:campaign" element={<ZombiesCharacterSelect />} />
-        <Route path="/zombies-character-sheet/:id" element={<ZombiesCharacterSheet />} />
+        <Route path="/zombies-character-sheet/:id" element={<ZombiesCharacterSheet setSpellSlots={setSpellSlots} />} />
         <Route path="/zombies-dm/:campaign" element={<ZombiesDM />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
-      {/* <Footer /> */}
+      <Footer spellSlots={spellSlots} />
     </>
   );
 }

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -145,6 +145,28 @@ label {
   background-color: #a00000; /* Darker red color on hover */
 }
 
+.footer-slot-tabs {
+  position: fixed;
+  bottom: 56px;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  font-family: 'Raleway, sans-serif';
+  z-index: 1030;
+}
+
+.footer-slot-tab {
+  background-color: var(--bs-dark);
+  color: var(--bs-light);
+  padding: 0.25rem 0.5rem;
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+  border: 1px solid var(--bs-light);
+  font-weight: 600;
+}
+
 // Dice Roller----------------------------------------------------------------------------------------------
 $transitionDuration: 0.5s;
 $animationDuration:  3s;
@@ -1087,7 +1109,3 @@ h1 {
 }
 
 // Transparent footer styling
-.footer-transparent {
-  background-color: rgba(0, 0, 0, 0.5) !important;
-  color: #fff;
-}

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -1,17 +1,23 @@
 import React from 'react';
-import { MDBFooter } from 'mdb-react-ui-kit';
 
-export default function Footer() {
+const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
+
+export default function Footer({ spellSlots = {} }) {
+  const hasSlots = Object.values(spellSlots).some((count) => count > 0);
+
+  if (!hasSlots) {
+    return null;
+  }
+
   return (
-    <MDBFooter
-      className='fixed-bottom text-center text-lg-start text-white footer-transparent'
-    >
-      <div className='text-center p-4 footer-transparent'>
-        © 2023 Copyright:
-        <a className='mx-1 text-white fw-bold' href='https://github.com/rjo6615/DnD'>
-          DnD
-        </a>
-      </div>
-    </MDBFooter>
+    <div className='footer-slot-tabs'>
+      {Object.entries(spellSlots).map(([level, count]) =>
+        [...Array(count)].map((_, idx) => (
+          <div key={`${level}-${idx}`} className='footer-slot-tab'>
+            {ROMAN[Number(level)]}
+          </div>
+        ))
+      )}
+    </div>
   );
 }

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -99,6 +99,9 @@ return(
                   </thead>
                 </Table>
               </div>
+              <p className="mt-2 small text-light">
+                © 2023 Copyright: <a href="https://github.com/rjo6615/DnD" className="text-light fw-bold">DnD</a>
+              </p>
             </Card.Body>
             <Card.Footer className="modal-footer justify-content-between">
               <Button className="action-btn btn-danger" onClick={handleShowDeleteCharacter}>Delete Character</Button>

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -2,35 +2,15 @@ import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Button, Form, Tabs, Tab, Table } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
+import {
+  SLOT_TABLE,
+  getEffectiveCasterLevel,
+} from '../../../utils/spellSlots';
 
 /**
  * Modal component allowing users to select spells for their character.
  * Spells are fetched from the server and filtered by class and level.
  */
-// Full-caster spell slot table indexed by class level then spell level
-const SLOT_TABLE = {
-  0: Array(10).fill(0),
-  1: [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
-  2: [0, 3, 0, 0, 0, 0, 0, 0, 0, 0],
-  3: [0, 4, 2, 0, 0, 0, 0, 0, 0, 0],
-  4: [0, 4, 3, 0, 0, 0, 0, 0, 0, 0],
-  5: [0, 4, 3, 2, 0, 0, 0, 0, 0, 0],
-  6: [0, 4, 3, 3, 0, 0, 0, 0, 0, 0],
-  7: [0, 4, 3, 3, 1, 0, 0, 0, 0, 0],
-  8: [0, 4, 3, 3, 2, 0, 0, 0, 0, 0],
-  9: [0, 4, 3, 3, 3, 1, 0, 0, 0, 0],
-  10: [0, 4, 3, 3, 3, 2, 0, 0, 0, 0],
-  11: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
-  12: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
-  13: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
-  14: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
-  15: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
-  16: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
-  17: [0, 4, 3, 3, 3, 2, 1, 1, 1, 1],
-  18: [0, 4, 3, 3, 3, 3, 1, 1, 1, 1],
-  19: [0, 4, 3, 3, 3, 3, 2, 1, 1, 1],
-  20: [0, 4, 3, 3, 3, 3, 2, 2, 1, 1],
-};
 
 // Number of cantrips known by class level
 const CANTRIP_TABLE = {
@@ -81,14 +61,10 @@ export default function SpellSelector({
         const name = o.Name || o.Occupation;
         const level = Number(o.Level) || 0;
         const casterProgression = o.casterProgression || o.CasterProgression || 'full';
-        const effectiveLevel =
-          casterProgression === 'half'
-            ? level < 2
-              ? 0
-              : Math.ceil(level / 2)
-            : casterProgression === 'full'
-            ? level
-            : 0;
+        const effectiveLevel = getEffectiveCasterLevel({
+          level,
+          casterProgression,
+        });
         return { name, level, casterProgression, effectiveLevel };
       })
       .filter((o) => o.effectiveLevel >= 1);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -19,10 +19,11 @@ import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
+import { getSpellSlots } from '../../../utils/spellSlots';
 
 const HEADER_PADDING = 16;
 
-export default function ZombiesCharacterSheet() {
+export default function ZombiesCharacterSheet({ setSpellSlots = () => {} }) {
   const params = useParams();
   const characterId = params.id; 
   const [form, setForm] = useState(null);
@@ -56,6 +57,10 @@ export default function ZombiesCharacterSheet() {
       setHeaderHeight(headerRef.current.offsetHeight + navHeight + HEADER_PADDING);
     }
   }, [form, navHeight]);
+
+  useEffect(() => {
+    setSpellSlots(getSpellSlots(form?.occupation || []));
+  }, [form?.occupation, setSpellSlots]);
 
   useEffect(() => {
     async function fetchCharacterData(id) {

--- a/client/src/utils/spellSlots.js
+++ b/client/src/utils/spellSlots.js
@@ -1,0 +1,48 @@
+export const SLOT_TABLE = {
+  0: Array(10).fill(0),
+  1: [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+  2: [0, 3, 0, 0, 0, 0, 0, 0, 0, 0],
+  3: [0, 4, 2, 0, 0, 0, 0, 0, 0, 0],
+  4: [0, 4, 3, 0, 0, 0, 0, 0, 0, 0],
+  5: [0, 4, 3, 2, 0, 0, 0, 0, 0, 0],
+  6: [0, 4, 3, 3, 0, 0, 0, 0, 0, 0],
+  7: [0, 4, 3, 3, 1, 0, 0, 0, 0, 0],
+  8: [0, 4, 3, 3, 2, 0, 0, 0, 0, 0],
+  9: [0, 4, 3, 3, 3, 1, 0, 0, 0, 0],
+  10: [0, 4, 3, 3, 3, 2, 0, 0, 0, 0],
+  11: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
+  12: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
+  13: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
+  14: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
+  15: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
+  16: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
+  17: [0, 4, 3, 3, 3, 2, 1, 1, 1, 1],
+  18: [0, 4, 3, 3, 3, 3, 1, 1, 1, 1],
+  19: [0, 4, 3, 3, 3, 3, 2, 1, 1, 1],
+  20: [0, 4, 3, 3, 3, 3, 2, 2, 1, 1],
+};
+
+export function getEffectiveCasterLevel({ level = 0, casterProgression = 'full' } = {}) {
+  if (casterProgression === 'half') {
+    return level < 2 ? 0 : Math.ceil(level / 2);
+  }
+  return casterProgression === 'full' ? level : 0;
+}
+
+export function getSpellSlots(occupation = []) {
+  const totalEffective = occupation.reduce((sum, o) => {
+    const level = Number(o.Level) || 0;
+    const casterProgression = o.casterProgression || o.CasterProgression || 'full';
+    return sum + getEffectiveCasterLevel({ level, casterProgression });
+  }, 0);
+
+  const slotRow = SLOT_TABLE[totalEffective] || [];
+  const slots = {};
+  slotRow.forEach((count, lvl) => {
+    if (lvl > 0 && count > 0) {
+      slots[lvl] = count;
+    }
+  });
+  return slots;
+}
+


### PR DESCRIPTION
## Summary
- extract spell slot table and utility helpers
- surface character spell slots in tabs above the module navbar
- relocate copyright message into the Help modal and remove legacy footer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be27410c088323b5c6d3ba2c199ef2