### PR TITLE
Use React-Bootstrap column prop for weapon grid

### DIFF
--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -127,7 +127,7 @@ return(
             {notification.message}
           </Alert>
         )}
-        <Row className="row-cols-3 g-2">
+        <Row xs={3} className="g-2">
           {form.weapon.map((el) => (
             <Col key={el[0]}>
               <Card className="weapon-card h-100">


### PR DESCRIPTION
## Summary
- ensure weapon list keeps three columns by using `xs={3}` on the Row

## Testing
- `CI=true npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c71bfc9884832e9cea967f58f4b209