### PR TITLE
Add status effect bar for player buffs

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef, useImperativeHandle } from 'react';
 import { Button, Modal, Card, Table } from "react-bootstrap";
 import sword from "../../../images/sword.png";
+import StatusEffectBar from './StatusEffectBar';
+import spellHasteIcon from "../../../images/spellHasteIcon.svg";
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -60,6 +62,10 @@ const PlayerTurnActions = React.forwardRef(({ form, strMod, atkBonus, dexMod, he
   const FOOTER_HEIGHT = 80;
   const damageRef = useRef(null);
   const [damageHeight, setDamageHeight] = useState(0);
+  const [activeEffects, setActiveEffects] = useState([]);
+
+  const removeEffect = (id) =>
+    setActiveEffects((effects) => effects.filter((e) => e.id !== id));
 
   useEffect(() => {
     if (damageRef.current) {
@@ -96,6 +102,10 @@ const handleSpellsButtonClick = (spell, crit = false) => {
   const damageValue = calculateDamage(spell.damage, 0, crit || isCritical);
   if (damageValue === null) return;
   updateDamageValueWithAnimation(damageValue);
+  if (spell.name === 'Haste') {
+    setActiveEffects((prev) => [...prev, { id: 'haste', icon: spellHasteIcon }]);
+    setTimeout(() => removeEffect('haste'), 60000);
+  }
 };
 
 const handleDamageClick = () => {
@@ -251,6 +261,7 @@ const showSparklesEffect = () => {
         }}
       >
         <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px', alignItems: 'center' }}>
+          <StatusEffectBar effects={activeEffects} />
           {/* Attack Button */}
           <button
             onClick={handleShowAttack}

--- a/client/src/components/Zombies/attributes/StatusEffectBar.js
+++ b/client/src/components/Zombies/attributes/StatusEffectBar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const barStyle = {
+  display: 'flex',
+  gap: '8px',
+  alignItems: 'center'
+};
+
+export default function StatusEffectBar({ effects = [] }) {
+  if (!effects.length) return null;
+  return (
+    <div style={barStyle}>
+      {effects.map(({ id, icon }) => (
+        <img key={id} src={icon} alt={id} style={{ width: 24, height: 24 }} />
+      ))}
+    </div>
+  );
+}

--- a/client/src/images/spellHasteIcon.svg
+++ b/client/src/images/spellHasteIcon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <line x1="10" y1="32" x2="54" y2="32" stroke="gold" stroke-width="6" />
+  <polyline points="40,16 54,32 40,48" fill="none" stroke="gold" stroke-width="6"/>
+</svg>


### PR DESCRIPTION
## Summary
- add StatusEffectBar component to render active status icons
- track Spell Haste in PlayerTurnActions and show effects bar next to actions

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c43304d4248323aa4a264d4670bd4d