### PR TITLE
Align weapon checkboxes in weapon list

### DIFF
--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -247,7 +247,7 @@ function WeaponList({
                     <Card.Text>Weight: {weapon.weight}</Card.Text>
                     <Card.Text>Cost: {weapon.cost}</Card.Text>
                   </Card.Body>
-                  <Card.Footer className="d-flex justify-content-between">
+                  <Card.Footer className="d-flex justify-content-center gap-2">
                     <Form.Check
                       type="checkbox"
                       className="weapon-checkbox"


### PR DESCRIPTION
## Summary
- Align weapon list ownership and proficiency toggles horizontally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c766d4c86c832e8179292900110cec