### PR TITLE
Fix character sheet layout for mobile viewport

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -26,7 +26,7 @@
     -->
     <title>Realm Tracker</title>
   </head>
-  <body class="bg-image" style="background-color: #000;">
+  <body class="bg-image" style="background-color: #000; overflow: hidden;">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1,7 +1,6 @@
 import React, {
   useState,
   useEffect,
-  useRef,
   useImperativeHandle,
   useMemo,
 } from 'react';
@@ -98,7 +97,6 @@ const PlayerTurnActions = React.forwardRef(
       form,
       strMod,
       dexMod,
-      headerHeight = 0,
       onCastSpell,
       availableSlots = { regular: {}, warlock: {} },
       longRestCount = 0,
@@ -111,17 +109,7 @@ const PlayerTurnActions = React.forwardRef(
   const handleCloseAttack = () => setShowAttack(false);
   const handleShowAttack = () => setShowAttack(true);
 
-  const damageRef = useRef(null);
-  const [damageHeight, setDamageHeight] = useState(0);
   const [footerHeight, setFooterHeight] = useState(0);
-
-  useEffect(() => {
-    if (damageRef.current) {
-      const style = getComputedStyle(damageRef.current);
-      const margins = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
-      setDamageHeight(damageRef.current.offsetHeight + margins);
-    }
-  }, []);
 
   useEffect(() => {
     const updateFooterHeight = () => {
@@ -427,34 +415,36 @@ const showSparklesEffect = () => {
           </ul>
         </Modal.Body>
       </Modal>
-      <div
-        id="damageAmount"
-        ref={damageRef}
-        className={`mt-3 ${loading ? 'loading' : ''} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
-        style={{ margin: "0 auto" }}
-        onClick={handleDamageClick}
-      >
-        <span
-          id="damageValue"
-          className={`${loading ? 'hidden' : ''} ${typeof damageValue === 'string' ? 'spell-cast-label' : ''}`}
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div
+          id="damageAmount"
+          className={`mt-3 ${loading ? 'loading' : ''} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${isFumble ? 'critical-failure' : ''}`}
+          style={{ margin: "0 auto" }}
+          onClick={handleDamageClick}
         >
-          {damageValue}
-        </span>
-        <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
-      </div>
+          <span
+            id="damageValue"
+            className={`${loading ? 'hidden' : ''} ${typeof damageValue === 'string' ? 'spell-cast-label' : ''}`}
+          >
+            {damageValue}
+          </span>
+          <div id="loadingSpinner" className={`spinner ${loading ? '' : 'hidden'}`}></div>
+        </div>
 
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: `calc(100vh - ${footerHeight + headerHeight + damageHeight}px)`
-        }}
-      >
-        <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px', alignItems: 'center' }}>
-          {/* Attack Button */}
-          <button
-            onClick={handleShowAttack}
-            style={{
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flex: 1,
+            overflowY: 'auto',
+            paddingBottom: `${footerHeight}px`
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px', alignItems: 'center' }}>
+            {/* Attack Button */}
+            <button
+              onClick={handleShowAttack}
+              style={{
               width: "64px",
               height: "64px",
               backgroundImage: `url(${sword})`,
@@ -601,6 +591,7 @@ const showSparklesEffect = () => {
         }}
       />
     </div>
+  </div>
   );
 });
 

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -94,7 +94,7 @@ export default function SpellSlots({
       });
 
   return (
-    <div style={{ display: 'flex' }}>
+    <div style={{ display: 'flex', flexShrink: 0 }}>
       <div className="spell-slot-container">
         <div className="spell-slot action-slot">
           <div className="slot-level">A</div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -646,11 +646,13 @@ return (
     style={{
       fontFamily: 'Raleway, sans-serif',
       backgroundImage: `url(${loginbg})`,
-      minHeight: "100vh",
-      overflowY: "auto",
+      height: "100vh",
+      overflow: "hidden",
       backgroundSize: "cover",
       backgroundRepeat: "no-repeat",
       paddingTop: navHeight + HEADER_PADDING,
+      display: 'flex',
+      flexDirection: 'column',
     }}
   >
     <div ref={headerRef}>
@@ -686,12 +688,27 @@ return (
         {...(spellAbilityMod !== null && { spellAbilityMod })}
       />
     </div>
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-      <Button
-       style={{
-          display: 'block',
-          margin: '15px auto',
-          padding: '4px 12px',
+    <div
+      style={{
+        height: `calc(100vh - ${headerHeight}px)`,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Button
+         style={{
+            display: 'block',
+            margin: '15px auto',
+            padding: '4px 12px',
           fontSize: '1.1rem',
           fontWeight: 'bold',
           color: '#fff',
@@ -715,19 +732,19 @@ return (
       >
         Pass ➔
       </Button>
-      <StatusEffectBar effects={activeEffects} />
+        <StatusEffectBar effects={activeEffects} />
+      </div>
+      <PlayerTurnActions
+        form={form}
+        dexMod={statMods.dex}
+        strMod={statMods.str}
+        ref={playerTurnActionsRef}
+        onCastSpell={handleCastSpell}
+        availableSlots={availableSlots}
+        longRestCount={longRestCount}
+        shortRestCount={shortRestCount}
+      />
     </div>
-    <PlayerTurnActions
-      form={form}
-      dexMod={statMods.dex}
-      strMod={statMods.str}
-      headerHeight={headerHeight}
-      ref={playerTurnActionsRef}
-      onCastSpell={handleCastSpell}
-      availableSlots={availableSlots}
-      longRestCount={longRestCount}
-      shortRestCount={shortRestCount}
-    />
     {form && (
       <SpellSlots
         form={form}


### PR DESCRIPTION
## Summary
- prevent body scroll by locking character sheet container to viewport height
- use flex-based layout for player actions with internal scrolling
- keep spell slot footer fixed and prevent shrinking
- hide global page scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57c29bb60832e855f54dac8cdab0e