### PR TITLE
Refactor spell slot container structure

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -72,8 +72,9 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
       .sort((a, b) => a - b)
       .map((lvl) => {
         const count = data[lvl];
+        const groupClass = type === 'warlock' ? 'warlock-slot' : 'spell-slot';
         return (
-          <div key={lvl} className="spell-slot">
+          <div key={`${type}-${lvl}`} className={groupClass}>
             <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
             <div className="slot-boxes">
               {Array.from({ length: count }).map((_, i) => {
@@ -92,13 +93,9 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
       });
 
   return (
-    <div style={{ display: 'flex' }}>
-      <div className="spell-slot-container">{renderGroup(slotData, 'regular')}</div>
-      {warlockLevels.length > 0 && (
-        <div className="spell-slot-container warlock-slot">
-          {renderGroup(warlockData, 'warlock')}
-        </div>
-      )}
+    <div className="spell-slot-container">
+      {renderGroup(slotData, 'regular')}
+      {renderGroup(warlockData, 'warlock')}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Use a single `.spell-slot-container` wrapper for spell slots
- Remove unnecessary nested container classes
- Ensure warlock slots render after regular slots within the container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7c9ada248323a6d3a1d41d302a0b