### PR TITLE
Separate pact magic spell slots into tabs

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Tabs, Tab } from 'react-bootstrap';
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 
 const SPELLCASTING_CLASSES = {
@@ -14,7 +15,8 @@ const SPELLCASTING_CLASSES = {
 const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
 
 export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCount = 0 }) {
-  const [used, setUsed] = useState({});
+  const [usedRegular, setUsedRegular] = useState({});
+  const [usedWarlock, setUsedWarlock] = useState({});
 
   const occupations = form.occupation || [];
   let casterLevel = 0;
@@ -37,59 +39,82 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
 
   const slotData = fullCasterSlots[casterLevel] || {};
   const warlockData = pactMagic[warlockLevel] || {};
-  const combined = { ...slotData };
-  Object.entries(warlockData).forEach(([lvl, cnt]) => {
-    combined[lvl] = (combined[lvl] || 0) + cnt;
-  });
 
   useEffect(() => {
-    setUsed({});
+    setUsedRegular({});
+    setUsedWarlock({});
   }, [longRestCount]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    setUsed((prev) => {
-      const updated = { ...prev };
-      Object.keys(warlockData).forEach((lvl) => {
-        delete updated[lvl];
-      });
-      return updated;
-    });
+    setUsedWarlock({});
   }, [shortRestCount]);
 
-  const toggleSlot = (lvl, idx) => {
-    setUsed((prev) => {
+  const toggleRegular = (lvl, idx) => {
+    setUsedRegular((prev) => {
       const levelState = { ...(prev[lvl] || {}) };
       levelState[idx] = !levelState[idx];
       return { ...prev, [lvl]: levelState };
     });
   };
 
-  const levels = Object.keys(combined).map(Number).sort((a, b) => a - b);
-  if (levels.length === 0) return null;
+  const toggleWarlock = (lvl, idx) => {
+    setUsedWarlock((prev) => {
+      const levelState = { ...(prev[lvl] || {}) };
+      levelState[idx] = !levelState[idx];
+      return { ...prev, [lvl]: levelState };
+    });
+  };
+  const regularLevels = Object.keys(slotData)
+    .map(Number)
+    .sort((a, b) => a - b);
+  const warlockLevels = Object.keys(warlockData)
+    .map(Number)
+    .sort((a, b) => a - b);
+  if (regularLevels.length === 0 && warlockLevels.length === 0) return null;
 
-  return (
-    <div className="spell-slot-container">
-      {levels.map((lvl) => {
-        const count = combined[lvl];
+  const renderSlots = (data, usedState, toggle) => {
+    return Object.keys(data)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((lvl) => {
+        const count = data[lvl];
         return (
           <div key={lvl} className="spell-slot">
             <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
             <div className="slot-boxes">
               {Array.from({ length: count }).map((_, i) => {
-                const isUsed = used[lvl]?.[i];
+                const isUsed = usedState[lvl]?.[i];
                 return (
                   <div
                     key={i}
                     className={`slot-small ${isUsed ? 'slot-used' : 'slot-active'}`}
-                    onClick={() => toggleSlot(lvl, i)}
+                    onClick={() => toggle(lvl, i)}
                   />
                 );
               })}
             </div>
           </div>
         );
-      })}
+      });
+  };
+
+  const defaultKey = regularLevels.length ? 'spells' : 'pact';
+
+  return (
+    <div className="spell-slot-container">
+      <Tabs defaultActiveKey={defaultKey} id="spell-slot-tabs">
+        {regularLevels.length > 0 && (
+          <Tab eventKey="spells" title="Spell Slots">
+            {renderSlots(slotData, usedRegular, toggleRegular)}
+          </Tab>
+        )}
+        {warlockLevels.length > 0 && (
+          <Tab eventKey="pact" title="Pact Magic">
+            {renderSlots(warlockData, usedWarlock, toggleWarlock)}
+          </Tab>
+        )}
+      </Tabs>
     </div>
   );
 }

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -33,13 +33,17 @@ test('short rest clears only warlock slots', () => {
     ],
   };
   const { rerender } = render(<SpellSlots form={form} />);
+  fireEvent.click(screen.getByRole('tab', { name: /pact magic/i }));
   const warlockSlot = screen.getByText('III').parentElement.querySelector('.slot-small');
-  const wizardSlot = screen.getByText('I').parentElement.querySelector('.slot-small');
   fireEvent.click(warlockSlot);
+  fireEvent.click(screen.getByRole('tab', { name: /spell slots/i }));
+  const wizardSlot = screen.getByText('I').parentElement.querySelector('.slot-small');
   fireEvent.click(wizardSlot);
   expect(warlockSlot).toHaveClass('slot-used');
   expect(wizardSlot).toHaveClass('slot-used');
   rerender(<SpellSlots form={form} shortRestCount={1} />);
+  fireEvent.click(screen.getByRole('tab', { name: /pact magic/i }));
   expect(screen.getByText('III').parentElement.querySelector('.slot-small')).not.toHaveClass('slot-used');
+  fireEvent.click(screen.getByRole('tab', { name: /spell slots/i }));
   expect(screen.getByText('I').parentElement.querySelector('.slot-small')).toHaveClass('slot-used');
 });


### PR DESCRIPTION
## Summary
- Split warlock pact-magic slots from regular spell slots
- Track usage separately and reset with long/short rests
- Render spell slots and pact magic in Bootstrap tabs

## Testing
- `CI=true npm test client/src/components/Zombies/attributes/SpellSlots.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf75489a448323b97037e868b4d83b