### PR TITLE
Wrap footer icons in tags for centered mobile display

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1363,6 +1363,10 @@ h1 {
   margin-top: 10px;
 }
 
+.footer-btn i {
+  margin: 0;
+}
+
 @media (max-width: 576px) {
   .footer-btn {
     width: 30px;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -742,47 +742,57 @@ return (
           <Button
             onClick={handleShowCharacterInfo}
             style={{ color: "black" }}
-            className="footer-btn fas fa-image-portrait"
+            className="footer-btn"
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-image-portrait fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowStats}
             style={{
               color: "black",
               backgroundColor: statPointsLeft > 0 ? "gold" : "#6C757D",
             }}
-            className="footer-btn fas fa-scroll"
+            className="footer-btn"
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-scroll fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowSkill}
             style={{
               color: "black",
               backgroundColor: skillsGold,
             }}
-            className={`footer-btn fas fa-book-open ${
+            className={`footer-btn ${
               skillPointsLeft > 0 || expertisePointsLeft > 0 ? 'points-glow' : ''
             }`}
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-book-open fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowFeats}
             style={{
               color: "black",
               backgroundColor: featsGold,
             }}
-            className={`footer-btn fas fa-hand-fist ${featPointsLeft > 0 ? 'points-glow' : ''}`}
+            className={`footer-btn ${featPointsLeft > 0 ? 'points-glow' : ''}`}
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-hand-fist fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowFeatures}
             style={{
               color: "black",
               backgroundColor: "#6C757D",
             }}
-            className="footer-btn fas fa-star"
+            className="footer-btn"
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-star fa-fw" aria-hidden="true"></i>
+          </Button>
           {hasSpellcasting && (
             <Button
               onClick={handleShowSpells}
@@ -790,9 +800,11 @@ return (
                 color: 'black',
                 backgroundColor: spellsGold,
               }}
-              className={`footer-btn fas fa-hat-wizard ${spellPointsLeft > 0 ? 'points-glow' : ''}`}
+              className={`footer-btn ${spellPointsLeft > 0 ? 'points-glow' : ''}`}
               variant="secondary"
-            ></Button>
+            >
+              <i className="fas fa-hat-wizard fa-fw" aria-hidden="true"></i>
+            </Button>
           )}
           <Button
             onClick={handleShowWeapons}
@@ -800,33 +812,41 @@ return (
               color: "black",
               backgroundColor: "#6C757D",
             }}
-            className="footer-btn fas fa-wand-sparkles"
+            className="footer-btn"
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-wand-sparkles fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowArmor}
             style={{
               color: "black",
               backgroundColor: "#6C757D",
             }}
-            className="footer-btn fas fa-shield"
+            className="footer-btn"
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-shield fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowItems}
             style={{
               color: "black",
               backgroundColor: "#6C757D",
             }}
-            className="footer-btn fas fa-briefcase"
+            className="footer-btn"
             variant="secondary"
-          ></Button>
+          >
+            <i className="fas fa-briefcase fa-fw" aria-hidden="true"></i>
+          </Button>
           <Button
             onClick={handleShowHelpModal}
             style={{ color: "white" }}
-            className="footer-btn fas fa-info"
+            className="footer-btn"
             variant="primary"
-          ></Button>
+          >
+            <i className="fas fa-info fa-fw" aria-hidden="true"></i>
+          </Button>
         </Nav>
       </Container>
     </Navbar>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -82,7 +82,7 @@ test('spells button includes points-glow when spell points available', async () 
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   await waitFor(() => expect(spellButton).toHaveClass('points-glow'));
 });
 
@@ -115,7 +115,7 @@ test('spells button glows when spellPoints absent but spells remain', async () =
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   await waitFor(() => expect(spellButton).toHaveClass('points-glow'));
 });
 
@@ -144,7 +144,7 @@ test('warlock character renders spells button', async () => {
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   expect(spellButton).toBeInTheDocument();
 });
 
@@ -200,7 +200,7 @@ test('skills button includes points-glow when skill points available', async () 
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const skillButton = buttons.find((btn) => btn.classList.contains('fa-book-open'));
+  const skillButton = buttons.find((btn) => btn.querySelector('.fa-book-open'));
   await waitFor(() => expect(skillButton).toHaveClass('points-glow'));
 });
 
@@ -229,7 +229,7 @@ test('skills button includes points-glow when expertise points available', async
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const skillButton = buttons.find((btn) => btn.classList.contains('fa-book-open'));
+  const skillButton = buttons.find((btn) => btn.querySelector('.fa-book-open'));
   await waitFor(() => expect(skillButton).toHaveClass('points-glow'));
 });
 
@@ -259,7 +259,7 @@ test('casting spells consumes action and bonus circles based on casting time', a
   const { container } = render(<ZombiesCharacterSheet />);
 
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
 
   await userEvent.click(spellButton);
   expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
@@ -344,7 +344,7 @@ test('feats button includes points-glow when feat points available', async () =>
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const featButton = buttons.find((btn) => btn.classList.contains('fa-hand-fist'));
+  const featButton = buttons.find((btn) => btn.querySelector('.fa-hand-fist'));
   await waitFor(() => expect(featButton).toHaveClass('points-glow'));
 });
 
@@ -403,7 +403,7 @@ test('handleCastSpell closes modal and outputs spell name', async () => {
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   await userEvent.click(spellButton);
   expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
   mockOnCastSpell.current({ level: 1, name: 'Mage Hand' });
@@ -437,7 +437,7 @@ test('handleCastSpell outputs calculated damage', async () => {
 
   render(<ZombiesCharacterSheet />);
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   await userEvent.click(spellButton);
   expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
   mockOnCastSpell.current({ level: 1, damage: '1d4' });
@@ -481,7 +481,7 @@ test('consumes higher-level slot when upcasting', async () => {
 
   // Open the spell selector so the mocked onCastSpell is set
   const buttons = await screen.findAllByRole('button');
-  const spellButton = buttons.find((btn) => btn.classList.contains('fa-hat-wizard'));
+  const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   await userEvent.click(spellButton);
   expect(await screen.findByTestId('spell-selector')).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- Wrap footer bar icons in `<i>` elements and keep buttons free of Font Awesome classes
- Ensure `.footer-btn` flex centering and reset icon margins
- Update tests to select icons within buttons

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6ff5b5100832eaf61014003cf890c