### PR TITLE
Handle item fetch errors without HTTP details

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -88,7 +88,9 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
       } catch (err) {
         console.error('Failed to load items:', err?.message, err?.status);
         setItems({});
-        setError(err);
+        const { status = 0, statusText = '', message = err?.message || 'Unknown error' } =
+          err || {};
+        setError({ status, statusText, message });
       }
     }
 
@@ -144,7 +146,11 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
       </Card.Header>
       <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
         {error && (
-          <Alert variant="danger">{`Failed to load items: ${error.status} ${error.statusText}`}</Alert>
+          <Alert variant="danger">
+            {`Failed to load items: ${
+              error.message || `${error.status} ${error.statusText}`
+            }`}
+          </Alert>
         )}
         {unknownItems.length > 0 && (
           <Alert variant="warning">


### PR DESCRIPTION
## Summary
- Ensure ItemList sets a default status, statusText, and message when fetch fails without HTTP response
- Show error.message in the alert with fallback to status and statusText

## Testing
- `CI=true npm test 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68c4ce4004f8832e85ec8f7b61b39d87