### PR TITLE
Propagate spell slot usage

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -51,7 +51,11 @@ export function calculateDamage(damageString, ability = 0, crit = false, roll = 
   return damageSum + modifier + ability;
 }
 
-const PlayerTurnActions = React.forwardRef(({ form, strMod, atkBonus, dexMod, headerHeight = 0 }, ref) => {
+const PlayerTurnActions = React.forwardRef(
+  (
+    { form, strMod, atkBonus, dexMod, headerHeight = 0, onCastSpell },
+    ref
+  ) => {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
@@ -96,6 +100,7 @@ const handleSpellsButtonClick = (spell, crit = false) => {
   const damageValue = calculateDamage(spell.damage, 0, crit || isCritical);
   if (damageValue === null) return;
   updateDamageValueWithAnimation(damageValue);
+  onCastSpell?.(spell.level);
 };
 
 const handleDamageClick = () => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act, fireEvent } from '@testing-library/react';
+import { render, act, fireEvent, screen } from '@testing-library/react';
 import PlayerTurnActions, { calculateDamage } from './PlayerTurnActions';
 
 describe('calculateDamage parser', () => {
@@ -121,5 +121,39 @@ describe('PlayerTurnActions critical events', () => {
     });
 
     expect(damage.classList.contains('critical-active')).toBe(false);
+  });
+});
+
+describe('PlayerTurnActions spell casting', () => {
+  test('invokes onCastSpell when a spell is rolled', async () => {
+    const onCastSpell = jest.fn();
+    const spell = {
+      name: 'Fire Bolt',
+      level: 1,
+      damage: '1d10 fire',
+      castingTime: '1 action',
+      range: '120 feet',
+      duration: 'Instantaneous',
+    };
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        strMod={0}
+        atkBonus={0}
+        dexMod={0}
+        onCastSpell={onCastSpell}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const rollButton = await screen.findByLabelText('roll');
+    act(() => {
+      fireEvent.click(rollButton);
+    });
+
+    expect(onCastSpell).toHaveBeenCalledWith(spell.level);
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -513,6 +513,7 @@ return (
       strMod={statMods.str}
       headerHeight={headerHeight}
       ref={playerTurnActionsRef}
+      onCastSpell={handleCastSpell}
     />
     {hasSpellcasting && form && (
       <SpellSlots


### PR DESCRIPTION
## Summary
- track spell-slot usage when casting through PlayerTurnActions
- pass spell casting handler down from ZombiesCharacterSheet
- test spell casting callback invocation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c092ce158883239343a5d22eb798e1