### PR TITLE
feat: add AI armor generation

### DIFF
--- a/client/src/__mocks__/openai.js
+++ b/client/src/__mocks__/openai.js
@@ -1,0 +1,8 @@
+const mockParse = jest.fn();
+
+const OpenAI = jest.fn(() => ({
+  responses: { parse: mockParse },
+}));
+
+module.exports = OpenAI;
+module.exports.mockParse = mockParse;

--- a/client/src/__mocks__/openai/helpers/zod.js
+++ b/client/src/__mocks__/openai/helpers/zod.js
@@ -1,0 +1,1 @@
+module.exports = { zodTextFormat: () => ({}) };

--- a/client/src/__mocks__/zod.js
+++ b/client/src/__mocks__/zod.js
@@ -1,0 +1,11 @@
+const makeType = () => ({ optional: () => makeType() });
+
+const z = {
+  string: makeType,
+  number: makeType,
+  enum: () => makeType(),
+  array: () => ({ optional: () => makeType() }),
+  object: () => ({ safeParse: (data) => ({ success: true, data }) }),
+};
+
+module.exports = { z };

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import apiFetch from '../../../utils/apiFetch';
+import useUser from '../../../hooks/useUser';
+import ZombiesDM from './ZombiesDM';
+import { mockParse } from 'openai';
+
+jest.mock('openai');
+jest.mock('../../../utils/apiFetch');
+jest.mock('../../../hooks/useUser');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ campaign: 'Camp1' }),
+  useNavigate: () => jest.fn(),
+}));
+
+describe('ZombiesDM AI generation', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    mockParse.mockReset();
+    useUser.mockReturnValue({ username: 'dm' });
+  });
+
+  test('generates armor via AI and populates form', async () => {
+    apiFetch.mockImplementation((url) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/equipment/armor/Camp1':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/armor/options':
+          return Promise.resolve({ ok: true, json: async () => ({ types: ['Light'], categories: ['Shield'] }) });
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    mockParse.mockResolvedValue({
+      output: [
+        {
+          content: [
+            {
+              parsed: {
+                name: 'AI Armor',
+                type: 'Light',
+                category: 'Shield',
+                armorBonus: 2,
+                maxDex: 4,
+                strength: 10,
+                stealth: 'false',
+                weight: 20,
+                cost: 100,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<ZombiesDM />);
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/characters'));
+
+    const openModalBtn = screen.getAllByText('Create Armor')[0];
+    await userEvent.click(openModalBtn);
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/armor/options'));
+
+    const modal = await screen.findByRole('dialog');
+    const insideCreateBtn = within(modal).getByText('Create Armor');
+    await userEvent.click(insideCreateBtn);
+
+    await screen.findByRole('option', { name: 'Light' });
+
+    const promptInput = await screen.findByPlaceholderText('Describe armor');
+    await userEvent.type(promptInput, 'test armor');
+
+    const generateBtn = screen.getByRole('button', { name: /Generate Armor/i });
+    await userEvent.click(generateBtn);
+
+    await waitFor(() => expect(mockParse).toHaveBeenCalled());
+
+    await waitFor(() => expect(screen.getByDisplayValue('AI Armor')).toBeInTheDocument());
+    expect(screen.getByDisplayValue('Light')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Shield')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- allow DMs to generate armor with OpenAI and populate the form automatically
- add test covering armor generation via mocked OpenAI

## Testing
- `npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c20fe2b6a4832e9b976947746fec62