### PR TITLE
Refactor OpenAI response format in AI routes

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -119,6 +119,7 @@ describe('AI item route', () => {
     expect(res.status).toBe(200);
     expect(res.body.statBonuses).toEqual({ str: 2 });
     expect(res.body.skillBonuses).toEqual({ acrobatics: 3 });
+    expect(mockParse.mock.calls[0][0].text.format.name).toBe('item');
   });
 
   test('extracts bonuses from prompt when AI omits them', async () => {
@@ -143,6 +144,7 @@ describe('AI item route', () => {
     expect(res.status).toBe(200);
     expect(res.body.statBonuses).toEqual({ str: 2 });
     expect(res.body.skillBonuses).toEqual({ stealth: 1 });
+    expect(mockParse.mock.calls[0][0].text.format.name).toBe('item');
   });
 
   test('validates incorrect bonus data', async () => {
@@ -165,6 +167,7 @@ describe('AI item route', () => {
     const res = await request(app).post('/ai/item').send({ prompt: 'bad item' });
     expect(res.status).toBe(500);
     expect(res.body.message).toBeDefined();
+    expect(mockParse.mock.calls[0][0].text.format.name).toBe('item');
   });
 });
 

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -46,13 +46,14 @@ module.exports = (router) => {
 
     try {
       const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const format = zodResponseFormat(WeaponSchema);
       const response = await openai.responses.parse({
         model: 'gpt-4o-2024-08-06',
         input: [
           { role: 'system', content: 'Create a Dungeons and Dragons weapon.' },
           { role: 'user', content: prompt },
         ],
-        text: { format: zodResponseFormat(WeaponSchema, 'weapon') },
+        text: { format: { name: 'weapon', ...format } },
       });
 
       const data = response.output?.[0]?.content?.[0]?.parsed;
@@ -90,13 +91,14 @@ module.exports = (router) => {
 
     try {
       const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const format = zodResponseFormat(ArmorSchema);
       const response = await openai.responses.parse({
         model: 'gpt-4o-2024-08-06',
         input: [
           { role: 'system', content: 'Create a Dungeons and Dragons armor.' },
           { role: 'user', content: prompt },
         ],
-        text: { format: zodResponseFormat(ArmorSchema, 'armor') },
+        text: { format: { name: 'armor', ...format } },
       });
 
       const data = response.output?.[0]?.content?.[0]?.parsed;
@@ -131,6 +133,7 @@ module.exports = (router) => {
 
     try {
       const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const format = zodResponseFormat(ItemSchema);
       const response = await openai.responses.parse({
         model: 'gpt-4o-2024-08-06',
         input: [
@@ -141,7 +144,7 @@ module.exports = (router) => {
           },
           { role: 'user', content: prompt },
         ],
-        text: { format: zodResponseFormat(ItemSchema, 'item') },
+        text: { format: { name: 'item', ...format } },
       });
 
       const data = response.output?.[0]?.content?.[0]?.parsed;


### PR DESCRIPTION
## Summary
- refactor AI routes to build response format objects with explicit `name` fields
- adjust AI route tests to expect `text.format.name` when calling OpenAI

## Testing
- `npm test`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c10b3398832e841c68bbe3a8035f