### PR TITLE
Refactor armor list into card grid

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -85,7 +85,18 @@
   background-color: #fff;
 }
 
+.armor-card {
+  height: 100%;
+  color: var(--bs-dark);
+  background-color: #fff;
+}
+
 .weapon-card .form-check-label {
+  font-size: 0.9rem;
+  color: var(--bs-body-color);
+}
+
+.armor-card .form-check-label {
   font-size: 0.9rem;
   color: var(--bs-body-color);
 }
@@ -96,21 +107,43 @@
   line-height: 1.2;
 }
 
+.armor-card .card-title,
+.armor-card .card-text {
+  margin-bottom: 0.25rem; // reduce vertical gap
+  line-height: 1.2;
+}
+
 @media (max-width: 576px) {
   .weapon-card {
+    font-size: 0.6rem;
+  }
+  .armor-card {
     font-size: 0.6rem;
   }
   .weapon-card .card-title {
     font-size: 0.85rem;
   }
+  .armor-card .card-title {
+    font-size: 0.85rem;
+  }
   .weapon-card .card-text {
+    font-size: 0.6rem;
+  }
+  .armor-card .card-text {
     font-size: 0.6rem;
   }
   .weapon-card .btn {
     font-size: 0.6rem;
     padding: 0.25rem 0.5rem;
   }
+  .armor-card .btn {
+    font-size: 0.6rem;
+    padding: 0.25rem 0.5rem;
+  }
   .weapon-card .form-check-label {
+    font-size: 0.65rem;
+  }
+  .armor-card .form-check-label {
     font-size: 0.65rem;
   }
 }


### PR DESCRIPTION
## Summary
- render armor entries as individual cards in a responsive grid
- add matching `.armor-card` styles for card appearance

## Testing
- `CI=true npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c82a394d88832e85b5f1a3eeba7afe