### PR TITLE
style: simplify Action Surge button appearance

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -94,17 +94,22 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
                           <td>{feat.name}</td>
                           <td>
                             {feat.name && feat.name.includes('Action Surge') ? (
-                              <Button aria-label="use feature">
+                              <Button
+                                aria-label="use feature"
+                                variant="link"
+                                className="p-0 border-0"
+                              >
                                 <img
                                   src={actionSurgeIcon}
                                   alt="Action Surge"
-                                  width={24}
-                                  height={24}
+                                  width={36}
+                                  height={36}
                                 />
                               </Button>
                             ) : (
                               <Button aria-label="use feature">Use</Button>
-                            )}                          </td>
+                            )}
+                          </td>
                           <td>
                             <Button
                               aria-label="view feature"


### PR DESCRIPTION
## Summary
- restyle Action Surge feature button as a link with no padding or border
- enlarge Action Surge icon by 50% for better visibility

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b6e479648323b0cbd5128443032a