### PR TITLE
style: add white border to bonus action triangle

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -204,11 +204,27 @@
 .bonus-slot { overflow: visible; }
 
 .bonus-slot .bonus-triangle {
-  width: 0; height: 0; margin: 20px auto 0;
+  position: relative;
+  width: 0;
+  height: 0;
+  margin: 20px auto 0;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
   border-bottom: 20px solid #ffc107;
   filter: drop-shadow(0 0 5px #ffa500) drop-shadow(0 0 10px #ffa500);
+}
+
+.bonus-slot .bonus-triangle::before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -11px;
+  width: 0;
+  height: 0;
+  border-left: 11px solid transparent;
+  border-right: 11px solid transparent;
+  border-bottom: 22px solid #fff;
+  z-index: -1;
 }
 
 .text-center {


### PR DESCRIPTION
## Summary
- outline bonus action indicator with white border to match action slot style

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ce7f0a5883238cc2c9388877e906