### PR TITLE
feat: add spell cast label styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -396,6 +396,11 @@ $rotateX: -$angle;
   animation: rollAnimation 0.5s ease-in-out; /* Apply animation */
 }
 
+#damageValue.spell-cast-label {
+  font-size: 10px;
+  line-height: 1.2;
+}
+
 /* Prevent the animation on initial load */
 #damageAmount:not(:hover) #damageValue {
   animation: none;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -237,7 +237,10 @@ const showSparklesEffect = () => {
         style={{ margin: "0 auto" }}
         onClick={handleDamageClick}
       >
-        <span id="damageValue" className={loading ? 'hidden' : ''}>
+        <span
+          id="damageValue"
+          className={`${loading ? 'hidden' : ''} ${typeof damageValue === 'string' ? 'spell-cast-label' : ''}`}
+        >
           {damageValue}
         </span>
         <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>


### PR DESCRIPTION
## Summary
- show a spell-cast label when damage value is a string
- style small label to fit within damage circle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c086039530832eb38c9cd112a2fb58