### PR TITLE
Use responsive cards for attack actions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -250,6 +250,16 @@
   }
 }
 
+.attack-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.attack-card .attack-btn {
+  width: 100%;
+}
+
 .App-header {
   background-color: #282c34;
   min-height: 100vh;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -4,7 +4,7 @@ import React, {
   useImperativeHandle,
   useMemo,
 } from 'react';
-import { Button, Modal, Card, Table } from "react-bootstrap";
+import { Button, Modal, Card, Table, Row, Col } from "react-bootstrap";
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -90,6 +90,24 @@ export function calculateDamage(
   const total = results.reduce((sum, r) => sum + r.value, 0);
   return { total, breakdown: formatDamageRolls(results) };
 }
+
+const WeaponAttackCard = ({ weapon, attackBonus, damage, onAttack }) => (
+  <Card className="attack-card h-100">
+    <Card.Body className="d-flex flex-column">
+      <Card.Title className="text-capitalize">{weapon.name}</Card.Title>
+      <Card.Text>Attack Bonus: {attackBonus}</Card.Text>
+      <Card.Text>Damage: {damage}</Card.Text>
+      <Button
+        className="mt-auto attack-btn w-100"
+        onClick={onAttack}
+        variant="primary"
+        aria-label="roll"
+      >
+        <i className="fa-solid fa-dice-d20"></i>
+      </Button>
+    </Card.Body>
+  </Card>
+);
 
 const PlayerTurnActions = React.forwardRef(
   (
@@ -532,38 +550,22 @@ const showSparklesEffect = () => {
           </Card.Header>
           <Card.Body>
             <Card.Title className="modal-title">Weapons</Card.Title>
-              <Table className="modern-table" striped bordered hover responsive>
-                <thead>
-                  <tr>
-                    <th>Weapon Name</th>
-                    <th>Attack Bonus</th>
-                    <th>Damage</th>
-                    <th>Attack</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {Array.isArray(form.weapon) &&
-                    form.weapon.map((weapon) => (
-                      <tr key={weapon.name}>
-                        <td className="text-capitalize">{weapon.name}</td>
-                        <td>{getAttackBonus(weapon)}</td>
-                        <td>{getDamageString(weapon)}</td>
-                        <td>
-                          <Button
-                            onClick={() => {
-                              handleWeaponAttack(weapon);
-                              handleCloseAttack();
-                            }}
-                            variant="link"
-                            aria-label="roll"
-                          >
-                            <i className="fa-solid fa-dice-d20"></i>
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                </tbody>
-              </Table>
+            <Row xs={1} sm={2} md={3} className="g-3">
+              {Array.isArray(form.weapon) &&
+                form.weapon.map((weapon) => (
+                  <Col key={weapon.name}>
+                    <WeaponAttackCard
+                      weapon={weapon}
+                      attackBonus={getAttackBonus(weapon)}
+                      damage={getDamageString(weapon)}
+                      onAttack={() => {
+                        handleWeaponAttack(weapon);
+                        handleCloseAttack();
+                      }}
+                    />
+                  </Col>
+                ))}
+            </Row>
             {Array.isArray(form.spells) && form.spells.some((s) => s?.damage) && (
               <>
                 <Card.Title className="modal-title mt-4">Spells</Card.Title>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -76,9 +76,9 @@ describe('PlayerTurnActions weapon damage display', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const row = screen.getByText('Frost Brand').closest('tr');
+    const card = screen.getByText('Frost Brand').closest('.card');
     expect(
-      within(row).getByText('1d4+2 cold + 1d6+2 slashing')
+      within(card).getByText('1d4+2 cold + 1d6+2 slashing', { exact: false })
     ).toBeInTheDocument();
   });
 });
@@ -149,9 +149,9 @@ describe('PlayerTurnActions weapon damage display', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const row = screen.getByText('Frost Brand').closest('tr');
+    const card = screen.getByText('Frost Brand').closest('.card');
     expect(
-      within(row).getByText('1d4+2 cold + 1d6+2 slashing')
+      within(card).getByText('1d4+2 cold + 1d6+2 slashing', { exact: false })
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Replace attack table with responsive card grid for weapons
- Style attack cards for full-width buttons
- Update tests for card-based layout

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c70a4dadfc832e95f832000786e8d7