### PR TITLE
Add logout handling to Zombies page

### DIFF
--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -12,6 +12,11 @@ export default function Zombies() {
   const navigate = useNavigate();
   const user = useUser();
 
+  const handleLogout = async () => {
+    await apiFetch("/logout", { method: "POST" });
+    window.location.assign("/");
+  };
+
 //--------------------------------------------Campaign Section------------------------------
 
 const [form1, setForm1] = useState({ 
@@ -150,6 +155,7 @@ return (
         <Button className="mb-3 fantasy-button campaign-button" style={{borderColor: "transparent"}} onClick={handleShowJoinCampaign}>Join Campaign</Button>
         <Button className="mb-3 hostCampaign campaign-button" style={{borderColor: "transparent"}} onClick={handleShowHostCampaign}>Host Campaign</Button>
         <Button className="create-button campaign-button" style={{borderColor: "transparent"}} onClick={handleShow1}>Create Campaign</Button>
+        <Button className="mt-3 fantasy-button campaign-button" style={{borderColor: "transparent"}} onClick={handleLogout}>Logout</Button>
       </div>
 
       <Modal className="dnd-modal" centered show={showJoinCampaignModal} onHide={handleCloseJoinCampaign}>


### PR DESCRIPTION
## Summary
- add logout handler to the Zombies page that posts to /logout and redirects home
- surface a logout button alongside other campaign controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c85a4a0c4483239cd737ce4043114b