### PR TITLE
Propagate spell names through cast events

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -187,7 +187,12 @@ const [isFumble, setIsFumble] = useState(false);
     );
     if (!value) return;
     updateDamageValueWithAnimation(value.total, value.breakdown);
-    onCastSpell?.({ level, slotType, castingTime: spell.castingTime });
+    onCastSpell?.({
+      level,
+      slotType,
+      castingTime: spell.castingTime,
+      name: spell.name,
+    });
   };
 
   const handleSpellsButtonClick = (spell, crit = false) => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -114,7 +114,7 @@ describe('PlayerTurnActions damage log', () => {
     expect(document.getElementById('damageValue').textContent).toBe('6');
 
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Damage Log' }));
+      fireEvent.click(screen.getByRole('button', { name: '⚔️ Log' }));
     });
     const modal = await screen.findByRole('dialog');
     expect(
@@ -124,9 +124,10 @@ describe('PlayerTurnActions damage log', () => {
   });
 
   test('handles multi-type damage and returns breakdown string', () => {
+    const fixedRoll = (count, sides) => Array(count).fill(1);
     expect(
       calculateDamage('1d4 cold + 1d6 slashing', 2, false, fixedRoll)
-    ).toBe('3 cold + 3 slashing');
+    ).toEqual({ total: 6, breakdown: '3 cold + 3 slashing' });
   });
 });
 
@@ -270,11 +271,14 @@ describe('PlayerTurnActions spell casting', () => {
       fireEvent.click(rollButton);
     });
 
-    expect(onCastSpell).toHaveBeenCalledWith({
-      level: spell.level,
-      slotType: undefined,
-      castingTime: spell.castingTime,
-    });
+    expect(onCastSpell).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: spell.level,
+        slotType: undefined,
+        castingTime: spell.castingTime,
+        name: spell.name,
+      })
+    );
   });
 
   test('consumes action circle for 1 action spells', async () => {

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -205,6 +205,7 @@ export default function SpellSelector({
       levelsAbove: diff > 0 ? diff : 0,
       slotType,
       castingTime: pendingSpell.castingTime,
+      name: pendingSpell.name,
     });
     setShowUpcast(false);
     setPendingSpell(null);
@@ -512,6 +513,7 @@ export default function SpellSelector({
                                         level: spell.level,
                                         damage,
                                         castingTime: spell.castingTime,
+                                        name: spell.name,
                                       });
                                       handleClose();
                                     }
@@ -632,6 +634,7 @@ export default function SpellSelector({
                                         level: spell.level,
                                         damage,
                                         castingTime: spell.castingTime,
+                                        name: spell.name,
                                       });
                                       handleClose();
                                     }

--- a/client/src/components/Zombies/attributes/SpellSelector.test.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.test.js
@@ -126,7 +126,7 @@ test('cast button disabled until spell checked and then calls onCastSpell', asyn
   expect(castBtn).not.toBeDisabled();
   await userEvent.click(castBtn);
   expect(onCast).toHaveBeenCalledWith(
-    expect.objectContaining({ level: 3, damage: undefined })
+    expect.objectContaining({ level: 3, damage: undefined, name: 'Fireball' })
   );
 });
 
@@ -159,7 +159,7 @@ test.each([
   const castBtn = within(rowEl).getAllByRole('button')[1];
   await userEvent.click(castBtn);
   expect(onCast).toHaveBeenCalledWith(
-    expect.objectContaining({ level: 0, damage: dmg })
+    expect.objectContaining({ level: 0, damage: dmg, name: 'Fire Bolt' })
   );
 });
 
@@ -256,7 +256,7 @@ test('UpcastModal returns warlock slot type', async () => {
   await userEvent.click(screen.getByText('Cast'));
   await waitFor(() =>
     expect(onCast).toHaveBeenCalledWith(
-      expect.objectContaining({ level: 2, slotType: 'warlock' })
+      expect.objectContaining({ level: 2, slotType: 'warlock', name: 'Burning Hands' })
     )
   );
 });
@@ -437,6 +437,7 @@ test('upcasting consumes higher slot and reports extra damage', async () => {
       extraDice: { count: 1, sides: 6 },
       levelsAbove: 2,
       slotType: 'regular',
+      name: 'Burning Hands',
     })
   );
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -276,6 +276,8 @@ export default function ZombiesCharacterSheet() {
           slotLevel,
           slotType,
           castingTime,
+          name,
+          spellName: altName,
         } = arg;
         const castLevel = typeof slotLevel === 'number' ? slotLevel : level;
         consumeSlot(castLevel, slotType);
@@ -298,7 +300,8 @@ export default function ZombiesCharacterSheet() {
               ? calc
               : { total: calc };
         } else {
-          result = { total: 'Spell Cast' };
+          const spellLabel = name || altName;
+          result = { total: spellLabel || 'Spell Cast' };
         }
         playerTurnActionsRef.current?.updateDamageValueWithAnimation(
           result.total,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -337,7 +337,7 @@ test('all footer buttons have footer-btn class', async () => {
   buttons.forEach((btn) => expect(btn).toHaveClass('footer-btn'));
 });
 
-test('handleCastSpell closes modal and outputs "Spell Cast"', async () => {
+test('handleCastSpell closes modal and outputs spell name', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,
     json: async () => ({
@@ -365,10 +365,10 @@ test('handleCastSpell closes modal and outputs "Spell Cast"', async () => {
   const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
   await userEvent.click(spellButton);
   expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
-  mockOnCastSpell.current({ level: 1 });
+  mockOnCastSpell.current({ level: 1, name: 'Mage Hand' });
   mockHandleClose.current();
   await waitFor(() => expect(screen.queryByTestId('spell-selector')).toBeNull());
-  expect(mockUpdateDamage).toHaveBeenCalledWith('Spell Cast', undefined);
+  expect(mockUpdateDamage).toHaveBeenCalledWith('Mage Hand', undefined);
 });
 
 test('handleCastSpell outputs calculated damage', async () => {


### PR DESCRIPTION
## Summary
- Include spell names in cast events to display cast spell label when no damage is rolled
- Forward spell names from casting components and player actions
- Update unit tests for new `name` argument

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c34730d6c4832e98e0966b45361fce