### PR TITLE
Highlight damage type segments in PlayerTurnActions

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -148,16 +148,27 @@ const [isFumble, setIsFumble] = useState(false);
     abilityForWeapon(weapon) +
     Number(weapon.attackBonus || weapon.bonus || 0);
 
-  const getDamageString = (weapon) => {
-    const ability = abilityForWeapon(weapon);
-    return weapon.damage
+  const formatDamageSegments = (damage, ability) =>
+    damage
       .split(/\s+\+\s+/)
-      .map((part) => {
+      .map((part, i, arr) => {
         const [token, ...rest] = part.trim().split(' ');
         const type = rest.join(' ').trim();
-        return `${token}+${ability}${type ? ` ${type}` : ''}`;
-      })
-      .join(' + ');
+        return (
+          <React.Fragment key={i}>
+            <span className={type ? `damage-${type}` : ''}>
+              {token}
+              {ability !== undefined ? `+${ability}` : ''}
+              {type ? ` ${type}` : ''}
+            </span>
+            {i < arr.length - 1 ? ' + ' : ''}
+          </React.Fragment>
+        );
+      });
+
+  const getDamageString = (weapon) => {
+    const ability = abilityForWeapon(weapon);
+    return formatDamageSegments(weapon.damage, ability);
   };
 
   const handleWeaponAttack = (weapon) => {
@@ -610,7 +621,7 @@ const showSparklesEffect = () => {
                           <td>{spell.name}</td>
                           <td>{spell.casterType || spell.caster || 'Unknown'}</td>
                           <td>{spell.level}</td>
-                          <td>{spell.damage}</td>
+                          <td>{formatDamageSegments(spell.damage)}</td>
                           <td>{spell.castingTime}</td>
                           <td>{spell.range}</td>
                           <td>{spell.duration}</td>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -60,7 +60,7 @@ describe('calculateDamage parser', () => {
 });
 
 describe('PlayerTurnActions weapon damage display', () => {
-  test('getDamageString applies ability to each component', () => {
+  test('weapon damage segments include ability and type classes', () => {
     const weapon = {
       name: 'Frost Brand',
       damage: '1d4 cold + 1d6 slashing',
@@ -78,9 +78,35 @@ describe('PlayerTurnActions weapon damage display', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
     const row = screen.getByText('Frost Brand').closest('tr');
-    expect(
-      within(row).getByText('1d4+2 cold + 1d6+2 slashing')
-    ).toBeInTheDocument();
+    const cold = within(row).getByText(/1d4\+2 cold/);
+    const slashing = within(row).getByText(/1d6\+2 slashing/);
+    expect(cold).toHaveClass('damage-cold');
+    expect(slashing).toHaveClass('damage-slashing');
+  });
+
+  test('spell damage segments include type classes', () => {
+    const spell = {
+      name: 'Fire Bolt',
+      level: 1,
+      damage: '1d10 fire',
+      castingTime: '1 action',
+      range: '120 feet',
+      duration: 'Instantaneous',
+      casterType: 'Wizard',
+    };
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        strMod={0}
+        dexMod={0}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const row = screen.getByText('Fire Bolt').closest('tr');
+    const fire = within(row).getByText(/1d10 fire/);
+    expect(fire).toHaveClass('damage-fire');
   });
 });
 
@@ -187,7 +213,7 @@ describe('PlayerTurnActions damage log', () => {
 });
 
 describe('PlayerTurnActions weapon damage display', () => {
-  test('getDamageString applies ability to each component', () => {
+  test('weapon damage segments include ability and type classes', () => {
     const weapon = {
       name: 'Frost Brand',
       damage: '1d4 cold + 1d6 slashing',
@@ -205,9 +231,35 @@ describe('PlayerTurnActions weapon damage display', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
     const row = screen.getByText('Frost Brand').closest('tr');
-    expect(
-      within(row).getByText('1d4+2 cold + 1d6+2 slashing')
-    ).toBeInTheDocument();
+    const cold = within(row).getByText(/1d4\+2 cold/);
+    const slashing = within(row).getByText(/1d6\+2 slashing/);
+    expect(cold).toHaveClass('damage-cold');
+    expect(slashing).toHaveClass('damage-slashing');
+  });
+
+  test('spell damage segments include type classes', () => {
+    const spell = {
+      name: 'Fire Bolt',
+      level: 1,
+      damage: '1d10 fire',
+      castingTime: '1 action',
+      range: '120 feet',
+      duration: 'Instantaneous',
+      casterType: 'Wizard',
+    };
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        strMod={0}
+        dexMod={0}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const row = screen.getByText('Fire Bolt').closest('tr');
+    const fire = within(row).getByText(/1d10 fire/);
+    expect(fire).toHaveClass('damage-fire');
   });
 });
 


### PR DESCRIPTION
## Summary
- Wrap weapon and spell damage components with `damage-*` spans
- Reuse formatting helper for weapon and spell damage
- Test that weapons and spells render damage segments with appropriate classes

## Testing
- `npm test -- client/src/components/Zombies/attributes/PlayerTurnActions.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c73c6194d883238c7a7ce220ea025d