### PR TITLE
Parse and surface spell damage types

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1374,10 +1374,10 @@ h1 {
 .damage-acid { color: #228B22; }
 .damage-cold { color: #00BFFF; }
 .damage-fire { color: #FF4500; }
-.damage-lightning { color: #FFD700; }
+.damage-lightning { color: #1E90FF; }
 .damage-poison { color: #32CD32; }
 .damage-thunder { color: #8A2BE2; }
-.damage-force { color: #FF1493; }
+.damage-force { color: #FF0000; }
 .damage-necrotic { color: #4B0082; }
 .damage-radiant { color: #FFFF99; }
 .damage-psychic { color: #BA55D3; }

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -620,7 +620,16 @@ const showSparklesEffect = () => {
                           <td>{spell.name}</td>
                           <td>{spell.casterType || spell.caster || 'Unknown'}</td>
                           <td>{spell.level}</td>
-                          <td>{formatDamageSegments(spell.damage)}</td>
+                          <td>
+                            {formatDamageSegments(
+                              spell.damageType &&
+                                !spell.damage
+                                  .toLowerCase()
+                                  .includes(spell.damageType.toLowerCase())
+                                ? `${spell.damage} ${spell.damageType}`
+                                : spell.damage
+                            )}
+                          </td>
                           <td>{spell.castingTime}</td>
                           <td>{spell.range}</td>
                           <td>{spell.duration}</td>

--- a/server/__tests__/spells.test.js
+++ b/server/__tests__/spells.test.js
@@ -49,11 +49,12 @@ describe('Spells routes', () => {
     expect(res.body.message).toBe('Spell not found');
   });
 
-  test('damaging spells include parsed damage field', async () => {
+  test('damaging spells include parsed damage and type fields', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app).get('/spells/fireball');
     expect(res.status).toBe(200);
-    expect(res.body.damage).toBe('8d6');
+    expect(res.body.damage).toBe('8d6 fire');
+    expect(res.body.damageType).toBe('fire');
   });
 
   test('upcastable spells include higherLevels field', async () => {

--- a/server/routes/spells.js
+++ b/server/routes/spells.js
@@ -2,10 +2,30 @@ const express = require('express');
 const spells = require('../data/spells');
 const classSpellLists = require('../data/classSpellLists');
 
-// Extract a basic damage dice string (e.g., "8d6" or "1d8+2") from spell descriptions
+// Extract damage dice and type (e.g., "8d6 fire") from spell descriptions
+const DAMAGE_TYPES = [
+  'acid',
+  'bludgeoning',
+  'cold',
+  'fire',
+  'force',
+  'lightning',
+  'necrotic',
+  'piercing',
+  'poison',
+  'psychic',
+  'radiant',
+  'slashing',
+  'thunder',
+];
+
 function extractDamage(description = '') {
-  const match = description.match(/(\d+d\d+(?:\s*[+\-]\s*\d+)?)[^\n]*damage/i);
-  return match ? match[1].replace(/\s+/g, '') : undefined;
+  const match = description.match(/(\d+d\d+(?:\s*[+\-]\s*\d+)?)\s+(\w+)\s+damage/i);
+  if (!match) return undefined;
+  const dice = match[1].replace(/\s+/g, '');
+  const type = match[2].toLowerCase();
+  if (!DAMAGE_TYPES.includes(type)) return undefined;
+  return { dice, type };
 }
 
 // Extract "At Higher Levels" text if present
@@ -29,7 +49,10 @@ function extractScaling(description = '') {
 Object.values(spells).forEach((spell) => {
   if (!spell.damage) {
     const dmg = extractDamage(spell.description);
-    if (dmg) spell.damage = dmg;
+    if (dmg) {
+      spell.damage = `${dmg.dice} ${dmg.type}`;
+      spell.damageType = dmg.type;
+    }
   }
   if (!spell.higherLevels) {
     const upcast = extractHigherLevels(spell.description);

--- a/types/spell.d.ts
+++ b/types/spell.d.ts
@@ -9,6 +9,14 @@ export interface Spell {
   description: string;
   classes: string[];
   /**
+   * Parsed damage string including dice and type (e.g., "8d6 fire").
+   */
+  damage?: string;
+  /**
+   * Damage type parsed from the description (e.g., "fire").
+   */
+  damageType?: string;
+  /**
    * Additional effects when the spell is cast using a higher-level slot.
    */
   higherLevels?: string;


### PR DESCRIPTION
## Summary
- parse damage types from spell descriptions and expose both `damage` and `damageType`
- surface damage type in player action spell table with appropriate color styling
- keep physical damage types unstyled and adjust lightning/force colors

## Testing
- `npm --prefix server test`
- `CI=true npm --prefix client test`


------
https://chatgpt.com/codex/tasks/task_e_68c750f5375c83239e132757e7bf6ffa