### PR TITLE
Include useMemo in equipment list components

### DIFF
--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Form, Alert, Row, Col, Button, Badge } from 'react-bootstrap';
 import {
   GiLeatherArmor,

--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Row, Col, Alert, Button, Modal, Badge } from 'react-bootstrap';
 import {
   GiAmmoBox,

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Row, Col, Form, Alert, Button, Badge } from 'react-bootstrap';
 import {
   GiStoneAxe,


### PR DESCRIPTION
## Summary
- add `useMemo` to the React imports for the weapon, armor, and item list components so the hook is properly declared

## Testing
- npx eslint src/components/Weapons/WeaponList.js src/components/Armor/ArmorList.js src/components/Items/ItemList.js

------
https://chatgpt.com/codex/tasks/task_e_68c9e43fad64832e974cad38376a04d6