### PR TITLE
Keep spell slot toolbar fixed on mobile

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -124,20 +124,13 @@
 
 .spell-slot-container {
   position: fixed;
-  bottom: 70px;
+  bottom: 60px;
   left: 0;
   right: 0;
   display: flex;
   justify-content: center;
   gap: 0.5rem;
   z-index: 1030;
-}
-
-@media (max-width: 768px) {
-  .spell-slot-container {
-    position: static;
-    margin-bottom: 4rem;
-  }
 }
 
 .spell-slot {


### PR DESCRIPTION
## Summary
- Remove mobile override that switched spell slot toolbar to static positioning
- Keep toolbar fixed and offset from screen bottom so it's visible above the bottom navbar

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e9527a7c832ea2d7e8bcfea184d0