### PR TITLE
Scale weapon cards on small screens

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -94,6 +94,16 @@
   .weapon-card {
     font-size: 0.75rem;
   }
+  .weapon-card .card-title {
+    font-size: 1rem;
+  }
+  .weapon-card .card-text {
+    font-size: 0.75rem;
+  }
+  .weapon-card .btn {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+  }
 }
 
 .upcast-slot {

--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -132,7 +132,7 @@ return(
             <Col key={el[0]}>
               <Card className="weapon-card h-100">
                 <Card.Body>
-                  <Card.Title>{el[0]}</Card.Title>
+                  <Card.Title as="h6">{el[0]}</Card.Title>
                   <Card.Text>Category: {el[1]}</Card.Text>
                   <Card.Text>Damage: {el[2]}</Card.Text>
                   <Card.Text>Properties: {el[3]}</Card.Text>


### PR DESCRIPTION
## Summary
- Add mobile styles to shrink weapon card titles, text, and buttons
- Render weapon titles as smaller h6 elements in zombies weapon modal

## Testing
- ⚠️ `npm test` *(fails: npm command not found; apt repositories denied access)*

------
https://chatgpt.com/codex/tasks/task_e_68c71bfe5de0832ea787b77a05a08b69