### PR TITLE
Handle armor maxDex as string in ZombiesDM

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -448,7 +448,7 @@ const [form2, setForm2] = useState({
         type: armor.type || "",
         category: armor.category || "",
         armorBonus: armor.armorBonus ?? armor.acBonus ?? "",
-        maxDex: armor.maxDex ?? "",
+        maxDex: armor.maxDex !== undefined ? String(armor.maxDex) : "",
         strength: armor.strength ?? "",
         stealth: armor.stealth !== undefined ? String(armor.stealth) : "",
         weight: armor.weight ?? "",


### PR DESCRIPTION
## Summary
- Ensure generated armor `maxDex` is converted to a string when populating the form
- Confirm form submission still casts `maxDex` back to a number before saving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c220451050832eb40d3b17777d2c5f