### PR TITLE
Refactor UpcastModal to use spell slot layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -79,14 +79,14 @@
   border-color: var(--bs-primary);
 }
 
-.upcast-slot.regular {
-  box-shadow: 0 0 10px #007bff;
-  border: 1px solid #007bff;
+.upcast-slot {
+  cursor: pointer;
 }
 
-.upcast-slot.warlock {
-  box-shadow: 0 0 10px #800080;
-  border: 1px solid #800080;
+.upcast-slot.selected {
+  outline: 2px solid #ffc107;
+  outline-offset: 2px;
+  transform: scale(1.1);
 }
 
 .skill-checkbox .form-check-input {

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -245,9 +245,9 @@ test('UpcastModal returns warlock slot type', async () => {
   await userEvent.click(within(rowEl).getByRole('checkbox'));
   const castBtn = within(rowEl).getAllByRole('button')[1];
   await userEvent.click(castBtn);
-  const warlockBtn = await screen.findByText('Level 2');
-  expect(warlockBtn).toHaveClass('warlock');
-  expect(warlockBtn).toHaveStyle('box-shadow: 0 0 10px #800080');
+  const warlockLvl = await screen.findByText('II');
+  const warlockBtn = warlockLvl.parentElement;
+  expect(warlockBtn).toHaveClass('warlock-slot');
   await userEvent.click(warlockBtn);
   await userEvent.click(screen.getByText('Cast'));
   await waitFor(() =>
@@ -423,8 +423,8 @@ test('upcasting consumes higher slot and reports extra damage', async () => {
   await userEvent.click(within(rowEl).getByRole('checkbox'));
   const castBtn = within(rowEl).getAllByRole('button')[1];
   await userEvent.click(castBtn);
-  const lvl3Btn = await screen.findByText('Level 3');
-  await userEvent.click(lvl3Btn);
+  const lvl3 = await screen.findByText('III');
+  await userEvent.click(lvl3.parentElement);
   await userEvent.click(screen.getByRole('button', { name: 'Cast' }));
   expect(onCast).toHaveBeenCalledWith({
     level: 3,

--- a/client/src/components/Zombies/attributes/UpcastModal.js
+++ b/client/src/components/Zombies/attributes/UpcastModal.js
@@ -63,36 +63,44 @@ export default function UpcastModal({
         {regularLevels.length > 0 && (
           <div className="mb-2 d-flex flex-wrap gap-2 justify-content-center">
             {regularLevels.map((lvl) => (
-              <Button
+              <div
                 key={`regular-${lvl}`}
-                className={`upcast-slot regular${
+                className={`spell-slot upcast-slot${
                   selection.type === 'regular' && selection.level === lvl
-                    ? ' active'
+                    ? ' selected'
                     : ''
                 }`}
-                style={{ boxShadow: '0 0 10px #007bff' }}
                 onClick={() => setSelection({ level: lvl, type: 'regular' })}
               >
-                {toRoman(lvl)}
-              </Button>
+                <div className="slot-level">{toRoman(lvl)}</div>
+                <div className="slot-boxes">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <div key={i} className="slot-small slot-active" />
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
         )}
         {warlockLevels.length > 0 && (
           <div className="d-flex flex-wrap gap-2 justify-content-center">
             {warlockLevels.map((lvl) => (
-              <Button
+              <div
                 key={`warlock-${lvl}`}
-                className={`upcast-slot warlock${
+                className={`spell-slot upcast-slot warlock-slot${
                   selection.type === 'warlock' && selection.level === lvl
-                    ? ' active'
+                    ? ' selected'
                     : ''
                 }`}
-                style={{ boxShadow: '0 0 10px #800080' }}
                 onClick={() => setSelection({ level: lvl, type: 'warlock' })}
               >
-                {toRoman(lvl)}
-              </Button>
+                <div className="slot-level">{toRoman(lvl)}</div>
+                <div className="slot-boxes">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <div key={i} className="slot-small slot-active" />
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- replace upcast level buttons with spell-slot style blocks
- add warlock-slot and selected states with new styling
- adjust tests for new upcast modal behavior

## Testing
- `npm --prefix client test --silent | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c0d61b27d8832399152a69502503f5