### PR TITLE
Include damage type in spell parsing

### DIFF
--- a/server/__tests__/spells.test.js
+++ b/server/__tests__/spells.test.js
@@ -53,7 +53,7 @@ describe('Spells routes', () => {
     dbo.mockResolvedValue({});
     const res = await request(app).get('/spells/fireball');
     expect(res.status).toBe(200);
-    expect(res.body.damage).toBe('8d6');
+    expect(res.body.damage).toBe('8d6 fire');
   });
 
   test('upcastable spells include higherLevels field', async () => {

--- a/server/routes/spells.js
+++ b/server/routes/spells.js
@@ -2,10 +2,31 @@ const express = require('express');
 const spells = require('../data/spells');
 const classSpellLists = require('../data/classSpellLists');
 
-// Extract a basic damage dice string (e.g., "8d6" or "1d8+2") from spell descriptions
+// Extract a basic damage dice string and type (e.g., "8d6 fire") from spell descriptions
 function extractDamage(description = '') {
-  const match = description.match(/(\d+d\d+(?:\s*[+\-]\s*\d+)?)[^\n]*damage/i);
-  return match ? match[1].replace(/\s+/g, '') : undefined;
+  const damageTypes = [
+    'acid',
+    'bludgeoning',
+    'piercing',
+    'slashing',
+    'fire',
+    'cold',
+    'lightning',
+    'thunder',
+    'force',
+    'psychic',
+    'radiant',
+    'necrotic',
+    'poison',
+  ];
+  const regex = new RegExp(
+    `(\\d+d\\d+(?:\\s*[+\-]\\s*\\d+)?)[^\\n]*?\\b(${damageTypes.join('|')})\\b[^\\n]*damage`,
+    'i'
+  );
+  const match = description.match(regex);
+  return match
+    ? { dice: match[1].replace(/\s+/g, ''), type: match[2].toLowerCase() }
+    : undefined;
 }
 
 // Extract "At Higher Levels" text if present
@@ -14,30 +35,30 @@ function extractHigherLevels(description = '') {
   return match ? match[1].trim() : undefined;
 }
 
-function extractScaling(description = '') {
+function extractScaling(description = '', type) {
   const level5 = description.match(/5th level \(([^)]+)\)/i);
   const level11 = description.match(/11th level \(([^)]+)\)/i);
   const level17 = description.match(/17th level \(([^)]+)\)/i);
   const scaling = {};
-  if (level5) scaling[5] = level5[1].replace(/\s+/g, '');
-  if (level11) scaling[11] = level11[1].replace(/\s+/g, '');
-  if (level17) scaling[17] = level17[1].replace(/\s+/g, '');
+  if (level5) scaling[5] = `${level5[1].replace(/\s+/g, '')}${type ? ` ${type}` : ''}`;
+  if (level11) scaling[11] = `${level11[1].replace(/\s+/g, '')}${type ? ` ${type}` : ''}`;
+  if (level17) scaling[17] = `${level17[1].replace(/\s+/g, '')}${type ? ` ${type}` : ''}`;
   return Object.keys(scaling).length ? scaling : undefined;
 }
 
 // Augment spells with a `damage` field when possible
 Object.values(spells).forEach((spell) => {
-  if (!spell.damage) {
-    const dmg = extractDamage(spell.description);
-    if (dmg) spell.damage = dmg;
+  const dmg = extractDamage(spell.description);
+  if (!spell.damage && dmg) {
+    spell.damage = `${dmg.dice} ${dmg.type}`;
+  }
+  if (spell.level === 0 && !spell.scaling) {
+    const scaling = extractScaling(spell.description, dmg?.type);
+    if (scaling) spell.scaling = scaling;
   }
   if (!spell.higherLevels) {
     const upcast = extractHigherLevels(spell.description);
     if (upcast) spell.higherLevels = upcast;
-  }
-  if (spell.level === 0 && !spell.scaling) {
-    const scaling = extractScaling(spell.description);
-    if (scaling) spell.scaling = scaling;
   }
 });
 


### PR DESCRIPTION
## Summary
- capture dice and damage type from spell descriptions
- ensure cantrip scaling keeps the same damage type
- update spell tests for damage type expectation

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68c7453cf7b48323aa78d0a15c64c1d5