### PR TITLE
Make HealthDefense spacing responsive

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -16,6 +16,8 @@ export default function HealthDefense({
   spellAbilityMod,
 }) {
   const params = useParams();
+  const isLargeScreen =
+    typeof window !== 'undefined' && window.innerWidth >= 768;
 //-----------------------Health/Defense------------------------------
   // Armor AC/MaxDex
   const armorItems = form.armor || [];
@@ -123,7 +125,7 @@ return (
     flexDirection: "column", // <-- vertical stacking
     alignItems: "center",
     gap: "32px",
-    marginBottom: "80px",
+    marginBottom: isLargeScreen ? "80px" : "1rem",
     padding: "0 16px",
     maxWidth: "100%",
   }}


### PR DESCRIPTION
## Summary
- reduce HealthDefense margin-bottom for small screens
- keep larger spacing on wide displays

## Testing
- `npm test -- HealthDefense.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c4e575a808832ea1bb57990937690f