### PR TITLE
feat: track rests for spell slots

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -3,7 +3,14 @@ import { Card, Table, Modal, Button } from "react-bootstrap";
 import levelup from "../../../images/levelup.png";
 import LevelUp from "./LevelUp"; // Import LevelUp component
 
-export default function CharacterInfo({ form, show, handleClose, onShowBackground }) {
+export default function CharacterInfo({
+  form,
+  show,
+  handleClose,
+  onShowBackground,
+  onLongRest = () => {},
+  onShortRest = () => {},
+}) {
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
 
@@ -91,10 +98,32 @@ export default function CharacterInfo({ form, show, handleClose, onShowBackgroun
           </Table>
         </Card.Body>
         <Card.Footer className="modal-footer">
-          <Button className="action-btn" variant="secondary" onClick={handleShowLevelUpModal}>
+          <Button
+            className="action-btn"
+            variant="secondary"
+            onClick={handleShowLevelUpModal}
+          >
             <img src={levelup} alt="Level Up" height="24" />
           </Button>
-          <Button className="action-btn close-btn" variant="primary" onClick={handleClose}>
+          <Button
+            className="action-btn"
+            variant="secondary"
+            onClick={onLongRest}
+          >
+            Long Rest
+          </Button>
+          <Button
+            className="action-btn"
+            variant="secondary"
+            onClick={onShortRest}
+          >
+            Short Rest
+          </Button>
+          <Button
+            className="action-btn close-btn"
+            variant="primary"
+            onClick={handleClose}
+          >
             Close
           </Button>
         </Card.Footer>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -14,7 +14,16 @@ test('renders race languages', () => {
     weight: 180,
   };
 
-  render(<CharacterInfo form={form} show={true} handleClose={() => {}} onShowBackground={() => {}} />);
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={() => {}}
+      onLongRest={() => {}}
+      onShortRest={() => {}}
+    />
+  );
 
   expect(screen.getByText('Common, Elvish')).toBeInTheDocument();
 });
@@ -37,6 +46,8 @@ test('renders background name and calls onShowBackground', () => {
       show={true}
       handleClose={() => {}}
       onShowBackground={onShowBackground}
+      onLongRest={() => {}}
+      onShortRest={() => {}}
     />
   );
 
@@ -44,5 +55,34 @@ test('renders background name and calls onShowBackground', () => {
   const button = screen.getByLabelText('Show Background');
   fireEvent.click(button);
   expect(onShowBackground).toHaveBeenCalled();
+});
+
+test('calls rest handlers when buttons clicked', () => {
+  const form = {
+    occupation: [],
+    race: { languages: [] },
+    age: 100,
+    sex: 'M',
+    height: "6'",
+    weight: 180,
+  };
+  const onLongRest = jest.fn();
+  const onShortRest = jest.fn();
+
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={() => {}}
+      onLongRest={onLongRest}
+      onShortRest={onShortRest}
+    />
+  );
+
+  fireEvent.click(screen.getByText('Long Rest'));
+  fireEvent.click(screen.getByText('Short Rest'));
+  expect(onLongRest).toHaveBeenCalled();
+  expect(onShortRest).toHaveBeenCalled();
 });
 

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 
 const SPELLCASTING_CLASSES = {
@@ -13,7 +13,7 @@ const SPELLCASTING_CLASSES = {
 
 const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
 
-export default function SpellSlots({ form = {} }) {
+export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCount = 0 }) {
   const [used, setUsed] = useState({});
 
   const occupations = form.occupation || [];
@@ -41,6 +41,21 @@ export default function SpellSlots({ form = {} }) {
   Object.entries(warlockData).forEach(([lvl, cnt]) => {
     combined[lvl] = (combined[lvl] || 0) + cnt;
   });
+
+  useEffect(() => {
+    setUsed({});
+  }, [longRestCount]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setUsed((prev) => {
+      const updated = { ...prev };
+      Object.keys(warlockData).forEach((lvl) => {
+        delete updated[lvl];
+      });
+      return updated;
+    });
+  }, [shortRestCount]);
 
   const toggleSlot = (lvl, idx) => {
     setUsed((prev) => {

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import SpellSlots from './SpellSlots';
 import { fullCasterSlots } from '../../../utils/spellSlots';
 
@@ -13,4 +13,33 @@ test('renders only the available number of slots', () => {
   Object.values(expected).forEach((count, idx) => {
     expect(slotBoxDivs[idx].querySelectorAll('.slot-small').length).toBe(count);
   });
+});
+
+test('long rest clears all used slots', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 3 }] };
+  const { container, rerender } = render(<SpellSlots form={form} />);
+  const firstSlot = container.querySelector('.slot-small');
+  fireEvent.click(firstSlot);
+  expect(firstSlot).toHaveClass('slot-used');
+  rerender(<SpellSlots form={form} longRestCount={1} />);
+  expect(container.querySelector('.slot-small')).not.toHaveClass('slot-used');
+});
+
+test('short rest clears only warlock slots', () => {
+  const form = {
+    occupation: [
+      { Name: 'Warlock', Level: 5 },
+      { Name: 'Wizard', Level: 3 },
+    ],
+  };
+  const { rerender } = render(<SpellSlots form={form} />);
+  const warlockSlot = screen.getByText('III').parentElement.querySelector('.slot-small');
+  const wizardSlot = screen.getByText('I').parentElement.querySelector('.slot-small');
+  fireEvent.click(warlockSlot);
+  fireEvent.click(wizardSlot);
+  expect(warlockSlot).toHaveClass('slot-used');
+  expect(wizardSlot).toHaveClass('slot-used');
+  rerender(<SpellSlots form={form} shortRestCount={1} />);
+  expect(screen.getByText('III').parentElement.querySelector('.slot-small')).not.toHaveClass('slot-used');
+  expect(screen.getByText('I').parentElement.querySelector('.slot-small')).toHaveClass('slot-used');
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -49,6 +49,8 @@ export default function ZombiesCharacterSheet() {
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showBackground, setShowBackground] = useState(false);
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
+  const [longRestCount, setLongRestCount] = useState(0);
+  const [shortRestCount, setShortRestCount] = useState(0);
 
   const playerTurnActionsRef = useRef(null);
 
@@ -140,6 +142,14 @@ export default function ZombiesCharacterSheet() {
 
   const handleRollResult = (result) => {
     playerTurnActionsRef.current?.updateDamageValueWithAnimation(result);
+  };
+
+  const handleLongRest = () => {
+    setLongRestCount((c) => c + 1);
+  };
+
+  const handleShortRest = () => {
+    setShortRestCount((c) => c + 1);
   };
 
   const handleWeaponsChange = useCallback(
@@ -422,7 +432,13 @@ return (
       headerHeight={headerHeight}
       ref={playerTurnActionsRef}
     />
-    {hasSpellcasting && form && <SpellSlots form={form} />}
+    {hasSpellcasting && form && (
+      <SpellSlots
+        form={form}
+        longRestCount={longRestCount}
+        shortRestCount={shortRestCount}
+      />
+    )}
     <Navbar
       fixed="bottom"
       data-bs-theme="dark"
@@ -537,6 +553,8 @@ return (
       show={showCharacterInfo}
       handleClose={handleCloseCharacterInfo}
       onShowBackground={handleShowBackground}
+      onLongRest={handleLongRest}
+      onShortRest={handleShortRest}
     />
     <Skills
       form={form}


### PR DESCRIPTION
## Summary
- add long and short rest counters to character sheet
- reset spell slot usage on rest and expose rest buttons in character info
- test rest mechanics for spell slots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf726079a483239f9d2c9c92aecc0f