### PR TITLE
Add spell slot tabs and fixed bottom nav

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3,6 +3,21 @@
 @import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
 
+.bottom-nav-wrapper {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  z-index: 1030;
+}
+.spell-slot-tabs {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
 .weapon-checkbox .form-check-input:checked {
   background-color: var(--bs-primary);
   border-color: var(--bs-primary);

--- a/client/src/components/Zombies/attributes/SpellSlotTabs.js
+++ b/client/src/components/Zombies/attributes/SpellSlotTabs.js
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import { Nav } from 'react-bootstrap';
+
+const SLOT_TABLE = {
+  0: Array(10).fill(0),
+  1: [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+  2: [0, 3, 0, 0, 0, 0, 0, 0, 0, 0],
+  3: [0, 4, 2, 0, 0, 0, 0, 0, 0, 0],
+  4: [0, 4, 3, 0, 0, 0, 0, 0, 0, 0],
+  5: [0, 4, 3, 2, 0, 0, 0, 0, 0, 0],
+  6: [0, 4, 3, 3, 0, 0, 0, 0, 0, 0],
+  7: [0, 4, 3, 3, 1, 0, 0, 0, 0, 0],
+  8: [0, 4, 3, 3, 2, 0, 0, 0, 0, 0],
+  9: [0, 4, 3, 3, 3, 1, 0, 0, 0, 0],
+  10: [0, 4, 3, 3, 3, 2, 0, 0, 0, 0],
+  11: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
+  12: [0, 4, 3, 3, 3, 2, 1, 0, 0, 0],
+  13: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
+  14: [0, 4, 3, 3, 3, 2, 1, 1, 0, 0],
+  15: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
+  16: [0, 4, 3, 3, 3, 2, 1, 1, 1, 0],
+  17: [0, 4, 3, 3, 3, 2, 1, 1, 1, 1],
+  18: [0, 4, 3, 3, 3, 3, 1, 1, 1, 1],
+  19: [0, 4, 3, 3, 3, 3, 2, 1, 1, 1],
+  20: [0, 4, 3, 3, 3, 3, 2, 2, 1, 1],
+};
+
+const ROMAN_NUMERALS = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
+
+export default function SpellSlotTabs({ form }) {
+  const totalEffectiveLevel = useMemo(() => {
+    return (form?.occupation || []).reduce((sum, o) => {
+      const lvl = Number(o.Level) || 0;
+      const progression = o.casterProgression || o.CasterProgression || 'full';
+      const effective =
+        progression === 'half'
+          ? lvl < 2
+            ? 0
+            : Math.ceil(lvl / 2)
+          : progression === 'full'
+          ? lvl
+          : 0;
+      return sum + effective;
+    }, 0);
+  }, [form?.occupation]);
+
+  const slotRow = SLOT_TABLE[totalEffectiveLevel] || [];
+  const levels = slotRow.reduce((acc, slots, lvl) => {
+    if (lvl > 0 && slots > 0) acc.push(lvl);
+    return acc;
+  }, []);
+
+  if (levels.length === 0) return null;
+
+  return (
+    <Nav variant="tabs" className="spell-slot-tabs">
+      {levels.map((lvl) => (
+        <Nav.Item key={lvl}>
+          <Nav.Link>{ROMAN_NUMERALS[lvl]}</Nav.Link>
+        </Nav.Item>
+      ))}
+    </Nav>
+  );
+}
+

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -17,6 +17,7 @@ import Help from "../attributes/Help";
 import { SKILLS } from "../skillSchema";
 import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
+import SpellSlotTabs from "../attributes/SpellSlotTabs";
 import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
 
@@ -317,16 +318,18 @@ return (
       headerHeight={headerHeight}
       ref={playerTurnActionsRef}
     />
-    <Navbar
-      fixed="bottom"
-      data-bs-theme="dark"
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
-    >
-      <Container style={{ backgroundColor: 'transparent' }}>
-        <Nav
-          className="me-auto mx-auto"
-          style={{ backgroundColor: 'transparent' }}
-        >
+    <div className="bottom-nav-wrapper">
+      <SpellSlotTabs form={form} />
+      <Navbar
+        fixed="bottom"
+        data-bs-theme="dark"
+        style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+      >
+        <Container style={{ backgroundColor: 'transparent' }}>
+          <Nav
+            className="me-auto mx-auto"
+            style={{ backgroundColor: 'transparent' }}
+          >
           <Button
             onClick={handleShowCharacterInfo}
             style={{ color: "black", padding: "8px", marginTop: "10px" }}
@@ -427,9 +430,10 @@ return (
             className="mx-1 fas fa-info"
             variant="primary"
           ></Button>
-        </Nav>
-      </Container>
-    </Navbar>
+          </Nav>
+        </Container>
+      </Navbar>
+    </div>
     <CharacterInfo
       form={form}
       show={showCharacterInfo}


### PR DESCRIPTION
## Summary
- Show spell slot tabs for available spell levels using Roman numerals
- Wrap navbar and spell tabs inside a fixed bottom container
- Add styling for new bottom nav wrapper and tabs

## Testing
- `CI=true npm test` *(fails: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01eada10832398816f33a4582da8