### PR TITLE
Add consistent styling to item card checkbox labels

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -107,6 +107,11 @@
   color: var(--bs-body-color);
 }
 
+.item-card .form-check-label {
+  font-size: 0.9rem;
+  color: var(--bs-body-color);
+}
+
 .weapon-card .card-title,
 .weapon-card .card-text {
   margin-bottom: 0.25rem; // reduce vertical gap


### PR DESCRIPTION
## Summary
- mirror the checkbox label styling on item cards to match weapon and armor cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8503fc7c0832ebbe8062474b5d80a