### PR TITLE
feat: allow dragging health bar

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -124,6 +124,13 @@ export default function HealthDefense({
     }
   };
 
+  const handleBarChange = (e) => {
+    const newHealth = Number(e.target.value);
+    const offset = newHealth - health;
+    setHealth(newHealth);
+    tempHealthUpdate(offset);
+  };
+
 return (
 <div
   style={{
@@ -182,6 +189,22 @@ return (
         flexShrink: 0
       }}
     >
+      <input
+        type="range"
+        min="-10"
+        max={maxHealth}
+        value={health ?? 0}
+        onChange={handleBarChange}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          opacity: 0,
+          cursor: "pointer",
+        }}
+      />
       <div
         style={{
           width: `${(health / maxHealth) * 100}%`,

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import HealthDefense from './HealthDefense';
+
+jest.mock('../../../utils/apiFetch', () => jest.fn(() => Promise.resolve()));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -67,4 +69,22 @@ test('uses provided proficiency bonus when supplied', () => {
   );
   expect(screen.getByText('Spell Save DC:').parentElement).toHaveTextContent('14');
   expect(screen.getByText('Proficiency Bonus:').parentElement).toHaveTextContent('4');
+});
+
+test('allows health adjustment by dragging the bar', () => {
+  render(
+    <HealthDefense
+      form={baseForm}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  const slider = screen.getByRole('slider');
+  fireEvent.change(slider, { target: { value: '7' } });
+  expect(screen.getByText('7/10')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- allow users to drag health bar to adjust current hit points
- cover health bar dragging with a new unit test

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf79ea2cb0832eaf06399da38c0989