### PR TITLE
Fix Haste spell damage update to prevent React child errors

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -361,7 +361,10 @@ export default function ZombiesCharacterSheet() {
           const spellLabel = name || altName;
           result = { total: spellLabel || 'Spell Cast' };
         }
-        playerTurnActionsRef.current?.updateDamageValueWithAnimation(result);
+        playerTurnActionsRef.current?.updateDamageValueWithAnimation(
+          result?.total,
+          result?.breakdown
+        );
         if (name === 'Haste') {
           setActiveEffects((prev) => [
             ...prev,


### PR DESCRIPTION
## Summary
- ensure `updateDamageValueWithAnimation` receives numeric totals when casting spells like Haste

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4d93c49d4832e96aef4935166116d