### PR TITLE
Allow dynamic property schemas for AI item bonuses

### DIFF
--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -128,8 +128,8 @@ module.exports = (router) => {
       weight: z.number().optional(),
       cost: z.string().optional(),
       properties: z.array(z.string()).optional(),
-      statBonuses: z.record(z.number()).optional(),
-      skillBonuses: z.record(z.number()).optional(),
+      statBonuses: z.object({}).catchall(z.number()).optional(),
+      skillBonuses: z.object({}).catchall(z.number()).optional(),
     });
 
     try {


### PR DESCRIPTION
## Summary
- allow item bonus schemas to define dynamic properties

## Testing
- `CI=true npm --prefix client test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c36fd3d4fc832eb3e183479a15062f