### PR TITLE
Show weapon cards in three columns on mobile

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -92,17 +92,20 @@
 
 @media (max-width: 576px) {
   .weapon-card {
-    font-size: 0.75rem;
+    font-size: 0.6rem;
   }
   .weapon-card .card-title {
-    font-size: 1rem;
+    font-size: 0.85rem;
   }
   .weapon-card .card-text {
-    font-size: 0.75rem;
+    font-size: 0.6rem;
   }
   .weapon-card .btn {
-    font-size: 0.75rem;
+    font-size: 0.6rem;
     padding: 0.25rem 0.5rem;
+  }
+  .weapon-card .form-check-label {
+    font-size: 0.65rem;
   }
 }
 

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -228,7 +228,7 @@ function WeaponList({
             Unrecognized weapons from server: {unknownWeapons.join(', ')}
           </Alert>
         )}
-        <Row className="row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+        <Row className="row-cols-3 g-3">
           {Object.entries(weapons).map(([key, weapon]) => {
             const Icon = categoryIcons[weapon.category] || GiCrossedSwords;
             return (


### PR DESCRIPTION
## Summary
- force weapon list to render three columns on small screens
- shrink weapon card text sizes for better mobile fit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75f19a40c832e833a75c4a4009c3b