### PR TITLE
feat: show damage breakdown on separate lines

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -468,25 +468,24 @@ const showSparklesEffect = () => {
                 <li key={idx} className="roll-separator" />
               ) : (
                 <li key={idx}>
-                  {entry.total}
+                  <div>{entry.total}</div>
                   {entry.breakdown && (
-                    <span>
-                      {' ('}
-                      {entry.breakdown.split(' + ').map((segment, i, arr) => {
+                    <div>
+                      {entry.breakdown.split(' + ').map((segment, i) => {
                         const match = segment.match(/(\d+)(?:\s+(\w+))?/);
                         const value = match ? match[1] : segment;
                         const type = match ? match[2] : '';
                         return (
-                          <React.Fragment key={i}>
+                          <div key={i}>
+                            -{' '}
                             <span className={type ? `damage-${type}` : ''}>
-                              {value}{type ? ` ${type}` : ''}
+                              {value}
+                              {type ? ` ${type}` : ''}
                             </span>
-                            {i < arr.length - 1 ? ' + ' : ''}
-                          </React.Fragment>
+                          </div>
                         );
                       })}
-                      {')'}
-                    </span>
+                    </div>
                   )}
                 </li>
               )

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -121,7 +121,13 @@ describe('PlayerTurnActions damage log', () => {
     const items = within(modal)
       .getAllByRole('listitem')
       .filter((li) => !li.classList.contains('roll-separator'));
-    expect(items[0]).toHaveTextContent('6 (3 cold + 3 slashing)');
+    const item = items[0];
+    const [totalLine, breakdownDiv] = item.querySelectorAll('div');
+    expect(totalLine).toHaveTextContent('6');
+    const breakdownLines = Array.from(breakdownDiv.querySelectorAll('div')).map(
+      (d) => d.textContent.trim()
+    );
+    expect(breakdownLines).toEqual(['- 3 cold', '- 3 slashing']);
     Math.random = orig;
   });
 


### PR DESCRIPTION
## Summary
- display each damage type on its own line in the damage log
- adjust damage log test expectations for new layout

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c73ccdf3ac83238c2c2c4d110ecbbe