### PR TITLE
Fix weapon grid layout on mobile

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -90,6 +90,12 @@
   color: var(--bs-body-color);
 }
 
+@media (max-width: 576px) {
+  .weapon-card {
+    font-size: 0.75rem;
+  }
+}
+
 .upcast-slot {
   cursor: pointer;
   background-color: #808080;

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -127,7 +127,7 @@ return(
             {notification.message}
           </Alert>
         )}
-        <Row className="row-cols-2 row-cols-md-3 g-3">
+        <Row className="row-cols-3 g-2">
           {form.weapon.map((el) => (
             <Col key={el[0]}>
               <Card className="weapon-card h-100">


### PR DESCRIPTION
## Summary
- Force weapons grid to always display three columns with tighter gaps
- Add mobile-only scaling for weapon card contents

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71917cb14832e881b158d7d425db9