### PR TITLE
feat: allow items to apply stat and skill bonuses

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -5,6 +5,8 @@ import Modal from 'react-bootstrap/Modal';
 import { useNavigate, useParams } from "react-router-dom";
 import loginbg from "../../../images/loginbg.png";
 import useUser from '../../../hooks/useUser';
+import { STATS } from '../statSchema';
+import { SKILLS } from '../skillSchema';
 
 export default function ZombiesDM() {
   const user = useUser();
@@ -501,6 +503,9 @@ const [form2, setForm2] = useState({
     category: "",
     weight: "",
     cost: "",
+    notes: "",
+    statBonuses: {},
+    skillBonuses: {},
   });
 
   const [itemPrompt, setItemPrompt] = useState("");
@@ -585,18 +590,23 @@ const [form2, setForm2] = useState({
 
   async function sendToDb4() {
     const weightNumber = form4.weight === "" ? undefined : Number(form4.weight);
+    const normalizeBonuses = (obj) => {
+      const entries = Object.entries(obj || {}).filter(([, v]) => v !== '' && v !== undefined);
+      if (!entries.length) return undefined;
+      return Object.fromEntries(entries.map(([k, v]) => [k, Number(v)]));
+    };
+    const statBonuses = normalizeBonuses(form4.statBonuses);
+    const skillBonuses = normalizeBonuses(form4.skillBonuses);
     const newItem = {
       campaign: currentCampaign,
       name: form4.name,
       category: form4.category,
       weight: weightNumber,
       cost: form4.cost,
+      ...(form4.notes && { notes: form4.notes }),
+      ...(statBonuses && { statBonuses }),
+      ...(skillBonuses && { skillBonuses }),
     };
-    Object.keys(newItem).forEach((key) => {
-      if (newItem[key] === "" || newItem[key] === undefined) {
-        delete newItem[key];
-      }
-    });
     try {
       const response = await apiFetch('/equipment/items', {
         method: 'POST',
@@ -622,6 +632,9 @@ const [form2, setForm2] = useState({
         category: "",
         weight: "",
         cost: "",
+        notes: "",
+        statBonuses: {},
+        skillBonuses: {},
       });
       handleClose4();
       fetchItems();
@@ -1142,6 +1155,53 @@ const [form2, setForm2] = useState({
                     type="text"
                     placeholder="Enter cost"
                   />
+
+                  <Form.Label className="text-light">Notes</Form.Label>
+                  <Form.Control
+                    className="mb-2"
+                    value={form4.notes}
+                    onChange={(e) => updateForm4({ notes: e.target.value })}
+                    type="text"
+                    placeholder="Enter notes"
+                  />
+
+                  <Form.Label className="text-light">Stat Bonuses</Form.Label>
+                  {STATS.map(({ key, label }) => (
+                    <Form.Control
+                      key={key}
+                      className="mb-2"
+                      type="number"
+                      placeholder={label}
+                      value={form4.statBonuses[key] ?? ''}
+                      onChange={(e) =>
+                        updateForm4({
+                          statBonuses: {
+                            ...form4.statBonuses,
+                            [key]: e.target.value === '' ? '' : Number(e.target.value)
+                          }
+                        })
+                      }
+                    />
+                  ))}
+
+                  <Form.Label className="text-light">Skill Bonuses</Form.Label>
+                  {SKILLS.map(({ key, label }) => (
+                    <Form.Control
+                      key={key}
+                      className="mb-2"
+                      type="number"
+                      placeholder={label}
+                      value={form4.skillBonuses[key] ?? ''}
+                      onChange={(e) =>
+                        updateForm4({
+                          skillBonuses: {
+                            ...form4.skillBonuses,
+                            [key]: e.target.value === '' ? '' : Number(e.target.value)
+                          }
+                        })
+                      }
+                    />
+                  ))}
 
                 </Form.Group>
                 <div className="text-center">

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -333,10 +333,15 @@ describe('Equipment routes', () => {
           name: 'Potion of healing',
           category: 'adventuring gear',
           weight: 0.5,
-          cost: '50 gp'
+          cost: '50 gp',
+          notes: 'heals slightly',
+          statBonuses: { str: 1 },
+          skillBonuses: { acrobatics: 2 }
         });
       expect(res.status).toBe(200);
       expect(res.body._id).toBeDefined();
+      expect(res.body.statBonuses.str).toBe(1);
+      expect(res.body.skillBonuses.acrobatics).toBe(2);
     });
 
     test('numeric validation failure', async () => {
@@ -358,12 +363,20 @@ describe('Equipment routes', () => {
     test('get items success', async () => {
       dbo.mockResolvedValue({
         collection: () => ({
-          find: () => ({ toArray: async () => [{ name: 'Potion of healing' }] })
+          find: () => ({
+            toArray: async () => [{
+              name: 'Potion of healing',
+              statBonuses: { str: 1 },
+              skillBonuses: { acrobatics: 2 }
+            }]
+          })
         })
       });
       const res = await request(app).get('/equipment/items/Camp1');
       expect(res.status).toBe(200);
       expect(res.body[0].name).toBe('Potion of healing');
+      expect(res.body[0].statBonuses.str).toBe(1);
+      expect(res.body[0].skillBonuses.acrobatics).toBe(2);
     });
 
     test('get items failure', async () => {

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -5,6 +5,18 @@ const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 const { armors: armorData } = require('../data/armor');
 
+const validateBonusObject = (value) => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('must be an object');
+  }
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'number') {
+      throw new Error('values must be numbers');
+    }
+  }
+  return true;
+};
+
 module.exports = (router) => {
   const equipmentRouter = express.Router();
 
@@ -252,6 +264,9 @@ module.exports = (router) => {
       body('category').trim().notEmpty().withMessage('category is required'),
       body('weight').isFloat().withMessage('weight must be a number').toFloat(),
       body('cost').trim().notEmpty().withMessage('cost is required'),
+      body('notes').optional().trim(),
+      body('statBonuses').optional().custom(validateBonusObject),
+      body('skillBonuses').optional().custom(validateBonusObject),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -274,6 +289,9 @@ module.exports = (router) => {
       body('category').optional().trim().notEmpty(),
       body('weight').optional().isFloat().toFloat(),
       body('cost').optional().trim().notEmpty(),
+      body('notes').optional().trim(),
+      body('statBonuses').optional().custom(validateBonusObject),
+      body('skillBonuses').optional().custom(validateBonusObject),
     ],
     handleValidationErrors,
     async (req, res, next) => {

--- a/types/item.d.ts
+++ b/types/item.d.ts
@@ -20,6 +20,18 @@ export interface Item {
    */
   properties?: string[];
   /**
+   * Optional notes about the item.
+   */
+  notes?: string;
+  /**
+   * Ability score bonuses granted by the item.
+   */
+  statBonuses?: Record<string, number>;
+  /**
+   * Skill bonuses granted by the item.
+   */
+  skillBonuses?: Record<string, number>;
+  /**
    * Whether the creature currently owns the item.
    */
   owned: boolean;


### PR DESCRIPTION
## Summary
- extend item type to include notes, statBonuses, and skillBonuses
- validate and store stat/skill modifiers on equipment routes
- support bonus fields in DM item creation form
- test creation and retrieval of items with stat/skill modifiers

## Testing
- `npm --prefix server test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c360febee8832e9271a4c0e0cd116c