### PR TITLE
Support spell upcasting and correct slot usage

### DIFF
--- a/client/src/components/Zombies/attributes/UpcastModal.js
+++ b/client/src/components/Zombies/attributes/UpcastModal.js
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Button, Form } from 'react-bootstrap';
+
+/**
+ * Modal allowing the user to choose a spell slot level to cast a spell at.
+ *
+ * @param {Object} props
+ * @param {boolean} props.show - Whether the modal is visible.
+ * @param {function} props.onHide - Callback when the modal is closed.
+ * @param {number} props.baseLevel - Minimum level of the spell.
+ * @param {Object} props.slots - Mapping of slot level => remaining slot count.
+ * @param {function} props.onSelect - Callback invoked with the chosen level.
+ */
+export default function UpcastModal({
+  show,
+  onHide,
+  baseLevel = 1,
+  slots = {},
+  onSelect,
+}) {
+  const availableLevels = Object.keys(slots)
+    .map(Number)
+    .filter((lvl) => lvl >= baseLevel && slots[lvl] > 0)
+    .sort((a, b) => a - b);
+
+  const [level, setLevel] = useState(availableLevels[0] || baseLevel);
+
+  useEffect(() => {
+    if (availableLevels.length > 0) setLevel(availableLevels[0]);
+  }, [availableLevels.join(','), show]);
+
+  const handleConfirm = () => {
+    if (onSelect) onSelect(level);
+    if (onHide) onHide();
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Cast at Level</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {availableLevels.length > 0 ? (
+          <Form.Select
+            aria-label="Slot Level"
+            value={level}
+            onChange={(e) => setLevel(Number(e.target.value))}
+          >
+            {availableLevels.map((lvl) => (
+              <option key={lvl} value={lvl}>{`Level ${lvl}`}</option>
+            ))}
+          </Form.Select>
+        ) : (
+          <p>No spell slots of this level available.</p>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onHide}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleConfirm}
+          disabled={availableLevels.length === 0}
+        >
+          Cast
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button, Modal } from 'react-bootstrap';
@@ -233,6 +233,43 @@ export default function ZombiesCharacterSheet() {
     },
     [form]
   );
+
+  const availableSlots = useMemo(() => {
+    if (!form) return {};
+    const occupations = form.occupation || [];
+    let casterLevel = 0;
+    let warlockLevel = 0;
+    occupations.forEach((occ) => {
+      const name = (occ.Name || occ.Occupation || '').toLowerCase();
+      const level = Number(occ.Level) || 0;
+      if (name === 'warlock') {
+        warlockLevel += level;
+        return;
+      }
+      const progression = SPELLCASTING_CLASSES[name];
+      if (progression === 'full') {
+        casterLevel += level;
+      } else if (progression === 'half') {
+        casterLevel += level === 1 ? 0 : Math.ceil(level / 2);
+      }
+    });
+    const slotData = fullCasterSlots[casterLevel] || {};
+    const warlockData = pactMagic[warlockLevel] || {};
+    const remaining = {};
+    Object.entries(slotData).forEach(([lvl, count]) => {
+      const used = Object.values(usedSlots[`regular-${lvl}`] || {}).filter(Boolean)
+        .length;
+      const left = count - used;
+      if (left > 0) remaining[lvl] = left;
+    });
+    Object.entries(warlockData).forEach(([lvl, count]) => {
+      const used = Object.values(usedSlots[`warlock-${lvl}`] || {}).filter(Boolean)
+        .length;
+      const left = count - used;
+      if (left > 0) remaining[lvl] = (remaining[lvl] || 0) + left;
+    });
+    return remaining;
+  }, [form, usedSlots]);
 
   const handleWeaponsChange = useCallback(
     async (weapons) => {
@@ -514,6 +551,7 @@ return (
       headerHeight={headerHeight}
       ref={playerTurnActionsRef}
       onCastSpell={handleCastSpell}
+      availableSlots={availableSlots}
     />
     {hasSpellcasting && form && (
       <SpellSlots
@@ -735,6 +773,7 @@ return (
           setForm((prev) => ({ ...prev, spells, spellPoints }))
         }
         onCastSpell={handleCastSpell}
+        availableSlots={availableSlots}
       />
     )}
     <Help


### PR DESCRIPTION
## Summary
- add reusable UpcastModal to pick available spell slot level
- enable upcasting in PlayerTurnActions and SpellSelector with damage scaling
- track remaining spell slots in ZombiesCharacterSheet and pass them to components

## Testing
- `npm test` *(fails: Unable to find text "Failed to load items: 500 Server Error" in ItemList.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a5c5e384832e8805652e62a32775