### PR TITLE
Clarify weapon attack bonus and clean up tests

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -60,7 +60,6 @@ describe('PlayerTurnActions critical events', () => {
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [] }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
       />
     );
@@ -113,7 +112,6 @@ describe('PlayerTurnActions critical events', () => {
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [] }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
       />
     );
@@ -152,7 +150,6 @@ describe('PlayerTurnActions spell casting', () => {
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
         onCastSpell={onCastSpell}
       />
@@ -200,7 +197,6 @@ describe('PlayerTurnActions spell casting', () => {
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
         onCastSpell={onCastSpell}
       />
@@ -242,7 +238,6 @@ describe('PlayerTurnActions spell casting', () => {
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
         onCastSpell={onCastSpell}
       />
@@ -292,7 +287,6 @@ describe('PlayerTurnActions spell casting', () => {
       <PlayerTurnActions
         form={{ diceColor: '#000000', weapon: [], spells }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
       />
     );
@@ -335,7 +329,6 @@ describe('cantrip scaling', () => {
           occupation: [{ Level: lvl }],
         }}
         strMod={0}
-        atkBonus={0}
         dexMod={0}
       />
     );

--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -28,6 +28,10 @@ export interface Weapon {
    */
   cost: number;
   /**
+   * Additional attack bonus provided by the weapon.
+   */
+  attackBonus?: number;
+  /**
    * Whether the creature currently owns the weapon.
    */
   owned: boolean;


### PR DESCRIPTION
## Summary
- Remove redundant `atkBonus={0}` props from `PlayerTurnActions` tests
- Allow weapons to store an optional `attackBonus` value in the type definition

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3ab1930ec8323a72b9ed99a8ad41c