### PR TITLE
Ensure SpellSlots always renders action and bonus markers

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -49,50 +49,45 @@ export default function SpellSlots({
   const bonusCount =
     propBonusCount ?? features.bonusCount ?? 1;
 
-  const regularLevels = Object.keys(slotData)
-    .map(Number)
-    .sort((a, b) => a - b);
-  const warlockLevels = Object.keys(warlockData)
-    .map(Number)
-    .sort((a, b) => a - b);
-  if (regularLevels.length === 0 && warlockLevels.length === 0) return null;
-
-  const renderGroup = (data, type) =>
-    Object.keys(data)
+  const renderGroup = (data, type) => {
+    const levels = Object.keys(data)
       .map(Number)
-      .sort((a, b) => a - b)
-      .map((lvl) => {
-        const count = data[lvl];
-        return (
-          <div
-            key={`${type}-${lvl}`}
-            className={`spell-slot ${type === 'warlock' ? 'warlock-slot' : ''}`}
-            data-slot-type={type}
-            data-slot-level={lvl}
-          >
-            <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
-            <div className="slot-boxes">
-              {Array.from({ length: count }).map((_, i) => {
-                const state = used[`${type}-${lvl}`]?.[i];
-                const cls =
-                  state === 'used' || state === true
-                    ? 'slot-used'
-                    : state === 'inactive'
-                    ? 'slot-inactive'
-                    : 'slot-active';
-                return (
-                  <div
-                    key={i}
-                    data-slot-index={i}
-                    className={`slot-small ${cls}`}
-                    onClick={() => onToggleSlot && onToggleSlot(type, lvl, i)}
-                  />
-                );
-              })}
-            </div>
+      .sort((a, b) => a - b);
+    if (levels.length === 0) return null;
+
+    return levels.map((lvl) => {
+      const count = data[lvl];
+      return (
+        <div
+          key={`${type}-${lvl}`}
+          className={`spell-slot ${type === 'warlock' ? 'warlock-slot' : ''}`}
+          data-slot-type={type}
+          data-slot-level={lvl}
+        >
+          <div className="slot-level">{ROMAN[lvl - 1] || lvl}</div>
+          <div className="slot-boxes">
+            {Array.from({ length: count }).map((_, i) => {
+              const state = used[`${type}-${lvl}`]?.[i];
+              const cls =
+                state === 'used' || state === true
+                  ? 'slot-used'
+                  : state === 'inactive'
+                  ? 'slot-inactive'
+                  : 'slot-active';
+              return (
+                <div
+                  key={i}
+                  data-slot-index={i}
+                  className={`slot-small ${cls}`}
+                  onClick={() => onToggleSlot && onToggleSlot(type, lvl, i)}
+                />
+              );
+            })}
           </div>
-        );
-      });
+        </div>
+      );
+    });
+  };
 
   return (
     <div style={{ display: 'flex' }}>
@@ -136,7 +131,7 @@ export default function SpellSlots({
           </div>
         </div>
         {renderGroup(slotData, 'regular')}
-        {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
+        {renderGroup(warlockData, 'warlock')}
       </div>
     </div>
   );

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -149,3 +149,12 @@ test('warlock slots render after regular slots and have purple styling', () => {
     expect(updatedBonus[2]).toHaveClass('slot-active');
     expect(updatedBonus[3]).toHaveClass('slot-active');
   });
+
+test('action and bonus slots render without spell slots', () => {
+  const form = { occupation: [] };
+  const { container } = render(
+    <SpellSlots form={form} used={{}} actionCount={2} bonusCount={2} />
+  );
+  expect(container.querySelectorAll('.action-circle').length).toBe(2);
+  expect(container.querySelectorAll('.bonus-circle').length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- Remove early return from SpellSlots so it always renders
- Handle empty slot groups in renderGroup and always render action/bonus circles
- Add regression test for rendering without spell slots

## Testing
- `npm test client/src/components/Zombies/attributes/SpellSlots.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2d5c67648832387f6b4ccad93ed3b