### PR TITLE
fix weapon parsing in ZombiesDM

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -230,7 +230,11 @@ const [form2, setForm2] = useState({
           format: zodTextFormat(WeaponSchema, "weapon"),
         },
       });
-      const weapon = response.output_parsed;
+      const weapon = response.output?.[0]?.content?.[0]?.parsed;
+      if (!weapon) {
+        setStatus({ type: 'danger', message: 'Failed to generate weapon' });
+        return;
+      }
       updateForm2({
         name: weapon.name || "",
         type: weapon.type || "",


### PR DESCRIPTION
## Summary
- adjust OpenAI weapon parsing in ZombiesDM to new response structure
- add guard to prevent form updates when weapon generation fails

## Testing
- `CI=true npm test` *(fails: Cannot find module 'openai' from 'src/components/Zombies/pages/ZombiesDM.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1fda47f34832eb61dc27acba30b71