### PR TITLE
Restrict casting to checked spells and display damage

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -378,43 +378,53 @@ export default function SpellSelector({
                         </tr>
                       </thead>
                       <tbody>
-                        {spellsForClass(cls).map((spell) => (
-                          <tr key={spell.name}>
-                            <td>
-                              <Form.Check
-                                id={`spell-${spell.name}`}
-                                type="checkbox"
-                                checked={selectedSpells.includes(spell.name)}
-                                disabled={
-                                  !selectedSpells.includes(spell.name) &&
-                                  (pointsLeft[cls] || 0) <= 0
-                                }
-                                onChange={() => toggleSpell(spell.name)}
-                              />
-                            </td>
-                            <td>{spell.name}</td>
-                            <td>{spell.school}</td>
-                            <td>{spell.castingTime}</td>
-                            <td>{spell.range}</td>
-                            <td>{spell.duration}</td>
-                            <td>
-                              <Button
-                                variant="link"
-                                onClick={() => setViewSpell(spell)}
-                              >
-                                <i className="fa-solid fa-eye"></i>
-                              </Button>
-                            </td>
-                            <td>
-                              <Button
-                                variant="link"
-                                onClick={() => onCastSpell && onCastSpell(spell.level)}
-                              >
-                                <i className="fa-solid fa-wand-sparkles"></i>
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
+                        {spellsForClass(cls).map((spell) => {
+                          const isSelected = selectedSpells.includes(spell.name);
+                          return (
+                            <tr key={spell.name}>
+                              <td>
+                                <Form.Check
+                                  id={`spell-${spell.name}`}
+                                  type="checkbox"
+                                  checked={isSelected}
+                                  disabled={
+                                    !isSelected && (pointsLeft[cls] || 0) <= 0
+                                  }
+                                  onChange={() => toggleSpell(spell.name)}
+                                />
+                              </td>
+                              <td>{spell.name}</td>
+                              <td>{spell.school}</td>
+                              <td>{spell.castingTime}</td>
+                              <td>{spell.range}</td>
+                              <td>{spell.duration}</td>
+                              <td>
+                                <Button
+                                  variant="link"
+                                  onClick={() => setViewSpell(spell)}
+                                >
+                                  <i className="fa-solid fa-eye"></i>
+                                </Button>
+                              </td>
+                              <td>
+                                <Button
+                                  variant="link"
+                                  disabled={!isSelected}
+                                  className={!isSelected ? 'text-secondary' : ''}
+                                  onClick={() => {
+                                    onCastSpell?.({
+                                      level: spell.level,
+                                      damage: spell.damage,
+                                    });
+                                    handleClose();
+                                  }}
+                                >
+                                  <i className="fa-solid fa-wand-sparkles" />
+                                </Button>
+                              </td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
                     </Table>
                   </>
@@ -481,43 +491,53 @@ export default function SpellSelector({
                         </tr>
                       </thead>
                       <tbody>
-                        {spellsForClass(name).map((spell) => (
-                          <tr key={spell.name}>
-                            <td>
-                              <Form.Check
-                                id={`spell-${spell.name}`}
-                                type="checkbox"
-                                checked={selectedSpells.includes(spell.name)}
-                                disabled={
-                                  !selectedSpells.includes(spell.name) &&
-                                  (pointsLeft[name] || 0) <= 0
-                                }
-                                onChange={() => toggleSpell(spell.name)}
-                              />
-                            </td>
-                            <td>{spell.name}</td>
-                            <td>{spell.school}</td>
-                            <td>{spell.castingTime}</td>
-                            <td>{spell.range}</td>
-                            <td>{spell.duration}</td>
-                            <td>
-                              <Button
-                                variant="link"
-                                onClick={() => setViewSpell(spell)}
-                              >
-                                <i className="fa-solid fa-eye"></i>
-                              </Button>
-                            </td>
-                            <td>
-                              <Button
-                                variant="link"
-                                onClick={() => onCastSpell && onCastSpell(spell.level)}
-                              >
-                                <i className="fa-solid fa-wand-sparkles"></i>
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
+                        {spellsForClass(name).map((spell) => {
+                          const isSelected = selectedSpells.includes(spell.name);
+                          return (
+                            <tr key={spell.name}>
+                              <td>
+                                <Form.Check
+                                  id={`spell-${spell.name}`}
+                                  type="checkbox"
+                                  checked={isSelected}
+                                  disabled={
+                                    !isSelected && (pointsLeft[name] || 0) <= 0
+                                  }
+                                  onChange={() => toggleSpell(spell.name)}
+                                />
+                              </td>
+                              <td>{spell.name}</td>
+                              <td>{spell.school}</td>
+                              <td>{spell.castingTime}</td>
+                              <td>{spell.range}</td>
+                              <td>{spell.duration}</td>
+                              <td>
+                                <Button
+                                  variant="link"
+                                  onClick={() => setViewSpell(spell)}
+                                >
+                                  <i className="fa-solid fa-eye"></i>
+                                </Button>
+                              </td>
+                              <td>
+                                <Button
+                                  variant="link"
+                                  disabled={!isSelected}
+                                  className={!isSelected ? 'text-secondary' : ''}
+                                  onClick={() => {
+                                    onCastSpell?.({
+                                      level: spell.level,
+                                      damage: spell.damage,
+                                    });
+                                    handleClose();
+                                  }}
+                                >
+                                  <i className="fa-solid fa-wand-sparkles" />
+                                </Button>
+                              </td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
                     </Table>
                   </Tab>

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -71,7 +71,7 @@ test('filters spells by level', async () => {
   expect(screen.queryByText('Cure Wounds')).toBeNull();
 });
 
-test('cast button calls onCastSpell with spell level', async () => {
+test('cast button disabled until spell checked and then calls onCastSpell', async () => {
   apiFetch
     .mockResolvedValueOnce({ ok: true, json: async () => spellsData })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ spellsKnown: 14 }) });
@@ -90,9 +90,14 @@ test('cast button calls onCastSpell with spell level', async () => {
   await screen.findByLabelText('Level');
   await userEvent.selectOptions(screen.getByLabelText('Level'), '3');
   const row = await screen.findByText('Fireball');
-  const castBtn = within(row.closest('tr')).getAllByRole('button')[1];
+  const rowEl = row.closest('tr');
+  const castBtn = within(rowEl).getAllByRole('button')[1];
+  expect(castBtn).toBeDisabled();
+  const checkbox = within(rowEl).getByRole('checkbox');
+  await userEvent.click(checkbox);
+  expect(castBtn).not.toBeDisabled();
   await userEvent.click(castBtn);
-  expect(onCast).toHaveBeenCalledWith(3);
+  expect(onCast).toHaveBeenCalledWith({ level: 3, damage: undefined });
 });
 
 test('saves selected spells', async () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import ZombiesCharacterSheet from './ZombiesCharacterSheet';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../../../utils/apiFetch');
 import apiFetch from '../../../utils/apiFetch';
@@ -15,20 +15,45 @@ jest.mock('../attributes/Stats', () => () => null);
 jest.mock('../attributes/Skills', () => () => null);
 jest.mock('../attributes/Feats', () => () => null);
 jest.mock('../../Weapons/WeaponList', () => () => null);
+var mockUpdateDamage;
+var mockCalcDamage;
 jest.mock('../attributes/PlayerTurnActions', () => {
   const React = require('react');
-  return React.forwardRef(() => null);
+  mockUpdateDamage = jest.fn();
+  mockCalcDamage = jest.fn(() => 7);
+  return {
+    __esModule: true,
+    default: React.forwardRef((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        updateDamageValueWithAnimation: mockUpdateDamage,
+      }));
+      return null;
+    }),
+    calculateDamage: mockCalcDamage,
+  };
 });
 jest.mock('../../Armor/ArmorList', () => () => null);
 jest.mock('../../Items/ItemList', () => () => null);
 jest.mock('../attributes/Help', () => () => null);
 jest.mock('../attributes/BackgroundModal', () => () => null);
 jest.mock('../attributes/Features', () => () => null);
-jest.mock('../attributes/SpellSelector', () => () => null);
+const mockOnCastSpell = { current: null };
+const mockHandleClose = { current: null };
+jest.mock('../attributes/SpellSelector', () => (props) => {
+  mockOnCastSpell.current = props.onCastSpell;
+  mockHandleClose.current = props.handleClose;
+  return props.show ? <div data-testid="spell-selector" /> : null;
+});
 jest.mock('../attributes/HealthDefense', () => () => null);
+
+import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
 beforeEach(() => {
   apiFetch.mockReset();
+  mockUpdateDamage.mockClear();
+  mockCalcDamage.mockClear();
+  mockOnCastSpell.current = null;
+  mockHandleClose.current = null;
 });
 
 test('spells button includes points-glow when spell points available', async () => {
@@ -233,4 +258,73 @@ test('all footer buttons have footer-btn class', async () => {
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
   buttons.forEach((btn) => expect(btn).toHaveClass('footer-btn'));
+});
+
+test('handleCastSpell closes modal and outputs "Spell Cast"', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  await userEvent.click(spellButton);
+  expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
+  mockOnCastSpell.current({ level: 1 });
+  mockHandleClose.current();
+  await waitFor(() => expect(screen.queryByTestId('spell-selector')).toBeNull());
+  expect(mockUpdateDamage).toHaveBeenCalledWith('Spell Cast');
+});
+
+test('handleCastSpell outputs calculated damage', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  await userEvent.click(spellButton);
+  expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
+  mockOnCastSpell.current({ level: 1, damage: '1d4' });
+  mockHandleClose.current();
+  await waitFor(() => expect(screen.queryByTestId('spell-selector')).toBeNull());
+  expect(mockCalcDamage).toHaveBeenCalledWith('1d4');
+  expect(mockUpdateDamage).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Disable casting unselected spells in SpellSelector and close modal after casting
- Handle spell cast results, computing damage or displaying a message
- Add tests for new spell casting behavior

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c06c2ea394832e9953ecb27f0ea426