### PR TITLE
Fix spell damage display on character sheet

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -190,6 +190,7 @@ const [isFumble, setIsFumble] = useState(false);
     onCastSpell?.({
       level,
       slotType,
+      damage: value.total,
       castingTime: spell.castingTime,
       name: spell.name,
     });


### PR DESCRIPTION
## Summary
- Ensure casting damage-dealing spells keeps numeric damage in the display
- Test that damage spells show their rolled damage instead of the spell name

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm --prefix client install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c48cc5f378832e968e200ff1a5bca6