### PR TITLE
Ensure SpellSlots always shows action and bonus sections

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -55,7 +55,6 @@ export default function SpellSlots({
   const warlockLevels = Object.keys(warlockData)
     .map(Number)
     .sort((a, b) => a - b);
-  if (regularLevels.length === 0 && warlockLevels.length === 0) return null;
 
   const renderGroup = (data, type) =>
     Object.keys(data)
@@ -135,7 +134,7 @@ export default function SpellSlots({
             })}
           </div>
         </div>
-        {renderGroup(slotData, 'regular')}
+        {regularLevels.length > 0 && renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
       </div>
     </div>

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -91,6 +91,17 @@ test('warlock slots render after regular slots and have purple styling', () => {
   );
 });
 
+test('renders action and bonus slots without spell slots', () => {
+  const form = { occupation: [{ Name: 'Fighter', Level: 1 }] };
+  const { container } = render(<SpellSlots form={form} used={{}} />);
+  const groups = container.querySelectorAll(
+    '.spell-slot-container .spell-slot'
+  );
+  expect(groups.length).toBe(2);
+  expect(groups[0]).toHaveClass('action-slot');
+  expect(groups[1]).toHaveClass('bonus-slot');
+});
+
   test('action and bonus markers toggle and reflect states', () => {
     const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
     const onToggle = jest.fn();


### PR DESCRIPTION
## Summary
- Guard regular and warlock spell slot rendering with slot availability instead of returning early
- Add regression test to verify action and bonus slots render even without spell slots

## Testing
- `CI=true npm test -- SpellSlots.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c2db8877e08323b50f66980b547940