### PR TITLE
Use statBonuses object for item modifiers

### DIFF
--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -214,7 +214,7 @@ export default function SpellSelector({
 
   const chaMod = useMemo(() => {
     const itemBonus = (form.item || []).reduce(
-      (sum, el) => sum + Number(el[7] || 0),
+      (sum, el) => sum + Number(el.statBonuses?.cha ?? el[7] ?? 0),
       0
     );
     const featBonus = (form.feat || []).reduce(
@@ -228,7 +228,7 @@ export default function SpellSelector({
 
   const wisMod = useMemo(() => {
     const itemBonus = (form.item || []).reduce(
-      (sum, el) => sum + Number(el[6] || 0),
+      (sum, el) => sum + Number(el.statBonuses?.wis ?? el[6] ?? 0),
       0
     );
     const featBonus = (form.feat || []).reduce(

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -18,12 +18,12 @@ export default function Stats({ form, showStats, handleCloseStats }) {
 
   const totalItemBonus = (form.item || []).reduce(
     (acc, el) => ({
-      str: acc.str + Number(el[2] || 0),
-      dex: acc.dex + Number(el[3] || 0),
-      con: acc.con + Number(el[4] || 0),
-      int: acc.int + Number(el[5] || 0),
-      wis: acc.wis + Number(el[6] || 0),
-      cha: acc.cha + Number(el[7] || 0),
+      str: acc.str + Number(el.statBonuses?.str ?? el[2] ?? 0),
+      dex: acc.dex + Number(el.statBonuses?.dex ?? el[3] ?? 0),
+      con: acc.con + Number(el.statBonuses?.con ?? el[4] ?? 0),
+      int: acc.int + Number(el.statBonuses?.int ?? el[5] ?? 0),
+      wis: acc.wis + Number(el.statBonuses?.wis ?? el[6] ?? 0),
+      cha: acc.cha + Number(el.statBonuses?.cha ?? el[7] ?? 0),
     }),
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -422,12 +422,12 @@ export default function ZombiesCharacterSheet() {
 
   const itemBonus = (form?.item || []).reduce(
     (acc, el) => ({
-      str: acc.str + Number(el[2] || 0),
-      dex: acc.dex + Number(el[3] || 0),
-      con: acc.con + Number(el[4] || 0),
-      int: acc.int + Number(el[5] || 0),
-      wis: acc.wis + Number(el[6] || 0),
-      cha: acc.cha + Number(el[7] || 0),
+      str: acc.str + Number(el.statBonuses?.str ?? el[2] ?? 0),
+      dex: acc.dex + Number(el.statBonuses?.dex ?? el[3] ?? 0),
+      con: acc.con + Number(el.statBonuses?.con ?? el[4] ?? 0),
+      int: acc.int + Number(el.statBonuses?.int ?? el[5] ?? 0),
+      wis: acc.wis + Number(el.statBonuses?.wis ?? el[6] ?? 0),
+      cha: acc.cha + Number(el.statBonuses?.cha ?? el[7] ?? 0),
     }),
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );


### PR DESCRIPTION
## Summary
- Handle item stat bonuses through `statBonuses` object, falling back to array indices for backward compatibility
- Update stats and spell selector calculations to use object-based bonuses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49fed4c50832eb6a7b88780489dae