### PR TITLE
Add Zombies inventory modal and tests

### DIFF
--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -22,6 +22,7 @@ import apiFetch from '../../utils/apiFetch';
  *   strength?: number,
  *   embedded?: boolean,
  *   onAddToCart?: (armor: Armor & { type?: string }) => void,
+ *   ownedOnly?: boolean,
  * }} props
  */
 function ArmorList({
@@ -33,6 +34,7 @@ function ArmorList({
   strength = Number.POSITIVE_INFINITY,
   embedded = false,
   onAddToCart = () => {},
+  ownedOnly = false,
 }) {
   const [armor, setArmor] =
     useState/** @type {Record<string, Armor & { owned?: boolean, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
@@ -210,6 +212,10 @@ function ArmorList({
   };
 
   const bodyStyle = { overflowY: 'auto', maxHeight: '70vh' };
+  const entries = Object.entries(armor).filter(([, piece]) =>
+    ownedOnly ? piece.owned : true
+  );
+
   const bodyContent = error ? (
     <div className="text-danger">{error}</div>
   ) : (
@@ -219,13 +225,20 @@ function ArmorList({
           Unrecognized armor from server: {unknownArmor.join(', ')}
         </Alert>
       )}
-      <Row className="g-2">
-        {Object.entries(armor).map(([key, piece]) => {
-          const Icon = categoryIcons[piece.category] || GiArmorVest;
-          return (
-            <Col xs={6} md={4} key={key}>
-              <Card className="armor-card h-100">
-                <Card.Body className="d-flex flex-column">
+      {entries.length === 0 ? (
+        <div className="text-center text-muted py-3">
+          {ownedOnly
+            ? 'No armor in inventory.'
+            : 'No armor available.'}
+        </div>
+      ) : (
+        <Row className="g-2">
+          {entries.map(([key, piece]) => {
+            const Icon = categoryIcons[piece.category] || GiArmorVest;
+            return (
+              <Col xs={6} md={4} key={key}>
+                <Card className="armor-card h-100">
+                  <Card.Body className="d-flex flex-column">
                   <div className="d-flex justify-content-center mb-2">
                     <Icon size={40} title={piece.category} />
                   </div>
@@ -271,15 +284,18 @@ function ArmorList({
                         : undefined
                     }
                   />
-                  <Button size="sm" onClick={handleAddToCart(piece)}>
-                    Add to Cart
-                  </Button>
+                  {!ownedOnly && (
+                    <Button size="sm" onClick={handleAddToCart(piece)}>
+                      Add to Cart
+                    </Button>
+                  )}
                 </Card.Footer>
               </Card>
             </Col>
           );
-        })}
-      </Row>
+          })}
+        </Row>
+      )}
     </>
   );
 

--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -53,6 +53,7 @@ const renderBonuses = (bonuses, labels) =>
  *   onClose?: () => void,
  *   embedded?: boolean,
  *   onAddToCart?: (item: Item & { type?: string }) => void,
+ *   ownedOnly?: boolean,
  * }} props
  */
 function ItemList({
@@ -64,6 +65,7 @@ function ItemList({
   onClose,
   embedded = false,
   onAddToCart = () => {},
+  ownedOnly = false,
 }) {
   const [items, setItems] =
     useState/** @type {Record<string, Item & { owned?: boolean, displayName?: string }> | null} */(null);
@@ -171,6 +173,9 @@ function ItemList({
   const handleShowNotes = (item) => () => setNotesItem(item);
 
   const bodyStyle = { overflowY: 'auto', maxHeight: '70vh' };
+  const entries = Object.entries(items).filter(([, item]) =>
+    ownedOnly ? item.owned : true
+  );
   const bodyContent = (
     <>
       {error && (
@@ -185,53 +190,71 @@ function ItemList({
           Unrecognized items from server: {unknownItems.join(', ')}
         </Alert>
       )}
-      <Row className="row-cols-2 row-cols-lg-3 g-3">
-        {Object.entries(items).map(([key, item]) => {
-          const categoryKey =
-            typeof item.category === 'string' ? item.category.toLowerCase() : '';
-          const Icon = categoryIcons[categoryKey] || GiTreasureMap;
-          return (
-            <Col key={key}>
-              <Card className="item-card h-100">
-                <Card.Body className="d-flex flex-column">
-                  <div className="d-flex justify-content-center mb-2">
-                    <Icon size={40} title={item.category} />
-                  </div>
-                  <Card.Title>{item.displayName || item.name}</Card.Title>
-                  <Card.Text>Category: {item.category}</Card.Text>
-                  <Card.Text>Weight: {item.weight}</Card.Text>
-                  <Card.Text>Cost: {item.cost}</Card.Text>
-                  {renderBonuses(item.statBonuses, STAT_LABELS) && (
-                    <Card.Text>
-                      Stat Bonuses: {renderBonuses(item.statBonuses, STAT_LABELS)}
-                    </Card.Text>
+      {entries.length === 0 ? (
+        <div className="text-center text-muted py-3">
+          {ownedOnly
+            ? 'No items in inventory.'
+            : 'No items available.'}
+        </div>
+      ) : (
+        <Row className="row-cols-2 row-cols-lg-3 g-3">
+          {entries.map(([key, item]) => {
+            const categoryKey =
+              typeof item.category === 'string'
+                ? item.category.toLowerCase()
+                : '';
+            const Icon = categoryIcons[categoryKey] || GiTreasureMap;
+            return (
+              <Col key={key}>
+                <Card className="item-card h-100">
+                  <Card.Body className="d-flex flex-column">
+                    <div className="d-flex justify-content-center mb-2">
+                      <Icon size={40} title={item.category} />
+                    </div>
+                    <Card.Title>{item.displayName || item.name}</Card.Title>
+                    <Card.Text>Category: {item.category}</Card.Text>
+                    <Card.Text>Weight: {item.weight}</Card.Text>
+                    <Card.Text>Cost: {item.cost}</Card.Text>
+                    {renderBonuses(item.statBonuses, STAT_LABELS) && (
+                      <Card.Text>
+                        Stat Bonuses: {renderBonuses(
+                          item.statBonuses,
+                          STAT_LABELS
+                        )}
+                      </Card.Text>
+                    )}
+                    {renderBonuses(item.skillBonuses, SKILL_LABELS) && (
+                      <Card.Text>
+                        Skill Bonuses: {renderBonuses(
+                          item.skillBonuses,
+                          SKILL_LABELS
+                        )}
+                      </Card.Text>
+                    )}
+                    {item.notes && (
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="mt-auto align-self-start p-0"
+                        onClick={handleShowNotes(item)}
+                      >
+                        Notes
+                      </Button>
+                    )}
+                  </Card.Body>
+                  {!ownedOnly && (
+                    <Card.Footer className="d-flex justify-content-center">
+                      <Button size="sm" onClick={handleAddToCart(item)}>
+                        Add to Cart
+                      </Button>
+                    </Card.Footer>
                   )}
-                  {renderBonuses(item.skillBonuses, SKILL_LABELS) && (
-                    <Card.Text>
-                      Skill Bonuses: {renderBonuses(item.skillBonuses, SKILL_LABELS)}
-                    </Card.Text>
-                  )}
-                  {item.notes && (
-                    <Button
-                      variant="link"
-                      size="sm"
-                      className="mt-auto align-self-start p-0"
-                      onClick={handleShowNotes(item)}
-                    >
-                      Notes
-                    </Button>
-                  )}
-                </Card.Body>
-                <Card.Footer className="d-flex justify-content-center">
-                  <Button size="sm" onClick={handleAddToCart(item)}>
-                    Add to Cart
-                  </Button>
-                </Card.Footer>
-              </Card>
-            </Col>
-          );
-        })}
-      </Row>
+                </Card>
+              </Col>
+            );
+          })}
+        </Row>
+      )}
     </>
   );
 

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -21,6 +21,7 @@ import apiFetch from '../../utils/apiFetch';
  *   show?: boolean,
  *   embedded?: boolean,
  *   onAddToCart?: (weapon: Weapon & { type?: string }) => void,
+ *   ownedOnly?: boolean,
  * }} props
  */
 function WeaponList({
@@ -31,6 +32,7 @@ function WeaponList({
   show = true,
   embedded = false,
   onAddToCart = () => {},
+  ownedOnly = false,
 }) {
   const [weapons, setWeapons] =
     useState/** @type {Record<string, Weapon & { owned?: boolean, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
@@ -200,6 +202,10 @@ function WeaponList({
   };
 
   const bodyStyle = { overflowY: 'auto', maxHeight: '70vh' };
+  const entries = Object.entries(weapons).filter(([, weapon]) =>
+    ownedOnly ? weapon.owned : true
+  );
+
   const bodyContent = error ? (
     <div className="text-danger">{error}</div>
   ) : (
@@ -209,13 +215,20 @@ function WeaponList({
           Unrecognized weapons from server: {unknownWeapons.join(', ')}
         </Alert>
       )}
-      <Row className="row-cols-2 row-cols-lg-3 g-3">
-        {Object.entries(weapons).map(([key, weapon]) => {
-          const Icon = categoryIcons[weapon.category] || GiCrossedSwords;
-          return (
-            <Col key={key}>
-              <Card className="weapon-card h-100">
-                <Card.Body className="d-flex flex-column">
+      {entries.length === 0 ? (
+        <div className="text-center text-muted py-3">
+          {ownedOnly
+            ? 'No weapons in inventory.'
+            : 'No weapons available.'}
+        </div>
+      ) : (
+        <Row className="row-cols-2 row-cols-lg-3 g-3">
+          {entries.map(([key, weapon]) => {
+            const Icon = categoryIcons[weapon.category] || GiCrossedSwords;
+            return (
+              <Col key={key}>
+                <Card className="weapon-card h-100">
+                  <Card.Body className="d-flex flex-column">
                   <div className="d-flex justify-content-center mb-2">
                     <Icon size={40} title={weapon.category} />
                   </div>
@@ -243,15 +256,18 @@ function WeaponList({
                         : undefined
                     }
                   />
-                  <Button size="sm" onClick={handleAddToCart(weapon)}>
-                    Add to Cart
-                  </Button>
+                  {!ownedOnly && (
+                    <Button size="sm" onClick={handleAddToCart(weapon)}>
+                      Add to Cart
+                    </Button>
+                  )}
                 </Card.Footer>
               </Card>
             </Col>
           );
-        })}
-      </Row>
+          })}
+        </Row>
+      )}
     </>
   );
 

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -1,0 +1,401 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Card, Tab, Nav, Button } from 'react-bootstrap';
+import WeaponList from '../../Weapons/WeaponList';
+import ArmorList from '../../Armor/ArmorList';
+import ItemList from '../../Items/ItemList';
+
+const DEFAULT_TAB = 'weapons';
+
+const parseProperties = (value) => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((prop) => prop.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const normalizeWeapons = (weapons) => {
+  if (!Array.isArray(weapons)) return [];
+  return weapons
+    .map((weapon) => {
+      if (!weapon || weapon.owned === false) return null;
+      if (Array.isArray(weapon)) {
+        if (weapon.owned === false) return null;
+        const [
+          name,
+          category,
+          damage,
+          properties,
+          weight,
+          cost,
+          type,
+          attackBonus,
+        ] = weapon;
+        if (!name) return null;
+        const normalized = {
+          name,
+          category: category ?? '',
+          damage: typeof damage === 'string' ? damage : String(damage || ''),
+          properties: parseProperties(properties),
+          weight: weight ?? '',
+          cost: cost ?? '',
+        };
+        if (type !== undefined) normalized.type = type;
+        if (attackBonus !== undefined) normalized.attackBonus = attackBonus;
+        return normalized;
+      }
+      if (typeof weapon === 'string') {
+        return {
+          name: weapon,
+          category: '',
+          damage: '',
+          properties: [],
+          weight: '',
+          cost: '',
+        };
+      }
+      if (typeof weapon === 'object') {
+        const {
+          name,
+          category = '',
+          damage = '',
+          properties,
+          weight = '',
+          cost = '',
+          type,
+          attackBonus,
+          owned,
+          ...rest
+        } = weapon;
+        if (!name || owned === false) return null;
+        return {
+          name,
+          category,
+          damage: typeof damage === 'string' ? damage : String(damage || ''),
+          properties: parseProperties(properties),
+          weight,
+          cost,
+          ...(type !== undefined ? { type } : {}),
+          ...(attackBonus !== undefined ? { attackBonus } : {}),
+          ...rest,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+};
+
+const normalizeArmor = (armor) => {
+  if (!Array.isArray(armor)) return [];
+  return armor
+    .map((piece) => {
+      if (!piece || piece.owned === false) return null;
+      if (Array.isArray(piece)) {
+        if (piece.owned === false) return null;
+        const [
+          name,
+          acBonus,
+          maxDex,
+          strengthRequirement,
+          stealth,
+          weight,
+          cost,
+          type,
+        ] = piece;
+        if (!name) return null;
+        const normalized = {
+          name,
+          acBonus: acBonus ?? '',
+          maxDex: maxDex ?? null,
+        };
+        if (strengthRequirement !== undefined)
+          normalized.strength = strengthRequirement;
+        if (stealth !== undefined) normalized.stealth = stealth;
+        if (weight !== undefined) normalized.weight = weight;
+        if (cost !== undefined) normalized.cost = cost;
+        if (type !== undefined) normalized.type = type;
+        return normalized;
+      }
+      if (typeof piece === 'string') {
+        return {
+          name: piece,
+          acBonus: '',
+          maxDex: null,
+          strength: null,
+          stealth: null,
+          weight: '',
+          cost: '',
+        };
+      }
+      if (typeof piece === 'object') {
+        const {
+          name,
+          acBonus = '',
+          maxDex = null,
+          strength = null,
+          stealth = null,
+          weight = '',
+          cost = '',
+          type,
+          owned,
+          ...rest
+        } = piece;
+        if (!name || owned === false) return null;
+        return {
+          name,
+          acBonus,
+          maxDex,
+          strength,
+          stealth,
+          weight,
+          cost,
+          ...(type !== undefined ? { type } : {}),
+          ...rest,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+};
+
+const normalizeItems = (items) => {
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item) => {
+      if (!item || item.owned === false) return null;
+      if (Array.isArray(item)) {
+        if (item.owned === false) return null;
+        const [
+          name,
+          category,
+          weight,
+          cost,
+          notes,
+          statBonuses,
+          skillBonuses,
+        ] = item;
+        if (!name) return null;
+        const normalized = {
+          name,
+          category: category ?? '',
+          weight: weight ?? '',
+          cost: cost ?? '',
+          statBonuses:
+            statBonuses && typeof statBonuses === 'object' ? statBonuses : {},
+          skillBonuses:
+            skillBonuses && typeof skillBonuses === 'object'
+              ? skillBonuses
+              : {},
+        };
+        if (notes) normalized.notes = notes;
+        return normalized;
+      }
+      if (typeof item === 'string') {
+        return {
+          name: item,
+          category: '',
+          weight: '',
+          cost: '',
+          statBonuses: {},
+          skillBonuses: {},
+        };
+      }
+      if (typeof item === 'object') {
+        const {
+          name,
+          category = '',
+          weight = '',
+          cost = '',
+          statBonuses,
+          skillBonuses,
+          notes,
+          owned,
+          ...rest
+        } = item;
+        if (!name || owned === false) return null;
+        const normalized = {
+          name,
+          category,
+          weight,
+          cost,
+          statBonuses:
+            statBonuses && typeof statBonuses === 'object' ? statBonuses : {},
+          skillBonuses:
+            skillBonuses && typeof skillBonuses === 'object'
+              ? skillBonuses
+              : {},
+          ...rest,
+        };
+        if (notes) normalized.notes = notes;
+        return normalized;
+      }
+      return null;
+    })
+    .filter(Boolean);
+};
+
+export default function InventoryModal({
+  show,
+  activeTab,
+  onHide,
+  onTabChange,
+  form = {},
+  characterId,
+}) {
+  const [activeTabState, setActiveTabState] = useState(
+    activeTab || DEFAULT_TAB
+  );
+
+  useEffect(() => {
+    if (activeTab && activeTab !== activeTabState) {
+      setActiveTabState(activeTab);
+    }
+  }, [activeTab, activeTabState]);
+
+  const currentTab =
+    (typeof activeTab === 'string' && activeTab.length
+      ? activeTab
+      : activeTabState) || DEFAULT_TAB;
+
+  const normalizedWeapons = useMemo(
+    () => normalizeWeapons(form.weapon || []),
+    [form.weapon]
+  );
+  const normalizedArmor = useMemo(
+    () => normalizeArmor(form.armor || []),
+    [form.armor]
+  );
+  const normalizedItems = useMemo(
+    () => normalizeItems(form.item || []),
+    [form.item]
+  );
+
+  const handleSelectTab = (key) => {
+    if (!key || key === currentTab) return;
+    setActiveTabState(key);
+    if (typeof onTabChange === 'function') {
+      onTabChange(key);
+    }
+  };
+
+  const tabConfigs = useMemo(
+    () => [
+      {
+        key: 'weapons',
+        title: 'Weapons',
+        render: (isActive) =>
+          !isActive ? null : normalizedWeapons.length === 0 ? (
+            <div className="text-center text-muted py-3">
+              No weapons in inventory.
+            </div>
+          ) : (
+            <WeaponList
+              campaign={form.campaign}
+              initialWeapons={normalizedWeapons}
+              characterId={characterId}
+              show={isActive}
+              embedded
+              ownedOnly
+            />
+          ),
+      },
+      {
+        key: 'armor',
+        title: 'Armor',
+        render: (isActive) =>
+          !isActive ? null : normalizedArmor.length === 0 ? (
+            <div className="text-center text-muted py-3">
+              No armor in inventory.
+            </div>
+          ) : (
+            <ArmorList
+              campaign={form.campaign}
+              initialArmor={normalizedArmor}
+              characterId={characterId}
+              show={isActive}
+              embedded
+              ownedOnly
+            />
+          ),
+      },
+      {
+        key: 'items',
+        title: 'Items',
+        render: (isActive) =>
+          !isActive ? null : normalizedItems.length === 0 ? (
+            <div className="text-center text-muted py-3">
+              No items in inventory.
+            </div>
+          ) : (
+            <ItemList
+              campaign={form.campaign}
+              initialItems={normalizedItems}
+              characterId={characterId}
+              show={isActive}
+              embedded
+              ownedOnly
+            />
+          ),
+      },
+    ],
+    [
+      characterId,
+      form.campaign,
+      normalizedArmor,
+      normalizedItems,
+      normalizedWeapons,
+    ]
+  );
+
+  return (
+    <Modal
+      className="dnd-modal modern-modal"
+      show={show}
+      onHide={onHide}
+      size="lg"
+      centered
+      scrollable
+      fullscreen="sm-down"
+    >
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Inventory</Card.Title>
+        </Card.Header>
+        <Card.Body
+          className="modal-body"
+          style={{ maxHeight: '80vh', overflowY: 'auto' }}
+        >
+          <Tab.Container activeKey={currentTab} onSelect={handleSelectTab}>
+            <div className="d-flex justify-content-between align-items-center mb-3">
+              <Nav variant="tabs" className="mb-0">
+                {tabConfigs.map(({ key, title }) => (
+                  <Nav.Item key={key}>
+                    <Nav.Link eventKey={key}>{title}</Nav.Link>
+                  </Nav.Item>
+                ))}
+              </Nav>
+            </div>
+            <Tab.Content>
+              {tabConfigs.map(({ key, render }) => {
+                const isActive = show && currentTab === key;
+                return (
+                  <Tab.Pane eventKey={key} key={key}>
+                    {render(isActive)}
+                  </Tab.Pane>
+                );
+              })}
+            </Tab.Content>
+          </Tab.Container>
+        </Card.Body>
+        <Card.Footer className="modal-footer">
+          <Button className="action-btn close-btn" onClick={onHide}>
+            Close
+          </Button>
+        </Card.Footer>
+      </Card>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/InventoryModal.test.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.test.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockWeaponListProps = { current: null };
+const mockArmorListProps = { current: null };
+const mockItemListProps = { current: null };
+
+jest.mock('../../Weapons/WeaponList', () => {
+  const React = require('react');
+  return (props) => {
+    mockWeaponListProps.current = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid="weapon-list">
+        {(props.initialWeapons || []).map((weapon) => (
+          <span key={weapon.name}>{weapon.name}</span>
+        ))}
+      </div>
+    );
+  };
+});
+
+jest.mock('../../Armor/ArmorList', () => {
+  const React = require('react');
+  return (props) => {
+    mockArmorListProps.current = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid="armor-list">
+        {(props.initialArmor || []).map((armor) => (
+          <span key={armor.name}>{armor.name}</span>
+        ))}
+      </div>
+    );
+  };
+});
+
+jest.mock('../../Items/ItemList', () => {
+  const React = require('react');
+  return (props) => {
+    mockItemListProps.current = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid="item-list">
+        {(props.initialItems || []).map((item) => (
+          <span key={item.name}>{item.name}</span>
+        ))}
+      </div>
+    );
+  };
+});
+
+import InventoryModal from './InventoryModal';
+
+describe('InventoryModal', () => {
+  beforeEach(() => {
+    mockWeaponListProps.current = null;
+    mockArmorListProps.current = null;
+    mockItemListProps.current = null;
+  });
+
+  test('switches tabs between weapons, armor, and items', async () => {
+    const form = {
+      weapon: [['Sword']],
+      armor: [['Shield Mail']],
+      item: [['Rations']],
+    };
+
+    render(
+      <InventoryModal
+        show
+        onHide={jest.fn()}
+        onTabChange={jest.fn()}
+        form={form}
+      />
+    );
+
+    expect(await screen.findByTestId('weapon-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('armor-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('item-list')).not.toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Armor' }));
+    });
+
+    expect(await screen.findByTestId('armor-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('weapon-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('item-list')).not.toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
+    });
+
+    expect(await screen.findByTestId('item-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('weapon-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('armor-list')).not.toBeInTheDocument();
+  });
+
+  test('only renders owned equipment from the form data', async () => {
+    const form = {
+      weapon: [
+        ['Longsword', 'martial melee'],
+        { name: 'Dagger', owned: true },
+        { name: 'Great Axe', owned: false },
+        null,
+      ],
+      armor: [
+        ['Chain Mail', 16],
+        { name: 'Leather Armor', owned: false },
+      ],
+      item: [
+        ['Torch'],
+        { name: 'Potion of Healing', owned: true },
+        { name: 'Scroll', owned: false },
+      ],
+    };
+
+    render(
+      <InventoryModal
+        show
+        onHide={jest.fn()}
+        onTabChange={jest.fn()}
+        form={form}
+      />
+    );
+
+    const weaponList = await screen.findByTestId('weapon-list');
+    expect(weaponList).toHaveTextContent('Longsword');
+    expect(weaponList).toHaveTextContent('Dagger');
+    expect(weaponList).not.toHaveTextContent('Great Axe');
+
+    expect(mockWeaponListProps.current?.ownedOnly).toBe(true);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Armor' }));
+    });
+
+    const armorList = await screen.findByTestId('armor-list');
+    expect(armorList).toHaveTextContent('Chain Mail');
+    expect(armorList).not.toHaveTextContent('Leather Armor');
+    expect(mockArmorListProps.current?.ownedOnly).toBe(true);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
+    });
+
+    const itemList = await screen.findByTestId('item-list');
+    expect(itemList).toHaveTextContent('Torch');
+    expect(itemList).toHaveTextContent('Potion of Healing');
+    expect(itemList).not.toHaveTextContent('Scroll');
+    expect(mockItemListProps.current?.ownedOnly).toBe(true);
+  });
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -24,6 +24,7 @@ import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import hasteIcon from "../../../images/spell-haste-icon.png";
 import ShopModal from "../attributes/ShopModal";
+import InventoryModal from "../attributes/InventoryModal";
 
 const HEADER_PADDING = 16;
 const SPELLCASTING_CLASSES = {
@@ -48,6 +49,8 @@ export default function ZombiesCharacterSheet() {
   const [showFeatures, setShowFeatures] = useState(false);
   const [showShop, setShowShop] = useState(false);
   const [shopTab, setShopTab] = useState('weapons');
+  const [showInventory, setShowInventory] = useState(false);
+  const [inventoryTab, setInventoryTab] = useState('weapons');
   const [showSpells, setShowSpells] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showBackground, setShowBackground] = useState(false);
@@ -244,6 +247,11 @@ export default function ZombiesCharacterSheet() {
     setShowShop(true);
   };
   const handleCloseShop = () => setShowShop(false);
+  const handleShowInventory = (tab) => {
+    setInventoryTab((prevTab) => tab ?? prevTab ?? 'weapons');
+    setShowInventory(true);
+  };
+  const handleCloseInventory = () => setShowInventory(false);
   const handleShowSpells = () => setShowSpells(true);
   const handleCloseSpells = () => setShowSpells(false);
   const handleShowHelpModal = () => setShowHelpModal(true);
@@ -803,6 +811,17 @@ return (
             </Button>
           )}
           <Button
+            onClick={() => handleShowInventory()}
+            style={{
+              color: "black",
+              backgroundColor: "#6C757D",
+            }}
+            className="footer-btn"
+            variant="secondary"
+          >
+            <i className="fas fa-box-open" aria-hidden="true"></i>
+          </Button>
+          <Button
             onClick={() => handleShowShop()}
             style={{
               color: "black",
@@ -861,6 +880,14 @@ return (
       longRestCount={longRestCount}
       shortRestCount={shortRestCount}
       actionCount={actionCount}
+    />
+    <InventoryModal
+      show={showInventory}
+      activeTab={inventoryTab}
+      onHide={handleCloseInventory}
+      onTabChange={setInventoryTab}
+      form={form}
+      characterId={characterId}
     />
     <ShopModal
       show={showShop}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -38,6 +38,11 @@ jest.mock('../../Items/ItemList', () => () => null);
 jest.mock('../attributes/Help', () => () => null);
 jest.mock('../attributes/BackgroundModal', () => () => null);
 jest.mock('../attributes/Features', () => () => null);
+const mockInventoryModalProps = { current: null };
+jest.mock('../attributes/InventoryModal', () => (props) => {
+  mockInventoryModalProps.current = props;
+  return null;
+});
 const mockShopModalProps = { current: null };
 jest.mock('../attributes/ShopModal', () => (props) => {
   mockShopModalProps.current = props;
@@ -61,6 +66,7 @@ beforeEach(() => {
   mockOnCastSpell.current = null;
   mockHandleClose.current = null;
   mockShopModalProps.current = null;
+  mockInventoryModalProps.current = null;
 });
 
 test('spells button includes points-glow when spell points available', async () => {
@@ -446,6 +452,51 @@ test('shop button opens ShopModal with default tab and retains previous tab', as
     expect(mockShopModalProps.current).toMatchObject({
       show: true,
       activeTab: 'armor',
+    })
+  );
+});
+
+test('inventory button opens InventoryModal with default tab', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  await waitFor(() => expect(mockInventoryModalProps.current).not.toBeNull());
+
+  const buttons = await screen.findAllByRole('button');
+  const inventoryButton = buttons.find((btn) =>
+    btn.querySelector('.fa-box-open')
+  );
+  expect(inventoryButton).toBeTruthy();
+
+  await act(async () => {
+    await userEvent.click(inventoryButton);
+  });
+
+  await waitFor(() =>
+    expect(mockInventoryModalProps.current).toMatchObject({
+      show: true,
+      activeTab: 'weapons',
     })
   );
 });


### PR DESCRIPTION
## Summary
- create a Zombies InventoryModal that shows owned weapons, armor, and items with tabbed navigation
- filter WeaponList, ArmorList, and ItemList when in owned-only mode and hide cart buttons in read-only view
- expose inventory controls on the character sheet and add tests for the new modal and button

## Testing
- CI=true npm test -- InventoryModal.test.js
- CI=true npm test -- ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8aaf2a510832e84dd6ca972ac8e41