### PR TITLE
Display spell class in player action spells table

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -445,6 +445,7 @@ const showSparklesEffect = () => {
                   <thead>
                     <tr>
                       <th>Spell Name</th>
+                      <th>Class</th>
                       <th>Level</th>
                       <th>Damage</th>
                       <th>Casting Time</th>
@@ -459,6 +460,7 @@ const showSparklesEffect = () => {
                       .map((spell, idx) => (
                         <tr key={idx}>
                           <td>{spell.name}</td>
+                          <td>{spell.casterType || spell.caster || 'Unknown'}</td>
                           <td>{spell.level}</td>
                           <td>{spell.damage}</td>
                           <td>{spell.castingTime}</td>


### PR DESCRIPTION
## Summary
- show each spell's class in the PlayerTurnActions spells table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0f22df62c8323972797cce6c7e367