### PR TITLE
Switch bonus action marker to circle

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -204,12 +204,13 @@
 
 .bonus-slot { overflow: visible; }
 
-.bonus-slot .bonus-triangle {
-  width: 0; height: 0; margin: 20px auto 0;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 20px solid #ffc107;
-  filter: drop-shadow(0 0 5px #ffa500) drop-shadow(0 0 10px #ffa500);
+.bonus-slot .bonus-circle {
+  width: 20px;
+  height: 20px;
+  margin: 20px auto 0;
+  border-radius: 50%;
+  background: #ffc107;
+  box-shadow: 0 0 5px #ffa500, 0 0 10px #ffa500;
   cursor: pointer;
 }
 
@@ -223,9 +224,9 @@
   box-shadow: none;
 }
 
-.bonus-triangle.slot-used {
-  border-bottom-color: transparent;
-  filter: none;
+.bonus-circle.slot-used {
+  background: transparent;
+  box-shadow: none;
 }
 
 .text-center {

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -87,7 +87,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot bonus-slot">
           <div className="slot-level">B</div>
           <div
-            className={`bonus-triangle ${used.bonus ? 'slot-used' : 'slot-active'}`}
+            className={`bonus-circle ${used.bonus ? 'slot-used' : 'slot-active'}`}
             onClick={() => onToggleSlot && onToggleSlot('bonus')}
           />
         </div>

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -51,7 +51,7 @@ test('renders action and bonus slots before regular slots', () => {
   expect(first.querySelector('.action-circle')).toBeTruthy();
   expect(second).toHaveClass('bonus-slot');
   expect(second.querySelector('.slot-level').textContent).toBe('B');
-  expect(second.querySelector('.bonus-triangle')).toBeTruthy();
+  expect(second.querySelector('.bonus-circle')).toBeTruthy();
 });
 
 test('warlock slots render after regular slots and have purple styling', () => {
@@ -96,7 +96,7 @@ test('action and bonus markers toggle and reflect usage', () => {
   );
   expect(container.querySelector('.action-circle')).toHaveClass('slot-used');
 
-  const bonus = container.querySelector('.bonus-triangle');
+  const bonus = container.querySelector('.bonus-circle');
   fireEvent.click(bonus);
   expect(onToggle).toHaveBeenNthCalledWith(2, 'bonus');
   rerender(
@@ -106,5 +106,5 @@ test('action and bonus markers toggle and reflect usage', () => {
       onToggleSlot={onToggle}
     />
   );
-  expect(container.querySelector('.bonus-triangle')).toHaveClass('slot-used');
+  expect(container.querySelector('.bonus-circle')).toHaveClass('slot-used');
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -404,7 +404,7 @@ test('pass-turn event resets action and bonus usage', async () => {
   const { container } = render(<ZombiesCharacterSheet />);
   await waitFor(() => expect(container.querySelector('.action-circle')).toBeTruthy());
   const action = container.querySelector('.action-circle');
-  const bonus = container.querySelector('.bonus-triangle');
+  const bonus = container.querySelector('.bonus-circle');
   fireEvent.click(action);
   fireEvent.click(bonus);
   expect(action).toHaveClass('slot-used');


### PR DESCRIPTION
## Summary
- restyle bonus action indicator as an orange circle with glow
- update spell slots component to use `bonus-circle` class
- fix tests to query `.bonus-circle`

## Testing
- `CI=true npm --prefix client test -- client/src/components/Zombies/attributes/SpellSlots.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1f71b6e088323bb491416d6235163