### PR TITLE
Refactor armor list to card layout

### DIFF
--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Table, Form, Alert } from 'react-bootstrap';
+import { Card, Form, Alert, Row, Col, Button } from 'react-bootstrap';
 import apiFetch from '../../utils/apiFetch';
 
 /** @typedef {import('../../../../types/armor').Armor} Armor */
@@ -246,77 +246,70 @@ function ArmorList({
             Unrecognized armor from server: {unknownArmor.join(', ')}
           </Alert>
         )}
-        <Table striped bordered hover size="sm" className="modern-table">
-          <thead>
-            <tr>
-              <th>Owned</th>
-              <th>Proficient</th>
-              <th>Name</th>
-              <th>AC Bonus</th>
-              <th>Max Dex</th>
-              <th>Strength</th>
-              <th>Stealth</th>
-              <th>Weight</th>
-              <th>Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(armor).map(([key, piece]) => {
-              const unmet = piece.strength && strength < piece.strength;
-              return (
-                <tr key={key}>
-                  <td>
+        <Row className="g-2">
+          {Object.entries(armor).map(([key, piece]) => {
+            const unmet = piece.strength && strength < piece.strength;
+            return (
+              <Col xs={6} md={4} key={key}>
+                <Card className="armor-card h-100">
+                  <Card.Body>
+                    <Card.Title as="h6">{piece.displayName || piece.name}</Card.Title>
                     <Form.Check
                       type="checkbox"
+                      label="Owned"
                       className="weapon-checkbox"
                       checked={piece.owned}
                       disabled={unmet}
                       onChange={handleOwnedToggle(key)}
                       aria-label={piece.displayName || piece.name}
-                      title={
-                        unmet ? `Requires STR ${piece.strength}` : undefined
+                      title={unmet ? `Requires STR ${piece.strength}` : undefined}
+                    />
+                    <Form.Check
+                      type="checkbox"
+                      label="Proficient"
+                      className="weapon-checkbox"
+                      checked={piece.proficient}
+                      disabled={piece.granted || piece.pending}
+                      onChange={handleToggle(key)}
+                      aria-label={`${piece.displayName || piece.name} proficiency`}
+                      style={
+                        piece.granted || piece.pending
+                          ? { opacity: 0.5 }
+                          : undefined
                       }
                     />
-                  </td>
-                <td>
-                  <Form.Check
-                    type="checkbox"
-                    className="weapon-checkbox"
-                    checked={piece.proficient}
-                    disabled={piece.granted || piece.pending}
-                    onChange={handleToggle(key)}
-                    aria-label={`${piece.displayName || piece.name} proficiency`}
-                    style={
-                      piece.granted || piece.pending
-                        ? { opacity: 0.5 }
-                        : undefined
-                    }
-                  />
-                </td>
-                <td>{piece.displayName || piece.name}</td>
-                <td>
-                  {piece.acBonus !== '' && piece.acBonus !== null && piece.acBonus !== undefined
-                    ? piece.acBonus
-                    : ''}
-                </td>
-                <td>
-                  {piece.maxDex === null || piece.maxDex === undefined
-                    ? '—'
-                    : piece.maxDex}
-                </td>
-                <td>
-                  {piece.strength === null || piece.strength === undefined
-                    ? '—'
-                    : piece.strength}
-                </td>
-                <td>{piece.stealth ? 'Disadvantage' : '—'}</td>
-                <td>{piece.weight}</td>
-                <td>{piece.cost}</td>
-              </tr>
+                    <Card.Text>AC Bonus: {piece.acBonus !== '' && piece.acBonus !== null && piece.acBonus !== undefined ? piece.acBonus : ''}</Card.Text>
+                    <Card.Text>
+                      Max Dex:{' '}
+                      {piece.maxDex === null || piece.maxDex === undefined
+                        ? '—'
+                        : piece.maxDex}
+                    </Card.Text>
+                    <Card.Text>
+                      Strength:{' '}
+                      {piece.strength === null || piece.strength === undefined
+                        ? '—'
+                        : piece.strength}
+                    </Card.Text>
+                    <Card.Text>
+                      Stealth: {piece.stealth ? 'Disadvantage' : '—'}
+                    </Card.Text>
+                    <Card.Text>Weight: {piece.weight}</Card.Text>
+                    <Card.Text>Cost: {piece.cost}</Card.Text>
+                  </Card.Body>
+                  <Card.Footer>
+                    <Button
+                      size="sm"
+                      className="btn-danger action-btn fa-solid fa-trash"
+                      hidden={!piece.owned}
+                      onClick={handleOwnedToggle(key)}
+                    ></Button>
+                  </Card.Footer>
+                </Card>
+              </Col>
             );
           })}
-          </tbody>
-        </Table>
+        </Row>
       </Card.Body>
     </Card>
   );

--- a/client/src/components/Armor/ArmorList.test.js
+++ b/client/src/components/Armor/ArmorList.test.js
@@ -136,10 +136,10 @@ test('marks armor proficiency', async () => {
   const chainRow = await screen.findByText('Chain Mail');
   expect(apiFetch).toHaveBeenCalledWith('/armor-proficiency/char1');
 
-  const chainTr = chainRow.closest('tr');
-  const leatherTr = screen.getByText('Leather Armor').closest('tr');
-  const chainProf = within(chainTr).getByLabelText('Chain Mail proficiency');
-  const leatherProf = within(leatherTr).getByLabelText('Leather Armor proficiency');
+  const chainCard = chainRow.closest('.card');
+  const leatherCard = screen.getByText('Leather Armor').closest('.card');
+  const chainProf = within(chainCard).getByLabelText('Chain Mail proficiency');
+  const leatherProf = within(leatherCard).getByLabelText('Leather Armor proficiency');
   expect(chainProf).toBeChecked();
   expect(chainProf).not.toBeDisabled();
   expect(leatherProf).not.toBeChecked();
@@ -159,8 +159,8 @@ test('granted proficiencies render checked and disabled', async () => {
   render(<ArmorList characterId="char1" strength={15} />);
 
   const chainRow = await screen.findByText('Chain Mail');
-  const chainTr = chainRow.closest('tr');
-  const chainProf = within(chainTr).getByLabelText('Chain Mail proficiency');
+  const chainCard = chainRow.closest('.card');
+  const chainProf = within(chainCard).getByLabelText('Chain Mail proficiency');
   expect(chainProf).toBeChecked();
   expect(chainProf).toBeDisabled();
 });
@@ -182,8 +182,8 @@ test('toggling a non-proficient armor allows checking and unchecking', async () 
   render(<ArmorList characterId="char1" strength={15} />);
 
   const leatherRow = await screen.findByText('Leather Armor');
-  const leatherTr = leatherRow.closest('tr');
-  const leatherProf = within(leatherTr).getByLabelText('Leather Armor proficiency');
+  const leatherCard = leatherRow.closest('.card');
+  const leatherProf = within(leatherCard).getByLabelText('Leather Armor proficiency');
 
   expect(leatherProf).not.toBeChecked();
   await userEvent.click(leatherProf);
@@ -227,23 +227,23 @@ test('reloads proficiency data when character changes', async () => {
   const leatherRow1 = await screen.findByText('Leather Armor');
   const chainRow1 = await screen.findByText('Chain Mail');
   expect(
-    within(leatherRow1.closest('tr')).getByLabelText('Leather Armor proficiency')
+    within(leatherRow1.closest('.card')).getByLabelText('Leather Armor proficiency')
   ).toBeChecked();
   expect(
-    within(chainRow1.closest('tr')).getByLabelText('Chain Mail proficiency')
+    within(chainRow1.closest('.card')).getByLabelText('Chain Mail proficiency')
   ).not.toBeChecked();
 
   rerender(<ArmorList characterId="char2" strength={15} />);
   await waitFor(() =>
     expect(
-      within(screen.getByText('Leather Armor').closest('tr')).getByLabelText(
+      within(screen.getByText('Leather Armor').closest('.card')).getByLabelText(
         'Leather Armor proficiency'
       )
     ).not.toBeChecked()
   );
   await waitFor(() =>
     expect(
-      within(screen.getByText('Chain Mail').closest('tr')).getByLabelText(
+      within(screen.getByText('Chain Mail').closest('.card')).getByLabelText(
         'Chain Mail proficiency'
       )
     ).toBeChecked()


### PR DESCRIPTION
## Summary
- replace armor table with card-based layout and delete button
- ensure `.armor-card` styles are applied and update tests accordingly

## Testing
- `CI=true npm test`
- `npm --prefix client run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c82da721f4832e9e44158bba10f50c