### PR TITLE
Colorize damage breakdown in damage log

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -8,6 +8,7 @@ import { Button, Modal, Card, Table } from "react-bootstrap";
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
+import damageTypeColors from '../../../utils/damageTypeColors';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -466,7 +467,25 @@ const showSparklesEffect = () => {
             {damageLog.map((entry, idx) => (
               <li key={idx}>
                 {entry.total}
-                {entry.breakdown ? ` (${entry.breakdown})` : ''}
+                {entry.breakdown && (
+                  <span>
+                    {' ('}
+                    {entry.breakdown.split(' + ').map((segment, i, arr) => {
+                      const match = segment.match(/(\d+)(?:\s+(\w+))?/);
+                      const value = match ? match[1] : segment;
+                      const type = match ? match[2] : '';
+                      return (
+                        <React.Fragment key={i}>
+                          <span style={{ color: damageTypeColors[type] }}>
+                            {value}{type ? ` ${type}` : ''}
+                          </span>
+                          {i < arr.length - 1 ? ' + ' : ''}
+                        </React.Fragment>
+                      );
+                    })}
+                    {')'}
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -118,8 +118,8 @@ describe('PlayerTurnActions damage log', () => {
     });
     const modal = await screen.findByRole('dialog');
     expect(
-      within(modal).getByText('6 (3 cold + 3 slashing)')
-    ).toBeInTheDocument();
+      within(modal).getByRole('listitem')
+    ).toHaveTextContent('6 (3 cold + 3 slashing)');
     Math.random = orig;
   });
 


### PR DESCRIPTION
## Summary
- show each damage type in the log with its corresponding `damageTypeColors`
- adjust damage log test for colorized breakdown output

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c72c84a43c8323a924e6dd93dca4e7