### PR TITLE
feat: add damage type color utility

### DIFF
--- a/client/src/utils/damageTypeColors.js
+++ b/client/src/utils/damageTypeColors.js
@@ -1,0 +1,14 @@
+const damageTypeColors = {
+  acid: '#228B22',
+  cold: '#00BFFF',
+  fire: '#FF4500',
+  lightning: '#FFD700',
+  poison: '#32CD32',
+  thunder: '#8A2BE2',
+  force: '#FF1493',
+  necrotic: '#4B0082',
+  radiant: '#FFFF99',
+  psychic: '#BA55D3',
+};
+
+export default damageTypeColors;


### PR DESCRIPTION
## Summary
- add utility mapping D&D damage types to color hex codes

## Testing
- `npx eslint src/utils/damageTypeColors.js`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c727e356d883238ab2419dce7551a5