### PR TITLE
Remove attack bonus from zombies character components

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -16,9 +16,7 @@ export default function HealthDefense({
   spellAbilityMod,
 }) {
   const params = useParams();
-//-----------------------Health/Defense-------------------------------------------------------------------------------------------------------------------------------------------------
-  let atkBonus = 0;
-    
+//-----------------------Health/Defense------------------------------
   // Armor AC/MaxDex
   const armorItems = form.armor || [];
   const armorAcBonus = armorItems.map((item) => {
@@ -45,21 +43,6 @@ export default function HealthDefense({
      }
     
   const occupations = form.occupation;
-
-  for (const occupation of occupations) {
-    const level = parseInt(occupation.Level, 10);
-    const attackBonusValue = parseInt(occupation.atkBonus, 10);
-
-    if (!isNaN(level)) {
-      if (attackBonusValue === 0) {
-        atkBonus += Math.floor(level / 2);
-      } else if (attackBonusValue === 1) {
-        atkBonus += Math.floor(level * 0.75);
-      } else if (attackBonusValue === 2) {
-        atkBonus += level;
-      }
-    }
-  }
 
   const totalLevel = occupations.reduce(
     (total, o) => total + Number(o.Level),
@@ -281,7 +264,6 @@ return (
   {/* First row */}
   <div style={{ display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
     <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
-    <div><strong>Attack Bonus:</strong> {atkBonus}</div>
     <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
     <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
   </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -562,26 +562,7 @@ const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
 const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
 const spellsGold =
   hasSpellcasting && spellPointsLeft > 0 ? 'gold' : '#6C757D';
-// ------------------------------------------Attack Bonus---------------------------------------------------
-let atkBonus = 0;
-const occupations = form.occupation;
-
-for (const occupation of occupations) {
-  const level = parseInt(occupation.Level, 10);
-  const attackBonusValue = parseInt(occupation.atkBonus, 10);
-
-  if (!isNaN(level)) {
-    if (attackBonusValue === 0) {
-      atkBonus += Math.floor(level / 2);
-    } else if (attackBonusValue === 1) {
-      atkBonus += Math.floor(level * 0.75);
-    } else if (attackBonusValue === 2) {
-      atkBonus += level;
-    }
-  }
-}
-
-return (
+  return (
   <div
     className="text-center"
     style={{
@@ -628,16 +609,15 @@ return (
         {...(spellAbilityMod !== null && { spellAbilityMod })}
       />
     </div>
-    <PlayerTurnActions
-      form={form}
-      atkBonus={atkBonus}
-      dexMod={statMods.dex}
-      strMod={statMods.str}
-      headerHeight={headerHeight}
-      ref={playerTurnActionsRef}
-      onCastSpell={handleCastSpell}
-      availableSlots={availableSlots}
-    />
+      <PlayerTurnActions
+        form={form}
+        dexMod={statMods.dex}
+        strMod={statMods.str}
+        headerHeight={headerHeight}
+        ref={playerTurnActionsRef}
+        onCastSpell={handleCastSpell}
+        availableSlots={availableSlots}
+      />
     {form && (
       <SpellSlots
         form={form}


### PR DESCRIPTION
## Summary
- Strip out attack bonus calculation and display from zombie HealthDefense
- Remove attack bonus computation and prop passing from ZombiesCharacterSheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3aad990d883238f926999a5a07f9d