### PR TITLE
style: add orange glow to bonus action triangle

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -207,7 +207,8 @@
   margin: 20px auto 0;
   background: #ffc107;
   clip-path: polygon(50% 0, 0 100%, 100% 100%);
-  filter: drop-shadow(0 0 5px #ffc107) drop-shadow(0 0 10px #ffc107);
+  box-shadow: 0 0 5px #ffa500, 0 0 10px #ffa500;
+  filter: drop-shadow(0 0 5px #ffa500) drop-shadow(0 0 10px #ffa500);
 }
 
 .text-center {


### PR DESCRIPTION
## Summary
- add orange glow to bonus action triangle icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1c8ac3a1c8323aa9fd8ddd91d33b4