### PR TITLE
feat: add spell slot tabs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9,6 +9,9 @@
   gap: 0.5rem;
   padding: 0.25rem;
   scrollbar-width: none;
+  position: relative;
+  margin-bottom: -0.5rem;
+  z-index: 1;
 }
 
 .spell-slot-tabs::-webkit-scrollbar {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -19,6 +19,8 @@ import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
+import SpellSlotTabs from '../attributes/SpellSlotTabs';
+import { getSpellSlots } from '../../../utils/spellSlots';
 
 const HEADER_PADDING = 16;
 const SPELLCASTING_CLASSES = {
@@ -48,6 +50,9 @@ export default function ZombiesCharacterSheet() {
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showBackground, setShowBackground] = useState(false);
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
+  const [spellSlots, setSpellSlots] = useState([]);
+  const [pactSlots, setPactSlots] = useState(null);
+  const [selectedLevel, setSelectedLevel] = useState(null);
 
   const playerTurnActionsRef = useRef(null);
 
@@ -113,6 +118,17 @@ export default function ZombiesCharacterSheet() {
 
     fetchCharacterData(characterId);
   }, [characterId]);
+
+  useEffect(() => {
+    if (!form || !form.occupation) {
+      setSpellSlots([]);
+      setPactSlots(null);
+      return;
+    }
+    const { spellSlots: slots, pactSlots } = getSpellSlots(form.occupation);
+    setSpellSlots(slots);
+    setPactSlots(pactSlots);
+  }, [form?.occupation]);
 
   const handleShowCharacterInfo = () => setShowCharacterInfo(true);
   const handleCloseCharacterInfo = () => setShowCharacterInfo(false);
@@ -420,6 +436,12 @@ return (
       strMod={statMods.str}
       headerHeight={headerHeight}
       ref={playerTurnActionsRef}
+    />
+    <SpellSlotTabs
+      spellSlots={spellSlots}
+      pactSlots={pactSlots}
+      selectedLevel={selectedLevel}
+      onLevelFilter={setSelectedLevel}
     />
     <Navbar
       fixed="bottom"

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
 jest.mock('../../../utils/apiFetch');
@@ -231,6 +231,7 @@ test('all footer buttons have footer-btn class', async () => {
   });
 
   render(<ZombiesCharacterSheet />);
-  const buttons = await screen.findAllByRole('button');
+  const nav = await screen.findByRole('navigation');
+  const buttons = within(nav).getAllByRole('button');
   buttons.forEach((btn) => expect(btn).toHaveClass('footer-btn'));
 });

--- a/client/src/utils/spellSlots.js
+++ b/client/src/utils/spellSlots.js
@@ -1,0 +1,95 @@
+export const fullCasterSlots = {
+  1: { 1: 2 },
+  2: { 1: 3 },
+  3: { 1: 4, 2: 2 },
+  4: { 1: 4, 2: 3 },
+  5: { 1: 4, 2: 3, 3: 2 },
+  6: { 1: 4, 2: 3, 3: 3 },
+  7: { 1: 4, 2: 3, 3: 3, 4: 1 },
+  8: { 1: 4, 2: 3, 3: 3, 4: 2 },
+  9: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+ 10: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+ 11: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+ 12: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+ 13: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+ 14: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+ 15: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+ 16: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+ 17: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 },
+ 18: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 1, 7: 1, 8: 1, 9: 1 },
+ 19: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 1, 8: 1, 9: 1 },
+ 20: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 2, 8: 1, 9: 1 }
+};
+
+export const pactMagic = {
+  1: { 1: 1 },
+  2: { 1: 2 },
+  3: { 2: 2 },
+  4: { 2: 2 },
+  5: { 3: 2 },
+  6: { 3: 2 },
+  7: { 4: 2 },
+  8: { 4: 2 },
+  9: { 5: 2 },
+ 10: { 5: 2 },
+ 11: { 5: 3 },
+ 12: { 5: 3 },
+ 13: { 5: 3 },
+ 14: { 5: 3 },
+ 15: { 5: 3 },
+ 16: { 5: 3 },
+ 17: { 5: 4 },
+ 18: { 5: 4 },
+ 19: { 5: 4 },
+ 20: { 5: 4 }
+};
+
+const PROGRESSION = {
+  bard: 'full',
+  cleric: 'full',
+  druid: 'full',
+  sorcerer: 'full',
+  wizard: 'full',
+  paladin: 'half',
+  ranger: 'half',
+  warlock: 'pact'
+};
+
+export function getSpellSlots(occupation = []) {
+  let casterLevel = 0;
+  let warlockLevel = 0;
+
+  occupation.forEach((cls) => {
+    const name = (cls.Name || cls.name || '').toLowerCase();
+    const level = Number(cls.Level || cls.level || 0);
+    const type = PROGRESSION[name];
+    if (type === 'full') {
+      casterLevel += level;
+    } else if (type === 'half') {
+      casterLevel += Math.floor(level / 2);
+    } else if (type === 'pact') {
+      warlockLevel += level;
+    }
+  });
+
+  const table = fullCasterSlots[casterLevel] || {};
+  const spellSlots = Object.entries(table).map(([lvl, total]) => ({
+    level: Number(lvl),
+    total,
+    remaining: total
+  }));
+
+  let pactSlots;
+  if (warlockLevel > 0) {
+    const warlockTable = pactMagic[warlockLevel] || {};
+    const entry = Object.entries(warlockTable)[0];
+    if (entry) {
+      const [lvl, total] = entry;
+      pactSlots = { level: Number(lvl), total, remaining: total };
+    }
+  }
+
+  return { spellSlots, pactSlots };
+}
+
+export default getSpellSlots;


### PR DESCRIPTION
## Summary
- add utility to compute multiclass spell slots and pact magic
- show spell slot tabs above footer controls
- adjust tests for new spell slot component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf2412c548832390be707b41f848e1