### PR TITLE
feat: add spell slot tabs to character sheet

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -26,6 +26,7 @@ jest.mock('../attributes/BackgroundModal', () => () => null);
 jest.mock('../attributes/Features', () => () => null);
 jest.mock('../attributes/SpellSelector', () => () => null);
 jest.mock('../attributes/HealthDefense', () => () => null);
+jest.mock('../attributes/SpellSlotTabs', () => () => null);
 
 beforeEach(() => {
   apiFetch.mockReset();


### PR DESCRIPTION
## Summary
- show spell slot tabs in zombie character sheet
- compute slots and pact magic for characters
- add tests for slot tab integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf16c3074883238d2a45b8bcdb23a0