### PR TITLE
Refactor spell slot container structure

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -92,12 +92,10 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
       });
 
   return (
-    <div style={{ display: 'flex' }}>
-      <div className="spell-slot-container">{renderGroup(slotData, 'regular')}</div>
+    <div className="spell-slot-container">
+      <div>{renderGroup(slotData, 'regular')}</div>
       {warlockLevels.length > 0 && (
-        <div className="spell-slot-container warlock-slot">
-          {renderGroup(warlockData, 'warlock')}
-        </div>
+        <div className="warlock-slot">{renderGroup(warlockData, 'warlock')}</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Use a single `.spell-slot-container` wrapper for spell slots
- Remove unnecessary nested container classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7c9ada248323a6d3a1d41d302a0b