### PR TITLE
feat: add spell slot tabs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -145,6 +145,39 @@ label {
   background-color: #a00000; /* Darker red color on hover */
 }
 
+.spell-slot-tabs {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  font-family: 'Raleway', sans-serif;
+}
+
+.spell-slot-tab {
+  background-color: var(--bs-secondary);
+  border: 1px solid var(--bs-dark);
+  padding: 0.25rem;
+  border-radius: 0.25rem 0.25rem 0 0;
+  color: var(--bs-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.spell-slot {
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--bs-light);
+  margin: 2px;
+}
+
+.spell-slot.available {
+  background-color: var(--bs-primary);
+}
+
 // Dice Roller----------------------------------------------------------------------------------------------
 $transitionDuration: 0.5s;
 $animationDuration:  3s;

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -8,7 +8,7 @@ import { useParams } from 'react-router-dom';
  * Spells are fetched from the server and filtered by class and level.
  */
 // Full-caster spell slot table indexed by class level then spell level
-const SLOT_TABLE = {
+export const SLOT_TABLE = {
   0: Array(10).fill(0),
   1: [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
   2: [0, 3, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/client/src/components/Zombies/attributes/SpellSlotTabs.js
+++ b/client/src/components/Zombies/attributes/SpellSlotTabs.js
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react';
+import { SLOT_TABLE } from './SpellSelector';
+
+const ROMAN_NUMERALS = {
+  1: 'I',
+  2: 'II',
+  3: 'III',
+  4: 'IV',
+  5: 'V',
+  6: 'VI',
+  7: 'VII',
+  8: 'VIII',
+  9: 'IX',
+};
+
+export default function SpellSlotTabs({ form, remainingSlots = {} }) {
+  const slotsByLevel = useMemo(() => {
+    const totalEffectiveLevel = (form.occupation || []).reduce((sum, occ) => {
+      const level = Number(occ.Level) || 0;
+      const progression = occ.casterProgression || occ.CasterProgression || 'full';
+      const effective = progression === 'half'
+        ? level < 2 ? 0 : Math.ceil(level / 2)
+        : progression === 'full'
+        ? level
+        : 0;
+      return sum + effective;
+    }, 0);
+
+    const slotRow = SLOT_TABLE[totalEffectiveLevel] || [];
+    const map = {};
+    slotRow.forEach((count, lvl) => {
+      if (lvl > 0 && count > 0) {
+        map[lvl] = count;
+      }
+    });
+    return map;
+  }, [form]);
+
+  return (
+    <div className="spell-slot-tabs">
+      {Object.entries(slotsByLevel).map(([lvl, count]) => {
+        const level = Number(lvl);
+        const remaining = remainingSlots[level] ?? count;
+        return (
+          <div
+            className="spell-slot-tab"
+            key={level}
+            data-testid={`spell-slot-tab-${level}`}
+          >
+            <div>{ROMAN_NUMERALS[level]}</div>
+            <div>
+              {Array.from({ length: count }).map((_, idx) => (
+                <div
+                  key={idx}
+                  data-testid="slot"
+                  className={`spell-slot ${idx < remaining ? 'available' : 'spent'}`}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/client/src/components/Zombies/attributes/SpellSlotTabs.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlotTabs.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import SpellSlotTabs from './SpellSlotTabs';
+
+test('renders tabs only for levels with slots', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 5 }] };
+  render(<SpellSlotTabs form={form} />);
+  expect(screen.getByText('I')).toBeInTheDocument();
+  expect(screen.getByText('II')).toBeInTheDocument();
+  expect(screen.getByText('III')).toBeInTheDocument();
+  expect(screen.queryByText('IV')).toBeNull();
+});
+
+test('shows correct number of slots per level', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 5 }] };
+  render(<SpellSlotTabs form={form} />);
+  const lvl1 = screen.getByTestId('spell-slot-tab-1');
+  expect(within(lvl1).getAllByTestId('slot').length).toBe(4);
+  const lvl2 = screen.getByTestId('spell-slot-tab-2');
+  expect(within(lvl2).getAllByTestId('slot').length).toBe(3);
+  const lvl3 = screen.getByTestId('spell-slot-tab-3');
+  expect(within(lvl3).getAllByTestId('slot').length).toBe(2);
+});
+

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -19,6 +19,7 @@ import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
+import SpellSlotTabs from "../attributes/SpellSlotTabs";
 
 const HEADER_PADDING = 16;
 
@@ -320,8 +321,9 @@ return (
     <Navbar
       fixed="bottom"
       data-bs-theme="dark"
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)', position: 'relative' }}
     >
+      <SpellSlotTabs form={form} />
       <Container style={{ backgroundColor: 'transparent' }}>
         <Nav
           className="me-auto mx-auto"


### PR DESCRIPTION
## Summary
- show available spell slots with roman numeral tabs on character sheet
- style spell slot tabs to match player sheet
- add tests for slot tab rendering and counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beff194ec883239aa6794af0f3a63a