### PR TITLE
Include bonuses and notes when tracking owned items

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -58,6 +58,9 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
                 category: it.category || 'custom',
                 weight: it.weight ?? '',
                 cost: it.cost ?? '',
+                statBonuses: it.statBonuses || {},
+                skillBonuses: it.skillBonuses || {},
+                ...(it.notes ? { notes: it.notes } : {}),
               };
               return acc;
             }, {})
@@ -107,12 +110,29 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
     if (typeof onChange === 'function') {
       const ownedItems = Object.values(nextItems)
         .filter((i) => i.owned)
-        .map(({ name, category, weight, cost }) => ({
-          name,
-          category,
-          weight,
-          cost,
-        }));
+        .map(
+          ({
+            name,
+            category,
+            weight,
+            cost,
+            statBonuses,
+            skillBonuses,
+            notes,
+          }) => {
+            const itemObj = { name, category, weight, cost };
+            if (statBonuses && Object.keys(statBonuses).length) {
+              itemObj.statBonuses = statBonuses;
+            }
+            if (skillBonuses && Object.keys(skillBonuses).length) {
+              itemObj.skillBonuses = skillBonuses;
+            }
+            if (notes) {
+              itemObj.notes = notes;
+            }
+            return itemObj;
+          }
+        );
       onChange(ownedItems);
     }
   };


### PR DESCRIPTION
## Summary
- preserve stat and skill bonuses and notes for custom items
- emit bonuses and notes when reporting owned items

## Testing
- `npm --prefix client test` *(fails: npm: command not found)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*
- `mise install node@20` *(fails: tunnel error: unsuccessful)*

------
https://chatgpt.com/codex/tasks/task_e_68c490af2704832e8ed021826e78b960