### PR TITLE
Add bonus slot indicator for spell slots

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -201,6 +201,16 @@
   box-shadow: 0 0 5px #28a745, 0 0 10px #28a745;
 }
 
+.bonus-slot .bonus-triangle {
+  width: 0;
+  height: 0;
+  margin: 20px auto 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid #ffc107;
+  box-shadow: 0 0 5px #ffc107, 0 0 10px #ffc107;
+}
+
 .text-center {
   text-align: center;
 }

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -81,6 +81,10 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
             <div className="action-circle" />
           </div>
         </div>
+        <div className="spell-slot bonus-slot">
+          <div className="slot-level">B</div>
+          <div className="bonus-triangle" />
+        </div>
         {renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
       </div>

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -11,7 +11,11 @@ test('renders only the available number of slots', () => {
   const expected = fullCasterSlots[casterLevel];
   const slotBoxDivs = Array.from(
     container.querySelectorAll('.spell-slot-container .spell-slot .slot-boxes')
-  ).filter((div) => !div.parentElement.classList.contains('action-slot'));
+  ).filter(
+    (div) =>
+      !div.parentElement.classList.contains('action-slot') &&
+      !div.parentElement.classList.contains('bonus-slot')
+  );
   Object.values(expected).forEach((count, idx) => {
     expect(slotBoxDivs[idx].querySelectorAll('.slot-small').length).toBe(count);
   });
@@ -36,13 +40,18 @@ test('reflects used slots from props and toggles via callback', () => {
   expect(container.querySelector('.slot-small')).toHaveClass('slot-used');
 });
 
-test('renders action slot before regular slots', () => {
+test('renders action and bonus slots before regular slots', () => {
   const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
   const { container } = render(<SpellSlots form={form} used={{}} />);
-  const first = container.querySelector('.spell-slot-container').firstChild;
+  const slotContainer = container.querySelector('.spell-slot-container');
+  const first = slotContainer.children[0];
+  const second = slotContainer.children[1];
   expect(first).toHaveClass('action-slot');
   expect(first.querySelector('.slot-level').textContent).toBe('A');
   expect(first.querySelector('.action-circle')).toBeTruthy();
+  expect(second).toHaveClass('bonus-slot');
+  expect(second.querySelector('.slot-level').textContent).toBe('B');
+  expect(second.querySelector('.bonus-triangle')).toBeTruthy();
 });
 
 test('warlock slots render after regular slots and have purple styling', () => {
@@ -59,7 +68,7 @@ test('warlock slots render after regular slots and have purple styling', () => {
   const firstWarlockIndex = groups.findIndex((g) =>
     g.classList.contains('warlock-slot')
   );
-  expect(firstWarlockIndex).toBeGreaterThan(0);
+  expect(firstWarlockIndex).toBeGreaterThan(2);
   groups.slice(firstWarlockIndex).forEach((g) => {
     expect(g).toHaveClass('warlock-slot');
   });


### PR DESCRIPTION
## Summary
- add bonus action slot indicator to SpellSlots component
- style bonus slot triangle and extend tests for new slot

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9fe0acc8323aa9a6f8d4d90aae2