### PR TITLE
Add spell slot tab bar and utilities

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3,6 +3,77 @@
 @import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
 
+.spell-slot-tabs {
+  display: flex;
+  overflow-x: auto;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  scrollbar-width: none;
+}
+
+.spell-slot-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.spell-slot-tabs.fade-left::before,
+.spell-slot-tabs.fade-right::after {
+  content: '';
+  position: sticky;
+  top: 0;
+  bottom: 0;
+  width: 1rem;
+  pointer-events: none;
+}
+
+.spell-slot-tabs.fade-left::before {
+  left: 0;
+  background: linear-gradient(to right, white, transparent);
+}
+
+.spell-slot-tabs.fade-right::after {
+  right: 0;
+  background: linear-gradient(to left, white, transparent);
+}
+
+.spell-slot-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #dee2e6;
+  border-radius: 9999px;
+  background-color: #fff;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  color: var(--bs-dark);
+}
+
+.spell-slot-tab.active {
+  background-color: var(--bs-primary);
+  color: #fff;
+}
+
+.spell-slot-tab.dimmed {
+  opacity: 0.5;
+}
+
+.spell-slot-tab .pips {
+  display: flex;
+  gap: 0.125rem;
+}
+
+.spell-slot-tab .pip {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  opacity: 0.4;
+}
+
+.spell-slot-tab .pip.filled {
+  background-color: currentColor;
+  opacity: 1;
+}
+
 .weapon-checkbox .form-check-input:checked {
   background-color: var(--bs-primary);
   border-color: var(--bs-primary);

--- a/client/src/components/Zombies/attributes/SpellSlotTabs.js
+++ b/client/src/components/Zombies/attributes/SpellSlotTabs.js
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+import toRoman from '../../../utils/toRoman';
+import classNames from '../../../utils/classNames';
+
+export default function SpellSlotTabs({
+  spellSlots = [],
+  pactSlots,
+  selectedLevel,
+  onLevelFilter,
+}) {
+  const containerRef = useRef(null);
+  const tabRefs = useRef([]);
+
+  const slots = pactSlots ? [...spellSlots, { ...pactSlots, pact: true }] : spellSlots;
+
+  const [showLeftFade, setShowLeftFade] = useState(false);
+  const [showRightFade, setShowRightFade] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      setShowLeftFade(el.scrollLeft > 0);
+      setShowRightFade(el.scrollLeft + el.clientWidth < el.scrollWidth);
+    };
+    update();
+    el.addEventListener('scroll', update);
+    window.addEventListener('resize', update);
+    return () => {
+      el.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+
+  const handleKeyDown = (idx, level) => (e) => {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const next = (idx + 1) % tabRefs.current.length;
+      tabRefs.current[next]?.focus();
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const prev = (idx - 1 + tabRefs.current.length) % tabRefs.current.length;
+      tabRefs.current[prev]?.focus();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      onLevelFilter && onLevelFilter(level);
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={classNames(
+        'spell-slot-tabs',
+        showLeftFade && 'fade-left',
+        showRightFade && 'fade-right'
+      )}
+      role="tablist"
+    >
+      {slots.map((slot, idx) => {
+        const level = slot.level;
+        const total = slot.total || 0;
+        const remaining = Math.max(0, Math.min(slot.remaining || 0, total));
+        const isSelected = selectedLevel === level;
+        const isDim = remaining === 0;
+
+        return (
+          <button
+            key={slot.pact ? `pact-${level}` : level}
+            ref={(el) => (tabRefs.current[idx] = el)}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            className={classNames('spell-slot-tab', isSelected && 'active', isDim && 'dimmed')}
+            onClick={() => onLevelFilter && onLevelFilter(level)}
+            onKeyDown={handleKeyDown(idx, level)}
+          >
+            <span className="level-label">{toRoman(level)}</span>
+            <span className="pips">
+              {Array.from({ length: total }).map((_, i) => (
+                <span
+                  key={i}
+                  className={classNames('pip', i < remaining && 'filled')}
+                />
+              ))}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/utils/classNames.js
+++ b/client/src/utils/classNames.js
@@ -1,0 +1,3 @@
+export default function classNames(...classes) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/client/src/utils/toRoman.js
+++ b/client/src/utils/toRoman.js
@@ -1,0 +1,5 @@
+const ROMANS = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
+
+export default function toRoman(n) {
+  return ROMANS[n - 1] || '';
+}


### PR DESCRIPTION
## Summary
- add toRoman and classNames helpers
- implement scrollable SpellSlotTabs component with keyboard controls and pips
- style spell slot tab bar

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bf0d9fafa0832388816485789307b7