### PR TITLE
Refactor spell slot grid styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -41,7 +41,7 @@
 
 .spell-slot-container {
   position: fixed;
-  bottom: 60px;
+  bottom: 100px;
   left: 0;
   right: 0;
   display: flex;
@@ -51,42 +51,54 @@
 }
 
 .spell-slot {
+  position: relative;
   width: 48px;
   height: 48px;
   border: 2px solid #fff;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
   padding: 2px;
 }
 
 .spell-slot .slot-level {
+  position: absolute;
+  top: 2px;
+  left: 2px;
   font-size: 0.75rem;
+  z-index: 1;
+  pointer-events: none;
 }
 
 .spell-slot .slot-boxes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2px;
-  justify-content: center;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  right: 2px;
+  bottom: 2px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  z-index: 0;
 }
 
 .spell-slot .slot-small {
-  width: 10px;
-  height: 10px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
   border: 1px solid #fff;
-  cursor: pointer;
 }
 
-.spell-slot .slot-filled {
-  background: #fff;
+.spell-slot .slot-active {
+  background: #007bff;
+  box-shadow: 0 0 5px #007bff, 0 0 10px #007bff;
 }
 
 .spell-slot .slot-used {
   background: transparent;
+}
+
+.spell-slot .slot-inactive {
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .text-center {

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -61,13 +61,17 @@ export default function SpellSlots({ form = {} }) {
           <div key={lvl} className="spell-slot">
             <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
             <div className="slot-boxes">
-              {Array.from({ length: Math.min(count, 4) }).map((_, i) => (
-                <div
-                  key={i}
-                  className={`slot-small ${used[lvl]?.[i] ? 'slot-used' : 'slot-filled'}`}
-                  onClick={() => toggleSlot(lvl, i)}
-                />
-              ))}
+              {Array.from({ length: 4 }).map((_, i) => {
+                const isActive = i < count;
+                const isUsed = used[lvl]?.[i];
+                return (
+                  <div
+                    key={i}
+                    className={`slot-small ${isActive ? (isUsed ? 'slot-used' : 'slot-active') : 'slot-inactive'}`}
+                    onClick={isActive ? () => toggleSlot(lvl, i) : undefined}
+                  />
+                );
+              })}
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary
- Always render four spell slot boxes and mark them active, used, or inactive
- Switch spell slot UI to a 2x2 grid with new active/used/inactive styles
- Position spell slots higher above the bottom nav and give active slots a blue glow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf592a31c8832ea67672e3a68c2de3