### PR TITLE
feat: highlight selected upcast slot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -84,8 +84,9 @@
 }
 
 .upcast-slot.selected {
-  outline: 2px solid #ffc107;
-  outline-offset: 2px;
+  background-color: #808080;
+  border: 2px solid #FFD700;
+  box-shadow: 0 0 10px #FFD700;
   transform: scale(1.1);
 }
 


### PR DESCRIPTION
## Summary
- add solid gray background to selected upcast slots
- emphasize selection with gold border and glow

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ea3d00c08323baaec9a05223591e