### PR TITLE
Refactor weapon list layout to cards

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Table, Form, Alert } from 'react-bootstrap';
+import { Card, Row, Col, Form, Alert } from 'react-bootstrap';
 import apiFetch from '../../utils/apiFetch';
 
 /** @typedef {import('../../../../types/weapon').Weapon} Weapon */
@@ -214,35 +214,33 @@ function WeaponList({
             Unrecognized weapons from server: {unknownWeapons.join(', ')}
           </Alert>
         )}
-        <Table striped bordered hover size="sm" className="modern-table">
-          <thead>
-            <tr>
-              <th>Owned</th>
-              <th>Proficient</th>
-              <th>Name</th>
-              <th>Damage</th>
-              <th>Category</th>
-              <th>Properties</th>
-              <th>Weight</th>
-              <th>Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(weapons).map(([key, weapon]) => (
-              <tr key={key}>
-                <td>
+        <Row className="row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+          {Object.entries(weapons).map(([key, weapon]) => (
+            <Col key={key}>
+              <Card className="weapon-card h-100">
+                <Card.Body>
+                  <Card.Title>{weapon.displayName || weapon.name}</Card.Title>
+                  <Card.Text>Damage: {weapon.damage}</Card.Text>
+                  <Card.Text>Category: {weapon.category}</Card.Text>
+                  <Card.Text>
+                    Properties: {weapon.properties.join(', ') || 'No properties'}
+                  </Card.Text>
+                  <Card.Text>Weight: {weapon.weight}</Card.Text>
+                  <Card.Text>Cost: {weapon.cost}</Card.Text>
+                </Card.Body>
+                <Card.Footer className="d-flex justify-content-between">
                   <Form.Check
                     type="checkbox"
                     className="weapon-checkbox"
+                    label="Owned"
                     checked={weapon.owned}
                     onChange={handleOwnedToggle(key)}
                     aria-label={weapon.displayName || weapon.name}
                   />
-                </td>
-                <td>
                   <Form.Check
                     type="checkbox"
                     className="weapon-checkbox"
+                    label="Proficient"
                     checked={weapon.proficient}
                     disabled={weapon.granted || weapon.pending}
                     onChange={handleToggle(key)}
@@ -253,17 +251,11 @@ function WeaponList({
                         : undefined
                     }
                   />
-                </td>
-                <td>{weapon.displayName || weapon.name}</td>
-                <td>{weapon.damage}</td>
-                <td>{weapon.category}</td>
-                <td>{weapon.properties.join(', ') || 'No properties'}</td>
-                <td>{weapon.weight}</td>
-                <td>{weapon.cost}</td>
-              </tr>
-            ))}
-          </tbody>
-        </Table>
+                </Card.Footer>
+              </Card>
+            </Col>
+          ))}
+        </Row>
       </Card.Body>
     </Card>
   );

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -92,10 +92,10 @@ test('marks weapon proficiency', async () => {
   const daggerRow = await screen.findByText('Dagger');
   expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char1');
 
-  const daggerTr = daggerRow.closest('tr');
-  const clubTr = screen.getByText('Club').closest('tr');
-  const daggerProf = within(daggerTr).getByLabelText('Dagger proficiency');
-  const clubProf = within(clubTr).getByLabelText('Club proficiency');
+  const daggerCard = daggerRow.closest('.card');
+  const clubCard = screen.getByText('Club').closest('.card');
+  const daggerProf = within(daggerCard).getByLabelText('Dagger proficiency');
+  const clubProf = within(clubCard).getByLabelText('Club proficiency');
   expect(daggerProf).toBeChecked();
   expect(daggerProf).not.toBeDisabled();
   expect(clubProf).not.toBeChecked();
@@ -115,8 +115,8 @@ test('granted proficiencies render checked and disabled', async () => {
   render(<WeaponList characterId="char1" />);
 
   const daggerRow = await screen.findByText('Dagger');
-  const daggerTr = daggerRow.closest('tr');
-  const daggerProf = within(daggerTr).getByLabelText('Dagger proficiency');
+  const daggerCard = daggerRow.closest('.card');
+  const daggerProf = within(daggerCard).getByLabelText('Dagger proficiency');
   expect(daggerProf).toBeChecked();
   expect(daggerProf).toBeDisabled();
 });
@@ -138,8 +138,8 @@ test('toggling a non-proficient weapon allows checking and unchecking', async ()
   render(<WeaponList characterId="char1" />);
 
   const clubRow = await screen.findByText('Club');
-  const clubTr = clubRow.closest('tr');
-  const clubProf = within(clubTr).getByLabelText('Club proficiency');
+  const clubCard = clubRow.closest('.card');
+  const clubProf = within(clubCard).getByLabelText('Club proficiency');
 
   expect(clubProf).not.toBeChecked();
   await userEvent.click(clubProf);
@@ -183,23 +183,23 @@ test('reloads proficiency data when character changes', async () => {
   const clubRow1 = await screen.findByText('Club');
   const daggerRow1 = await screen.findByText('Dagger');
   expect(
-    within(clubRow1.closest('tr')).getByLabelText('Club proficiency')
+    within(clubRow1.closest('.card')).getByLabelText('Club proficiency')
   ).toBeChecked();
   expect(
-    within(daggerRow1.closest('tr')).getByLabelText('Dagger proficiency')
+    within(daggerRow1.closest('.card')).getByLabelText('Dagger proficiency')
   ).not.toBeChecked();
 
   rerender(<WeaponList characterId="char2" />);
   await waitFor(() =>
     expect(
-      within(screen.getByText('Club').closest('tr')).getByLabelText(
+      within(screen.getByText('Club').closest('.card')).getByLabelText(
         'Club proficiency'
       )
     ).not.toBeChecked()
   );
   await waitFor(() =>
     expect(
-      within(screen.getByText('Dagger').closest('tr')).getByLabelText(
+      within(screen.getByText('Dagger').closest('.card')).getByLabelText(
         'Dagger proficiency'
       )
     ).toBeChecked()


### PR DESCRIPTION
## Summary
- Replace weapons table with responsive card grid
- Preserve owned and proficient toggles in card footers
- Update tests for new card-based layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70e4297d0832eb09b8e49329e3f29