### PR TITLE
feat: add pass button to navbar and action indicator to spell slots

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -186,6 +186,21 @@
   cursor: default;
 }
 
+.action-slot .slot-boxes {
+  padding-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.action-slot .action-circle {
+  width: 20px;
+  height: 20px;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  background: #28a745;
+  box-shadow: 0 0 5px #28a745, 0 0 10px #28a745;
+}
+
 .text-center {
   text-align: center;
 }

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -1,34 +1,64 @@
 import React from "react";
-import Container from 'react-bootstrap/Container';
-import Nav from 'react-bootstrap/Nav';
-import Navbar from 'react-bootstrap/Navbar';
-import Button from 'react-bootstrap/Button';
+import Container from "react-bootstrap/Container";
+import Nav from "react-bootstrap/Nav";
+import Navbar from "react-bootstrap/Navbar";
+import Button from "react-bootstrap/Button";
 import logoLight from "../../images/logo-light.png";
 import apiFetch from "../../utils/apiFetch";
 
 function NavbarComponent() {
   const handleLogout = async () => {
-    await apiFetch('/logout', { method: 'POST' });
-    window.location.assign('/');
+    await apiFetch("/logout", { method: "POST" });
+    window.location.assign("/");
+  };
+
+  const handlePass = () => {
+    // Placeholder for future pass-turn logic
   };
 
   return (
-    <Navbar fixed="top" style={{ fontFamily: 'Raleway, sans-serif', height: "80px", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
+    <Navbar
+      fixed="top"
+      style={{
+        fontFamily: "Raleway, sans-serif",
+        height: "80px",
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+      }}
+    >
       <Container fluid>
         <Navbar.Brand href="/">
-          <img src={logoLight} alt="" width="60px" height="60px" className="d-inline-block align-text-top" />
+          <img
+            src={logoLight}
+            alt=""
+            width="60px"
+            height="60px"
+            className="d-inline-block align-text-top"
+          />
         </Navbar.Brand>
-          <Nav className="ml-auto">
-            {/* <Nav.Link as={Link} to="/spells">Spells</Nav.Link> */}
-            {/* <Nav.Link as={Link} to="/weapons">Weapons</Nav.Link> */}
-            <Nav.Link>
-              <Button style={{ borderColor: "gray" }} className='bg-secondary' onClick={handleLogout}>
-                Logout
-              </Button>
-            </Nav.Link>
-          </Nav>
-        </Container>
-      </Navbar>
+        <Nav className="ml-auto">
+          {/* <Nav.Link as={Link} to="/spells">Spells</Nav.Link> */}
+          {/* <Nav.Link as={Link} to="/weapons">Weapons</Nav.Link> */}
+          <Nav.Link>
+            <Button
+              style={{ borderColor: "gray" }}
+              className="bg-secondary me-2"
+              onClick={handlePass}
+            >
+              Pass
+            </Button>
+          </Nav.Link>
+          <Nav.Link>
+            <Button
+              style={{ borderColor: "gray" }}
+              className="bg-secondary"
+              onClick={handleLogout}
+            >
+              Logout
+            </Button>
+          </Nav.Link>
+        </Nav>
+      </Container>
+    </Navbar>
   );
 }
 

--- a/client/src/components/Navbar/Navbar.test.js
+++ b/client/src/components/Navbar/Navbar.test.js
@@ -39,3 +39,14 @@ test('logout calls endpoint and redirects', async () => {
   expect(window.location.assign).toHaveBeenCalledWith('/');
 });
 
+test('renders pass button', () => {
+  render(
+    <MemoryRouter>
+      <Navbar />
+    </MemoryRouter>
+  );
+
+  const passButtons = screen.getAllByRole('button', { name: /pass/i });
+  expect(passButtons[passButtons.length - 1]).toBeInTheDocument();
+});
+

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -75,6 +75,12 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
   return (
     <div style={{ display: 'flex' }}>
       <div className="spell-slot-container">
+        <div className="spell-slot action-slot">
+          <div className="slot-level">A</div>
+          <div className="slot-boxes">
+            <div className="action-circle" />
+          </div>
+        </div>
         {renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
       </div>

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -9,7 +9,9 @@ test('renders only the available number of slots', () => {
   const { container } = render(<SpellSlots form={form} used={{}} />);
 
   const expected = fullCasterSlots[casterLevel];
-  const slotBoxDivs = container.querySelectorAll('.slot-boxes');
+  const slotBoxDivs = Array.from(
+    container.querySelectorAll('.spell-slot-container .spell-slot .slot-boxes')
+  ).filter((div) => !div.parentElement.classList.contains('action-slot'));
   Object.values(expected).forEach((count, idx) => {
     expect(slotBoxDivs[idx].querySelectorAll('.slot-small').length).toBe(count);
   });
@@ -32,6 +34,15 @@ test('reflects used slots from props and toggles via callback', () => {
     />
   );
   expect(container.querySelector('.slot-small')).toHaveClass('slot-used');
+});
+
+test('renders action slot before regular slots', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
+  const { container } = render(<SpellSlots form={form} used={{}} />);
+  const first = container.querySelector('.spell-slot-container').firstChild;
+  expect(first).toHaveClass('action-slot');
+  expect(first.querySelector('.slot-level').textContent).toBe('A');
+  expect(first.querySelector('.action-circle')).toBeTruthy();
 });
 
 test('warlock slots render after regular slots and have purple styling', () => {


### PR DESCRIPTION
## Summary
- add Pass button alongside Logout in navbar
- show green glowing action circle with 'A' before spell slots
- test presence of Pass button and action indicator

## Testing
- `npm test -- --runInBand`
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68c1aec072288323ac737be58d10f8fb