### PR TITLE
Place damage indicator below PlayerTurn action buttons

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -434,6 +434,8 @@ const showSparklesEffect = () => {
         >
           ⚔️ Log
         </Button>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '4px' }}>
         <div
           id="damageAmount"
           className={`${loading ? 'loading' : ''} ${pulseClass} ${


### PR DESCRIPTION
## Summary
- Keep pass and log buttons in a single row
- Center damage indicator in its own row beneath the buttons

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c582427538832eb557d8d9025b9151