### PR TITLE
Add roll separators to damage log

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1381,3 +1381,8 @@ h1 {
 .damage-necrotic { color: #4B0082; }
 .damage-radiant { color: #FFFF99; }
 .damage-psychic { color: #BA55D3; }
+
+.roll-separator {
+  border-top: 1px solid #ccc;
+  margin: 0.25rem 0;
+}

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -269,7 +269,7 @@ const updateDamageValueWithAnimation = (newValue, breakdown) => {
   if (newValue !== undefined) {
     setDamageLog((prev) => {
       const entry = { total: newValue, breakdown };
-      return [entry, ...prev].slice(0, 10);
+      return [entry, { divider: true }, ...prev].slice(0, 10);
     });
   }
 };
@@ -463,30 +463,34 @@ const showSparklesEffect = () => {
         </Modal.Header>
         <Modal.Body>
           <ul className="list-unstyled mb-0">
-            {damageLog.map((entry, idx) => (
-              <li key={idx}>
-                {entry.total}
-                {entry.breakdown && (
-                  <span>
-                    {' ('}
-                    {entry.breakdown.split(' + ').map((segment, i, arr) => {
-                      const match = segment.match(/(\d+)(?:\s+(\w+))?/);
-                      const value = match ? match[1] : segment;
-                      const type = match ? match[2] : '';
-                      return (
-                        <React.Fragment key={i}>
-                          <span className={type ? `damage-${type}` : ''}>
-                            {value}{type ? ` ${type}` : ''}
-                          </span>
-                          {i < arr.length - 1 ? ' + ' : ''}
-                        </React.Fragment>
-                      );
-                    })}
-                    {')'}
-                  </span>
-                )}
-              </li>
-            ))}
+            {damageLog.map((entry, idx) =>
+              entry.divider ? (
+                <li key={idx} className="roll-separator" />
+              ) : (
+                <li key={idx}>
+                  {entry.total}
+                  {entry.breakdown && (
+                    <span>
+                      {' ('}
+                      {entry.breakdown.split(' + ').map((segment, i, arr) => {
+                        const match = segment.match(/(\d+)(?:\s+(\w+))?/);
+                        const value = match ? match[1] : segment;
+                        const type = match ? match[2] : '';
+                        return (
+                          <React.Fragment key={i}>
+                            <span className={type ? `damage-${type}` : ''}>
+                              {value}{type ? ` ${type}` : ''}
+                            </span>
+                            {i < arr.length - 1 ? ' + ' : ''}
+                          </React.Fragment>
+                        );
+                      })}
+                      {')'}
+                    </span>
+                  )}
+                </li>
+              )
+            )}
           </ul>
         </Modal.Body>
       </Modal>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -118,9 +118,10 @@ describe('PlayerTurnActions damage log', () => {
       fireEvent.click(screen.getByRole('button', { name: '⚔️ Log' }));
     });
     const modal = await screen.findByRole('dialog');
-    expect(
-      within(modal).getByRole('listitem')
-    ).toHaveTextContent('6 (3 cold + 3 slashing)');
+    const items = within(modal)
+      .getAllByRole('listitem')
+      .filter((li) => !li.classList.contains('roll-separator'));
+    expect(items[0]).toHaveTextContent('6 (3 cold + 3 slashing)');
     Math.random = orig;
   });
 


### PR DESCRIPTION
## Summary
- insert divider entries between damage rolls and render them as `roll-separator` list items
- style roll separators with a thin grey line
- update damage log tests to ignore separator elements

## Testing
- `npm test -- --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c73b46b60483239cbf78779d006b15