### PR TITLE
Reduce weapon card text spacing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -90,6 +90,12 @@
   color: var(--bs-body-color);
 }
 
+.weapon-card .card-title,
+.weapon-card .card-text {
+  margin-bottom: 0.25rem; // reduce vertical gap
+  line-height: 1.2;
+}
+
 @media (max-width: 576px) {
   .weapon-card {
     font-size: 0.6rem;


### PR DESCRIPTION
## Summary
- compact weapon card titles and descriptions by reducing margins
- adjust line height for tighter spacing

## Testing
- `CI=true npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c766d3ded4832eae2369e4ced6e6f1