### PR TITLE
Remove inactive styles for action and bonus circles

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -218,13 +218,6 @@
   cursor: pointer;
 }
 
-.action-circle.slot-inactive,
-.bonus-circle.slot-inactive {
-  background: rgba(255, 255, 255, 0.1);
-  box-shadow: none;
-  cursor: default;
-}
-
 .action-circle.slot-used {
   background: transparent;
   box-shadow: none;

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -86,12 +86,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
           <div className="slot-boxes">
             {Array.from({ length: 4 }).map((_, i) => {
               const state = used.action?.[i];
-              const cls =
-                state === 'used'
-                  ? 'slot-used'
-                  : state === 'inactive'
-                  ? 'slot-inactive'
-                  : 'slot-active';
+              const cls = state === 'used' ? 'slot-used' : 'slot-active';
               return (
                 <div
                   key={i}
@@ -108,12 +103,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
           <div className="slot-boxes">
             {Array.from({ length: 4 }).map((_, i) => {
               const state = used.bonus?.[i];
-              const cls =
-                state === 'used'
-                  ? 'slot-used'
-                  : state === 'inactive'
-                  ? 'slot-inactive'
-                  : 'slot-active';
+              const cls = state === 'used' ? 'slot-used' : 'slot-active';
               return (
                 <div
                   key={i}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -111,9 +111,9 @@ test('warlock slots render after regular slots and have purple styling', () => {
     );
     const updatedAction = container.querySelectorAll('.action-circle');
     expect(updatedAction[0]).toHaveClass('slot-used');
-    expect(updatedAction[1]).toHaveClass('slot-inactive');
+    expect(updatedAction[1]).toHaveClass('slot-active');
     expect(updatedAction[2]).toHaveClass('slot-active');
-    expect(updatedAction[3]).toHaveClass('slot-inactive');
+    expect(updatedAction[3]).toHaveClass('slot-active');
 
     const bonusCircles = container.querySelectorAll('.bonus-circle');
     bonusCircles.forEach((circle, i) => {
@@ -132,8 +132,8 @@ test('warlock slots render after regular slots and have purple styling', () => {
       />
     );
     const updatedBonus = container.querySelectorAll('.bonus-circle');
-    expect(updatedBonus[0]).toHaveClass('slot-inactive');
+    expect(updatedBonus[0]).toHaveClass('slot-active');
     expect(updatedBonus[1]).toHaveClass('slot-used');
     expect(updatedBonus[2]).toHaveClass('slot-active');
-    expect(updatedBonus[3]).toHaveClass('slot-inactive');
+    expect(updatedBonus[3]).toHaveClass('slot-active');
   });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -198,8 +198,7 @@ export default function ZombiesCharacterSheet() {
           const currentState = prev[arg] || initCircleState();
           const nextState = { ...currentState };
           const cur = currentState[index] || 'active';
-          nextState[index] =
-            cur === 'active' ? 'used' : cur === 'used' ? 'inactive' : 'active';
+          nextState[index] = cur === 'active' ? 'used' : 'active';
           return { ...prev, [arg]: nextState };
         });
         return;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -449,14 +449,14 @@ test('action and bonus markers cycle through states', async () => {
   fireEvent.click(action);
   expect(action).toHaveClass('slot-used');
   fireEvent.click(action);
-  expect(action).toHaveClass('slot-inactive');
-  fireEvent.click(action);
   expect(action).toHaveClass('slot-active');
+  fireEvent.click(action);
+  expect(action).toHaveClass('slot-used');
 
   fireEvent.click(bonus);
   expect(bonus).toHaveClass('slot-used');
   fireEvent.click(bonus);
-  expect(bonus).toHaveClass('slot-inactive');
-  fireEvent.click(bonus);
   expect(bonus).toHaveClass('slot-active');
+  fireEvent.click(bonus);
+  expect(bonus).toHaveClass('slot-used');
 });


### PR DESCRIPTION
## Summary
- drop CSS and state for `.action-circle.slot-inactive` and `.bonus-circle.slot-inactive`
- simplify action/bonus slot toggle logic
- adjust tests to reflect two-state cycle

## Testing
- `CI=true npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_68c22bed62c883238b00cd275b53d075