### PR TITLE
Render grid-based action and bonus spell slots

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -186,9 +186,13 @@
   cursor: default;
 }
 
-.action-slot .slot-boxes {
+.action-slot .slot-boxes,
+.bonus-slot .slot-boxes {
   padding-top: 20px;
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, 20px);
+  grid-template-rows: repeat(2, 20px);
+  gap: 2px;
   justify-content: center;
 }
 
@@ -208,7 +212,6 @@
   width: 20px;
   height: 20px;
   border: 1px solid #fff;
-  margin: 20px auto 0;
   border-radius: 50%;
   background: #ffa500;
   box-shadow: 0 0 5px #ffa500, 0 0 10px #ffa500;

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -78,18 +78,28 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot action-slot">
           <div className="slot-level">A</div>
           <div className="slot-boxes">
-            <div
-              className={`action-circle ${used.action ? 'slot-used' : 'slot-active'}`}
-              onClick={() => onToggleSlot && onToggleSlot('action')}
-            />
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                data-slot-index={i}
+                className={`action-circle ${used.action?.[i] ? 'slot-used' : 'slot-active'}`}
+                onClick={() => onToggleSlot && onToggleSlot('action', i)}
+              />
+            ))}
           </div>
         </div>
         <div className="spell-slot bonus-slot">
           <div className="slot-level">B</div>
-          <div
-            className={`bonus-circle ${used.bonus ? 'slot-used' : 'slot-active'}`}
-            onClick={() => onToggleSlot && onToggleSlot('bonus')}
-          />
+          <div className="slot-boxes">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                data-slot-index={i}
+                className={`bonus-circle ${used.bonus?.[i] ? 'slot-used' : 'slot-active'}`}
+                onClick={() => onToggleSlot && onToggleSlot('bonus', i)}
+              />
+            ))}
+          </div>
         </div>
         {renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -40,19 +40,23 @@ test('reflects used slots from props and toggles via callback', () => {
   expect(container.querySelector('.slot-small')).toHaveClass('slot-used');
 });
 
-test('renders action and bonus slots before regular slots', () => {
-  const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
-  const { container } = render(<SpellSlots form={form} used={{}} />);
-  const slotContainer = container.querySelector('.spell-slot-container');
-  const first = slotContainer.children[0];
-  const second = slotContainer.children[1];
-  expect(first).toHaveClass('action-slot');
-  expect(first.querySelector('.slot-level').textContent).toBe('A');
-  expect(first.querySelector('.action-circle')).toBeTruthy();
-  expect(second).toHaveClass('bonus-slot');
-  expect(second.querySelector('.slot-level').textContent).toBe('B');
-  expect(second.querySelector('.bonus-circle')).toBeTruthy();
-});
+  test('renders action and bonus slots before regular slots', () => {
+    const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
+    const { container } = render(<SpellSlots form={form} used={{}} />);
+    const slotContainer = container.querySelector('.spell-slot-container');
+    const first = slotContainer.children[0];
+    const second = slotContainer.children[1];
+    expect(first).toHaveClass('action-slot');
+    expect(first.querySelector('.slot-level').textContent).toBe('A');
+    const actionBoxes = first.querySelector('.slot-boxes');
+    expect(getComputedStyle(actionBoxes).display).toBe('grid');
+    expect(actionBoxes.querySelectorAll('.action-circle').length).toBe(4);
+    expect(second).toHaveClass('bonus-slot');
+    expect(second.querySelector('.slot-level').textContent).toBe('B');
+    const bonusBoxes = second.querySelector('.slot-boxes');
+    expect(getComputedStyle(bonusBoxes).display).toBe('grid');
+    expect(bonusBoxes.querySelectorAll('.bonus-circle').length).toBe(4);
+  });
 
 test('warlock slots render after regular slots and have purple styling', () => {
   const form = {
@@ -81,30 +85,45 @@ test('warlock slots render after regular slots and have purple styling', () => {
   );
 });
 
-test('action and bonus markers toggle and reflect usage', () => {
-  const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
-  const onToggle = jest.fn();
-  const { container, rerender } = render(
-    <SpellSlots form={form} used={{}} onToggleSlot={onToggle} />
-  );
+  test('action and bonus markers toggle and reflect usage', () => {
+    const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
+    const onToggle = jest.fn();
+    const { container, rerender } = render(
+      <SpellSlots form={form} used={{}} onToggleSlot={onToggle} />
+    );
 
-  const action = container.querySelector('.action-circle');
-  fireEvent.click(action);
-  expect(onToggle).toHaveBeenNthCalledWith(1, 'action');
-  rerender(
-    <SpellSlots form={form} used={{ action: true }} onToggleSlot={onToggle} />
-  );
-  expect(container.querySelector('.action-circle')).toHaveClass('slot-used');
+    const actionCircles = container.querySelectorAll('.action-circle');
+    actionCircles.forEach((circle, i) => {
+      fireEvent.click(circle);
+      expect(onToggle).toHaveBeenNthCalledWith(i + 1, 'action', i);
+    });
+    rerender(
+      <SpellSlots
+        form={form}
+        used={{ action: { 0: true, 1: true, 2: true, 3: true } }}
+        onToggleSlot={onToggle}
+      />
+    );
+    container
+      .querySelectorAll('.action-circle')
+      .forEach((c) => expect(c).toHaveClass('slot-used'));
 
-  const bonus = container.querySelector('.bonus-circle');
-  fireEvent.click(bonus);
-  expect(onToggle).toHaveBeenNthCalledWith(2, 'bonus');
-  rerender(
-    <SpellSlots
-      form={form}
-      used={{ action: true, bonus: true }}
-      onToggleSlot={onToggle}
-    />
-  );
-  expect(container.querySelector('.bonus-circle')).toHaveClass('slot-used');
-});
+    const bonusCircles = container.querySelectorAll('.bonus-circle');
+    bonusCircles.forEach((circle, i) => {
+      fireEvent.click(circle);
+      expect(onToggle).toHaveBeenNthCalledWith(4 + i + 1, 'bonus', i);
+    });
+    rerender(
+      <SpellSlots
+        form={form}
+        used={{
+          action: { 0: true, 1: true, 2: true, 3: true },
+          bonus: { 0: true, 1: true, 2: true, 3: true },
+        }}
+        onToggleSlot={onToggle}
+      />
+    );
+    container
+      .querySelectorAll('.bonus-circle')
+      .forEach((c) => expect(c).toHaveClass('slot-used'));
+  });


### PR DESCRIPTION
## Summary
- switch action and bonus slot layout to grid and remove hardcoded margin
- render four toggleable action and bonus circles
- update tests for new layout and toggle behavior

## Testing
- `CI=true npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ffee524483239c499d2ba8e39791