### PR TITLE
Render only available spell slots

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -61,14 +61,13 @@ export default function SpellSlots({ form = {} }) {
           <div key={lvl} className="spell-slot">
             <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
             <div className="slot-boxes">
-              {Array.from({ length: 4 }).map((_, i) => {
-                const isActive = i < count;
+              {Array.from({ length: count }).map((_, i) => {
                 const isUsed = used[lvl]?.[i];
                 return (
                   <div
                     key={i}
-                    className={`slot-small ${isActive ? (isUsed ? 'slot-used' : 'slot-active') : 'slot-inactive'}`}
-                    onClick={isActive ? () => toggleSlot(lvl, i) : undefined}
+                    className={`slot-small ${isUsed ? 'slot-used' : 'slot-active'}`}
+                    onClick={() => toggleSlot(lvl, i)}
                   />
                 );
               })}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SpellSlots from './SpellSlots';
+import { fullCasterSlots } from '../../../utils/spellSlots';
+
+test('renders only the available number of slots', () => {
+  const casterLevel = 3; // corresponds to levels 1 and 2
+  const form = { occupation: [{ Name: 'Wizard', Level: casterLevel }] };
+  const { container } = render(<SpellSlots form={form} />);
+
+  const expected = fullCasterSlots[casterLevel];
+  const slotBoxDivs = container.querySelectorAll('.slot-boxes');
+  Object.values(expected).forEach((count, idx) => {
+    expect(slotBoxDivs[idx].querySelectorAll('.slot-small').length).toBe(count);
+  });
+});


### PR DESCRIPTION
## Summary
- Render only the available spell slot count and toggle each slot
- Add tests for SpellSlots to ensure correct slot rendering

## Testing
- `CI=true npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bf6ded870883239cdc714a075ebf9c