### PR TITLE
refactor skill bonus handling

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -131,11 +131,34 @@ export default function Skills({
     cha: chaMod,
   };
 
-  const itemTotals = SKILLS.reduce((acc, { key, itemBonusIndex }) => {
-    acc[key] = form.item.reduce(
-      (sum, el) => sum + Number(el[itemBonusIndex] || 0),
-      0
-    );
+  const legacySkillIndex = {
+    acrobatics: 8,
+    animalHandling: 9,
+    arcana: 10,
+    athletics: 11,
+    deception: 12,
+    history: 13,
+    insight: 14,
+    intimidation: 15,
+    investigation: 16,
+    medicine: 17,
+    nature: 18,
+    perception: 19,
+    performance: 20,
+    persuasion: 21,
+    religion: 22,
+    sleightOfHand: 23,
+    stealth: 24,
+    survival: 25,
+  };
+
+  const itemTotals = SKILLS.reduce((acc, { key }) => {
+    acc[key] = (form.item || []).reduce((sum, el) => {
+      if (Array.isArray(el)) {
+        return sum + Number(el[legacySkillIndex[key]] || 0);
+      }
+      return sum + Number(el.skillBonuses?.[key] || 0);
+    }, 0);
     return acc;
   }, {});
 

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -75,3 +75,57 @@ describe('Skills expertise toggle', () => {
     await waitFor(() => expect(expertiseCheckbox).toBeChecked());
   });
 });
+
+describe('item skill bonuses', () => {
+  test('applies bonuses from item skillBonuses object', async () => {
+    render(
+      <Skills
+        form={{
+          item: [{ skillBonuses: { acrobatics: 2 } }],
+          feat: [],
+          race: {},
+          skills: {},
+        }}
+        showSkill={true}
+        handleCloseSkill={() => {}}
+        totalLevel={1}
+        strMod={0}
+        dexMod={0}
+        conMod={0}
+        intMod={0}
+        chaMod={0}
+        wisMod={0}
+      />
+    );
+
+    const row = await screen.findByText('Acrobatics');
+    expect(within(row.closest('tr')).getByText('2')).toBeInTheDocument();
+  });
+
+  test('applies bonuses from legacy array items', async () => {
+    const legacy = Array(26).fill(0);
+    legacy[8] = 3; // acrobatics index
+    render(
+      <Skills
+        form={{
+          item: [legacy],
+          feat: [],
+          race: {},
+          skills: {},
+        }}
+        showSkill={true}
+        handleCloseSkill={() => {}}
+        totalLevel={1}
+        strMod={0}
+        dexMod={0}
+        conMod={0}
+        intMod={0}
+        chaMod={0}
+        wisMod={0}
+      />
+    );
+
+    const row = await screen.findByText('Acrobatics');
+    expect(within(row.closest('tr')).getByText('3')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Zombies/skillSchema.js
+++ b/client/src/components/Zombies/skillSchema.js
@@ -3,7 +3,6 @@ export const SKILLS = [
     key: 'acrobatics',
     label: 'Acrobatics',
     ability: 'dex',
-    itemBonusIndex: 8,
     armorPenalty: 1,
     proficient: false,
     expertise: false,
@@ -13,7 +12,6 @@ export const SKILLS = [
     key: 'animalHandling',
     label: 'Animal Handling',
     ability: 'wis',
-    itemBonusIndex: 9,
     proficient: false,
     expertise: false,
     description: 'Calming animals, intuiting their intentions, and training them.'
@@ -22,7 +20,6 @@ export const SKILLS = [
     key: 'arcana',
     label: 'Arcana',
     ability: 'int',
-    itemBonusIndex: 10,
     proficient: false,
     expertise: false,
     description: 'Knowledge about magical lore, spells, and artifacts.'
@@ -31,7 +28,6 @@ export const SKILLS = [
     key: 'athletics',
     label: 'Athletics',
     ability: 'str',
-    itemBonusIndex: 11,
     armorPenalty: 1,
     proficient: false,
     expertise: false,
@@ -41,7 +37,6 @@ export const SKILLS = [
     key: 'deception',
     label: 'Deception',
     ability: 'cha',
-    itemBonusIndex: 12,
     proficient: false,
     expertise: false,
     description: 'Concealing the truth through lies, feints, and trickery.'
@@ -50,7 +45,6 @@ export const SKILLS = [
     key: 'history',
     label: 'History',
     ability: 'int',
-    itemBonusIndex: 13,
     proficient: false,
     expertise: false,
     description: 'Recall of historical events, legendary people, and ancient civilizations.'
@@ -59,7 +53,6 @@ export const SKILLS = [
     key: 'insight',
     label: 'Insight',
     ability: 'wis',
-    itemBonusIndex: 14,
     proficient: false,
     expertise: false,
     description: 'Reading body language, motives, and intentions.'
@@ -68,7 +61,6 @@ export const SKILLS = [
     key: 'intimidation',
     label: 'Intimidation',
     ability: 'cha',
-    itemBonusIndex: 15,
     proficient: false,
     expertise: false,
     description: 'Influencing others through threats, hostile actions, and fear.'
@@ -77,7 +69,6 @@ export const SKILLS = [
     key: 'investigation',
     label: 'Investigation',
     ability: 'int',
-    itemBonusIndex: 16,
     proficient: false,
     expertise: false,
     description: 'Searching for clues and making deductions.'
@@ -86,7 +77,6 @@ export const SKILLS = [
     key: 'medicine',
     label: 'Medicine',
     ability: 'wis',
-    itemBonusIndex: 17,
     proficient: false,
     expertise: false,
     description: 'Stabilizing the dying, diagnosing illnesses, and treating wounds.'
@@ -95,7 +85,6 @@ export const SKILLS = [
     key: 'nature',
     label: 'Nature',
     ability: 'int',
-    itemBonusIndex: 18,
     proficient: false,
     expertise: false,
     description: 'Knowledge of terrain, plants, animals, weather, and natural cycles.'
@@ -104,7 +93,6 @@ export const SKILLS = [
     key: 'perception',
     label: 'Perception',
     ability: 'wis',
-    itemBonusIndex: 19,
     proficient: false,
     expertise: false,
     description: 'Noticing clues, spotting hidden objects, and detecting danger.'
@@ -113,7 +101,6 @@ export const SKILLS = [
     key: 'performance',
     label: 'Performance',
     ability: 'cha',
-    itemBonusIndex: 20,
     proficient: false,
     expertise: false,
     description: 'Entertaining audiences through music, dance, or acting.'
@@ -122,7 +109,6 @@ export const SKILLS = [
     key: 'persuasion',
     label: 'Persuasion',
     ability: 'cha',
-    itemBonusIndex: 21,
     proficient: false,
     expertise: false,
     description: 'Influencing others with tact, diplomacy, and social grace.'
@@ -131,7 +117,6 @@ export const SKILLS = [
     key: 'religion',
     label: 'Religion',
     ability: 'int',
-    itemBonusIndex: 22,
     proficient: false,
     expertise: false,
     description: 'Knowledge of deities, rites, prayers, and religious hierarchies.'
@@ -140,7 +125,6 @@ export const SKILLS = [
     key: 'sleightOfHand',
     label: 'Sleight of Hand',
     ability: 'dex',
-    itemBonusIndex: 23,
     armorPenalty: 1,
     proficient: false,
     expertise: false,
@@ -150,7 +134,6 @@ export const SKILLS = [
     key: 'stealth',
     label: 'Stealth',
     ability: 'dex',
-    itemBonusIndex: 24,
     armorPenalty: 1,
     proficient: false,
     expertise: false,
@@ -160,7 +143,6 @@ export const SKILLS = [
     key: 'survival',
     label: 'Survival',
     ability: 'wis',
-    itemBonusIndex: 25,
     proficient: false,
     expertise: false,
     description: 'Tracking, hunting, and navigating the wilderness.'


### PR DESCRIPTION
## Summary
- remove `itemBonusIndex` from skill definitions
- compute skill item bonuses using item `skillBonuses` with legacy array fallback
- test item skill bonuses including regression for DM items

## Testing
- `npm test -- client/src/components/Zombies/attributes/Skills.test.js`
- `npm test -- client/src/components/Zombies/pages/ZombiesDM.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4a1f7127c832e95c6bb9a678fde06