### PR TITLE
Add dynamic action and bonus spell slots

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -13,7 +13,13 @@ const SPELLCASTING_CLASSES = {
 
 const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
 
-export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
+export default function SpellSlots({
+  form = {},
+  used = {},
+  onToggleSlot,
+  actionCount = 1,
+  bonusCount = 1,
+}) {
 
   const occupations = form.occupation || [];
   let casterLevel = 0;
@@ -78,18 +84,36 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot action-slot">
           <div className="slot-level">A</div>
           <div className="slot-boxes">
-            <div
-              className={`action-circle ${used.action ? 'slot-used' : 'slot-active'}`}
-              onClick={() => onToggleSlot && onToggleSlot('action')}
-            />
+            {Array.from({ length: actionCount }).map((_, i) => {
+              const isUsed = used.action?.[i];
+              return (
+                <div
+                  key={i}
+                  className={`slot-small action-circle ${
+                    isUsed ? 'slot-used' : 'slot-active'
+                  }`}
+                  onClick={() => onToggleSlot && onToggleSlot('action', i)}
+                />
+              );
+            })}
           </div>
         </div>
         <div className="spell-slot bonus-slot">
           <div className="slot-level">B</div>
-          <div
-            className={`bonus-triangle ${used.bonus ? 'slot-used' : 'slot-active'}`}
-            onClick={() => onToggleSlot && onToggleSlot('bonus')}
-          />
+          <div className="slot-boxes">
+            {Array.from({ length: bonusCount }).map((_, i) => {
+              const isUsed = used.bonus?.[i];
+              return (
+                <div
+                  key={i}
+                  className={`slot-small bonus-triangle ${
+                    isUsed ? 'slot-used' : 'slot-active'
+                  }`}
+                  onClick={() => onToggleSlot && onToggleSlot('bonus', i)}
+                />
+              );
+            })}
+          </div>
         </div>
         {renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -27,7 +27,9 @@ test('reflects used slots from props and toggles via callback', () => {
   const { container, rerender } = render(
     <SpellSlots form={form} used={{}} onToggleSlot={onToggle} />
   );
-  const first = container.querySelector('.slot-small');
+  const first = container.querySelector(
+    '[data-slot-type="regular"][data-slot-level="1"] .slot-small'
+  );
   fireEvent.click(first);
   expect(onToggle).toHaveBeenCalledWith('regular', 1, 0);
   rerender(
@@ -37,7 +39,11 @@ test('reflects used slots from props and toggles via callback', () => {
       onToggleSlot={onToggle}
     />
   );
-  expect(container.querySelector('.slot-small')).toHaveClass('slot-used');
+  expect(
+    container.querySelector(
+      '[data-slot-type="regular"][data-slot-level="1"] .slot-small'
+    )
+  ).toHaveClass('slot-used');
 });
 
 test('renders action and bonus slots before regular slots', () => {
@@ -48,10 +54,10 @@ test('renders action and bonus slots before regular slots', () => {
   const second = slotContainer.children[1];
   expect(first).toHaveClass('action-slot');
   expect(first.querySelector('.slot-level').textContent).toBe('A');
-  expect(first.querySelector('.action-circle')).toBeTruthy();
+  expect(first.querySelectorAll('.action-circle').length).toBe(1);
   expect(second).toHaveClass('bonus-slot');
   expect(second.querySelector('.slot-level').textContent).toBe('B');
-  expect(second.querySelector('.bonus-triangle')).toBeTruthy();
+  expect(second.querySelectorAll('.bonus-triangle').length).toBe(1);
 });
 
 test('warlock slots render after regular slots and have purple styling', () => {
@@ -90,21 +96,34 @@ test('action and bonus markers toggle and reflect usage', () => {
 
   const action = container.querySelector('.action-circle');
   fireEvent.click(action);
-  expect(onToggle).toHaveBeenNthCalledWith(1, 'action');
+  expect(onToggle).toHaveBeenNthCalledWith(1, 'action', 0);
   rerender(
-    <SpellSlots form={form} used={{ action: true }} onToggleSlot={onToggle} />
+    <SpellSlots form={form} used={{ action: { 0: true } }} onToggleSlot={onToggle} />
   );
   expect(container.querySelector('.action-circle')).toHaveClass('slot-used');
 
   const bonus = container.querySelector('.bonus-triangle');
   fireEvent.click(bonus);
-  expect(onToggle).toHaveBeenNthCalledWith(2, 'bonus');
+  expect(onToggle).toHaveBeenNthCalledWith(2, 'bonus', 0);
   rerender(
     <SpellSlots
       form={form}
-      used={{ action: true, bonus: true }}
+      used={{ action: { 0: true }, bonus: { 0: true } }}
       onToggleSlot={onToggle}
     />
   );
   expect(container.querySelector('.bonus-triangle')).toHaveClass('slot-used');
+});
+
+test('renders multiple action and bonus slots when counts provided', () => {
+  const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
+  const { container } = render(
+    <SpellSlots form={form} used={{}} actionCount={2} bonusCount={3} />
+  );
+  expect(
+    container.querySelectorAll('.action-slot .slot-boxes .slot-small').length
+  ).toBe(2);
+  expect(
+    container.querySelectorAll('.bonus-slot .slot-boxes .slot-small').length
+  ).toBe(3);
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -54,7 +54,7 @@ export default function ZombiesCharacterSheet() {
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
   const [longRestCount, setLongRestCount] = useState(0);
   const [shortRestCount, setShortRestCount] = useState(0);
-  const [usedSlots, setUsedSlots] = useState({ action: false, bonus: false });
+  const [usedSlots, setUsedSlots] = useState({ action: {}, bonus: {} });
 
   const playerTurnActionsRef = useRef(null);
 
@@ -63,12 +63,12 @@ export default function ZombiesCharacterSheet() {
   const [navHeight, setNavHeight] = useState(0);
 
   useEffect(() => {
-    setUsedSlots({ action: false, bonus: false });
+    setUsedSlots({ action: {}, bonus: {} });
   }, [longRestCount]);
 
   useEffect(() => {
     setUsedSlots((prev) => {
-      const updated = { action: false, bonus: false, ...prev };
+      const updated = { action: {}, bonus: {}, ...prev };
       Object.keys(updated).forEach((key) => {
         if (key.startsWith('warlock-')) delete updated[key];
       });
@@ -78,7 +78,7 @@ export default function ZombiesCharacterSheet() {
 
   useEffect(() => {
     const handler = () =>
-      setUsedSlots((prev) => ({ ...prev, action: false, bonus: false }));
+      setUsedSlots((prev) => ({ ...prev, action: {}, bonus: {} }));
     window.addEventListener('pass-turn', handler);
     return () => window.removeEventListener('pass-turn', handler);
   }, []);
@@ -180,7 +180,12 @@ export default function ZombiesCharacterSheet() {
   const handleCastSpell = useCallback(
     (arg, lvl, idx) => {
       if (arg === 'action' || arg === 'bonus') {
-        setUsedSlots((prev) => ({ ...prev, [arg]: !prev[arg] }));
+        const index = typeof lvl === 'number' ? lvl : 0;
+        setUsedSlots((prev) => {
+          const state = { ...(prev[arg] || {}) };
+          state[index] = !state[index];
+          return { ...prev, [arg]: state };
+        });
         return;
       }
       const consumeSlot = (level, preferredType) => {


### PR DESCRIPTION
## Summary
- render action and bonus slots based on counts so each use is tracked individually
- store action/bonus usage by index and expose default counts
- cover new slot behavior with tests

## Testing
- `npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/SpellSlots.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1e50b80b88323bd065008867c0276