### PR TITLE
feat: track and reset action and bonus usage

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -199,6 +199,7 @@
   border-radius: 50%;
   background: #28a745;
   box-shadow: 0 0 5px #28a745, 0 0 10px #28a745;
+  cursor: pointer;
 }
 
 .bonus-slot { overflow: visible; }
@@ -209,6 +210,17 @@
   border-right: 10px solid transparent;
   border-bottom: 20px solid #ffc107;
   filter: drop-shadow(0 0 5px #ffa500) drop-shadow(0 0 10px #ffa500);
+  cursor: pointer;
+}
+
+.action-circle.slot-used {
+  background: transparent;
+  box-shadow: none;
+}
+
+.bonus-triangle.slot-used {
+  border-bottom-color: transparent;
+  filter: none;
 }
 
 .text-center {

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -13,7 +13,7 @@ function NavbarComponent() {
   };
 
   const handlePass = () => {
-    // Placeholder for future pass-turn logic
+    window.dispatchEvent(new Event('pass-turn'));
   };
 
   return (

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -78,12 +78,18 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot action-slot">
           <div className="slot-level">A</div>
           <div className="slot-boxes">
-            <div className="action-circle" />
+            <div
+              className={`action-circle ${used.action ? 'slot-used' : 'slot-active'}`}
+              onClick={() => onToggleSlot && onToggleSlot('action')}
+            />
           </div>
         </div>
         <div className="spell-slot bonus-slot">
           <div className="slot-level">B</div>
-          <div className="bonus-triangle" />
+          <div
+            className={`bonus-triangle ${used.bonus ? 'slot-used' : 'slot-active'}`}
+            onClick={() => onToggleSlot && onToggleSlot('bonus')}
+          />
         </div>
         {renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -80,3 +80,31 @@ test('warlock slots render after regular slots and have purple styling', () => {
     'rgb(128, 0, 128)'
   );
 });
+
+test('action and bonus markers toggle and reflect usage', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
+  const onToggle = jest.fn();
+  const { container, rerender } = render(
+    <SpellSlots form={form} used={{}} onToggleSlot={onToggle} />
+  );
+
+  const action = container.querySelector('.action-circle');
+  fireEvent.click(action);
+  expect(onToggle).toHaveBeenNthCalledWith(1, 'action');
+  rerender(
+    <SpellSlots form={form} used={{ action: true }} onToggleSlot={onToggle} />
+  );
+  expect(container.querySelector('.action-circle')).toHaveClass('slot-used');
+
+  const bonus = container.querySelector('.bonus-triangle');
+  fireEvent.click(bonus);
+  expect(onToggle).toHaveBeenNthCalledWith(2, 'bonus');
+  rerender(
+    <SpellSlots
+      form={form}
+      used={{ action: true, bonus: true }}
+      onToggleSlot={onToggle}
+    />
+  );
+  expect(container.querySelector('.bonus-triangle')).toHaveClass('slot-used');
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -54,7 +54,7 @@ export default function ZombiesCharacterSheet() {
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
   const [longRestCount, setLongRestCount] = useState(0);
   const [shortRestCount, setShortRestCount] = useState(0);
-  const [usedSlots, setUsedSlots] = useState({});
+  const [usedSlots, setUsedSlots] = useState({ action: false, bonus: false });
 
   const playerTurnActionsRef = useRef(null);
 
@@ -63,18 +63,25 @@ export default function ZombiesCharacterSheet() {
   const [navHeight, setNavHeight] = useState(0);
 
   useEffect(() => {
-    setUsedSlots({});
+    setUsedSlots({ action: false, bonus: false });
   }, [longRestCount]);
 
   useEffect(() => {
     setUsedSlots((prev) => {
-      const updated = { ...prev };
+      const updated = { action: false, bonus: false, ...prev };
       Object.keys(updated).forEach((key) => {
         if (key.startsWith('warlock-')) delete updated[key];
       });
       return updated;
     });
   }, [shortRestCount]);
+
+  useEffect(() => {
+    const handler = () =>
+      setUsedSlots((prev) => ({ ...prev, action: false, bonus: false }));
+    window.addEventListener('pass-turn', handler);
+    return () => window.removeEventListener('pass-turn', handler);
+  }, []);
 
   useEffect(() => {
     const nav = document.querySelector('.navbar.fixed-top');
@@ -172,6 +179,10 @@ export default function ZombiesCharacterSheet() {
 
   const handleCastSpell = useCallback(
     (arg, lvl, idx) => {
+      if (arg === 'action' || arg === 'bonus') {
+        setUsedSlots((prev) => ({ ...prev, [arg]: !prev[arg] }));
+        return;
+      }
       const consumeSlot = (level, preferredType) => {
         const occupations = form?.occupation || [];
         let casterLevel = 0;


### PR DESCRIPTION
## Summary
- track action and bonus usage and reset them on pass turn
- make action and bonus markers clickable with used styling
- dispatch pass-turn event from navbar and listen in character sheet
- add tests for new marker behaviour

## Testing
- `CI=true npm test --silent --prefix client src/components/Zombies/attributes/SpellSlots.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js 2>&1 | tail -n 20`
- `CI=true npm test --silent --prefix client 2>&1 | tail -n 20` *(fails: ItemList.test)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d958bdc483238cace88591f3a241