### PR TITLE
Add switchable d4/d20 dice roller

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -435,6 +435,64 @@ $rotateX: -$angle;
   90% { transform: rotateX(480deg) rotateY(960deg) rotateZ(0deg) }
 }
 
+.die.d4 {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform $transitionDuration ease-out;
+  cursor: pointer;
+  transform: rotateX(-35deg);
+
+  &.rolling {
+    animation: roll-d4 $animationDuration linear;
+  }
+
+  &[data-face="1"] { transform: rotateX(-60deg) rotateY(0deg); }
+  &[data-face="2"] { transform: rotateX(-60deg) rotateY(-120deg); }
+  &[data-face="3"] { transform: rotateX(-60deg) rotateY(-240deg); }
+  &[data-face="4"] { transform: rotateX(60deg) rotateY(0deg); }
+
+  .face {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    margin-left: -25%;
+    border-left: 25% solid transparent;
+    border-right: 25% solid transparent;
+    border-bottom: 43% solid $color;
+    width: 0;
+    height: 0;
+    transform-origin: 50% 100%;
+    backface-visibility: hidden;
+    counter-increment: steps 1;
+
+    &:before {
+      content: counter(steps);
+      position: absolute;
+      top: -35%;
+      left: -50%;
+      width: 100%;
+      text-align: center;
+      color: #fff;
+      font-size: 0.8em;
+    }
+  }
+
+  .face:nth-child(1) { transform: rotateY(0deg) rotateX(60deg) translateZ(20%); }
+  .face:nth-child(2) { transform: rotateY(120deg) rotateX(60deg) translateZ(20%); }
+  .face:nth-child(3) { transform: rotateY(240deg) rotateX(60deg) translateZ(20%); }
+  .face:nth-child(4) { transform: rotateX(-60deg) translateZ(20%); }
+}
+
+@keyframes roll-d4 {
+  10% { transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg); }
+  30% { transform: rotateX(120deg) rotateY(120deg) rotateZ(0deg); }
+  50% { transform: rotateX(240deg) rotateY(240deg) rotateZ(0deg); }
+  70% { transform: rotateX(360deg) rotateY(360deg) rotateZ(0deg); }
+  90% { transform: rotateX(480deg) rotateY(480deg) rotateZ(0deg); }
+}
+
 @include dice-size(min(25vw, 120px));
 
 @media (max-height: 600px) {

--- a/client/src/components/Zombies/attributes/Dice/d4.js
+++ b/client/src/components/Zombies/attributes/Dice/d4.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const D4 = ({ onClick, rolling, activeFace }) => (
+  <div onClick={onClick} className={`die d4 ${rolling ? 'rolling' : ''}`} data-face={activeFace}>
+    {Array.from({ length: 4 }, (_, i) => (
+      <figure className={`face face-${i + 1}`} key={i + 1}></figure>
+    ))}
+  </div>
+);
+
+export default D4;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -262,16 +262,17 @@ useEffect(() => {
     return () => clearTimeout(timer);
   }
 }, [loading]);
-//-------------------------------------------D20 Dice Roller--------------------------------------------------------------------------
-const [sides] = useState(20);
-const [initialSide] = useState(1);
+//-------------------------------------------Dice Roller-----------------------------------------------
+const [dieType, setDieType] = useState('d20');
+const sides = dieType === 'd4' ? 4 : 20;
+const initialSide = 1;
 const [timeoutId, setTimeoutId] = useState(null);
 const [animationDuration] = useState('3000ms');
 const [activeFace, setActiveFace] = useState(null);
 const [rolling, setRolling] = useState(false);
-const face = Math.floor(Math.random() * sides) + initialSide;
 
 const randomFace = () => {
+  const face = Math.floor(Math.random() * sides) + initialSide;
   return face === activeFace ? randomFace() : face;
 };
 
@@ -279,50 +280,57 @@ const rollTo = (face) => {
   clearTimeout(timeoutId);
   setActiveFace(face);
   setRolling(false);
-
-  if (face === 20 || face === 1) {
-    showSparklesEffect({ x: 100 / 2, y: 100 / 2 });
+  if (face === sides || face === 1) {
+    showSparklesEffect(face);
     setTimeout(() => {
-      showSparklesEffect();
+      showSparklesEffect(face);
     }, 5000);
   }
 };
 
 const handleRandomizeClick = (e) => {
-  e.preventDefault(); // Prevent page refresh
+  e.preventDefault();
   setRolling(true);
   clearTimeout(timeoutId);
-
   const newTimeoutId = setTimeout(() => {
     setRolling(false);
     rollTo(randomFace());
   }, parseInt(animationDuration, 10));
-
   setTimeoutId(newTimeoutId);
 };
 
 useEffect(() => {
-  // Cleanup effect
   return () => clearTimeout(timeoutId);
 }, [timeoutId]);
 
-const faceElements = [];
-for (let i = 1; i <= 20; i++) {
-  faceElements.push(
-    <figure className={`face face-${i}`} key={i}></figure>
-  );
-}
+const renderDieFaces = (sides) => {
+  const faces = [];
+  for (let i = 1; i <= sides; i++) {
+    faces.push(<figure className={`face face-${i}`} key={i}></figure>);
+  }
+  return faces;
+};
+
+const changeDie = (type) => {
+  if (rolling) {
+    clearTimeout(timeoutId);
+  }
+  setRolling(false);
+  setActiveFace(null);
+  setDieType(type);
+};
+
 const [showSparkles, setShowSparkles] = useState(false);
 const [showSparkles1, setShowSparkles1] = useState(false);
 
 // Create a function to display sparkles
-const showSparklesEffect = () => {
-  if (face === 20) {
+const showSparklesEffect = (faceValue) => {
+  if (faceValue === sides) {
     setShowSparkles(true);
     setTimeout(() => {
       setShowSparkles(false);
     }, 2000);
-  } else if (face === 1) {
+  } else if (faceValue === 1) {
     setShowSparkles1(true);
     setTimeout(() => {
       setShowSparkles1(false);
@@ -383,17 +391,20 @@ const showSparklesEffect = () => {
             justifyContent: 'center'
           }}
         >
-          <div className="content">
-            {showSparkles && (
-              <div className="sparkle"></div>
-            )}
-            {showSparkles1 && (
-              <div className="sparkle1"></div>
-            )}
-            <div onClick={handleRandomizeClick}
-    className={`die ${rolling ? 'rolling' : ''}`} data-face={activeFace}>
-      {faceElements}
-    </div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <button aria-label="previous die" onClick={() => changeDie('d4')}>&lt;</button>
+            <div className="content">
+              {showSparkles && <div className="sparkle"></div>}
+              {showSparkles1 && <div className="sparkle1"></div>}
+              <div
+                onClick={handleRandomizeClick}
+                className={`die ${dieType} ${rolling ? 'rolling' : ''}`}
+                data-face={activeFace}
+              >
+                {renderDieFaces(sides)}
+              </div>
+            </div>
+            <button aria-label="next die" onClick={() => changeDie('d20')}>&gt;</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow switching between d20 and d4 dice in PlayerTurnActions
- add reusable D4 dice component and styles/animations for tetrahedral die
- support animated die face rendering and sparkles for critical/fumble

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f7a5fb308323b32c3ef772cb7381