### PR TITLE
feat: add optional close footer to item list

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -29,9 +29,17 @@ const renderBonuses = (bonuses, labels) =>
  *   initialItems?: Item[],
  *   characterId?: string,
  *   show?: boolean,
+ *   onClose?: () => void,
  * }} props
  */
-function ItemList({ campaign, onChange, initialItems = [], characterId, show = true }) {
+function ItemList({
+  campaign,
+  onChange,
+  initialItems = [],
+  characterId,
+  show = true,
+  onClose,
+}) {
   const [items, setItems] =
     useState/** @type {Record<string, Item & { owned?: boolean, displayName?: string }> | null} */(null);
   const [error, setError] = useState(null);
@@ -227,6 +235,13 @@ function ItemList({ campaign, onChange, initialItems = [], characterId, show = t
           </tbody>
         </Table>
       </Card.Body>
+      {typeof onClose === 'function' && (
+        <Card.Footer className="modal-footer">
+          <Button className="action-btn close-btn" onClick={onClose}>
+            Close
+          </Button>
+        </Card.Footer>
+      )}
       <Modal show={!!notesItem} onHide={handleCloseNotes} size="sm">
         <Modal.Header closeButton>
           <Modal.Title>{notesItem?.displayName || notesItem?.name}</Modal.Title>

--- a/client/src/components/Zombies/attributes/Items.js
+++ b/client/src/components/Zombies/attributes/Items.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Modal, Button } from 'react-bootstrap';
+import { Modal } from 'react-bootstrap';
 import ItemList from '../../Items/ItemList';
 import apiFetch from '../../../utils/apiFetch';
 
@@ -57,17 +57,15 @@ export default function Items({ form, showItems, handleCloseItems }) {
       size="lg"
       centered
     >
-      <ItemList
-        campaign={campaign}
-        initialItems={normalized}
-        onChange={handleItemsChange}
-        characterId={characterId}
-        show={showItems}
-      />
-      <div className="modal-footer">
-        <Button className="action-btn close-btn" onClick={handleCloseItems}>
-          Close
-        </Button>
+      <div className="text-center">
+        <ItemList
+          campaign={campaign}
+          initialItems={normalized}
+          onChange={handleItemsChange}
+          characterId={characterId}
+          show={showItems}
+          onClose={handleCloseItems}
+        />
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Summary
- support an optional onClose handler in ItemList with a matching Card footer
- align Items modal layout with weapons/armor by wrapping ItemList and delegating its close button

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c83655f500832eae3f86aca9720711