### PR TITLE
Remove item type field and simplify item options

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -55,7 +55,6 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
               acc[key] = {
                 name: key,
                 displayName: it.name,
-                type: it.type,
                 category: it.category || 'custom',
                 weight: it.weight ?? '',
                 cost: it.cost ?? '',
@@ -108,12 +107,11 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
     if (typeof onChange === 'function') {
       const ownedItems = Object.values(nextItems)
         .filter((i) => i.owned)
-        .map(({ name, category, weight, cost, type }) => ({
+        .map(({ name, category, weight, cost }) => ({
           name,
           category,
           weight,
           cost,
-          type,
         }));
       onChange(ownedItems);
     }

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -492,14 +492,12 @@ const [form2, setForm2] = useState({
 
   const [items, setItems] = useState([]);
   const [itemOptions, setItemOptions] = useState({
-    types: [],
     categories: [],
   });
 
   const [form4, setForm4] = useState({
     campaign: currentCampaign,
     name: "",
-    type: "",
     category: "",
     weight: "",
     cost: "",
@@ -546,7 +544,7 @@ const [form2, setForm2] = useState({
   async function generateItem() {
     setItemLoading(true);
     try {
-      if (!itemOptions.types.length || !itemOptions.categories.length) {
+      if (!itemOptions.categories.length) {
         setStatus({ type: 'danger', message: 'Item options not loaded' });
         return;
       }
@@ -569,7 +567,6 @@ const [form2, setForm2] = useState({
       const item = await response.json();
       updateForm4({
         name: item.name || '',
-        type: item.type || '',
         category: item.category || '',
         weight: item.weight ?? '',
         cost: item.cost ?? '',
@@ -591,7 +588,6 @@ const [form2, setForm2] = useState({
     const newItem = {
       campaign: currentCampaign,
       name: form4.name,
-      type: form4.type,
       category: form4.category,
       weight: weightNumber,
       cost: form4.cost,
@@ -623,7 +619,6 @@ const [form2, setForm2] = useState({
       setForm4({
         campaign: currentCampaign,
         name: "",
-        type: "",
         category: "",
         weight: "",
         cost: "",
@@ -1116,18 +1111,6 @@ const [form2, setForm2] = useState({
                   <Form.Control className="mb-2" value={form4.name} onChange={(e) => updateForm4({ name: e.target.value })}
                     type="text" placeholder="Enter item name" />
 
-                  <Form.Label className="text-light">Type</Form.Label>
-                  <Form.Select
-                    className="mb-2"
-                    value={form4.type}
-                    onChange={(e) => updateForm4({ type: e.target.value })}
-                  >
-                    <option value="">Select type</option>
-                    {itemOptions.types.map((t) => (
-                      <option key={t} value={t}>{t}</option>
-                    ))}
-                  </Form.Select>
-
                   <Form.Label className="text-light">Category</Form.Label>
                   <Form.Select
                     className="mb-2"
@@ -1176,7 +1159,6 @@ const [form2, setForm2] = useState({
                   <thead>
                     <tr>
                       <th>Name</th>
-                      <th>Type</th>
                       <th>Category</th>
                       <th>Weight</th>
                       <th>Cost</th>
@@ -1187,7 +1169,6 @@ const [form2, setForm2] = useState({
                     {items.map((i) => (
                       <tr key={i._id}>
                         <td>{i.name}</td>
-                        <td>{i.type}</td>
                         <td>{i.category}</td>
                         <td>{i.weight}</td>
                         <td>{i.cost}</td>

--- a/server/__tests__/items.test.js
+++ b/server/__tests__/items.test.js
@@ -33,8 +33,8 @@ describe('Item routes', () => {
   test('provides item options', async () => {
     const res = await request(app).get('/items/options');
     expect(res.status).toBe(200);
-    expect(res.body.types).toContain('potion-healing');
     expect(res.body.categories).toContain('tool');
+    expect(res.body.types).toBeUndefined();
   });
 
   test('fetches item by name', async () => {

--- a/server/data/items.js
+++ b/server/data/items.js
@@ -171,15 +171,13 @@ const items = {
   warship: { name: "Warship", category: "water vehicle", weight: 0, cost: "25000 gp" },
 };
 
-// Default the type of each item to its key for canonical mapping
-for (const [key, item] of Object.entries(items)) {
-  item.type = item.type || key;
+// Default the properties list for each item
+for (const item of Object.values(items)) {
   item.properties = item.properties || [];
 }
 // Derive canonical option lists for client consumption
-const types = Object.keys(items);
 const categories = [
   ...new Set(Object.values(items).map((i) => i.category)),
 ];
 
-module.exports = { items, types, categories };
+module.exports = { items, categories };

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -19,7 +19,7 @@ try {
 }
 const { types: weaponTypes, categories: weaponCategories } = require('../data/weapons');
 const { types: armorTypes, categories: armorCategories } = require('../data/armor');
-const { types: itemTypes, categories: itemCategories } = require('../data/items');
+const { categories: itemCategories } = require('../data/items');
 
 module.exports = (router) => {
   const aiRouter = express.Router();
@@ -124,7 +124,6 @@ module.exports = (router) => {
 
     const ItemSchema = z.object({
       name: z.string(),
-      type: z.enum(itemTypes),
       category: z.enum(itemCategories),
       weight: z.number().optional(),
       cost: z.string().optional(),

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { items, types, categories } = require('../data/items');
+const { items, categories } = require('../data/items');
 
 module.exports = (router) => {
   const itemRouter = express.Router();
@@ -9,7 +9,7 @@ module.exports = (router) => {
   });
 
   itemRouter.get('/options', (_req, res) => {
-    res.json({ types, categories });
+    res.json({ categories });
   });
 
   itemRouter.get('/:name', (req, res) => {

--- a/types/item.d.ts
+++ b/types/item.d.ts
@@ -4,10 +4,6 @@ export interface Item {
    */
   name: string;
   /**
-   * Canonical item key used for lookup.
-   */
-  type?: string;
-  /**
    * Item category such as "adventuring gear", "tool", or "mount".
    */
   category: string;


### PR DESCRIPTION
## Summary
- drop `type` from item model and API
- item options endpoint now returns only categories
- update item list and DM tools to work without item type

## Testing
- `npm --prefix server test server/__tests__/items.test.js`
- `CI=1 npm --prefix client test client/src/components/Items/ItemList.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c35ee57ce0832e8cea92dbb3cd17ff