### PR TITLE
feat: validate numeric weapon cost

### DIFF
--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -42,7 +42,7 @@ describe('Equipment routes', () => {
         damage: '1d8',
         properties: ['versatile'],
         weight: 6,
-        cost: '10 gp',
+        cost: 10,
       };
       dbo.mockResolvedValue({
         collection: () => ({ insertOne: async () => ({ insertedId }) })

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -62,7 +62,8 @@ module.exports = (router) => {
       body('damage').trim().notEmpty().withMessage('damage is required'),
       body('properties').optional().isArray(),
       body('weight').optional().isFloat().toFloat(),
-      body('cost').optional().isString().trim(),
+      // Accept numeric cost values
+      body('cost').optional().isFloat().toFloat(),
     ],
     handleValidationErrors,
     async (req, response, next) => {

--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -24,9 +24,9 @@ export interface Weapon {
    */
   weight: number;
   /**
-   * Cost as a string, e.g. "15 gp".
+   * Cost value in gold pieces.
    */
-  cost: string;
+  cost: number;
   /**
    * Whether the creature currently owns the weapon.
    */


### PR DESCRIPTION
## Summary
- validate weapon cost as a float in equipment API
- define weapon cost as number type
- adjust tests for numeric weapon costs

## Testing
- `npm test --prefix server`
- `node -e ...` start express server and POST weapon with numeric cost

------
https://chatgpt.com/codex/tasks/task_e_68c20d291f08832e90a08e46b3e4dea8