### PR TITLE
Align help logout button with navbar styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3,6 +3,63 @@
 @import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
 
+.logout-button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  background: #2b2b2b;
+  color: #f5f5f5;
+  border: 1px solid #3a3a3a;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  transition: all 0.2s ease;
+}
+
+.logout-button:hover,
+.logout-button:focus {
+  background: #333;
+  border: 1px solid #555;
+  color: #f5f5f5;
+}
+
+.logout-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 0.25rem rgba(85, 85, 85, 0.25);
+}
+
+.logout-button__icon {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+}
+
+.logout-button__door {
+  position: absolute;
+  top: 2px;
+  left: 0;
+  width: 10px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-radius: 2px;
+}
+
+.logout-button__arrow {
+  position: absolute;
+  top: 50%;
+  left: 12px;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 7px solid currentColor;
+}
+
 .spell-slot-tabs {
   display: flex;
   overflow-x: auto;

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -35,70 +35,13 @@ function NavbarComponent() {
           {/* <Nav.Link as={Link} to="/spells">Spells</Nav.Link> */}
           {/* <Nav.Link as={Link} to="/weapons">Weapons</Nav.Link> */}
           <Nav.Link>
-  <button
-      onClick={handleLogout}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "10px",
-        padding: "10px 16px",
-        background: "#2b2b2b",
-        color: "#f5f5f5",
-        border: "1px solid #3a3a3a",
-        borderRadius: "10px",
-        fontSize: "15px",
-        fontWeight: 500,
-        cursor: "pointer",
-        boxShadow: "0 2px 6px rgba(0,0,0,0.25)",
-        transition: "all 0.2s ease",
-      }}
-      onMouseOver={(e) => {
-        e.currentTarget.style.background = "#333";
-        e.currentTarget.style.border = "1px solid #555";
-      }}
-      onMouseOut={(e) => {
-        e.currentTarget.style.background = "#2b2b2b";
-        e.currentTarget.style.border = "1px solid #3a3a3a";
-      }}
-    >
-      {/* Minimal logout icon */}
-      <span
-        style={{
-          position: "relative",
-          width: "18px",
-          height: "18px",
-          display: "inline-block",
-        }}
-      >
-        {/* Doorframe */}
-        <span
-          style={{
-            position: "absolute",
-            top: "2px",
-            left: "0",
-            width: "10px",
-            height: "14px",
-            border: "2px solid currentColor",
-            borderRadius: "2px",
-          }}
-        />
-        {/* Arrow */}
-        <span
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "12px",
-            transform: "translateY(-50%)",
-            width: "0",
-            height: "0",
-            borderTop: "5px solid transparent",
-            borderBottom: "5px solid transparent",
-            borderLeft: "7px solid currentColor",
-          }}
-        />
-      </span>
-      Logout
-    </button>
+            <Button onClick={handleLogout} className="logout-button">
+              <span className="logout-button__icon" aria-hidden="true">
+                <span className="logout-button__door" />
+                <span className="logout-button__arrow" />
+              </span>
+              Logout
+            </Button>
           </Nav.Link>
         </Nav>
       </Container>

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -104,8 +104,16 @@ return(
                   </thead>
                   <tbody>
                     <tr>
-                      <td className="center-td" colSpan="3">
-                        <Button onClick={handleLogout} className="action-btn close-btn">
+                      <td className="center-td">
+                        <strong className="text-light">Logout:</strong>
+                      </td>
+                      <td className="center-td"></td>
+                      <td className="text-end">
+                        <Button onClick={handleLogout} className="logout-button">
+                          <span className="logout-button__icon" aria-hidden="true">
+                            <span className="logout-button__door" />
+                            <span className="logout-button__arrow" />
+                          </span>
                           Logout
                         </Button>
                       </td>


### PR DESCRIPTION
## Summary
- adjust the help modal logout row to use three cells and place the styled button on the right with the shared icon markup
- centralize the logout button appearance with reusable CSS and apply it in the navbar for consistent styling

## Testing
- npm --prefix client test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c85de8323c8323b3dcb9b7e4b5dca9