### PR TITLE
feat: support extra dice upcasting

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -38,6 +38,16 @@ describe('calculateDamage parser', () => {
   test('flat damage ignores crit flag', () => {
     expect(calculateDamage('100', 0, true, fixedRoll)).toBe(100);
   });
+
+  test('adds extra dice for levels above', () => {
+    const extra = { count: 1, sides: 4 };
+    expect(calculateDamage('1d4', 0, false, fixedRoll, extra, 2)).toBe(3);
+  });
+
+  test('doubles extra dice on a critical hit', () => {
+    const extra = { count: 1, sides: 4 };
+    expect(calculateDamage('1d4', 0, true, fixedRoll, extra, 2)).toBe(6);
+  });
 });
 
 describe('PlayerTurnActions critical events', () => {

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -159,18 +159,23 @@ export default function SpellSelector({
 
   const handleUpcastSelect = (level) => {
     if (!pendingSpell) return;
-    let dmg = pendingSpell.damage;
     const diff = level - (pendingSpell.level || 0);
+    let extra;
     if (diff > 0 && pendingSpell.higherLevels) {
       const incMatch = pendingSpell.higherLevels.match(/(\d+)d(\d+)/);
-      const baseMatch = (pendingSpell.damage || '').match(/(\d+)d(\d+)([+-]\d+)?/);
-      if (incMatch && baseMatch && incMatch[2] === baseMatch[2]) {
-        const extra = diff * parseInt(incMatch[1], 10);
-        const total = parseInt(baseMatch[1], 10) + extra;
-        dmg = `${total}d${baseMatch[2]}${baseMatch[3] || ''}`;
+      if (incMatch) {
+        extra = {
+          count: parseInt(incMatch[1], 10),
+          sides: parseInt(incMatch[2], 10),
+        };
       }
     }
-    onCastSpell?.({ level, damage: dmg });
+    onCastSpell?.({
+      level,
+      damage: pendingSpell.damage,
+      extraDice: extra,
+      levelsAbove: diff > 0 ? diff : 0,
+    });
     setShowUpcast(false);
     setPendingSpell(null);
     handleClose();

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -213,9 +213,23 @@ export default function ZombiesCharacterSheet() {
       };
 
       if (typeof arg === 'object') {
-        const { level, damage } = arg;
+        const { level, damage, extraDice, levelsAbove } = arg;
         consumeSlot(level);
-        const result = damage ? calculateDamage(damage) : 'Spell Cast';
+        let result;
+        if (typeof damage === 'number') {
+          result = damage;
+        } else {
+          result = damage
+            ? calculateDamage(
+                damage,
+                0,
+                false,
+                undefined,
+                extraDice,
+                levelsAbove
+              )
+            : 'Spell Cast';
+        }
         playerTurnActionsRef.current?.updateDamageValueWithAnimation(result);
         return;
       }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -325,6 +325,13 @@ test('handleCastSpell outputs calculated damage', async () => {
   mockOnCastSpell.current({ level: 1, damage: '1d4' });
   mockHandleClose.current();
   await waitFor(() => expect(screen.queryByTestId('spell-selector')).toBeNull());
-  expect(mockCalcDamage).toHaveBeenCalledWith('1d4');
+  expect(mockCalcDamage).toHaveBeenCalledWith(
+    '1d4',
+    0,
+    false,
+    undefined,
+    undefined,
+    undefined
+  );
   expect(mockUpdateDamage).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- allow calculateDamage to roll extra dice for upcast levels
- propagate upcast levels from PlayerTurnActions and SpellSelector
- cover extra-dice behavior with new unit tests

## Testing
- `npm --prefix client test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0a7cb70bc832ea20f779c13eee85d