### PR TITLE
Improve shop cart button accessibility

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1334,6 +1334,30 @@ h1 {
   width: 100%;
 }
 
+.shop-cart-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  color: inherit;
+}
+
+.shop-cart-btn svg {
+  color: currentColor;
+}
+
+.modern-card .shop-cart-btn {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.modern-card .shop-cart-btn:hover,
+.modern-card .shop-cart-btn:focus {
+  color: #000;
+  background-color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.85);
+}
+
 /* Points Section */
 .points-container {
   display: flex;

--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -393,8 +393,9 @@ export default function ShopModal({
               <div className="ms-auto d-flex align-items-center gap-3 text-nowrap">
                 <span>PP {pp} • GP {gp} • SP {sp} • CP {cp}</span>
                 <Button
-                  variant="link"
-                  className="position-relative p-0"
+                  variant="outline-secondary"
+                  className="shop-cart-btn position-relative"
+                  aria-label="View cart"
                   onClick={() => setShowCart(true)}
                 >
                   <FaShoppingCart size={20} />

--- a/client/src/components/Zombies/attributes/ShopModal.test.js
+++ b/client/src/components/Zombies/attributes/ShopModal.test.js
@@ -196,7 +196,7 @@ describe('cart interactions', () => {
   }) => {
     renderShopModal();
 
-    const cartButton = screen.getByRole('button', { name: '0' });
+    const cartButton = screen.getByRole('button', { name: /view cart/i });
 
     if (tab) {
       await act(async () => {


### PR DESCRIPTION
## Summary
- switch the shop cart trigger to an outline button with an aria-label for screen reader support
- add shared styling to keep the cart button icon visible in the dark modal layout
- update the ShopModal test to look up the cart button by its new accessible name

## Testing
- CI=1 npm --prefix client test -- ShopModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8a5b5dfd4832e990009576e9e0216