### PR TITLE
Add test for default action/bonus slot circles

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -102,6 +102,17 @@ test('renders action and bonus slots without spell slots', () => {
   expect(groups[1]).toHaveClass('bonus-slot');
 });
 
+test('includes action and bonus slots with default circle counts for non-casters', () => {
+  const form = { occupation: [{ Name: 'Fighter', Level: 1 }] };
+  const { container } = render(<SpellSlots form={form} used={{}} />);
+  const actionSlot = container.querySelector('.action-slot');
+  const bonusSlot = container.querySelector('.bonus-slot');
+  expect(actionSlot).toBeTruthy();
+  expect(bonusSlot).toBeTruthy();
+  expect(actionSlot.querySelectorAll('.action-circle').length).toBe(1);
+  expect(bonusSlot.querySelectorAll('.bonus-circle').length).toBe(1);
+});
+
   test('action and bonus markers toggle and reflect states', () => {
     const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
     const onToggle = jest.fn();


### PR DESCRIPTION
## Summary
- add unit test confirming action and bonus slots render with default circle counts for non-spellcasting classes

## Testing
- `npm --prefix client test -- client/src/components/Zombies/attributes/SpellSlots.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2df405cbc8323906e17d70c843ca5