### PR TITLE
feat: add AI weapon generation to DM page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,9 @@
     "react-router-dom": "^6.8.2",
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "openai": "^4.0.0",
+    "zod": "^3.23.8"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6,6 +6,24 @@ import { useNavigate, useParams } from "react-router-dom";
 import loginbg from "../../../images/loginbg.png";
 import useUser from '../../../hooks/useUser';
 import { SKILLS } from "../skillSchema";
+import OpenAI from "openai";
+import { z } from "zod";
+import { zodTextFormat } from "openai/helpers/zod";
+
+const openai = new OpenAI({
+  apiKey: process.env.REACT_APP_OPENAI_API_KEY,
+  dangerouslyAllowBrowser: true,
+});
+
+const WeaponSchema = z.object({
+  name: z.string(),
+  type: z.string().optional(),
+  category: z.string().optional(),
+  damage: z.string(),
+  properties: z.array(z.string()).optional(),
+  weight: z.string().optional(),
+  cost: z.string().optional(),
+});
 
 export default function ZombiesDM() {
   const user = useUser();
@@ -147,6 +165,8 @@ const [form2, setForm2] = useState({
     weight: "",
     cost: "",
   });
+
+  const [weaponPrompt, setWeaponPrompt] = useState("");
   
   const [show2, setShow2] = useState(false);
   const [isCreatingWeapon, setIsCreatingWeapon] = useState(false);
@@ -196,6 +216,33 @@ const [form2, setForm2] = useState({
     return setForm2((prev) => {
       return { ...prev, ...value };
     });
+  }
+
+  async function generateWeapon() {
+    try {
+      const response = await openai.responses.parse({
+        model: "gpt-4o-2024-08-06",
+        input: [
+          { role: "system", content: "Create a Dungeons and Dragons weapon." },
+          { role: "user", content: weaponPrompt },
+        ],
+        text: {
+          format: zodTextFormat(WeaponSchema, "weapon"),
+        },
+      });
+      const weapon = response.output_parsed;
+      updateForm2({
+        name: weapon.name || "",
+        type: weapon.type || "",
+        category: weapon.category || "",
+        damage: weapon.damage || "",
+        properties: weapon.properties || [],
+        weight: weapon.weight || "",
+        cost: weapon.cost || "",
+      });
+    } catch (err) {
+      setStatus({ type: 'danger', message: err.message || 'Failed to generate weapon' });
+    }
   }
   
   async function onSubmit2(e) {
@@ -582,6 +629,20 @@ const [form2, setForm2] = useState({
             {isCreatingWeapon ? (
               <Form onSubmit={onSubmit2} className="px-5">
                <Form.Group className="mb-3 pt-3" >
+
+               <Form.Label className="text-light">Weapon Prompt</Form.Label>
+               <Form.Control
+                className="mb-2"
+                value={weaponPrompt}
+                onChange={(e) => setWeaponPrompt(e.target.value)}
+                type="text"
+                placeholder="Describe a weapon" />
+               <Button
+                className="mb-3"
+                variant="outline-primary"
+                onClick={(e) => { e.preventDefault(); generateWeapon(); }}>
+                Generate with AI
+               </Button>
 
                <Form.Label className="text-light">Name</Form.Label>
                <Form.Control className="mb-2" onChange={(e) => updateForm2({ name: e.target.value })}


### PR DESCRIPTION
## Summary
- add OpenAI and zod dependencies
- integrate OpenAI-powered weapon generation into DM equipment page

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*
- `CI=true npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f741e1bc832eada15bfb43eef3ca