### PR TITLE
Add currency summary to ShopModal

### DIFF
--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -242,6 +242,7 @@ export default function ShopModal({
   onArmorChange,
   onItemsChange,
   onTabChange,
+  currency = {},
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -250,6 +251,8 @@ export default function ShopModal({
     (typeof activeTab === 'string' && activeTab.length
       ? activeTab
       : activeTabState) || DEFAULT_TAB;
+
+  const { cp = 0, sp = 0, gp = 0, pp = 0 } = currency || {};
 
   useEffect(() => {
     if (activeTab && activeTab !== activeTabState) {
@@ -357,16 +360,25 @@ export default function ShopModal({
           className="modal-body"
           style={{ maxHeight: '80vh', overflowY: 'auto' }}
         >
-          <Tabs activeKey={currentTab} onSelect={handleSelectTab} className="mb-3">
-            {tabConfigs.map(({ key, title, render }) => {
-              const isActive = show && currentTab === key;
-              return (
-                <Tab eventKey={key} title={title} key={key}>
-                  {render(isActive)}
-                </Tab>
-              );
-            })}
-          </Tabs>
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <Tabs
+              activeKey={currentTab}
+              onSelect={handleSelectTab}
+              className="mb-0"
+            >
+              {tabConfigs.map(({ key, title, render }) => {
+                const isActive = show && currentTab === key;
+                return (
+                  <Tab eventKey={key} title={title} key={key}>
+                    {render(isActive)}
+                  </Tab>
+                );
+              })}
+            </Tabs>
+            <div className="ms-auto text-nowrap">
+              PP {pp} • GP {gp} • SP {sp} • CP {cp}
+            </div>
+          </div>
         </Card.Body>
         <Card.Footer className="modal-footer">
           <Button className="action-btn close-btn" onClick={onHide}>

--- a/client/src/components/Zombies/attributes/ShopModal.test.js
+++ b/client/src/components/Zombies/attributes/ShopModal.test.js
@@ -54,6 +54,7 @@ jest.mock('../../Items/ItemList', () => {
 import ShopModal from './ShopModal';
 
 const defaultForm = { weapon: [], armor: [], item: [], campaign: 'alpha' };
+const defaultCurrency = { cp: 1, sp: 2, gp: 3, pp: 4 };
 
 const renderShopModal = (props = {}) =>
   render(
@@ -67,6 +68,7 @@ const renderShopModal = (props = {}) =>
       form={defaultForm}
       characterId="char-1"
       strength={12}
+      currency={defaultCurrency}
       {...props}
     />
   );
@@ -116,4 +118,12 @@ test('each list fetches once when its tab is activated', async () => {
     await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
   });
   await waitFor(() => expect(mockItemListFetch).toHaveBeenCalledTimes(1));
+});
+
+test('displays the provided currency summary when shown', () => {
+  renderShopModal({ currency: { cp: 9, sp: 8, gp: 7, pp: 6 } });
+
+  expect(
+    screen.getByText(/PP 6 • GP 7 • SP 8 • CP 9/)
+  ).toBeInTheDocument();
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -873,6 +873,12 @@ return (
       onWeaponsChange={handleWeaponsChange}
       onArmorChange={handleArmorChange}
       onItemsChange={handleItemsChange}
+      currency={{
+        cp: form?.cp ?? 0,
+        sp: form?.sp ?? 0,
+        gp: form?.gp ?? 0,
+        pp: form?.pp ?? 0,
+      }}
     />
     {hasSpellcasting && (
       <SpellSelector


### PR DESCRIPTION
## Summary
- add a currency prop to the Zombies shop modal and show the coin totals beside the tabs
- supply the character's coin totals when opening the shop modal
- verify the currency display alongside the existing tab behaviour tests

## Testing
- CI=true npm test -- ShopModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c89a4017dc832e80c0d525e8a10c11