### PR TITLE
Refactor character items to object schema

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -131,34 +131,11 @@ export default function Skills({
     cha: chaMod,
   };
 
-  const legacySkillIndex = {
-    acrobatics: 8,
-    animalHandling: 9,
-    arcana: 10,
-    athletics: 11,
-    deception: 12,
-    history: 13,
-    insight: 14,
-    intimidation: 15,
-    investigation: 16,
-    medicine: 17,
-    nature: 18,
-    perception: 19,
-    performance: 20,
-    persuasion: 21,
-    religion: 22,
-    sleightOfHand: 23,
-    stealth: 24,
-    survival: 25,
-  };
-
   const itemTotals = SKILLS.reduce((acc, { key }) => {
-    acc[key] = (form.item || []).reduce((sum, el) => {
-      if (Array.isArray(el)) {
-        return sum + Number(el[legacySkillIndex[key]] || 0);
-      }
-      return sum + Number(el.skillBonuses?.[key] || 0);
-    }, 0);
+    acc[key] = (form.item || []).reduce(
+      (sum, el) => sum + Number(el.skillBonuses?.[key] || 0),
+      0
+    );
     return acc;
   }, {});
 

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -102,30 +102,4 @@ describe('item skill bonuses', () => {
     expect(within(row.closest('tr')).getByText('2')).toBeInTheDocument();
   });
 
-  test('applies bonuses from legacy array items', async () => {
-    const legacy = Array(26).fill(0);
-    legacy[8] = 3; // acrobatics index
-    render(
-      <Skills
-        form={{
-          item: [legacy],
-          feat: [],
-          race: {},
-          skills: {},
-        }}
-        showSkill={true}
-        handleCloseSkill={() => {}}
-        totalLevel={1}
-        strMod={0}
-        dexMod={0}
-        conMod={0}
-        intMod={0}
-        chaMod={0}
-        wisMod={0}
-      />
-    );
-
-    const row = await screen.findByText('Acrobatics');
-    expect(within(row.closest('tr')).getByText('3')).toBeInTheDocument();
-  });
 });

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -214,7 +214,7 @@ export default function SpellSelector({
 
   const chaMod = useMemo(() => {
     const itemBonus = (form.item || []).reduce(
-      (sum, el) => sum + Number(el.statBonuses?.cha ?? el[7] ?? 0),
+      (sum, el) => sum + Number(el.statBonuses?.cha || 0),
       0
     );
     const featBonus = (form.feat || []).reduce(
@@ -228,7 +228,7 @@ export default function SpellSelector({
 
   const wisMod = useMemo(() => {
     const itemBonus = (form.item || []).reduce(
-      (sum, el) => sum + Number(el.statBonuses?.wis ?? el[6] ?? 0),
+      (sum, el) => sum + Number(el.statBonuses?.wis || 0),
       0
     );
     const featBonus = (form.feat || []).reduce(

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -18,12 +18,12 @@ export default function Stats({ form, showStats, handleCloseStats }) {
 
   const totalItemBonus = (form.item || []).reduce(
     (acc, el) => ({
-      str: acc.str + Number(el.statBonuses?.str ?? el[2] ?? 0),
-      dex: acc.dex + Number(el.statBonuses?.dex ?? el[3] ?? 0),
-      con: acc.con + Number(el.statBonuses?.con ?? el[4] ?? 0),
-      int: acc.int + Number(el.statBonuses?.int ?? el[5] ?? 0),
-      wis: acc.wis + Number(el.statBonuses?.wis ?? el[6] ?? 0),
-      cha: acc.cha + Number(el.statBonuses?.cha ?? el[7] ?? 0),
+      str: acc.str + Number(el.statBonuses?.str || 0),
+      dex: acc.dex + Number(el.statBonuses?.dex || 0),
+      con: acc.con + Number(el.statBonuses?.con || 0),
+      int: acc.int + Number(el.statBonuses?.int || 0),
+      wis: acc.wis + Number(el.statBonuses?.wis || 0),
+      cha: acc.cha + Number(el.statBonuses?.cha || 0),
     }),
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -13,7 +13,7 @@ test('clicking view shows description and breakdown', async () => {
     cha: 0,
     race: { abilities: { str: 2 } },
     feat: [{ str: 1 }],
-    item: [[0, 0, 1, 0, 0, 0, 0, 0]],
+    item: [{ statBonuses: { str: 1 } }],
     occupation: [{ str: 1 }],
   };
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -422,12 +422,12 @@ export default function ZombiesCharacterSheet() {
 
   const itemBonus = (form?.item || []).reduce(
     (acc, el) => ({
-      str: acc.str + Number(el.statBonuses?.str ?? el[2] ?? 0),
-      dex: acc.dex + Number(el.statBonuses?.dex ?? el[3] ?? 0),
-      con: acc.con + Number(el.statBonuses?.con ?? el[4] ?? 0),
-      int: acc.int + Number(el.statBonuses?.int ?? el[5] ?? 0),
-      wis: acc.wis + Number(el.statBonuses?.wis ?? el[6] ?? 0),
-      cha: acc.cha + Number(el.statBonuses?.cha ?? el[7] ?? 0),
+      str: acc.str + Number(el.statBonuses?.str || 0),
+      dex: acc.dex + Number(el.statBonuses?.dex || 0),
+      con: acc.con + Number(el.statBonuses?.con || 0),
+      int: acc.int + Number(el.statBonuses?.int || 0),
+      wis: acc.wis + Number(el.statBonuses?.wis || 0),
+      cha: acc.cha + Number(el.statBonuses?.cha || 0),
     }),
     { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
   );

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -463,7 +463,7 @@ describe('Equipment routes', () => {
       });
       const res = await request(app)
         .put('/equipment/update-item/507f1f77bcf86cd799439011')
-        .send({ item: ['potion-healing'] });
+        .send({ item: [{ name: 'potion-healing' }] });
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Item updated');
     });
@@ -474,7 +474,7 @@ describe('Equipment routes', () => {
       });
       const res = await request(app)
         .put('/equipment/update-item/507f1f77bcf86cd799439011')
-        .send({ item: ['potion-healing'] });
+        .send({ item: [{ name: 'potion-healing' }] });
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Item not found');
     });
@@ -483,7 +483,7 @@ describe('Equipment routes', () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
         .put('/equipment/update-item/123')
-        .send({ item: ['potion-healing'] });
+        .send({ item: [{ name: 'potion-healing' }] });
       expect(res.status).toBe(400);
     });
 
@@ -492,6 +492,14 @@ describe('Equipment routes', () => {
       const res = await request(app)
         .put('/equipment/update-item/507f1f77bcf86cd799439011')
         .send({ item: 'potion-healing' });
+      expect(res.status).toBe(400);
+    });
+
+    test('update item invalid structure', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({ item: ['potion-healing'] });
       expect(res.status).toBe(400);
     });
   });


### PR DESCRIPTION
## Summary
- require object-based items in update-item route with validation for stat and skill bonuses
- drop legacy array support in client, using item.statBonuses and item.skillBonuses directly
- update tests for new item structure

## Testing
- `npm --prefix server test`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4cb138560832e89fa45eb13f528ea