### PR TITLE
Refactor spell slot grid styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -68,25 +68,29 @@
 }
 
 .spell-slot .slot-boxes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
   justify-content: center;
 }
 
 .spell-slot .slot-small {
-  width: 10px;
-  height: 10px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
   border: 1px solid #fff;
-  cursor: pointer;
 }
 
-.spell-slot .slot-filled {
-  background: #fff;
+.spell-slot .slot-active {
+  background: #007bff;
 }
 
 .spell-slot .slot-used {
   background: transparent;
+}
+
+.spell-slot .slot-inactive {
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .text-center {

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -61,13 +61,17 @@ export default function SpellSlots({ form = {} }) {
           <div key={lvl} className="spell-slot">
             <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
             <div className="slot-boxes">
-              {Array.from({ length: Math.min(count, 4) }).map((_, i) => (
-                <div
-                  key={i}
-                  className={`slot-small ${used[lvl]?.[i] ? 'slot-used' : 'slot-filled'}`}
-                  onClick={() => toggleSlot(lvl, i)}
-                />
-              ))}
+              {Array.from({ length: 4 }).map((_, i) => {
+                const isActive = i < count;
+                const isUsed = used[lvl]?.[i];
+                return (
+                  <div
+                    key={i}
+                    className={`slot-small ${isActive ? (isUsed ? 'slot-used' : 'slot-active') : 'slot-inactive'}`}
+                    onClick={isActive ? () => toggleSlot(lvl, i) : undefined}
+                  />
+                );
+              })}
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary
- Always render four spell slot boxes and mark them active, used, or inactive
- Switch spell slot UI to a 2x2 grid with new active/used/inactive styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf592a31c8832ea67672e3a68c2de3