### PR TITLE
Use CSS classes for damage type coloring

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1369,3 +1369,15 @@ h1 {
     font-size: 0.9rem;
   }
 }
+
+/* Damage type colors */
+.damage-acid { color: #228B22; }
+.damage-cold { color: #00BFFF; }
+.damage-fire { color: #FF4500; }
+.damage-lightning { color: #FFD700; }
+.damage-poison { color: #32CD32; }
+.damage-thunder { color: #8A2BE2; }
+.damage-force { color: #FF1493; }
+.damage-necrotic { color: #4B0082; }
+.damage-radiant { color: #FFFF99; }
+.damage-psychic { color: #BA55D3; }

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -8,7 +8,6 @@ import { Button, Modal, Card, Table } from "react-bootstrap";
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
-import damageTypeColors from '../../../utils/damageTypeColors';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -476,7 +475,7 @@ const showSparklesEffect = () => {
                       const type = match ? match[2] : '';
                       return (
                         <React.Fragment key={i}>
-                          <span style={{ color: damageTypeColors[type] }}>
+                          <span className={type ? `damage-${type}` : ''}>
                             {value}{type ? ` ${type}` : ''}
                           </span>
                           {i < arr.length - 1 ? ' + ' : ''}


### PR DESCRIPTION
## Summary
- define reusable CSS classes for damage type colors
- apply damage type classes in damage log rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72d73d14c8323a7bfdfb0720f876f