### PR TITLE
Disable glow on used spell slots

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -179,6 +179,7 @@
 
 .spell-slot .slot-used {
   background: transparent;
+  box-shadow: none;
 }
 
 .spell-slot .slot-inactive {


### PR DESCRIPTION
## Summary
- remove box shadow from `.spell-slot .slot-used` so used slots no longer glow

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c21d666c8c83238fc73e6e6dd100a3