### PR TITLE
Add server AI item generation endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ The server uses a `config.env` file for configuration. Ensure the following vari
 | Variable | Description |
 |----------|-------------|
 | `CLIENT_ORIGINS` | Comma-separated list of client application URLs allowed to make cross-origin requests, e.g., `http://localhost,http://example.com`. |
+| `OPENAI_API_KEY` | API key used by the server to access OpenAI for item generation. |
 
 ### Client Environment Variables
 
-When running the React client separately from the server, configure the API base URL by setting a `REACT_APP_API_URL` environment variable. It must point to the origin of the server so the client can reach the backend.
+When running the React client separately from the server, configure the API base URL by setting a `REACT_APP_API_URL` environment variable. It must point to the origin of the server so the client can reach the backend. No OpenAI key is required on the client.
 
 For local development, create a `.env` file in the `client` directory with a value such as:
 

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,6 @@
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
     "web-vitals": "^2.1.4",
-    "openai": "^4.0.0",
     "zod": "^3.23.8"
   },
   "scripts": {

--- a/client/src/__mocks__/openai.js
+++ b/client/src/__mocks__/openai.js
@@ -1,8 +1,0 @@
-const mockParse = jest.fn();
-
-const OpenAI = jest.fn(() => ({
-  responses: { parse: mockParse },
-}));
-
-module.exports = OpenAI;
-module.exports.mockParse = mockParse;

--- a/client/src/__mocks__/openai/helpers/zod.js
+++ b/client/src/__mocks__/openai/helpers/zod.js
@@ -1,1 +1,0 @@
-module.exports = { zodTextFormat: () => ({}) };

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -4,9 +4,6 @@ import userEvent from '@testing-library/user-event';
 import apiFetch from '../../../utils/apiFetch';
 import useUser from '../../../hooks/useUser';
 import ZombiesDM from './ZombiesDM';
-import { mockParse } from 'openai';
-
-jest.mock('openai');
 jest.mock('../../../utils/apiFetch');
 jest.mock('../../../hooks/useUser');
 jest.mock('react-router-dom', () => ({
@@ -18,7 +15,6 @@ jest.mock('react-router-dom', () => ({
 describe('ZombiesDM AI generation', () => {
   beforeEach(() => {
     apiFetch.mockReset();
-    mockParse.mockReset();
     useUser.mockReturnValue({ username: 'dm' });
   });
 
@@ -35,31 +31,21 @@ describe('ZombiesDM AI generation', () => {
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/armor/options':
           return Promise.resolve({ ok: true, json: async () => ({ types: ['Light'], categories: ['Shield'] }) });
+        case '/ai/armor':
+          return Promise.resolve({ ok: true, json: async () => ({
+            name: 'AI Armor',
+            type: 'Light',
+            category: 'Shield',
+            armorBonus: 2,
+            maxDex: 4,
+            strength: 10,
+            stealth: false,
+            weight: 20,
+            cost: 100,
+          }) });
         default:
           return Promise.resolve({ ok: true, json: async () => ({}) });
       }
-    });
-
-    mockParse.mockResolvedValue({
-      output: [
-        {
-          content: [
-            {
-              parsed: {
-                name: 'AI Armor',
-                type: 'Light',
-                category: 'Shield',
-                armorBonus: 2,
-                maxDex: 4,
-                strength: 10,
-                stealth: false,
-                weight: 20,
-                cost: '100',
-              },
-            },
-          ],
-        },
-      ],
     });
 
     render(<ZombiesDM />);

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,9 @@
     "winston": "^3.10.0",
     "helmet": "^7.0.0",
     "express-rate-limit": "^6.7.0",
-    "csurf": "^1.11.0"
+    "csurf": "^1.11.0",
+    "openai": "^4.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -1,0 +1,116 @@
+const express = require('express');
+let OpenAI;
+try {
+  OpenAI = require('openai');
+} catch {
+  OpenAI = null;
+}
+let z;
+try {
+  ({ z } = require('zod'));
+} catch {
+  z = null;
+}
+let zodTextFormat;
+try {
+  ({ zodTextFormat } = require('openai/helpers/zod'));
+} catch {
+  zodTextFormat = null;
+}
+const { types: weaponTypes, categories: weaponCategories } = require('../data/weapons');
+const { types: armorTypes, categories: armorCategories } = require('../data/armor');
+
+module.exports = (router) => {
+  const aiRouter = express.Router();
+
+  aiRouter.post('/weapon', async (req, res) => {
+    const { prompt } = req.body || {};
+    if (!prompt) {
+      return res.status(400).json({ message: 'Prompt is required' });
+    }
+    if (!OpenAI || !z || !zodTextFormat) {
+      return res.status(500).json({ message: 'OpenAI not configured' });
+    }
+
+    const WeaponSchema = z.object({
+      name: z.string(),
+      type: z.enum(weaponTypes),
+      category: z.enum(weaponCategories),
+      damage: z.string(),
+      properties: z.array(z.string()).optional(),
+      weight: z.number().optional(),
+      cost: z.number().optional(),
+    });
+
+    try {
+      const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const response = await openai.responses.parse({
+        model: 'gpt-4o-2024-08-06',
+        input: [
+          { role: 'system', content: 'Create a Dungeons and Dragons weapon.' },
+          { role: 'user', content: prompt },
+        ],
+        text: {
+          format: zodTextFormat(WeaponSchema, 'weapon'),
+        },
+      });
+
+      const data = response.output?.[0]?.content?.[0]?.parsed;
+      const parsed = WeaponSchema.safeParse(data);
+      if (!parsed.success) {
+        return res.status(500).json({ message: parsed.error.message });
+      }
+      return res.json(parsed.data);
+    } catch (err) {
+      return res.status(500).json({ message: err.message });
+    }
+  });
+
+  aiRouter.post('/armor', async (req, res) => {
+    const { prompt } = req.body || {};
+    if (!prompt) {
+      return res.status(400).json({ message: 'Prompt is required' });
+    }
+    if (!OpenAI || !z || !zodTextFormat) {
+      return res.status(500).json({ message: 'OpenAI not configured' });
+    }
+
+    const ArmorSchema = z.object({
+      name: z.string(),
+      type: z.enum(armorTypes),
+      category: z.enum(armorCategories),
+      armorBonus: z.number().optional(),
+      acBonus: z.number().optional(),
+      maxDex: z.number().optional(),
+      strength: z.number().optional(),
+      stealth: z.boolean().optional(),
+      weight: z.number().optional(),
+      cost: z.string().optional(),
+    });
+
+    try {
+      const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const response = await openai.responses.parse({
+        model: 'gpt-4o-2024-08-06',
+        input: [
+          { role: 'system', content: 'Create a Dungeons and Dragons armor.' },
+          { role: 'user', content: prompt },
+        ],
+        text: {
+          format: zodTextFormat(ArmorSchema, 'armor'),
+        },
+      });
+
+      const data = response.output?.[0]?.content?.[0]?.parsed;
+      const parsed = ArmorSchema.safeParse(data);
+      if (!parsed.success) {
+        return res.status(500).json({ message: parsed.error.message });
+      }
+      return res.json(parsed.data);
+    } catch (err) {
+      return res.status(500).json({ message: err.message });
+    }
+  });
+
+  router.use('/ai', aiRouter);
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -22,6 +22,7 @@ const armor = require('./armor');
 const items = require('./items');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
+const ai = require('./ai');
 
 routes.use(async (req, res, next) => {
   try {
@@ -42,6 +43,7 @@ spells(routes);
 weapons(routes);
 armor(routes);
 items(routes);
+ai(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.
 characterOccupations(routes);


### PR DESCRIPTION
## Summary
- add `/ai/weapon` and `/ai/armor` routes that call OpenAI and validate results with Zod
- expose AI routes in server router
- update ZombiesDM page to request new API instead of using OpenAI directly
- remove OpenAI client dependency and mocks
- document `OPENAI_API_KEY` server environment variable

## Testing
- `npm --prefix server test`
- `CI=true npm --prefix client test`


------
https://chatgpt.com/codex/tasks/task_e_68c34cb58658832ea0bfec156eea6506