### PR TITLE
Ensure weapon grid maintains two columns

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -85,6 +85,11 @@
   background-color: #fff;
 }
 
+.weapon-card .form-check-label {
+  font-size: 0.9rem;
+  color: var(--bs-body-color);
+}
+
 .upcast-slot {
   cursor: pointer;
   background-color: #808080;

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -127,7 +127,7 @@ return(
             {notification.message}
           </Alert>
         )}
-        <Row className="row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+        <Row className="row-cols-2 row-cols-md-3 g-3">
           {form.weapon.map((el) => (
             <Col key={el[0]}>
               <Card className="weapon-card h-100">


### PR DESCRIPTION
## Summary
- prevent weapons modal grid from collapsing below two columns
- improve readability of weapon checkbox labels

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71490b38c832e9ceae11ac4e68035