### PR TITLE
Refactor item handling to object-based structure

### DIFF
--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react'; // Import useState and React
+import React, { useState, useEffect } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button, Form, Col, Row, Alert } from 'react-bootstrap'; // Adjust as per your actual UI library
+import { Modal, Card, Table, Button, Form, Col, Row, Alert } from 'react-bootstrap';
 import { useNavigate, useParams } from "react-router-dom";
 import { SKILLS } from "../skillSchema";
 
@@ -9,16 +9,9 @@ export default function Items({form, showItems, handleCloseItems}) {
   const navigate = useNavigate();
   //--------------------------------------------Items-----------------------------------------------------------------------------------------------------------------------------------------------
   const currentCampaign = form.campaign.toString();
-  const emptyItem = [Array(SKILLS.length + 8).fill("")];
-  const [item, setItem] = useState({ 
-    item: [], 
-  });
-  const [addItem, setAddItem] = useState({ 
-    item: "",
-  });
-  const [modalItemData, setModalItemData] = useState({
-    item: "",
-  })
+  const [item, setItem] = useState({ item: [] });
+  const [addItem, setAddItem] = useState({ item: null });
+  const [modalItemData, setModalItemData] = useState({});
   const [showNotes, setShowNotes] = useState(false);
   const handleCloseNotes = () => setShowNotes(false);
   const handleShowNotes = () => setShowNotes(true);
@@ -59,35 +52,16 @@ export default function Items({form, showItems, handleCloseItems}) {
     
   }, [navigate, currentCampaign]);
    // Sends item data to database for update
-   const splitItemArr = (array, size) => {
-    let result = [];
-    for (let i = 0; i < array.length; i += size) {
-      let chunk = array.slice(i, i + size);
-      result.push(chunk);
-    }
-    return result;
-  };
-   let newItem;
-   if (JSON.stringify(form.item) === JSON.stringify(emptyItem)) {
-    let newItemArr = addItem.item.split(',');
-    const itemArrSize = SKILLS.length + 8;
-    const itemArrChunks = splitItemArr(newItemArr, itemArrSize);
-    newItem = itemArrChunks;
-   } else {
-    let newItemArr = (form.item + "," + addItem.item).split(',');
-    const itemArrSize = SKILLS.length + 8;
-    const itemArrChunks = splitItemArr(newItemArr, itemArrSize);
-    newItem = itemArrChunks;
-   }
-   async function addItemToDb(e){
+  async function addItemToDb(e){
     e.preventDefault();
+    const newItems = [...form.item, addItem.item];
     await apiFetch(`/equipment/update-item/${params.id}`, {
      method: "PUT",
      headers: {
        "Content-Type": "application/json",
      },
      body: JSON.stringify({
-      item: newItem,
+      item: newItems,
      }),
    })
    .catch(error => {
@@ -96,53 +70,34 @@ export default function Items({form, showItems, handleCloseItems}) {
    });
    navigate(0);
   }
-   // This method will delete an item
-   function deleteItems(el) {
-    const index = form.item.indexOf(el);
-    form.item.splice(index, 1);
-    updateItem(form.item);
-    addDeleteItemToDb();
-   }
-   let showDeleteItemBtn = "";
-   if (JSON.stringify(form.item) === JSON.stringify(emptyItem)){
-    showDeleteItemBtn = "none";
-   }
-  async function addDeleteItemToDb(){
-    let newItemForm = form.item;
-    if (JSON.stringify(form.item) === JSON.stringify([])){
-      newItemForm = [Array(SKILLS.length + 8).fill("")];
-      await apiFetch(`/equipment/update-item/${params.id}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-         item: newItemForm,
-        }),
-      })
-      .catch(error => {
-        setNotification({ message: error.message || error, variant: 'danger' });
-        return;
-      });
-      setNotification({ message: 'Item Deleted', variant: 'success' });
-      setTimeout(() => navigate(0), 2000);
-    } else {
-    await apiFetch(`/equipment/update-item/${params.id}`, {
-     method: "PUT",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify({
-      item: newItemForm,
-     }),
-   })
-   .catch(error => {
-     setNotification({ message: error.message || error, variant: 'danger' });
-     return;
-   });
-   setNotification({ message: 'Item Deleted', variant: 'success' });
-   setTimeout(() => navigate(0), 2000);
+
+  // This method will delete an item
+  function deleteItems(el) {
+    const newItems = form.item.filter((item) => item !== el);
+    addDeleteItemToDb(newItems);
   }
+
+  let showDeleteItemBtn = "";
+  if (form.item.length === 0){
+    showDeleteItemBtn = "none";
+  }
+
+  async function addDeleteItemToDb(newItemForm){
+    await apiFetch(`/equipment/update-item/${params.id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        item: newItemForm,
+      }),
+    })
+    .catch(error => {
+      setNotification({ message: error.message || error, variant: 'danger' });
+      return;
+    });
+    setNotification({ message: 'Item Deleted', variant: 'success' });
+    setTimeout(() => navigate(0), 2000);
   }
 return(
 <div>
@@ -163,6 +118,9 @@ return(
           <thead>
             <tr>
               <th>Name</th>
+              <th>Category</th>
+              <th>Weight</th>
+              <th>Cost</th>
               <th>Notes</th>
               <th>Stats</th>
               <th>Skills</th>
@@ -170,9 +128,12 @@ return(
             </tr>
           </thead>
           <tbody>
-          {form.item.map((el) => (  
-            <tr key={el[0]}>           
-              <td>{el[0]}</td>
+          {form.item.map((el) => (
+            <tr key={el.name}>
+              <td>{el.name}</td>
+              <td>{el.category}</td>
+              <td>{el.weight}</td>
+              <td>{el.cost}</td>
               <td style={{ display: showDeleteItemBtn}}>
                 <Button
                   size="sm"
@@ -184,41 +145,14 @@ return(
                 ></Button>
               </td>
               <td style={{ display: showDeleteItemBtn}}>
-              {(() => {
-               const attributeValues = [];
-
-               if (el[2] !== "0") attributeValues.push("STR:" + el[2] + " ");
-               if (el[3] !== "0") attributeValues.push("DEX:" + el[3] + " ");
-               if (el[4] !== "0") attributeValues.push("CON:" + el[4] + " ");
-               if (el[5] !== "0") attributeValues.push("INT:" + el[5] + " ");
-               if (el[6] !== "0") attributeValues.push("WIS:" + el[6] + " ");
-               if (el[7] !== "0") attributeValues.push("CHA:" + el[7] + " ");
-
-               return(    <div>
-                {attributeValues.map((attribute, index) => (
-                  <div key={index}>{attribute}</div>
-                ))}
-              </div>);
-              })()}
-              
+              {Object.entries(el.statBonuses || {}).filter(([_, val]) => val && val !== "0").map(([stat, val]) => (
+                <div key={stat}>{stat}:{val} </div>
+              ))}
               </td>
               <td style={{ display: showDeleteItemBtn}}>
-              {(() => {
-               const skillValues = [];
-               SKILLS.forEach(({label, itemBonusIndex}) => {
-                 if (el[itemBonusIndex] !== "0") {
-                   skillValues.push(`${label}: ${el[itemBonusIndex]} `);
-                 }
-               });
-               return(
-                 <div>
-                   {skillValues.map((skill, index) => (
-                     <div key={index}>{skill}</div>
-                   ))}
-                 </div>
-               );
-              })()}
-                
+              {Object.entries(el.skillBonuses || {}).map(([skill, val]) => (
+                <div key={skill}>{skill}: {val}</div>
+              ))}
               </td>
               <td>
                 <Button
@@ -231,7 +165,7 @@ return(
                 ></Button>
               </td>
             </tr>
-            ))}   
+            ))}
           </tbody>
         </Table>        
     <Row>
@@ -239,13 +173,41 @@ return(
           <Form onSubmit={addItemToDb}>
           <Form.Group className="mb-3 mx-5">
         <Form.Label className="text-light">Select Item</Form.Label>
-        <Form.Select 
-        onChange={(e) => {updateItem({ item: e.target.value }); handleChosenItemChange(e);}}
+        <Form.Select
+        onChange={(e) => {
+          const selectedName = e.target.value;
+          handleChosenItemChange(e);
+          const selected = item.item.find((i) => i.itemName === selectedName);
+          if (selected) {
+            const formatted = {
+              name: selected.itemName,
+              category: selected.category,
+              weight: selected.weight,
+              cost: selected.cost,
+              notes: selected.notes,
+              statBonuses: {
+                STR: selected.str,
+                DEX: selected.dex,
+                CON: selected.con,
+                INT: selected.int,
+                WIS: selected.wis,
+                CHA: selected.cha,
+              },
+              skillBonuses: SKILLS.reduce((acc, { key, label }) => {
+                if (selected[key] && selected[key] !== "0") {
+                  acc[label] = selected[key];
+                }
+                return acc;
+              }, {}),
+            };
+            updateItem({ item: formatted });
+          }
+        }}
         defaultValue=""
          type="text">
           <option value="" disabled>Select your item</option>
           {item.item.map((el) => (
-          <option key={el.itemName} value={[el.itemName, el.notes, el.str, el.dex, el.con, el.int, el.wis, el.cha, ...SKILLS.map(({key}) => el[key])]}>{el.itemName}</option>
+          <option key={el.itemName} value={el.itemName}>{el.itemName}</option>
           ))}
           </Form.Select>
       </Form.Group>
@@ -261,9 +223,9 @@ return(
         <Modal className="dnd-modal modern-modal" show={showNotes} onHide={handleCloseNotes} size="lg" centered>
           <Card className="modern-card text-center">
             <Card.Header className="modal-header">
-              <Card.Title className="modal-title">{modalItemData[0]}</Card.Title>
+              <Card.Title className="modal-title">{modalItemData.name}</Card.Title>
             </Card.Header>
-            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>{modalItemData[1]}</Card.Body>
+            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>{modalItemData.notes}</Card.Body>
             <Card.Footer className="modal-footer">
               <Button className="action-btn close-btn" onClick={handleCloseNotes}>Close</Button>
             </Card.Footer>


### PR DESCRIPTION
## Summary
- store character items as objects including category, weight, cost, notes, statBonuses, and skillBonuses
- render new item details and bonuses in the Items table and modal
- adjust add/delete logic to work with object format

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ca03b070832e83f3f7040edd69fa