### PR TITLE
Add action surge tracking and dynamic action count

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -4,12 +4,20 @@ import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import actionSurgeIcon from '../../../images/action-surge-icon.png';
 
-export default function Features({ form, showFeatures, handleCloseFeatures }) {
+export default function Features({
+  form,
+  showFeatures,
+  handleCloseFeatures,
+  onActionSurge,
+  longRestCount,
+  shortRestCount,
+}) {
   const [features, setFeatures] = useState([]);
   const [modalFeature, setModalFeature] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [surgeUsed, setSurgeUsed] = useState(false);
 
   useEffect(() => {
     if (!showFeatures) return;
@@ -48,6 +56,10 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
     }
     fetchFeatures();
   }, [form.occupation, showFeatures]);
+
+  useEffect(() => {
+    setSurgeUsed(false);
+  }, [longRestCount, shortRestCount]);
 
   return (
     <>
@@ -97,7 +109,16 @@ export default function Features({ form, showFeatures, handleCloseFeatures }) {
                               <Button
                                 aria-label="use feature"
                                 variant="link"
-                                className="p-0 border-0"
+                                className={`p-0 border-0 ${
+                                  surgeUsed ? 'opacity-50' : ''
+                                }`}
+                                onClick={() => {
+                                  if (!surgeUsed) {
+                                    onActionSurge?.();
+                                    setSurgeUsed(true);
+                                  }
+                                }}
+                                disabled={surgeUsed}
                               >
                                 <img
                                   src={actionSurgeIcon}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -54,6 +54,8 @@ export default function ZombiesCharacterSheet() {
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
   const [longRestCount, setLongRestCount] = useState(0);
   const [shortRestCount, setShortRestCount] = useState(0);
+  const baseActionCount = form?.features?.actionCount ?? 1;
+  const [actionCount, setActionCount] = useState(baseActionCount);
   const initCircleState = () => ({
     0: 'active',
     1: 'active',
@@ -64,6 +66,10 @@ export default function ZombiesCharacterSheet() {
     action: initCircleState(),
     bonus: initCircleState(),
   });
+
+  useEffect(() => {
+    setActionCount(baseActionCount);
+  }, [baseActionCount]);
 
   const consumeCircle = useCallback(
     (type, index) => {
@@ -83,6 +89,17 @@ export default function ZombiesCharacterSheet() {
     [initCircleState]
   );
 
+  const handleActionSurge = useCallback(() => {
+    setActionCount((prev) => {
+      const next = prev + 1;
+      setUsedSlots((used) => ({
+        ...used,
+        action: { ...used.action, [next - 1]: 'active' },
+      }));
+      return next;
+    });
+  }, []);
+
   const playerTurnActionsRef = useRef(null);
 
   const headerRef = useRef(null);
@@ -91,7 +108,8 @@ export default function ZombiesCharacterSheet() {
 
   useEffect(() => {
     setUsedSlots({ action: initCircleState(), bonus: initCircleState() });
-  }, [longRestCount]);
+    setActionCount(baseActionCount);
+  }, [longRestCount, baseActionCount]);
 
   useEffect(() => {
     setUsedSlots((prev) => {
@@ -101,18 +119,21 @@ export default function ZombiesCharacterSheet() {
       });
       return updated;
     });
-  }, [shortRestCount]);
+    setActionCount(baseActionCount);
+  }, [shortRestCount, baseActionCount]);
 
   useEffect(() => {
-    const handler = () =>
+    const handler = () => {
       setUsedSlots((prev) => ({
         ...prev,
         action: initCircleState(),
         bonus: initCircleState(),
       }));
+      setActionCount(baseActionCount);
+    };
     window.addEventListener('pass-turn', handler);
     return () => window.removeEventListener('pass-turn', handler);
-  }, []);
+  }, [baseActionCount]);
 
   useEffect(() => {
     const nav = document.querySelector('.navbar.fixed-top');
@@ -623,6 +644,10 @@ return (
         form={form}
         used={usedSlots}
         onToggleSlot={handleCastSpell}
+        actionCount={actionCount}
+        longRestCount={longRestCount}
+        shortRestCount={shortRestCount}
+        onActionSurge={handleActionSurge}
       />
     )}
     <Navbar
@@ -767,6 +792,10 @@ return (
       form={form}
       showFeatures={showFeatures}
       handleCloseFeatures={handleCloseFeatures}
+      onActionSurge={handleActionSurge}
+      longRestCount={longRestCount}
+      shortRestCount={shortRestCount}
+      actionCount={actionCount}
     />
       <Modal
         className="dnd-modal modern-modal"


### PR DESCRIPTION
## Summary
- Track Action Surge usage and reset on rests in Features modal
- Manage base action count on character sheet and increment via Action Surge
- Pass dynamic action counts to SpellSlots and Features so extra circles render

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3b99c242c8323b516ab2913dd3505