### PR TITLE
Fix weapon cards layout on mobile

### DIFF
--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -127,7 +127,7 @@ return(
             {notification.message}
           </Alert>
         )}
-        <Row xs={3} className="g-2">
+        <Row xs={2} md={3} className="g-2">
           {form.weapon.map((el) => (
             <Col key={el[0]}>
               <Card className="weapon-card h-100">


### PR DESCRIPTION
## Summary
- ensure weapon cards render in two columns on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71ddf0a88832eb9a4848af7289c78