### PR TITLE
Consolidate Zombies shop button behavior

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -239,8 +239,8 @@ export default function ZombiesCharacterSheet() {
   const handleCloseFeats = () => setShowFeats(false);
   const handleShowFeatures = () => setShowFeatures(true);
   const handleCloseFeatures = () => setShowFeatures(false);
-  const handleShowShop = (tab = 'weapons') => {
-    setShopTab(tab);
+  const handleShowShop = (tab) => {
+    setShopTab((prevTab) => tab ?? prevTab ?? 'weapons');
     setShowShop(true);
   };
   const handleCloseShop = () => setShowShop(false);
@@ -803,7 +803,7 @@ return (
             </Button>
           )}
           <Button
-            onClick={() => handleShowShop('weapons')}
+            onClick={() => handleShowShop()}
             style={{
               color: "black",
               backgroundColor: "#6C757D",
@@ -812,28 +812,6 @@ return (
             variant="secondary"
           >
             <i className="fas fa-wand-sparkles" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={() => handleShowShop('armor')}
-            style={{
-              color: "black",
-              backgroundColor: "#6C757D",
-            }}
-            className="footer-btn"
-            variant="secondary"
-          >
-            <i className="fas fa-shield" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={() => handleShowShop('items')}
-            style={{
-              color: "black",
-              backgroundColor: "#6C757D",
-            }}
-            className="footer-btn"
-            variant="secondary"
-          >
-            <i className="fas fa-briefcase" aria-hidden="true"></i>
           </Button>
           <Button
             onClick={handleShowHelpModal}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -384,7 +384,7 @@ test('all footer buttons have footer-btn class', async () => {
   footerButtons.forEach((btn) => expect(btn).toHaveClass('footer-btn'));
 });
 
-test('weapon, armor, and item buttons open ShopModal with correct tab', async () => {
+test('shop button opens ShopModal with default tab and retains previous tab', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,
     json: async () => ({
@@ -407,15 +407,16 @@ test('weapon, armor, and item buttons open ShopModal with correct tab', async ()
   });
 
   render(<ZombiesCharacterSheet />);
+  await waitFor(() => expect(mockShopModalProps.current).not.toBeNull());
+
   const buttons = await screen.findAllByRole('button');
-  const weaponButton = buttons.find((btn) =>
+  const shopButton = buttons.find((btn) =>
     btn.querySelector('.fa-wand-sparkles')
   );
-  const armorButton = buttons.find((btn) => btn.querySelector('.fa-shield'));
-  const itemButton = buttons.find((btn) => btn.querySelector('.fa-briefcase'));
+  expect(shopButton).toBeTruthy();
 
   await act(async () => {
-    await userEvent.click(weaponButton);
+    await userEvent.click(shopButton);
   });
   await waitFor(() =>
     expect(mockShopModalProps.current).toMatchObject({
@@ -425,20 +426,10 @@ test('weapon, armor, and item buttons open ShopModal with correct tab', async ()
   );
 
   act(() => {
-    mockShopModalProps.current?.onHide?.();
+    mockShopModalProps.current?.onTabChange?.('armor');
   });
   await waitFor(() =>
-    expect(mockShopModalProps.current).toMatchObject({ show: false })
-  );
-
-  await act(async () => {
-    await userEvent.click(armorButton);
-  });
-  await waitFor(() =>
-    expect(mockShopModalProps.current).toMatchObject({
-      show: true,
-      activeTab: 'armor',
-    })
+    expect(mockShopModalProps.current).toMatchObject({ activeTab: 'armor' })
   );
 
   act(() => {
@@ -449,12 +440,12 @@ test('weapon, armor, and item buttons open ShopModal with correct tab', async ()
   );
 
   await act(async () => {
-    await userEvent.click(itemButton);
+    await userEvent.click(shopButton);
   });
   await waitFor(() =>
     expect(mockShopModalProps.current).toMatchObject({
       show: true,
-      activeTab: 'items',
+      activeTab: 'armor',
     })
   );
 });


### PR DESCRIPTION
## Summary
- replace the separate weapons, armor, and items shop buttons with a single entry that opens the modal
- default the shop modal to the previously active tab (or weapons) when reopened via the consolidated button
- extend the ZombiesCharacterSheet test suite to cover the new shop button behavior

## Testing
- CI=true npm --prefix client test -- ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c88ece16a4832e917b5663b055b20d