### PR TITLE
Simplify feature usage interaction

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -9,7 +9,6 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
   const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [usedFeatures, setUsedFeatures] = useState({});
 
   useEffect(() => {
     if (!showFeatures) return;
@@ -83,25 +82,13 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
                   ) : features.length > 0 ? (
                     features.map((feat, idx) => {
                       const featKey = `${feat.class}-${feat.level}-${idx}`;
-                      const used = usedFeatures[featKey];
                       return (
                         <tr key={featKey}>
                           <td>{feat.class}</td>
                           <td>{feat.level}</td>
                           <td>{feat.name}</td>
                           <td>
-                            <Button
-                              aria-label="use feature"
-                              onClick={() =>
-                                setUsedFeatures((prev) => ({
-                                  ...prev,
-                                  [featKey]: true
-                                }))
-                              }
-                              disabled={used}
-                            >
-                              {used ? 'Used' : 'Use'}
-                            </Button>
+                            <Button aria-label="use feature">Use</Button>
                           </td>
                           <td>
                             <Button

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act, within } from '@testing-library/react';
+import { render, screen, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Features from './Features';
 
@@ -47,17 +47,6 @@ test('renders features and opens modal with description', async () => {
   expect(useButtons).toHaveLength(2);
 
   const actionSurgeRow = (await screen.findByText('Action Surge')).closest('tr');
-  const actionSurgeUseButton = within(actionSurgeRow).getByRole('button', {
-    name: /use feature/i
-  });
-
-  await act(async () => {
-    await userEvent.click(actionSurgeUseButton);
-  });
-
-  expect(actionSurgeUseButton).toBeDisabled();
-  expect(actionSurgeUseButton).toHaveTextContent(/used/i);
-
   const actionSurgeButton = within(actionSurgeRow).getByRole('button', {
     name: /view feature/i
   });


### PR DESCRIPTION
## Summary
- Remove tracking of used features and disable logic
- Simplify "Use" buttons to non-functional placeholders
- Update tests to only check presence of "Use" buttons and feature modal

## Testing
- `CI=true npm test -- src/components/Zombies/attributes/Features.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2cdc394688323b5285116c0335c49