### PR TITLE
Fix health bar interaction and add tests

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -203,6 +203,7 @@ return (
           height: "100%",
           opacity: 0,
           cursor: "pointer",
+          zIndex: 1,
         }}
       />
       <div
@@ -211,6 +212,7 @@ return (
           height: "100%",
           background: health > maxHealth * 0.5 ? "#2ecc71" : "#c0392b",
           transition: "width 0.3s ease-in-out",
+          pointerEvents: "none",
         }}
       />
       <span
@@ -224,6 +226,7 @@ return (
           fontWeight: 600,
           color: "#222",
           lineHeight: "24px",
+          pointerEvents: "none",
         }}
       >
         {health}/{maxHealth}

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -88,3 +88,44 @@ test('allows health adjustment by dragging the bar', () => {
   fireEvent.change(slider, { target: { value: '7' } });
   expect(screen.getByText('7/10')).toBeInTheDocument();
 });
+
+test('places range input above fill bar and label', () => {
+  render(
+    <HealthDefense
+      form={baseForm}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  const slider = screen.getByRole('slider');
+  const fill = slider.nextSibling;
+  const label = fill.nextSibling;
+  expect(slider).toHaveStyle('z-index: 1');
+  expect(fill).toHaveStyle('pointer-events: none');
+  expect(label).toHaveStyle('pointer-events: none');
+});
+
+test('updates health when slider is dragged', () => {
+  render(
+    <HealthDefense
+      form={baseForm}
+      conMod={0}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+  const slider = screen.getByRole('slider');
+  fireEvent.mouseDown(slider);
+  fireEvent.change(slider, { target: { value: '8' } });
+  fireEvent.mouseUp(slider);
+  expect(screen.getByText('8/10')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- ensure range slider sits above bar and label so any click/drag updates health
- cover health bar stacking and drag behaviors with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf7c405dc4832e91b0276b51b6d4a2