### PR TITLE
feat: add bonus action indicator

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -201,6 +201,17 @@
   box-shadow: 0 0 5px #28a745, 0 0 10px #28a745;
 }
 
+.bonus-action-indicator {
+  margin-left: 10px;
+  align-self: center;
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-bottom: 20px solid orange;
+  filter: drop-shadow(0 0 4px orange);
+}
+
 .text-center {
   text-align: center;
 }

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -374,6 +374,7 @@ const showSparklesEffect = () => {
             onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
             title="Attack"
           />
+          <div className="bonus-action-indicator"></div>
         </div>
         <div
           style={{

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -52,6 +52,21 @@ describe('calculateDamage parser', () => {
   });
 });
 
+describe('PlayerTurnActions layout', () => {
+  test('renders bonus action indicator', () => {
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [] }}
+        strMod={0}
+        atkBonus={0}
+        dexMod={0}
+      />
+    );
+
+    expect(document.querySelector('.bonus-action-indicator')).toBeInTheDocument();
+  });
+});
+
 describe('PlayerTurnActions critical events', () => {
   test('damage-roll event toggles classes on damageAmount', () => {
     jest.useFakeTimers();


### PR DESCRIPTION
## Summary
- add bonus action indicator next to action button
- style indicator as glowing orange triangle
- test rendering of bonus action indicator

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b796e68c8323a4d258f02b83d0df