### PR TITLE
feat: add AI item creation

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -482,63 +482,204 @@ const [form2, setForm2] = useState({
     }
   }
   
-  //------------------------------------Items-------------------------------------------------------------------------------
+//------------------------------------Items------------------------------------------------------------
   const [show4, setShow4] = useState(false);
-  const handleClose4 = () => setShow4(false);
+  const [isCreatingItem, setIsCreatingItem] = useState(false);
+  const handleClose4 = () => {
+    setShow4(false);
+    setIsCreatingItem(false);
+  };
   const handleShow4 = () => setShow4(true);
-  
-   const skillDefaults = Object.fromEntries(SKILLS.map(({ key }) => [key, "0"]));
-   const [form4, setForm4] = useState({
+
+  const [items, setItems] = useState([]);
+  const [itemOptions, setItemOptions] = useState({
+    categories: [],
+  });
+
+  const emptyStats = { str: "", dex: "", con: "", int: "", wis: "", cha: "" };
+  const emptySkills = SKILLS.reduce((acc, { key }) => ({ ...acc, [key]: "" }), {});
+
+  const [form4, setForm4] = useState({
     campaign: currentCampaign,
-    itemName: "",
+    name: "",
+    category: "",
+    weight: "",
+    cost: "",
     notes: "",
-    str: "0",
-    dex: "0",
-    con: "0",
-    int: "0",
-    wis: "0",
-    cha: "0",
-    ...skillDefaults,
+    stats: emptyStats,
+    skills: emptySkills,
   });
-  
+
+  const [itemPrompt, setItemPrompt] = useState("");
+  const [itemLoading, setItemLoading] = useState(false);
+
   function updateForm4(value) {
-    return setForm4((prev) => {
-      return { ...prev, ...value };
-    });
+    return setForm4((prev) => ({ ...prev, ...value }));
   }
-  
+
+  function updateStat(stat, value) {
+    setForm4((prev) => ({
+      ...prev,
+      stats: { ...prev.stats, [stat]: value },
+    }));
+  }
+
+  function updateSkill(skill, value) {
+    setForm4((prev) => ({
+      ...prev,
+      skills: { ...prev.skills, [skill]: value },
+    }));
+  }
+
+  const fetchItems = useCallback(async () => {
+    const response = await apiFetch(`/equipment/items/${currentCampaign}`);
+    if (!response.ok) {
+      const message = `An error has occurred: ${response.statusText}`;
+      setStatus({ type: 'danger', message });
+      return;
+    }
+    const data = await response.json();
+    setItems(data);
+  }, [currentCampaign]);
+
+  const fetchItemOptions = useCallback(async () => {
+    const response = await apiFetch('/items/options');
+    if (!response.ok) {
+      const message = `An error has occurred: ${response.statusText}`;
+      setStatus({ type: 'danger', message });
+      return;
+    }
+    const data = await response.json();
+    setItemOptions(data);
+  }, []);
+
+  useEffect(() => {
+    if (show4) {
+      fetchItems();
+      fetchItemOptions();
+    }
+  }, [show4, currentCampaign, fetchItems, fetchItemOptions]);
+
+  async function generateItem() {
+    setItemLoading(true);
+    try {
+      if (!itemOptions.categories.length) {
+        setStatus({ type: 'danger', message: 'Item options not loaded' });
+        return;
+      }
+      const response = await apiFetch('/ai/item', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: itemPrompt }),
+      });
+      if (!response.ok) {
+        let message;
+        try {
+          const errorData = await response.json();
+          message = errorData?.message || response.statusText;
+        } catch {
+          message = response.statusText;
+        }
+        setStatus({ type: 'danger', message });
+        return;
+      }
+      const item = await response.json();
+      updateForm4({
+        name: item.name || '',
+        category: item.category || '',
+        weight: item.weight ?? '',
+        cost: item.cost ?? '',
+        notes: item.notes || '',
+        stats: { ...emptyStats, ...(item.stats || {}) },
+        skills: { ...emptySkills, ...(item.skills || {}) },
+      });
+    } catch (err) {
+      setStatus({ type: 'danger', message: err.message || 'Failed to generate item' });
+    } finally {
+      setItemLoading(false);
+    }
+  }
+
   async function onSubmit4(e) {
-    e.preventDefault();   
-     sendToDb4();
+    e.preventDefault();
+    sendToDb4();
   }
-  
-  async function sendToDb4(){
-    const newItem = { ...form4 };
-    await apiFetch("/equipment/item/add", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(newItem),
-    })
-   .catch(error => {
-     setStatus({ type: 'danger', message: error.toString() });
-     return;
-   });
-  
-   const skillReset = Object.fromEntries(SKILLS.map(({ key }) => [key, ""]));
-   setForm4({
-    itemName: "",
-    notes: "",
-    str: "",
-    dex: "",
-    con: "",
-    int: "",
-    wis: "",
-    cha: "",
-    ...skillReset,
-  });
-   navigate(0);
+
+  async function sendToDb4() {
+    const weightNumber = form4.weight === "" ? undefined : Number(form4.weight);
+    const stats = Object.fromEntries(
+      Object.entries(form4.stats).filter(([, v]) => v !== "" && v !== undefined && v !== 0)
+    );
+    const skills = Object.fromEntries(
+      Object.entries(form4.skills).filter(([, v]) => v !== "" && v !== undefined && v !== 0)
+    );
+    const newItem = {
+      campaign: currentCampaign,
+      name: form4.name,
+      category: form4.category,
+      weight: weightNumber,
+      cost: form4.cost,
+      notes: form4.notes,
+      stats,
+      skills,
+    };
+    Object.keys(newItem).forEach((key) => {
+      if (
+        newItem[key] === "" ||
+        newItem[key] === undefined ||
+        (typeof newItem[key] === 'object' && Object.keys(newItem[key]).length === 0)
+      ) {
+        delete newItem[key];
+      }
+    });
+    try {
+      const response = await apiFetch('/equipment/items', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(newItem),
+      });
+      if (!response.ok) {
+        let message;
+        try {
+          const errorData = await response.json();
+          message = errorData?.message || errorData?.error || response.statusText;
+        } catch {
+          message = response.statusText;
+        }
+        setStatus({ type: 'danger', message });
+        return;
+      }
+      setForm4({
+        campaign: currentCampaign,
+        name: "",
+        category: "",
+        weight: "",
+        cost: "",
+        notes: "",
+        stats: emptyStats,
+        skills: emptySkills,
+      });
+      handleClose4();
+      fetchItems();
+    } catch (error) {
+      setStatus({ type: 'danger', message: error.toString() });
+    }
+  }
+
+  async function deleteItem(id) {
+    try {
+      const response = await apiFetch(`/equipment/items/${id}`, { method: 'DELETE' });
+      if (!response.ok) {
+        const message = `An error has occurred: ${response.statusText}`;
+        setStatus({ type: 'danger', message });
+        return;
+      }
+      setItems((prev) => prev.filter((i) => i._id !== id));
+    } catch (error) {
+      setStatus({ type: 'danger', message: error.toString() });
+    }
   }
   
 
@@ -977,74 +1118,174 @@ const [form2, setForm2] = useState({
   </div>
   </Modal>
   {/* -----------------------------------------Item Modal--------------------------------------------- */}
-  <Modal className="dnd-modal" size="lg" centered show={show4} onHide={handleClose4}>
-       <div className="text-center">
-        <Card className="dnd-background">
-            <Card.Title>Create Item</Card.Title>
-          <Card.Body>   
+  <Modal className="dnd-modal modern-modal" size="lg" centered show={show4} onHide={handleClose4}>
+    <div className="text-center">
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">{isCreatingItem ? "Create Item" : "Items"}</Card.Title>
+        </Card.Header>
+        <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
           <div className="text-center">
-        <Form onSubmit={onSubmit4} className="px-5">
-        <Form.Group className="mb-3 pt-3" >
-  
-         <Form.Label className="text-light">Item Name</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ itemName: e.target.value })}
-          type="text" placeholder="Enter Item name" /> 
-  
-         <Form.Label className="text-light">Notes</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ notes: e.target.value })}
-          type="text" placeholder="Enter Notes" />
-  
-         <Form.Label className="text-light">Strength</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ str: e.target.value === "" ? 0 : e.target.value, })}
-          type="text" placeholder="Enter Strength" />  
-  
-         <Form.Label className="text-light">Dexterity</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ dex: e.target.value === "" ? 0 : e.target.value, })}
-          type="text" placeholder="Enter Dexterity" />
-  
-         <Form.Label className="text-light">Constitution</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ con: e.target.value === "" ? 0 : e.target.value, })}
-          type="text" placeholder="Enter Constitution" />   
-  
-         <Form.Label className="text-light">Intellect</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ int: e.target.value === "" ? 0 : e.target.value, })}
-          type="text" placeholder="Enter Intellect" />  
-  
-         <Form.Label className="text-light">Wisdom</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ wis: e.target.value === "" ? 0 : e.target.value, })}
-          type="text" placeholder="Enter Wisdom" />  
-  
-         <Form.Label className="text-light">Charisma</Form.Label>
-         <Form.Control className="mb-2" onChange={(e) => updateForm4({ cha: e.target.value === "" ? 0 : e.target.value, })}
-          type="text" placeholder="Enter Charisma" />
+            {isCreatingItem ? (
+              <Form onSubmit={onSubmit4} className="px-5">
+                <Form.Group className="mb-3 pt-3" >
+                  <Form.Label className="text-light">Item Prompt</Form.Label>
+                  <Form.Control
+                    className="mb-2"
+                    value={itemPrompt}
+                    onChange={(e) => setItemPrompt(e.target.value)}
+                    type="text"
+                    placeholder="Describe an item" />
+                  <Button
+                    className="mb-3"
+                    variant="outline-primary"
+                    onClick={(e) => { e.preventDefault(); generateItem(); }}
+                    disabled={itemLoading}
+                  >
+                    {itemLoading ? <Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" /> : "Generate with AI"}
+                  </Button>
+                  <br></br>
+                  <Form.Label className="text-light">Name</Form.Label>
+                  <Form.Control className="mb-2" value={form4.name} onChange={(e) => updateForm4({ name: e.target.value })}
+                    type="text" placeholder="Enter item name" />
+                  <Form.Label className="text-light">Category</Form.Label>
+                  <Form.Select
+                    className="mb-2"
+                    value={form4.category}
+                    onChange={(e) => updateForm4({ category: e.target.value })}
+                  >
+                    <option value="">Select category</option>
+                    {itemOptions.categories.map((c) => (
+                      <option key={c} value={c}>{c}</option>
+                    ))}
+                  </Form.Select>
 
-         {SKILLS.map(({ key, label }) => (
-           <React.Fragment key={key}>
-             <Form.Label className="text-light">{label}</Form.Label>
-             <Form.Control
-               className="mb-2"
-               onChange={(e) => updateForm4({ [key]: e.target.value === "" ? 0 : e.target.value })}
-               type="text"
-               placeholder={`Enter ${label}`}
-             />
-           </React.Fragment>
-         ))}
-  
-       </Form.Group>
-       <div className="text-center">
-       <Button variant="primary" onClick={handleClose4} type="submit">
-              Create
-            </Button>
-            <Button className="ms-4" variant="secondary" onClick={handleClose4}>
-              Close
-            </Button>
-            </div>
-       </Form>
-       </div>
-       </Card.Body> 
-       </Card>
-       </div>       
-        </Modal>
+                  <Form.Label className="text-light">Weight</Form.Label>
+                  <Form.Control
+                    className="mb-2"
+                    value={form4.weight}
+                    onChange={(e) =>
+                      updateForm4({ weight: e.target.value === "" ? "" : Number(e.target.value) })
+                    }
+                    type="number"
+                    placeholder="Enter weight"
+                  />
+
+                  <Form.Label className="text-light">Cost</Form.Label>
+                  <Form.Control
+                    className="mb-2"
+                    value={form4.cost}
+                    onChange={(e) => updateForm4({ cost: e.target.value })}
+                    type="text"
+                    placeholder="Enter cost"
+                  />
+
+                  <Form.Label className="text-light">Notes</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    className="mb-2"
+                    value={form4.notes}
+                    onChange={(e) => updateForm4({ notes: e.target.value })}
+                    placeholder="Enter notes"
+                  />
+
+                  <Form.Label className="text-light">Stat Bonuses</Form.Label>
+                  <Row className="mb-2">
+                    {Object.entries(form4.stats).map(([s, val]) => (
+                      <Col key={s}>
+                        <Form.Control
+                          className="mb-2"
+                          type="number"
+                          placeholder={s.toUpperCase()}
+                          value={val}
+                          onChange={(e) =>
+                            updateStat(s, e.target.value === "" ? "" : Number(e.target.value))
+                          }
+                        />
+                      </Col>
+                    ))}
+                  </Row>
+
+                  <Form.Label className="text-light">Skill Bonuses</Form.Label>
+                  {SKILLS.map(({ key, label }) => (
+                    <Form.Control
+                      key={key}
+                      className="mb-2"
+                      type="number"
+                      placeholder={label}
+                      value={form4.skills[key]}
+                      onChange={(e) =>
+                        updateSkill(key, e.target.value === "" ? "" : Number(e.target.value))
+                      }
+                    />
+                  ))}
+
+                </Form.Group>
+                <div className="text-center">
+                  <Button variant="primary" type="submit">
+                    Create
+                  </Button>
+                  <Button className="ms-4" variant="secondary" onClick={() => setIsCreatingItem(false)}>
+                    Cancel
+                  </Button>
+                </div>
+              </Form>
+            ) : (
+              <>
+                <Table responsive striped bordered hover size="sm" className="modern-table mt-3">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Category</th>
+                      <th>Weight</th>
+                      <th>Cost</th>
+                      <th>Stats</th>
+                      <th>Skills</th>
+                      <th>Delete</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {items.map((i) => (
+                      <tr key={i._id}>
+                        <td>{i.name}</td>
+                        <td>{i.category}</td>
+                        <td>{i.weight}</td>
+                        <td>{i.cost}</td>
+                        <td>
+                          {i.stats &&
+                            Object.entries(i.stats).map(([k, v]) => (
+                              <div key={k}>{k.toUpperCase()}: {v}</div>
+                            ))}
+                        </td>
+                        <td>
+                          {i.skills &&
+                            Object.entries(i.skills).map(([k, v]) => (
+                              <div key={k}>{(SKILLS.find((s) => s.key === k)?.label) || k}: {v}</div>
+                            ))}
+                        </td>
+                        <td>
+                          <Button
+                            className="btn-danger action-btn fa-solid fa-trash"
+                            onClick={() => deleteItem(i._id)}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+                <Button variant="primary" onClick={() => setIsCreatingItem(true)}>
+                  Create Item
+                </Button>
+                <Button className="ms-4" variant="secondary" onClick={handleClose4}>
+                  Close
+                </Button>
+              </>
+            )}
+          </div>
+        </Card.Body>
+      </Card>
+    </div>
+  </Modal>
       </div>
     )
 }

--- a/server/__tests__/items.test.js
+++ b/server/__tests__/items.test.js
@@ -33,7 +33,6 @@ describe('Item routes', () => {
   test('provides item options', async () => {
     const res = await request(app).get('/items/options');
     expect(res.status).toBe(200);
-    expect(res.body.types).toContain('potion-healing');
     expect(res.body.categories).toContain('tool');
   });
 

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -19,7 +19,7 @@ try {
 }
 const { types: weaponTypes, categories: weaponCategories } = require('../data/weapons');
 const { types: armorTypes, categories: armorCategories } = require('../data/armor');
-const { types: itemTypes, categories: itemCategories } = require('../data/items');
+const { categories: itemCategories } = require('../data/items');
 
 module.exports = (router) => {
   const aiRouter = express.Router();
@@ -124,11 +124,12 @@ module.exports = (router) => {
 
     const ItemSchema = z.object({
       name: z.string(),
-      type: z.enum(itemTypes),
       category: z.enum(itemCategories),
       weight: z.number().optional(),
       cost: z.string().optional(),
       properties: z.array(z.string()).optional(),
+      stats: z.record(z.number()).optional(),
+      skills: z.record(z.number()).optional(),
     });
 
     try {

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -252,6 +252,9 @@ module.exports = (router) => {
       body('category').trim().notEmpty().withMessage('category is required'),
       body('weight').isFloat().withMessage('weight must be a number').toFloat(),
       body('cost').trim().notEmpty().withMessage('cost is required'),
+      body('notes').optional().trim(),
+      body('stats').optional().isObject(),
+      body('skills').optional().isObject(),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -274,6 +277,9 @@ module.exports = (router) => {
       body('category').optional().trim().notEmpty(),
       body('weight').optional().isFloat().toFloat(),
       body('cost').optional().trim().notEmpty(),
+      body('notes').optional().trim(),
+      body('stats').optional().isObject(),
+      body('skills').optional().isObject(),
     ],
     handleValidationErrors,
     async (req, res, next) => {

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { items, types, categories } = require('../data/items');
+const { items, categories } = require('../data/items');
 
 module.exports = (router) => {
   const itemRouter = express.Router();
@@ -9,7 +9,7 @@ module.exports = (router) => {
   });
 
   itemRouter.get('/options', (_req, res) => {
-    res.json({ types, categories });
+    res.json({ categories });
   });
 
   itemRouter.get('/:name', (req, res) => {

--- a/types/item.d.ts
+++ b/types/item.d.ts
@@ -17,12 +17,24 @@ export interface Item {
   weight: number;
   /**
    * Cost as a string, e.g. "5 gp".
-   */
+  */
   cost: string;
   /**
    * Optional list of SRD properties, may be empty.
    */
   properties?: string[];
+  /**
+   * Optional notes or description for custom items.
+   */
+  notes?: string;
+  /**
+   * Ability score modifiers granted by the item.
+   */
+  stats?: Record<string, number>;
+  /**
+   * Skill modifiers granted by the item.
+   */
+  skills?: Record<string, number>;
   /**
    * Whether the creature currently owns the item.
    */


### PR DESCRIPTION
## Summary
- drop item type option and allow notes plus stat/skill bonuses in Zombies DM item creator
- validate optional notes, stats, and skills fields on equipment item routes
- expose only item categories and broaden AI item schema

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3547c0b2c832ebc49cb9ed52c39c1