### PR TITLE
Add cart actions to shop lists

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Row, Col, Form, Alert, Button, Modal } from 'react-bootstrap';
+import { Card, Row, Col, Alert, Button, Modal } from 'react-bootstrap';
 import {
   GiAmmoBox,
   GiBackpack,
@@ -43,7 +43,7 @@ const renderBonuses = (bonuses, labels) =>
 /** @typedef {import('../../../../types/item').Item} Item */
 
 /**
- * List of items with ownership toggles.
+ * List of items with cart actions and notes display.
  * @param {{
  *   campaign?: string,
  *   onChange?: (items: Item[]) => void,
@@ -52,6 +52,7 @@ const renderBonuses = (bonuses, labels) =>
  *   show?: boolean,
  *   onClose?: () => void,
  *   embedded?: boolean,
+ *   onAddToCart?: (item: Item & { type?: string }) => void,
  * }} props
  */
 function ItemList({
@@ -62,6 +63,7 @@ function ItemList({
   show = true,
   onClose,
   embedded = false,
+  onAddToCart = () => {},
 }) {
   const [items, setItems] =
     useState/** @type {Record<string, Item & { owned?: boolean, displayName?: string }> | null} */(null);
@@ -156,42 +158,13 @@ function ItemList({
     return null;
   }
 
-  const handleOwnedToggle = (key) => () => {
-    const item = items[key];
-    const desired = !item.owned;
-    const nextItems = {
-      ...items,
-      [key]: { ...item, owned: desired },
+  const handleAddToCart = (item) => () => {
+    const payload = {
+      ...item,
+      ...(item.type ? { itemType: item.type } : {}),
+      type: 'item',
     };
-    setItems(nextItems);
-    if (typeof onChange === 'function') {
-      const ownedItems = Object.values(nextItems)
-        .filter((i) => i.owned)
-        .map(
-          ({
-            name,
-            category,
-            weight,
-            cost,
-            statBonuses,
-            skillBonuses,
-            notes,
-          }) => {
-            const itemObj = { name, category, weight, cost };
-            if (statBonuses && Object.keys(statBonuses).length) {
-              itemObj.statBonuses = statBonuses;
-            }
-            if (skillBonuses && Object.keys(skillBonuses).length) {
-              itemObj.skillBonuses = skillBonuses;
-            }
-            if (notes) {
-              itemObj.notes = notes;
-            }
-            return itemObj;
-          }
-        );
-      onChange(ownedItems);
-    }
+    onAddToCart(payload);
   };
 
   const handleCloseNotes = () => setNotesItem(null);
@@ -250,14 +223,9 @@ function ItemList({
                   )}
                 </Card.Body>
                 <Card.Footer className="d-flex justify-content-center">
-                  <Form.Check
-                    type="checkbox"
-                    className="weapon-checkbox"
-                    label="Owned"
-                    checked={item.owned}
-                    onChange={handleOwnedToggle(key)}
-                    aria-label={item.displayName || item.name}
-                  />
+                  <Button size="sm" onClick={handleAddToCart(item)}>
+                    Add to Cart
+                  </Button>
                 </Card.Footer>
               </Card>
             </Col>

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Row, Col, Form, Alert } from 'react-bootstrap';
+import { Card, Row, Col, Form, Alert, Button } from 'react-bootstrap';
 import {
   GiStoneAxe,
   GiBowArrow,
@@ -12,8 +12,16 @@ import apiFetch from '../../utils/apiFetch';
 /** @typedef {import('../../../../types/weapon').Weapon} Weapon */
 
 /**
- * List of weapons with ownership toggles.
- * @param {{ campaign?: string, onChange?: (weapons: Weapon[]) => void, initialWeapons?: Weapon[], characterId?: string, show?: boolean, embedded?: boolean }} props
+ * List of weapons with proficiency toggles and cart actions.
+ * @param {{
+ *   campaign?: string,
+ *   onChange?: (weapons: Weapon[]) => void,
+ *   initialWeapons?: Weapon[],
+ *   characterId?: string,
+ *   show?: boolean,
+ *   embedded?: boolean,
+ *   onAddToCart?: (weapon: Weapon & { type?: string }) => void,
+ * }} props
  */
 function WeaponList({
   campaign,
@@ -22,6 +30,7 @@ function WeaponList({
   characterId,
   show = true,
   embedded = false,
+  onAddToCart = () => {},
 }) {
   const [weapons, setWeapons] =
     useState/** @type {Record<string, Weapon & { owned?: boolean, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
@@ -150,28 +159,13 @@ function WeaponList({
     'martial ranged': GiCrossbow,
   };
 
-  const handleOwnedToggle = (key) => () => {
-    const weapon = weapons[key];
-    const desired = !weapon.owned;
-    const nextWeapons = {
-      ...weapons,
-      [key]: { ...weapon, owned: desired },
+  const handleAddToCart = (weapon) => () => {
+    const payload = {
+      ...weapon,
+      ...(weapon.type ? { weaponType: weapon.type } : {}),
+      type: 'weapon',
     };
-    setWeapons(nextWeapons);
-    if (typeof onChange === 'function') {
-      const ownedWeapons = Object.values(nextWeapons)
-        .filter((w) => w.owned)
-        .map(({ name, category, damage, properties, weight, cost, type }) => ({
-          name,
-          category,
-          damage,
-          properties,
-          weight,
-          cost,
-          type,
-        }));
-      onChange(ownedWeapons);
-    }
+    onAddToCart(payload);
   };
 
   const handleToggle = (key) => async () => {
@@ -234,15 +228,7 @@ function WeaponList({
                   <Card.Text>Weight: {weapon.weight}</Card.Text>
                   <Card.Text>Cost: {weapon.cost}</Card.Text>
                 </Card.Body>
-                <Card.Footer className="d-flex justify-content-center gap-2">
-                  <Form.Check
-                    type="checkbox"
-                    className="weapon-checkbox"
-                    label="Owned"
-                    checked={weapon.owned}
-                    onChange={handleOwnedToggle(key)}
-                    aria-label={weapon.displayName || weapon.name}
-                  />
+                <Card.Footer className="d-flex justify-content-center gap-2 flex-wrap">
                   <Form.Check
                     type="checkbox"
                     className="weapon-checkbox"
@@ -257,6 +243,9 @@ function WeaponList({
                         : undefined
                     }
                   />
+                  <Button size="sm" onClick={handleAddToCart(weapon)}>
+                    Add to Cart
+                  </Button>
                 </Card.Footer>
               </Card>
             </Col>

--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Modal, Card, Tab, Button, Nav } from 'react-bootstrap';
 import WeaponList from '../../Weapons/WeaponList';
 import ArmorList from '../../Armor/ArmorList';
@@ -244,6 +244,7 @@ export default function ShopModal({
   onTabChange,
   currency = {},
 }) {
+  const [cart, setCart] = useState([]);
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
   );
@@ -253,6 +254,10 @@ export default function ShopModal({
       : activeTabState) || DEFAULT_TAB;
 
   const { cp = 0, sp = 0, gp = 0, pp = 0 } = currency || {};
+
+  const handleAddToCart = useCallback((item) => {
+    setCart((prevCart) => [...prevCart, item]);
+  }, []);
 
   useEffect(() => {
     if (activeTab && activeTab !== activeTabState) {
@@ -294,6 +299,7 @@ export default function ShopModal({
               onChange={onWeaponsChange}
               characterId={characterId}
               show={isActive}
+              onAddToCart={handleAddToCart}
             />
           ) : null,
       },
@@ -309,6 +315,7 @@ export default function ShopModal({
               characterId={characterId}
               show={isActive}
               strength={strength}
+              onAddToCart={handleAddToCart}
             />
           ) : null,
       },
@@ -324,6 +331,7 @@ export default function ShopModal({
               characterId={characterId}
               show={isActive}
               onClose={onHide}
+              onAddToCart={handleAddToCart}
             />
           ) : null,
       },
@@ -334,6 +342,7 @@ export default function ShopModal({
       normalizedArmor,
       normalizedItems,
       normalizedWeapons,
+      handleAddToCart,
       onArmorChange,
       onHide,
       onItemsChange,
@@ -369,7 +378,8 @@ export default function ShopModal({
                   </Nav.Item>
                 ))}
               </Nav>
-              <div className="ms-auto text-nowrap">
+              <div className="ms-auto d-flex align-items-center gap-3 text-nowrap">
+                <span>Cart: {cart.length}</span>
                 PP {pp} • GP {gp} • SP {sp} • CP {cp}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a cart callback to weapon, armor, and item lists and replace the old Owned checkbox with a small “Add to Cart” button that supplies type-tagged payloads
- track cart selections inside the shop modal, surface the current cart size, and pass the add-to-cart handler through to each tab
- refresh the Jest suites for the affected lists to exercise the new cart behavior

## Testing
- CI=true npm --prefix client test -- WeaponList.test.js ArmorList.test.js ItemList.test.js ShopModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c89df6e8d0832eae01ec7d943219cd