### PR TITLE
Display damage breakdown for spell attacks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -224,11 +224,12 @@ const [pendingSpell, setPendingSpell] = useState(null);
       diff > 0 ? diff : 0
     );
     if (!value) return;
-    updateDamageValueWithAnimation(value.total, value.breakdown, spell.name);
+    updateDamageValueWithAnimation(value.total, value.breakdown, spell.name, true);
     onCastSpell?.({
       level,
       slotType,
       damage: value.total,
+      breakdown: value.breakdown,
       castingTime: spell.castingTime,
       name: spell.name,
     });
@@ -290,10 +291,15 @@ useEffect(() => {
   }
 }, [loading]);
 
-const updateDamageValueWithAnimation = (newValue, breakdown, source) => {
+const updateDamageValueWithAnimation = (
+  newValue,
+  breakdown,
+  source,
+  showBreakdown = false
+) => {
   setLoading(true);
   setPulseClass('');
-  setDamageValue(newValue);
+  setDamageValue(showBreakdown && breakdown ? breakdown : newValue);
   if (newValue !== undefined) {
     setDamageLog((prev) => {
       const entry = {
@@ -313,8 +319,15 @@ const [pulseClass, setPulseClass] = useState('');
 // Allow other components to display values in the damage circle
 useEffect(() => {
   const handler = (e) => {
-    const { value, breakdown, source, critical, fumble } = e.detail || {};
-    updateDamageValueWithAnimation(value, breakdown, source);
+    const {
+      value,
+      breakdown,
+      source,
+      critical,
+      fumble,
+      displayBreakdown,
+    } = e.detail || {};
+    updateDamageValueWithAnimation(value, breakdown, source, displayBreakdown);
     setIsCritical(!!critical && !fumble);
     setIsFumble(!!fumble);
   };

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -477,6 +477,7 @@ describe('PlayerTurnActions spell casting', () => {
         level: spell.level,
         slotType: undefined,
         damage: expect.any(Number),
+        breakdown: expect.any(String),
         castingTime: spell.castingTime,
         name: spell.name,
       })
@@ -518,8 +519,8 @@ describe('PlayerTurnActions spell casting', () => {
       if (!el || el.textContent === '0') throw new Error('waiting');
     });
     const el = document.getElementById('damageValue');
-    expect(el.classList.contains('spell-cast-label')).toBe(false);
-    expect(el.textContent).not.toBe(spell.name);
+    expect(el.classList.contains('spell-cast-label')).toBe(true);
+    expect(el.textContent).toBe('6 fire');
     Math.random = orig;
   });
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -259,7 +259,8 @@ export default function ZombiesCharacterSheet() {
     playerTurnActionsRef.current?.updateDamageValueWithAnimation(
       result,
       breakdown,
-      source
+      source,
+      !!breakdown
     );
   };
 
@@ -331,6 +332,7 @@ export default function ZombiesCharacterSheet() {
         const {
           level,
           damage,
+          breakdown,
           extraDice,
           levelsAbove,
           slotLevel,
@@ -345,7 +347,7 @@ export default function ZombiesCharacterSheet() {
         else if (castingTime?.includes('1 bonus action')) consumeCircle('bonus');
         let result;
         if (typeof damage === 'number') {
-          result = { total: damage };
+          result = { total: damage, breakdown };
         } else if (damage) {
           const calc = calculateDamage(
             damage,
@@ -367,7 +369,8 @@ export default function ZombiesCharacterSheet() {
         playerTurnActionsRef.current?.updateDamageValueWithAnimation(
           result?.total,
           result?.breakdown,
-          typeof result?.total === 'number' ? spellLabel : undefined
+          typeof result?.total === 'number' ? spellLabel : undefined,
+          !!result?.breakdown
         );
         if (name === 'Haste') {
           setActiveEffects((prev) => [

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -409,7 +409,12 @@ test('handleCastSpell closes modal and outputs spell name', async () => {
   mockOnCastSpell.current({ level: 1, name: 'Mage Hand' });
   mockHandleClose.current();
   await waitFor(() => expect(screen.queryByTestId('spell-selector')).toBeNull());
-  expect(mockUpdateDamage).toHaveBeenCalledWith('Mage Hand', undefined, undefined);
+  expect(mockUpdateDamage).toHaveBeenCalledWith(
+    'Mage Hand',
+    undefined,
+    undefined,
+    false
+  );
 });
 
 test('handleCastSpell outputs calculated damage', async () => {


### PR DESCRIPTION
## Summary
- Pass damage breakdowns to `onCastSpell` and show them in the damage circle when spells are rolled
- Allow `updateDamageValueWithAnimation` to optionally display breakdown strings
- Update character sheet and tests to handle damage-type breakdowns

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c77b0fcf3c832393b778cebd8e85c8