### PR TITLE
Add logout action to help modal

### DIFF
--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -16,6 +16,11 @@ export default function Help({props, form, showHelpModal, handleCloseHelpModal})
   });
   navigate(`/zombies-character-select/${form.campaign}`);
 }
+
+ async function handleLogout() {
+  await apiFetch("/logout", { method: "POST" });
+  window.location.assign("/");
+ }
   //-------------------------------------------Help Module--------------------------------------------------------------------
 // Color Picker
 document.documentElement.style.setProperty('--dice-face-color', form.diceColor);
@@ -97,6 +102,15 @@ return(
                       </td>
                     </tr>
                   </thead>
+                  <tbody>
+                    <tr>
+                      <td className="center-td" colSpan="3">
+                        <Button onClick={handleLogout} className="action-btn close-btn">
+                          Logout
+                        </Button>
+                      </td>
+                    </tr>
+                  </tbody>
                 </Table>
               </div>
             </Card.Body>


### PR DESCRIPTION
## Summary
- add a logout handler to the Help modal component
- add a logout button row to the Help modal table using existing action styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c85a7cd904832395a3075b891dc1e0