### PR TITLE
Use URL-based apiFetch mock for ItemList tests

### DIFF
--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -19,8 +19,15 @@ afterEach(() => {
 });
 
 test('fetches items and toggles ownership', async () => {
-  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => itemsData });
-  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => customData });
+  apiFetch.mockImplementation((url) => {
+    if (url === '/items') {
+      return Promise.resolve({ ok: true, json: async () => itemsData });
+    }
+    if (url === '/equipment/items/Camp1') {
+      return Promise.resolve({ ok: true, json: async () => customData });
+    }
+    return Promise.resolve({ ok: false, status: 500, statusText: 'Server Error' });
+  });
   const onChange = jest.fn();
 
   render(
@@ -56,9 +63,19 @@ test('fetches items and toggles ownership', async () => {
 });
 
 test('shows error message when item fetch fails', async () => {
-  apiFetch
-    .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' })
-    .mockResolvedValueOnce({ ok: true, json: async () => [] });
+  apiFetch.mockImplementation((url) => {
+    if (url === '/items') {
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+      });
+    }
+    if (url === '/equipment/items/Camp1') {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+    return Promise.resolve({ ok: false, status: 500, statusText: 'Server Error' });
+  });
 
   render(<ItemList campaign="Camp1" />);
 


### PR DESCRIPTION
## Summary
- Refactor ItemList tests to mock apiFetch once per test based on request URL
- Handle failure path with explicit 500 Server Error response

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21b4abb9c832eae8e4560e3e233e8