### PR TITLE
Separate regular and warlock spell slot handling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -79,6 +79,16 @@
   border-color: var(--bs-primary);
 }
 
+.upcast-slot.regular {
+  box-shadow: 0 0 10px #007bff;
+  border: 1px solid #007bff;
+}
+
+.upcast-slot.warlock {
+  box-shadow: 0 0 10px #800080;
+  border: 1px solid #800080;
+}
+
 .skill-checkbox .form-check-input {
   width: 1.25rem;
   height: 1.25rem;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -86,7 +86,7 @@ const PlayerTurnActions = React.forwardRef(
       dexMod,
       headerHeight = 0,
       onCastSpell,
-      availableSlots = {},
+      availableSlots = { regular: {}, warlock: {} },
     },
     ref
   ) => {
@@ -140,7 +140,7 @@ const [isFumble, setIsFumble] = useState(false);
     [form.occupation]
   );
 
-  const applyUpcast = (spell, level, crit) => {
+  const applyUpcast = (spell, level, crit, slotType) => {
     const diff = level - (spell.level || 0);
     let extra;
     if (diff > 0 && spell.higherLevels) {
@@ -167,7 +167,8 @@ const [isFumble, setIsFumble] = useState(false);
     );
     if (value === null) return;
     updateDamageValueWithAnimation(value);
-    onCastSpell?.(level);
+    if (slotType) onCastSpell?.(slotType, level);
+    else onCastSpell?.(level);
   };
 
   const handleSpellsButtonClick = (spell, crit = false) => {
@@ -494,9 +495,9 @@ const showSparklesEffect = () => {
         onHide={() => setShowUpcast(false)}
         baseLevel={pendingSpell?.spell?.level}
         slots={availableSlots}
-        onSelect={(lvl) => {
+        onSelect={(lvl, type) => {
           if (pendingSpell) {
-            applyUpcast(pendingSpell.spell, lvl, pendingSpell.crit);
+            applyUpcast(pendingSpell.spell, lvl, pendingSpell.crit, type);
             setPendingSpell(null);
           }
           setShowUpcast(false);

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -75,7 +75,7 @@ export default function SpellSelector({
   handleClose,
   onSpellsChange,
   onCastSpell,
-  availableSlots = {},
+  availableSlots = { regular: {}, warlock: {} },
 }) {
   const params = useParams();
 
@@ -184,7 +184,7 @@ export default function SpellSelector({
     [totalLevel]
   );
 
-  const handleUpcastSelect = (level) => {
+  const handleUpcastSelect = (level, slotType) => {
     if (!pendingSpell) return;
     const diff = level - (pendingSpell.level || 0);
     let extra;
@@ -203,6 +203,7 @@ export default function SpellSelector({
       damage,
       extraDice: extra,
       levelsAbove: diff > 0 ? diff : 0,
+      slotType,
     });
     setShowUpcast(false);
     setPendingSpell(null);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -284,20 +284,24 @@ export default function ZombiesCharacterSheet() {
     });
     const slotData = fullCasterSlots[casterLevel] || {};
     const warlockData = pactMagic[warlockLevel] || {};
-    const remaining = {};
+
+    const regular = {};
     Object.entries(slotData).forEach(([lvl, count]) => {
       const used = Object.values(usedSlots[`regular-${lvl}`] || {}).filter(Boolean)
         .length;
       const left = count - used;
-      if (left > 0) remaining[lvl] = left;
+      if (left > 0) regular[lvl] = left;
     });
+
+    const warlock = {};
     Object.entries(warlockData).forEach(([lvl, count]) => {
       const used = Object.values(usedSlots[`warlock-${lvl}`] || {}).filter(Boolean)
         .length;
       const left = count - used;
-      if (left > 0) remaining[lvl] = (remaining[lvl] || 0) + left;
+      if (left > 0) warlock[lvl] = left;
     });
-    return remaining;
+
+    return { regular, warlock };
   }, [form, usedSlots]);
 
   const handleWeaponsChange = useCallback(


### PR DESCRIPTION
## Summary
- Distinguish regular and warlock spell slots throughout the spell casting flow
- Redesign UpcastModal with clickable slot buttons and glowing borders
- Verify warlock slot selection and styling in SpellSelector tests

## Testing
- `CI=true npm test -- client/src/components/Zombies/attributes/SpellSelector.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c0c7df55f8832ea992372b90696ddc