### PR TITLE
Use explicit column widths for weapon grid

### DIFF
--- a/client/src/components/Zombies/attributes/Weapons.js
+++ b/client/src/components/Zombies/attributes/Weapons.js
@@ -127,9 +127,9 @@ return(
             {notification.message}
           </Alert>
         )}
-        <Row xs={2} md={3} className="g-2">
+        <Row className="g-2">
           {form.weapon.map((el) => (
-            <Col key={el[0]}>
+            <Col xs={6} md={4} key={el[0]}>
               <Card className="weapon-card h-100">
                 <Card.Body>
                   <Card.Title as="h6">{el[0]}</Card.Title>


### PR DESCRIPTION
## Summary
- ensure Zombies weapon grid uses column widths instead of row-cols
- confirm no custom CSS overrides row/col or weapon-card layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7208b5974832e8c7c507bdf6ca5b4