### PR TITLE
feat: allow configurable action and bonus counts

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -13,7 +13,13 @@ const SPELLCASTING_CLASSES = {
 
 const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
 
-export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
+export default function SpellSlots({
+  form = {},
+  used = {},
+  onToggleSlot,
+  actionCount: propActionCount,
+  bonusCount: propBonusCount,
+}) {
 
   const occupations = form.occupation || [];
   let casterLevel = 0;
@@ -37,8 +43,18 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
   const slotData = fullCasterSlots[casterLevel] || {};
   const warlockData = pactMagic[warlockLevel] || {};
 
-  const regularLevels = Object.keys(slotData).map(Number).sort((a, b) => a - b);
-  const warlockLevels = Object.keys(warlockData).map(Number).sort((a, b) => a - b);
+  const features = form.features || {};
+  const actionCount =
+    propActionCount ?? features.actionCount ?? 1;
+  const bonusCount =
+    propBonusCount ?? features.bonusCount ?? 1;
+
+  const regularLevels = Object.keys(slotData)
+    .map(Number)
+    .sort((a, b) => a - b);
+  const warlockLevels = Object.keys(warlockData)
+    .map(Number)
+    .sort((a, b) => a - b);
   if (regularLevels.length === 0 && warlockLevels.length === 0) return null;
 
   const renderGroup = (data, type) =>
@@ -84,7 +100,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot action-slot">
           <div className="slot-level">A</div>
           <div className="slot-boxes">
-            {Array.from({ length: 4 }).map((_, i) => {
+            {Array.from({ length: actionCount }).map((_, i) => {
               const state = used.action?.[i];
               const cls = state === 'used' ? 'slot-used' : 'slot-active';
               return (
@@ -92,7 +108,9 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
                   key={i}
                   data-slot-index={i}
                   className={`action-circle ${cls}`}
-                  onClick={() => onToggleSlot && onToggleSlot('action', i)}
+                  onClick={() =>
+                    onToggleSlot && onToggleSlot('action', i, actionCount)
+                  }
                 />
               );
             })}
@@ -101,7 +119,7 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
         <div className="spell-slot bonus-slot">
           <div className="slot-level">B</div>
           <div className="slot-boxes">
-            {Array.from({ length: 4 }).map((_, i) => {
+            {Array.from({ length: bonusCount }).map((_, i) => {
               const state = used.bonus?.[i];
               const cls = state === 'used' ? 'slot-used' : 'slot-active';
               return (
@@ -109,7 +127,9 @@ export default function SpellSlots({ form = {}, used = {}, onToggleSlot }) {
                   key={i}
                   data-slot-index={i}
                   className={`bonus-circle ${cls}`}
-                  onClick={() => onToggleSlot && onToggleSlot('bonus', i)}
+                  onClick={() =>
+                    onToggleSlot && onToggleSlot('bonus', i, bonusCount)
+                  }
                 />
               );
             })}

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -46,7 +46,9 @@ test('reflects used slots from props and toggles via callback', () => {
     style.innerHTML =
       '.action-slot .slot-boxes, .bonus-slot .slot-boxes { display: grid; }';
     document.head.appendChild(style);
-    const { container } = render(<SpellSlots form={form} used={{}} />);
+    const { container } = render(
+      <SpellSlots form={form} used={{}} actionCount={4} bonusCount={4} />
+    );
     const slotContainer = container.querySelector('.spell-slot-container');
     const first = slotContainer.children[0];
     const second = slotContainer.children[1];
@@ -93,19 +95,27 @@ test('warlock slots render after regular slots and have purple styling', () => {
     const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
     const onToggle = jest.fn();
     const { container, rerender } = render(
-      <SpellSlots form={form} used={{}} onToggleSlot={onToggle} />
+      <SpellSlots
+        form={form}
+        used={{}}
+        actionCount={4}
+        bonusCount={4}
+        onToggleSlot={onToggle}
+      />
     );
 
     const actionCircles = container.querySelectorAll('.action-circle');
     actionCircles.forEach((circle, i) => {
       expect(circle).toHaveClass('slot-active');
       fireEvent.click(circle);
-      expect(onToggle).toHaveBeenNthCalledWith(i + 1, 'action', i);
+      expect(onToggle).toHaveBeenNthCalledWith(i + 1, 'action', i, 4);
     });
     rerender(
       <SpellSlots
         form={form}
         used={{ action: { 0: 'used', 1: 'inactive', 2: 'active', 3: 'inactive' } }}
+        actionCount={4}
+        bonusCount={4}
         onToggleSlot={onToggle}
       />
     );
@@ -119,7 +129,7 @@ test('warlock slots render after regular slots and have purple styling', () => {
     bonusCircles.forEach((circle, i) => {
       expect(circle).toHaveClass('slot-active');
       fireEvent.click(circle);
-      expect(onToggle).toHaveBeenNthCalledWith(4 + i + 1, 'bonus', i);
+      expect(onToggle).toHaveBeenNthCalledWith(4 + i + 1, 'bonus', i, 4);
     });
     rerender(
       <SpellSlots
@@ -128,6 +138,8 @@ test('warlock slots render after regular slots and have purple styling', () => {
           action: { 0: 'used', 1: 'inactive', 2: 'active', 3: 'inactive' },
           bonus: { 0: 'inactive', 1: 'used', 2: 'active', 3: 'inactive' },
         }}
+        actionCount={4}
+        bonusCount={4}
         onToggleSlot={onToggle}
       />
     );


### PR DESCRIPTION
## Summary
- make action and bonus slot counts configurable in SpellSlots
- update tests for adjustable slot counts and callback index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c22dd133ec8323a6a1a3108d8939bd