### PR TITLE
Include scaling and higher-level data when saving spells

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -343,6 +343,8 @@ export default function SpellSelector({
           range: info.range || '',
           duration: info.duration || '',
           casterType: casters[name] || info.classes?.[0] || '',
+          higherLevels: info.higherLevels,
+          scaling: info.scaling,
         };
       });
       const res = await apiFetch(`/characters/${params.id}/spells`, {


### PR DESCRIPTION
## Summary
- include `higherLevels` and `scaling` when serializing selected spells
- update spell saving test to validate new fields
- add test for saving cantrip scaling data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0bf1556bc832e924334748fbde5f8