### PR TITLE
fix: remove blue artifact on bonus slot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -213,6 +213,11 @@
   cursor: pointer;
 }
 
+.bonus-slot .slot-active {
+  background: transparent;
+  box-shadow: none;
+}
+
 .action-circle.slot-used {
   background: transparent;
   box-shadow: none;


### PR DESCRIPTION
## Summary
- override `.bonus-slot .slot-active` style to prevent blue background and box shadow

## Testing
- `CI=true npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_68c1e06f84e88323b2ca2b1f8151e1b7