### PR TITLE
feat: support cantrip scaling

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -132,6 +132,14 @@ const [isFumble, setIsFumble] = useState(false);
   const [showUpcast, setShowUpcast] = useState(false);
   const [pendingSpell, setPendingSpell] = useState(null);
 
+  const totalLevel = useMemo(
+    () =>
+      Array.isArray(form.occupation)
+        ? form.occupation.reduce((total, el) => total + Number(el.Level), 0)
+        : 0,
+    [form.occupation]
+  );
+
   const applyUpcast = (spell, level, crit) => {
     const diff = level - (spell.level || 0);
     let extra;
@@ -143,6 +151,11 @@ const [isFumble, setIsFumble] = useState(false);
           sides: parseInt(incMatch[2], 10),
         };
       }
+    }
+    if (spell.scaling) {
+      if (totalLevel >= 17 && spell.scaling[17]) spell.damage = spell.scaling[17];
+      else if (totalLevel >= 11 && spell.scaling[11]) spell.damage = spell.scaling[11];
+      else if (totalLevel >= 5 && spell.scaling[5]) spell.damage = spell.scaling[5];
     }
     const value = calculateDamage(
       spell.damage,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, act, fireEvent, screen, within } from '@testing-library/react';
-import PlayerTurnActions, { calculateDamage } from './PlayerTurnActions';
+import { render, act, fireEvent, screen, within, waitFor } from '@testing-library/react';
+import PlayerTurnActions, * as PlayerTurnActionsModule from './PlayerTurnActions';
+
+const { calculateDamage } = PlayerTurnActionsModule;
 
 describe('calculateDamage parser', () => {
   const fixedRoll = (count, sides) => Array(count).fill(1);
@@ -218,5 +220,65 @@ describe('PlayerTurnActions spell casting', () => {
       (row) => within(row).getAllByRole('cell')[0].textContent
     );
     expect(names).toEqual(['Cure Wounds', 'Magic Missile', 'Fireball']);
+  });
+});
+
+describe('cantrip scaling', () => {
+  const baseSpell = {
+    name: 'Fire Bolt',
+    level: 0,
+    damage: '1d10',
+    scaling: { 5: '2d10', 11: '3d10', 17: '4d10' },
+    castingTime: '1 action',
+    range: '120 feet',
+    duration: 'Instantaneous',
+    casterType: 'Wizard',
+  };
+
+  const renderAndCast = async (lvl) => {
+    const orig = Math.random;
+    Math.random = () => 0; // always roll minimum = 1
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          weapon: [],
+          spells: [{ ...baseSpell }],
+          occupation: [{ Level: lvl }],
+        }}
+        strMod={0}
+        atkBonus={0}
+        dexMod={0}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const rollButton = await screen.findByLabelText('roll');
+    act(() => {
+      fireEvent.click(rollButton);
+    });
+    await waitFor(() => {
+      const el = document.getElementById('damageValue');
+      if (!el || el.textContent === '0') throw new Error('waiting');
+    });
+    const text = document.getElementById('damageValue').textContent;
+    Math.random = orig;
+    return text;
+  };
+
+  test('uses 2d10 at level 5', async () => {
+    const value = await renderAndCast(5);
+    expect(value).toBe('2');
+  });
+
+  test('uses 3d10 at level 11', async () => {
+    const value = await renderAndCast(11);
+    expect(value).toBe('3');
+  });
+
+  test('uses 4d10 at level 17', async () => {
+    const value = await renderAndCast(17);
+    expect(value).toBe('4');
   });
 });

--- a/scripts/regenerate-spells.js
+++ b/scripts/regenerate-spells.js
@@ -7,6 +7,17 @@ function extractHigherLevels(description = '') {
   return match ? match[1].trim() : undefined;
 }
 
+function extractScaling(description = '') {
+  const level5 = description.match(/5th level \(([^)]+)\)/i);
+  const level11 = description.match(/11th level \(([^)]+)\)/i);
+  const level17 = description.match(/17th level \(([^)]+)\)/i);
+  const scaling = {};
+  if (level5) scaling[5] = level5[1].replace(/\s+/g, '');
+  if (level11) scaling[11] = level11[1].replace(/\s+/g, '');
+  if (level17) scaling[17] = level17[1].replace(/\s+/g, '');
+  return Object.keys(scaling).length ? scaling : undefined;
+}
+
 // Manual overrides for spells whose descriptions are missing higher-level text
 const manualHigherLevels = {
   'burning-hands': 'When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.',
@@ -35,6 +46,10 @@ Object.values(spells).forEach(spell => {
     } else if (manualHigherLevels[spell.name.toLowerCase().replace(/\s+/g, '-')]) {
       spell.higherLevels = manualHigherLevels[spell.name.toLowerCase().replace(/\s+/g, '-')];
     }
+  }
+  if (spell.level === 0 && !spell.scaling) {
+    const scaling = extractScaling(spell.description);
+    if (scaling) spell.scaling = scaling;
   }
 });
 

--- a/server/routes/spells.js
+++ b/server/routes/spells.js
@@ -14,6 +14,17 @@ function extractHigherLevels(description = '') {
   return match ? match[1].trim() : undefined;
 }
 
+function extractScaling(description = '') {
+  const level5 = description.match(/5th level \(([^)]+)\)/i);
+  const level11 = description.match(/11th level \(([^)]+)\)/i);
+  const level17 = description.match(/17th level \(([^)]+)\)/i);
+  const scaling = {};
+  if (level5) scaling[5] = level5[1].replace(/\s+/g, '');
+  if (level11) scaling[11] = level11[1].replace(/\s+/g, '');
+  if (level17) scaling[17] = level17[1].replace(/\s+/g, '');
+  return Object.keys(scaling).length ? scaling : undefined;
+}
+
 // Augment spells with a `damage` field when possible
 Object.values(spells).forEach((spell) => {
   if (!spell.damage) {
@@ -23,6 +34,10 @@ Object.values(spells).forEach((spell) => {
   if (!spell.higherLevels) {
     const upcast = extractHigherLevels(spell.description);
     if (upcast) spell.higherLevels = upcast;
+  }
+  if (spell.level === 0 && !spell.scaling) {
+    const scaling = extractScaling(spell.description);
+    if (scaling) spell.scaling = scaling;
   }
 });
 

--- a/server/validation/spell.js
+++ b/server/validation/spell.js
@@ -22,7 +22,14 @@ function isSpell(spell) {
     typeof spell.description === 'string' &&
     Array.isArray(spell.classes) &&
     spell.classes.every(c => typeof c === 'string') &&
-    (spell.higherLevels === undefined || typeof spell.higherLevels === 'string')
+    (spell.higherLevels === undefined || typeof spell.higherLevels === 'string') &&
+    (spell.scaling === undefined ||
+      (
+        typeof spell.scaling === 'object' &&
+        [5, 11, 17].every(l =>
+          spell.scaling[l] === undefined || typeof spell.scaling[l] === 'string'
+        )
+      ))
   );
 }
 

--- a/types/spell.d.ts
+++ b/types/spell.d.ts
@@ -12,4 +12,8 @@ export interface Spell {
    * Additional effects when the spell is cast using a higher-level slot.
    */
   higherLevels?: string;
+  /**
+   * Damage dice replacements at key character levels for cantrips.
+   */
+  scaling?: { 5: string; 11: string; 17: string };
 }


### PR DESCRIPTION
## Summary
- add optional cantrip `scaling` field to Spell definitions
- parse cantrip descriptions to populate `scaling`
- apply `scaling` when casting cantrips and add tests for level-based dice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b4d805ec832e9aeb440f559e76b8