### PR TITLE
Refactor spell slot layout

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -37,10 +37,6 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
 
   const slotData = fullCasterSlots[casterLevel] || {};
   const warlockData = pactMagic[warlockLevel] || {};
-  const combined = { ...slotData };
-  Object.entries(warlockData).forEach(([lvl, cnt]) => {
-    combined[lvl] = (combined[lvl] || 0) + cnt;
-  });
 
   useEffect(() => {
     setUsed({});
@@ -51,45 +47,58 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
     setUsed((prev) => {
       const updated = { ...prev };
       Object.keys(warlockData).forEach((lvl) => {
-        delete updated[lvl];
+        delete updated[`warlock-${lvl}`];
       });
       return updated;
     });
   }, [shortRestCount]);
 
-  const toggleSlot = (lvl, idx) => {
+  const toggleSlot = (type, lvl, idx) => {
+    const key = `${type}-${lvl}`;
     setUsed((prev) => {
-      const levelState = { ...(prev[lvl] || {}) };
+      const levelState = { ...(prev[key] || {}) };
       levelState[idx] = !levelState[idx];
-      return { ...prev, [lvl]: levelState };
+      return { ...prev, [key]: levelState };
     });
   };
 
-  const levels = Object.keys(combined).map(Number).sort((a, b) => a - b);
-  if (levels.length === 0) return null;
+  const regularLevels = Object.keys(slotData).map(Number).sort((a, b) => a - b);
+  const warlockLevels = Object.keys(warlockData).map(Number).sort((a, b) => a - b);
+  if (regularLevels.length === 0 && warlockLevels.length === 0) return null;
 
-  return (
-    <div className="spell-slot-container">
-      {levels.map((lvl) => {
-        const count = combined[lvl];
+  const renderGroup = (data, type) =>
+    Object.keys(data)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((lvl) => {
+        const count = data[lvl];
         return (
           <div key={lvl} className="spell-slot">
             <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
             <div className="slot-boxes">
               {Array.from({ length: count }).map((_, i) => {
-                const isUsed = used[lvl]?.[i];
+                const isUsed = used[`${type}-${lvl}`]?.[i];
                 return (
                   <div
                     key={i}
                     className={`slot-small ${isUsed ? 'slot-used' : 'slot-active'}`}
-                    onClick={() => toggleSlot(lvl, i)}
+                    onClick={() => toggleSlot(type, lvl, i)}
                   />
                 );
               })}
             </div>
           </div>
         );
-      })}
+      });
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <div className="spell-slot-container">{renderGroup(slotData, 'regular')}</div>
+      {warlockLevels.length > 0 && (
+        <div className="spell-slot-container warlock-slot">
+          {renderGroup(warlockData, 'warlock')}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- render regular and warlock spell slots side by side in a flex container
- reset warlock slots independently after short rests

## Testing
- `npm test`
- `CI=true npm test` *(fails: shows 1 failing test in Items/ItemList.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bf79712e0883238fe64b8cf925aa48