### PR TITLE
Add bonus action slot to player turn actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Example gif is listed below:
 
 ![Example](./client/public/images/Gif-for-Dnd.gif)
 
+During a player's turn, the interface provides an Attack button and a **Bonus Action** slot labeled "B" next to the damage display for quick access to bonus actions.
+
 ## Deployment
 
 Run `npm run build` to generate the production build of the client. The `npm start` script runs this build step before launching the server so deployments always serve the latest assets from `client/build`.

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -476,6 +476,42 @@ $rotateX: -$angle;
   background-size: 70px;
 }
 
+.bonus-action-slot {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: #228B22;
+  color: #ffffff;
+  font-size: 22px;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  box-shadow: 0 0 6px orange;
+  animation: orangeGlow 2s ease-in-out infinite;
+  transform: rotate(-20deg);
+}
+
+.bonus-action-slot::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: -10px;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 10px solid orange;
+}
+
+@keyframes orangeGlow {
+  0% { box-shadow: 0 0 6px orange; }
+  50% { box-shadow: 0 0 12px orange; }
+  100% { box-shadow: 0 0 6px orange; }
+}
+
 #damageAmount.critical-active {
   border: 2px solid #FFD700;
   color: #FFD700;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -333,21 +333,30 @@ const showSparklesEffect = () => {
   return (
     <div>
       <div
-        id="damageAmount"
-        ref={damageRef}
-        className={`mt-3 ${loading ? 'loading' : ''} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
-        style={{ margin: "0 auto" }}
-        onClick={handleDamageClick}
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '10px'
+        }}
       >
-        <span
-          id="damageValue"
-          className={`${loading ? 'hidden' : ''} ${typeof damageValue === 'string' ? 'spell-cast-label' : ''}`}
+        <div
+          id="damageAmount"
+          ref={damageRef}
+          className={`mt-3 ${loading ? 'loading' : ''} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
+          onClick={handleDamageClick}
         >
-          {damageValue}
-        </span>
-        <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
+          <span
+            id="damageValue"
+            className={`${loading ? 'hidden' : ''} ${typeof damageValue === 'string' ? 'spell-cast-label' : ''}`}
+          >
+            {damageValue}
+          </span>
+          <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
+        </div>
+        <div className="bonus-action-slot" aria-label="bonus action">B</div>
       </div>
-      
+
       <div
         style={{
           display: 'flex',

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, act, fireEvent, screen, within, waitFor } from '@testing-library/react';
+import fs from 'fs';
+import path from 'path';
 import PlayerTurnActions, * as PlayerTurnActionsModule from './PlayerTurnActions';
 
 const { calculateDamage } = PlayerTurnActionsModule;
@@ -280,5 +282,24 @@ describe('cantrip scaling', () => {
   test('uses 4d10 at level 17', async () => {
     const value = await renderAndCast(17);
     expect(value).toBe('4');
+  });
+});
+
+describe('PlayerTurnActions bonus action slot', () => {
+  test('renders bonus action slot with triangle', () => {
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [] }}
+        strMod={0}
+        atkBonus={0}
+        dexMod={0}
+      />
+    );
+
+    const bonus = screen.getByText('B');
+    expect(bonus).toBeInTheDocument();
+    const cssPath = path.resolve(__dirname, '../../../App.scss');
+    const cssContent = fs.readFileSync(cssPath, 'utf8');
+    expect(cssContent.includes('.bonus-action-slot::after')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add a bonus action slot next to the damage display with a tilted "B"
- style slot with animated orange glow and triangle indicator
- test bonus action slot rendering and document new control in README

## Testing
- `npm test -- client/src/components/Zombies/attributes/PlayerTurnActions.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1b577eda48323aa3dc58e255bbdb8