### PR TITLE
refactor bonus triangle styling with clip-path

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -202,13 +202,12 @@
 }
 
 .bonus-slot .bonus-triangle {
-  width: 0;
-  height: 0;
+  width: 20px;
+  height: 20px;
   margin: 20px auto 0;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 20px solid #ffc107;
-  box-shadow: 0 0 5px #ffc107, 0 0 10px #ffc107;
+  background: #ffc107;
+  clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  filter: drop-shadow(0 0 5px #ffa500) drop-shadow(0 0 10px #ffa500);
 }
 
 .text-center {


### PR DESCRIPTION
## Summary
- style bonus triangle via clip-path and drop-shadows for cleaner rendering
- switch glow to #ffa500 for consistent orange highlight

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1bbc9ff108323945d2b4b44a66d37