### PR TITLE
Remove redundant action/bonus slot styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -205,11 +205,13 @@
 .bonus-slot { overflow: visible; }
 
 .bonus-slot .bonus-triangle {
-  width: 0; height: 0; margin: 20px auto 0;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 20px solid #ffc107;
-  filter: drop-shadow(0 0 5px #ffa500) drop-shadow(0 0 10px #ffa500);
+  width: 20px;
+  height: 20px;
+  margin: 20px auto 0;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  background: #ffc107;
+  border: 1px solid #fff;
+  box-shadow: 0 0 5px #ffa500, 0 0 10px #ffa500;
   cursor: pointer;
 }
 
@@ -219,8 +221,8 @@
 }
 
 .bonus-triangle.slot-used {
-  border-bottom-color: transparent;
-  filter: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 .text-center {

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -56,8 +56,11 @@ test('fetches items and toggles ownership', async () => {
 });
 
 test('shows error message when item fetch fails', async () => {
+  const err = new Error('500 Server Error');
+  err.status = 500;
+  err.statusText = 'Server Error';
   apiFetch
-    .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' })
+    .mockRejectedValueOnce(err)
     .mockResolvedValueOnce({ ok: true, json: async () => [] });
 
   render(<ItemList campaign="Camp1" />);

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -79,7 +79,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
           <div className="slot-level">A</div>
           <div className="slot-boxes">
             <div
-              className={`action-circle ${used.action ? 'slot-used' : 'slot-active'}`}
+              className={`action-circle ${used.action ? 'slot-used' : ''}`}
               onClick={() => onToggleSlot && onToggleSlot('action')}
             />
           </div>
@@ -87,7 +87,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot bonus-slot">
           <div className="slot-level">B</div>
           <div
-            className={`bonus-triangle ${used.bonus ? 'slot-used' : 'slot-active'}`}
+            className={`bonus-triangle ${used.bonus ? 'slot-used' : ''}`}
             onClick={() => onToggleSlot && onToggleSlot('bonus')}
           />
         </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -413,7 +413,7 @@ test('pass-turn event resets action and bonus usage', async () => {
   window.dispatchEvent(new Event('pass-turn'));
 
   await waitFor(() => {
-    expect(action).toHaveClass('slot-active');
-    expect(bonus).toHaveClass('slot-active');
+    expect(action).not.toHaveClass('slot-used');
+    expect(bonus).not.toHaveClass('slot-used');
   });
 });


### PR DESCRIPTION
## Summary
- remove `slot-active` from action and bonus slots
- rebuild bonus slot triangle using clip-path for proper borders
- update unit tests to match new slot behavior

## Testing
- `CI=true npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_68c1dc1852dc8323a6e945257cb5ca05