### PR TITLE
Add cart interaction coverage for shop modal

### DIFF
--- a/client/src/components/Armor/ArmorList.test.js
+++ b/client/src/components/Armor/ArmorList.test.js
@@ -37,6 +37,7 @@ const customData = [
     stealth: false,
     weight: 5,
     cost: '1000 gp',
+    type: 'shield',
   },
 ];
 
@@ -65,18 +66,28 @@ test('fetches armor and handles add to cart', async () => {
   expect(apiFetch).toHaveBeenCalledWith('/armor');
   expect(apiFetch).toHaveBeenCalledWith('/equipment/armor/Camp1');
   expect(apiFetch).toHaveBeenCalledWith('/armor-proficiency/char1');
-  const chainMailHeading = await screen.findByText('Chain Mail');
-  const chainMailButton = within(chainMailHeading.closest('.card')).getByRole(
+  const forceShieldHeading = await screen.findByText('Force Shield');
+  const forceShieldButton = within(
+    forceShieldHeading.closest('.card')
+  ).getByRole(
     'button',
     {
       name: /add to cart/i,
     }
   );
 
-  await userEvent.click(chainMailButton);
+  await userEvent.click(forceShieldButton);
 
   expect(onAddToCart).toHaveBeenCalledWith(
-    expect.objectContaining({ name: 'chain mail', type: 'armor' })
+    expect.objectContaining({
+      name: 'force shield',
+      displayName: 'Force Shield',
+      type: 'armor',
+      armorType: 'shield',
+      cost: '1000 gp',
+      acBonus: 8,
+      category: 'special',
+    })
   );
 });
 

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -48,7 +48,14 @@ test('fetches items and handles add to cart', async () => {
   await userEvent.click(addButton);
 
   expect(onAddToCart).toHaveBeenCalledWith(
-    expect.objectContaining({ name: 'potion-healing', type: 'item' })
+    expect.objectContaining({
+      name: 'potion-healing',
+      displayName: 'Potion of healing',
+      type: 'item',
+      cost: '50 gp',
+      category: 'adventuring gear',
+      weight: 0.5,
+    })
   );
 });
 

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -10,7 +10,15 @@ const weaponsData = {
   dagger: { name: 'Dagger', damage: '1d4 piercing', category: 'simple melee', properties: ['finesse'], weight: 1, cost: '2 gp' },
 };
 const customData = [
-  { name: 'Laser Sword', damage: '1d8 radiant', category: 'martial melee', properties: [] },
+  {
+    name: 'Laser Sword',
+    damage: '1d8 radiant',
+    category: 'martial melee',
+    properties: [],
+    type: 'exotic',
+    cost: '100 gp',
+    weight: 6,
+  },
 ];
 
 afterEach(() => {
@@ -37,15 +45,24 @@ test('fetches weapons and handles add to cart', async () => {
   expect(apiFetch).toHaveBeenCalledWith('/weapons');
   expect(apiFetch).toHaveBeenCalledWith('/equipment/weapons/Camp1');
   expect(apiFetch).toHaveBeenCalledWith('/weapon-proficiency/char1');
-  const daggerCard = await screen.findByText('Dagger');
-  const daggerButton = within(daggerCard.closest('.card')).getByRole('button', {
+  const laserHeading = await screen.findByText('Laser Sword');
+  const laserButton = within(laserHeading.closest('.card')).getByRole('button', {
     name: /add to cart/i,
   });
 
-  await userEvent.click(daggerButton);
+  await userEvent.click(laserButton);
 
   expect(onAddToCart).toHaveBeenCalledWith(
-    expect.objectContaining({ name: 'dagger', type: 'weapon' })
+    expect.objectContaining({
+      name: 'laser sword',
+      displayName: 'Laser Sword',
+      type: 'weapon',
+      weaponType: 'exotic',
+      cost: '100 gp',
+      damage: '1d8 radiant',
+      category: 'martial melee',
+      weight: 6,
+    })
   );
 });
 


### PR DESCRIPTION
## Summary
- extend the ShopModal tests with add/remove cart flows that exercise the mocked list components
- verify the weapon, armor, and item list tests assert the onAddToCart payload includes the expected metadata

## Testing
- CI=true npm test -- ShopModal.test.js WeaponList.test.js ArmorList.test.js ItemList.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8a1aee0c4832eb77ae2d3ee7986be