### PR TITLE
Centralize spell slot state and expose cast actions

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -73,6 +73,7 @@ export default function SpellSelector({
   show,
   handleClose,
   onSpellsChange,
+  onCastSpell,
 }) {
   const params = useParams();
 
@@ -373,6 +374,7 @@ export default function SpellSelector({
                           <th>Range</th>
                           <th>Duration</th>
                           <th></th>
+                          <th></th>
                         </tr>
                       </thead>
                       <tbody>
@@ -401,6 +403,14 @@ export default function SpellSelector({
                                 onClick={() => setViewSpell(spell)}
                               >
                                 <i className="fa-solid fa-eye"></i>
+                              </Button>
+                            </td>
+                            <td>
+                              <Button
+                                variant="link"
+                                onClick={() => onCastSpell && onCastSpell(spell.level)}
+                              >
+                                <i className="fa-solid fa-wand-sparkles"></i>
                               </Button>
                             </td>
                           </tr>
@@ -467,6 +477,7 @@ export default function SpellSelector({
                           <th>Range</th>
                           <th>Duration</th>
                           <th></th>
+                          <th></th>
                         </tr>
                       </thead>
                       <tbody>
@@ -495,6 +506,14 @@ export default function SpellSelector({
                                 onClick={() => setViewSpell(spell)}
                               >
                                 <i className="fa-solid fa-eye"></i>
+                              </Button>
+                            </td>
+                            <td>
+                              <Button
+                                variant="link"
+                                onClick={() => onCastSpell && onCastSpell(spell.level)}
+                              >
+                                <i className="fa-solid fa-wand-sparkles"></i>
                               </Button>
                             </td>
                           </tr>

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -71,6 +71,30 @@ test('filters spells by level', async () => {
   expect(screen.queryByText('Cure Wounds')).toBeNull();
 });
 
+test('cast button calls onCastSpell with spell level', async () => {
+  apiFetch
+    .mockResolvedValueOnce({ ok: true, json: async () => spellsData })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ spellsKnown: 14 }) });
+  const onCast = jest.fn();
+  render(
+    <SpellSelector
+      form={{
+        occupation: [{ Name: 'Wizard', Level: 5, casterProgression: 'full' }],
+        spells: [],
+      }}
+      show={true}
+      handleClose={() => {}}
+      onCastSpell={onCast}
+    />
+  );
+  await screen.findByLabelText('Level');
+  await userEvent.selectOptions(screen.getByLabelText('Level'), '3');
+  const row = await screen.findByText('Fireball');
+  const castBtn = within(row.closest('tr')).getAllByRole('button')[1];
+  await userEvent.click(castBtn);
+  expect(onCast).toHaveBeenCalledWith(3);
+});
+
 test('saves selected spells', async () => {
   apiFetch
     .mockResolvedValueOnce({ ok: true, json: async () => spellsData })

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 
 const SPELLCASTING_CLASSES = {
@@ -13,8 +13,7 @@ const SPELLCASTING_CLASSES = {
 
 const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
 
-export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCount = 0 }) {
-  const [used, setUsed] = useState({});
+export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
 
   const occupations = form.occupation || [];
   let casterLevel = 0;
@@ -37,30 +36,6 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
 
   const slotData = fullCasterSlots[casterLevel] || {};
   const warlockData = pactMagic[warlockLevel] || {};
-
-  useEffect(() => {
-    setUsed({});
-  }, [longRestCount]);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    setUsed((prev) => {
-      const updated = { ...prev };
-      Object.keys(warlockData).forEach((lvl) => {
-        delete updated[`warlock-${lvl}`];
-      });
-      return updated;
-    });
-  }, [shortRestCount]);
-
-  const toggleSlot = (type, lvl, idx) => {
-    const key = `${type}-${lvl}`;
-    setUsed((prev) => {
-      const levelState = { ...(prev[key] || {}) };
-      levelState[idx] = !levelState[idx];
-      return { ...prev, [key]: levelState };
-    });
-  };
 
   const regularLevels = Object.keys(slotData).map(Number).sort((a, b) => a - b);
   const warlockLevels = Object.keys(warlockData).map(Number).sort((a, b) => a - b);
@@ -85,7 +60,7 @@ export default function SpellSlots({ form = {}, longRestCount = 0, shortRestCoun
                   <div
                     key={i}
                     className={`slot-small ${isUsed ? 'slot-used' : 'slot-active'}`}
-                    onClick={() => toggleSlot(type, lvl, i)}
+                    onClick={() => onToggleSlot && onToggleSlot(type, lvl, i)}
                   />
                 );
               })}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import SpellSlots from './SpellSlots';
 import { fullCasterSlots } from '../../../utils/spellSlots';
 
 test('renders only the available number of slots', () => {
   const casterLevel = 3; // corresponds to levels 1 and 2
   const form = { occupation: [{ Name: 'Wizard', Level: casterLevel }] };
-  const { container } = render(<SpellSlots form={form} />);
+  const { container } = render(<SpellSlots form={form} used={{}} />);
 
   const expected = fullCasterSlots[casterLevel];
   const slotBoxDivs = container.querySelectorAll('.slot-boxes');
@@ -15,33 +15,23 @@ test('renders only the available number of slots', () => {
   });
 });
 
-test('long rest clears all used slots', () => {
-  const form = { occupation: [{ Name: 'Wizard', Level: 3 }] };
-  const { container, rerender } = render(<SpellSlots form={form} />);
-  const firstSlot = container.querySelector('.slot-small');
-  fireEvent.click(firstSlot);
-  expect(firstSlot).toHaveClass('slot-used');
-  rerender(<SpellSlots form={form} longRestCount={1} />);
-  expect(container.querySelector('.slot-small')).not.toHaveClass('slot-used');
-});
-
-test('short rest clears only warlock slots', () => {
-  const form = {
-    occupation: [
-      { Name: 'Warlock', Level: 5 },
-      { Name: 'Wizard', Level: 3 },
-    ],
-  };
-  const { rerender } = render(<SpellSlots form={form} />);
-  const warlockSlot = screen.getByText('III').parentElement.querySelector('.slot-small');
-  const wizardSlot = screen.getByText('I').parentElement.querySelector('.slot-small');
-  fireEvent.click(warlockSlot);
-  fireEvent.click(wizardSlot);
-  expect(warlockSlot).toHaveClass('slot-used');
-  expect(wizardSlot).toHaveClass('slot-used');
-  rerender(<SpellSlots form={form} shortRestCount={1} />);
-  expect(screen.getByText('III').parentElement.querySelector('.slot-small')).not.toHaveClass('slot-used');
-  expect(screen.getByText('I').parentElement.querySelector('.slot-small')).toHaveClass('slot-used');
+test('reflects used slots from props and toggles via callback', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
+  const onToggle = jest.fn();
+  const { container, rerender } = render(
+    <SpellSlots form={form} used={{}} onToggleSlot={onToggle} />
+  );
+  const first = container.querySelector('.slot-small');
+  fireEvent.click(first);
+  expect(onToggle).toHaveBeenCalledWith('regular', 1, 0);
+  rerender(
+    <SpellSlots
+      form={form}
+      used={{ 'regular-1': { 0: true } }}
+      onToggleSlot={onToggle}
+    />
+  );
+  expect(container.querySelector('.slot-small')).toHaveClass('slot-used');
 });
 
 test('warlock slots render after regular slots and have purple styling', () => {
@@ -51,9 +41,13 @@ test('warlock slots render after regular slots and have purple styling', () => {
       { Name: 'Warlock', Level: 3 },
     ],
   };
-  const { container } = render(<SpellSlots form={form} />);
-  const groups = Array.from(container.querySelectorAll('.spell-slot-container .spell-slot'));
-  const firstWarlockIndex = groups.findIndex((g) => g.classList.contains('warlock-slot'));
+  const { container } = render(<SpellSlots form={form} used={{}} />);
+  const groups = Array.from(
+    container.querySelectorAll('.spell-slot-container .spell-slot')
+  );
+  const firstWarlockIndex = groups.findIndex((g) =>
+    g.classList.contains('warlock-slot')
+  );
   expect(firstWarlockIndex).toBeGreaterThan(0);
   groups.slice(firstWarlockIndex).forEach((g) => {
     expect(g).toHaveClass('warlock-slot');
@@ -62,5 +56,7 @@ test('warlock slots render after regular slots and have purple styling', () => {
   style.innerHTML = '.warlock-slot .slot-active { background: #800080; }';
   document.head.appendChild(style);
   const warlockActive = container.querySelector('.warlock-slot .slot-active');
-  expect(getComputedStyle(warlockActive).backgroundColor).toBe('rgb(128, 0, 128)');
+  expect(getComputedStyle(warlockActive).backgroundColor).toBe(
+    'rgb(128, 0, 128)'
+  );
 });


### PR DESCRIPTION
## Summary
- Centralize spell slot usage in `ZombiesCharacterSheet` and share with slots/selector components
- Allow external components to toggle slots and cast spells via new callbacks
- Display cast button in spell selector and add tests for slot usage and casting

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c04d37ed80832e926b3c385895c1fd