### PR TITLE
Ensure action/bonus markers render without spell slots

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -55,7 +55,6 @@ export default function SpellSlots({
   const warlockLevels = Object.keys(warlockData)
     .map(Number)
     .sort((a, b) => a - b);
-  if (regularLevels.length === 0 && warlockLevels.length === 0) return null;
 
   const renderGroup = (data, type) =>
     Object.keys(data)
@@ -135,7 +134,7 @@ export default function SpellSlots({
             })}
           </div>
         </div>
-        {renderGroup(slotData, 'regular')}
+        {regularLevels.length > 0 && renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
       </div>
     </div>

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -40,6 +40,17 @@ test('reflects used slots from props and toggles via callback', () => {
   expect(container.querySelector('.slot-small')).toHaveClass('slot-used');
 });
 
+test('renders action and bonus markers even without spell slots', () => {
+  const form = { occupation: [{ Name: 'Fighter', Level: 1 }] };
+  const { container } = render(<SpellSlots form={form} used={{}} />);
+  expect(container.querySelector('.action-slot')).toBeInTheDocument();
+  expect(container.querySelector('.bonus-slot')).toBeInTheDocument();
+  const otherSlots = container.querySelectorAll(
+    '.spell-slot-container .spell-slot:not(.action-slot):not(.bonus-slot)'
+  );
+  expect(otherSlots.length).toBe(0);
+});
+
   test('renders action and bonus slots before regular slots', () => {
     const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
     const style = document.createElement('style');


### PR DESCRIPTION
## Summary
- Always show action and bonus action markers in SpellSlots
- Only render regular and warlock slot groups when slots exist
- Add tests covering marker rendering with no spell slots

## Testing
- `CI=true npm test` *(fails: ItemList.test.js, SpellSelector.test.js)*
- `CI=true npm --prefix client test -- SpellSlots.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2d2993b2c83238261f3db9011ee5d