### PR TITLE
Sort class features by class and level

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -36,7 +36,11 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
         console.error(err);
         setError('Unable to load class features');
       } finally {
-        allFeatures.sort((a, b) => (a.level || 0) - (b.level || 0));
+        allFeatures.sort(
+          (a, b) =>
+            (a.class || '').localeCompare(b.class || '') ||
+            (a.level || 0) - (b.level || 0)
+        );
         setFeatures(allFeatures);
         setLoading(false);
       }

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -6,6 +6,10 @@ import Features from './Features';
 jest.mock('../../../utils/apiFetch');
 import apiFetch from '../../../utils/apiFetch';
 
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
 test('renders features and opens modal with description', async () => {
   apiFetch.mockImplementation((url) => {
     const levelMatch = url.match(/features\/(\d+)/);
@@ -58,4 +62,56 @@ test('renders features and opens modal with description', async () => {
   expect(
     await screen.findByText('You can take one additional action.')
   ).toBeInTheDocument();
+});
+
+test('features are sorted by class then level', async () => {
+  apiFetch.mockImplementation((url) => {
+    const match = url.match(/classes\/(.*?)\/features\/(\d+)/);
+    const className = match ? match[1] : '';
+    const level = match ? parseInt(match[2]) : 0;
+    let features = [];
+    if (className === 'wizard' && level === 1) {
+      features = [{ name: 'Arcane Recovery' }];
+    } else if (className === 'fighter') {
+      if (level === 1)
+        features = [{ name: 'Second Wind' }];
+      else if (level === 2)
+        features = [{ name: 'Action Surge' }];
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ features }),
+    });
+  });
+
+  const form = {
+    occupation: [
+      { Name: 'Wizard', Level: 1 },
+      { Name: 'Fighter', Level: 2 },
+    ],
+  };
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+    />
+  );
+
+  expect(await screen.findByText('Arcane Recovery')).toBeInTheDocument();
+
+  const rows = screen.getAllByRole('row').slice(1); // skip header
+  const order = rows.map((row) => {
+    const cells = within(row).getAllByRole('cell');
+    return {
+      cls: cells[0].textContent,
+      lvl: cells[1].textContent,
+      feat: cells[2].textContent,
+    };
+  });
+  expect(order).toEqual([
+    { cls: 'Fighter', lvl: '1', feat: 'Second Wind' },
+    { cls: 'Fighter', lvl: '2', feat: 'Action Surge' },
+    { cls: 'Wizard', lvl: '1', feat: 'Arcane Recovery' },
+  ]);
 });


### PR DESCRIPTION
## Summary
- Sort zombie features alphabetically by class and then by level
- Test that features from multiple classes render in class then level order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b2e3264c8323bace5bec8808305d