### PR TITLE
Refactor Zombies equipment pipeline

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -11,6 +11,7 @@ jest.mock('react-router-dom', () => ({
 
 const baseForm = {
   armor: [],
+  equipment: {},
   occupation: [{ Level: 3 }, { Level: 2 }],
   health: 10,
   tempHealth: 5,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -8,6 +8,8 @@ import { Button, Modal, Card, Table } from "react-bootstrap";
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
+import { normalizeEquipmentMap } from './equipmentNormalization';
+import { normalizeWeapons } from './inventoryNormalization';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -30,6 +32,8 @@ function formatDamageRolls(rolls) {
     .map(({ value, type }) => `${value}${type ? ` ${type}` : ''}`)
     .join(' + ');
 }
+
+const WEAPON_SLOT_KEYS = ['mainHand', 'offHand', 'ranged'];
 
 export function calculateDamage(
   damageString,
@@ -128,9 +132,42 @@ const PlayerTurnActions = React.forwardRef(
 //--------------------------------------------Critical status------------------------------------------------
 const [isCritical, setIsCritical] = useState(false);
 const [isFumble, setIsFumble] = useState(false);
+  const equipmentProvided = useMemo(
+    () => typeof form?.equipment === 'object' && form.equipment !== null,
+    [form.equipment]
+  );
+  const normalizedEquipment = useMemo(
+    () => normalizeEquipmentMap(form.equipment),
+    [form.equipment]
+  );
+  const equippedWeapons = useMemo(() => {
+    if (equipmentProvided) {
+      return WEAPON_SLOT_KEYS.map((slot) => {
+        const weapon = normalizedEquipment[slot];
+        if (!weapon) return null;
+        if (weapon.source && weapon.source !== 'weapon') return null;
+        const damage =
+          typeof weapon.damage === 'string' ? weapon.damage.trim() : '';
+        if (!damage) return null;
+        return { slot, weapon };
+      }).filter(Boolean);
+    }
+
+    const legacyWeapons = normalizeWeapons(form.weapon || [], {
+      includeUnowned: true,
+    });
+    return legacyWeapons.map((weapon, index) => ({
+      slot: `legacy-${index}`,
+      weapon,
+    }));
+  }, [equipmentProvided, normalizedEquipment, form.weapon]);
   // --------------------------------Breaks down weapon damage into useable numbers--------------------------------
-  const abilityForWeapon = (weapon) =>
-    weapon.category?.toLowerCase().includes('ranged') ? dexMod : strMod;
+  const abilityForWeapon = (weapon) => {
+    const category = weapon?.category;
+    return typeof category === 'string' && category.toLowerCase().includes('ranged')
+      ? dexMod
+      : strMod;
+  };
 
   const totalLevel = useMemo(
     () =>
@@ -146,22 +183,29 @@ const [isFumble, setIsFumble] = useState(false);
   const getAttackBonus = (weapon) =>
     profBonus +
     abilityForWeapon(weapon) +
-    Number(weapon.attackBonus || weapon.bonus || 0);
+    Number(weapon?.attackBonus ?? weapon?.bonus ?? 0);
 
   const getDamageString = (weapon) => {
     const ability = abilityForWeapon(weapon);
-    return weapon.damage
-      .split(/\s+\+\s+/)
+    if (typeof weapon?.damage !== 'string') return '—';
+    const segments = weapon.damage.split(/\s+\+\s+/);
+    if (segments.length === 0) return '—';
+    return segments
       .map((part) => {
-        const [token, ...rest] = part.trim().split(' ');
+        const trimmed = part.trim();
+        if (!trimmed) return null;
+        const [token, ...rest] = trimmed.split(' ');
+        if (!token) return null;
         const type = rest.join(' ').trim();
         return `${token}+${ability}${type ? ` ${type}` : ''}`;
       })
-      .join(' + ');
+      .filter(Boolean)
+      .join(' + ') || '—';
   };
 
   const handleWeaponAttack = (weapon) => {
     const ability = abilityForWeapon(weapon);
+    if (typeof weapon?.damage !== 'string' || !weapon.damage.trim()) return;
     const result = calculateDamage(weapon.damage, ability, isCritical);
     if (!result) return;
     updateDamageValueWithAnimation(result.total, result.breakdown);
@@ -542,10 +586,16 @@ const showSparklesEffect = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {Array.isArray(form.weapon) &&
-                    form.weapon.map((weapon) => (
-                      <tr key={weapon.name}>
-                        <td className="text-capitalize">{weapon.name}</td>
+                  {equippedWeapons.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="text-center text-muted">
+                        No weapons equipped.
+                      </td>
+                    </tr>
+                  ) : (
+                    equippedWeapons.map(({ slot, weapon }) => (
+                      <tr key={`${slot}-${weapon.name || slot}`}>
+                        <td className="text-capitalize">{weapon.name || 'Unknown'}</td>
                         <td>{getAttackBonus(weapon)}</td>
                         <td>{getDamageString(weapon)}</td>
                         <td>
@@ -561,7 +611,8 @@ const showSparklesEffect = () => {
                           </Button>
                         </td>
                       </tr>
-                    ))}
+                    ))
+                  )}
                 </tbody>
               </Table>
             {Array.isArray(form.spells) && form.spells.some((s) => s?.damage) && (

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -64,10 +64,15 @@ describe('PlayerTurnActions weapon damage display', () => {
       name: 'Frost Brand',
       damage: '1d4 cold + 1d6 slashing',
       category: 'melee',
+      source: 'weapon',
     };
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [weapon], spells: [] }}
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          spells: [],
+        }}
         strMod={2}
         atkBonus={0}
         dexMod={0}
@@ -89,12 +94,17 @@ describe('PlayerTurnActions damage log', () => {
       name: 'Frost Brand',
       damage: '1d4 cold + 1d6 slashing',
       category: 'melee',
+      source: 'weapon',
     };
     const orig = Math.random;
     Math.random = () => 0; // deterministic rolls
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [weapon], spells: [] }}
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          spells: [],
+        }}
         strMod={2}
         atkBonus={0}
         dexMod={0}
@@ -137,10 +147,15 @@ describe('PlayerTurnActions weapon damage display', () => {
       name: 'Frost Brand',
       damage: '1d4 cold + 1d6 slashing',
       category: 'melee',
+      source: 'weapon',
     };
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [weapon], spells: [] }}
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          spells: [],
+        }}
         strMod={2}
         atkBonus={0}
         dexMod={0}
@@ -162,7 +177,7 @@ describe('PlayerTurnActions critical events', () => {
 
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells: [] }}
+        form={{ diceColor: '#000000', equipment: {}, spells: [] }}
         strMod={0}
         dexMod={0}
       />
@@ -214,7 +229,7 @@ describe('PlayerTurnActions critical events', () => {
   test('clicking damageAmount toggles critical class', () => {
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells: [] }}
+        form={{ diceColor: '#000000', equipment: {}, spells: [] }}
         strMod={0}
         dexMod={0}
       />
@@ -252,7 +267,7 @@ describe('PlayerTurnActions spell casting', () => {
     };
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        form={{ diceColor: '#000000', equipment: {}, spells: [spell] }}
         strMod={0}
         dexMod={0}
         onCastSpell={onCastSpell}
@@ -293,7 +308,7 @@ describe('PlayerTurnActions spell casting', () => {
     };
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        form={{ diceColor: '#000000', equipment: {}, spells: [spell] }}
         strMod={0}
         atkBonus={0}
         dexMod={0}
@@ -343,7 +358,7 @@ describe('PlayerTurnActions spell casting', () => {
     };
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        form={{ diceColor: '#000000', equipment: {}, spells: [spell] }}
         strMod={0}
         dexMod={0}
         onCastSpell={onCastSpell}
@@ -384,7 +399,7 @@ describe('PlayerTurnActions spell casting', () => {
     };
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+        form={{ diceColor: '#000000', equipment: {}, spells: [spell] }}
         strMod={0}
         dexMod={0}
         onCastSpell={onCastSpell}
@@ -433,7 +448,7 @@ describe('PlayerTurnActions spell casting', () => {
     ];
     render(
       <PlayerTurnActions
-        form={{ diceColor: '#000000', weapon: [], spells }}
+        form={{ diceColor: '#000000', equipment: {}, spells }}
         strMod={0}
         dexMod={0}
       />
@@ -472,7 +487,7 @@ describe('cantrip scaling', () => {
       <PlayerTurnActions
         form={{
           diceColor: '#000000',
-          weapon: [],
+          equipment: {},
           spells: [{ ...baseSpell }],
           occupation: [{ Level: lvl }],
         }}

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -81,7 +81,10 @@ describe('item skill bonuses', () => {
     render(
       <Skills
         form={{
-          item: [{ skillBonuses: { acrobatics: 2 } }],
+          equipment: {
+            ringLeft: { name: 'Ring of Agility', skillBonuses: { acrobatics: 2 }, source: 'item' },
+          },
+          item: [],
           feat: [],
           race: {},
           skills: {},

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Card, Table, Modal, Button } from "react-bootstrap";
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
+import { normalizeEquipmentMap } from './equipmentNormalization';
 
 export default function Stats({ form, showStats, handleCloseStats }) {
   const [stats] = useState({
@@ -15,8 +16,15 @@ export default function Stats({ form, showStats, handleCloseStats }) {
 
   const [showBreakdown, setShowBreakdown] = useState(false);
   const [selectedStat, setSelectedStat] = useState(null);
+  const equippedItems = useMemo(() => {
+    if (typeof form?.equipment === 'object' && form.equipment !== null) {
+      const normalized = normalizeEquipmentMap(form.equipment);
+      return Object.values(normalized).filter(Boolean);
+    }
+    return Array.isArray(form.item) ? form.item.filter(Boolean) : [];
+  }, [form.equipment, form.item]);
 
-  const totalItemBonus = (form.item || []).reduce(
+  const totalItemBonus = equippedItems.reduce(
     (acc, el) => ({
       str: acc.str + Number(el.statBonuses?.str || 0),
       dex: acc.dex + Number(el.statBonuses?.dex || 0),

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -13,7 +13,10 @@ test('clicking view shows description and breakdown', async () => {
     cha: 0,
     race: { abilities: { str: 2 } },
     feat: [{ str: 1 }],
-    item: [{ statBonuses: { str: 1 } }],
+    equipment: {
+      ringLeft: { name: 'Belt of Strength', statBonuses: { str: 1 }, source: 'item' },
+    },
+    item: [],
     occupation: [{ str: 1 }],
   };
 

--- a/client/src/components/Zombies/attributes/equipmentSlots.js
+++ b/client/src/components/Zombies/attributes/equipmentSlots.js
@@ -20,6 +20,7 @@ export const EQUIPMENT_SLOT_LAYOUT = [
   [
     { key: 'mainHand', label: 'Main Hand' },
     { key: 'offHand', label: 'Off Hand' },
+    { key: 'ranged', label: 'Ranged' },
     { key: 'ringLeft', label: 'Ring I' },
     { key: 'ringRight', label: 'Ring II' },
   ],


### PR DESCRIPTION
## Summary
- add a dedicated ranged equipment slot and drive PlayerTurnActions attacks from equipped weapons with legacy fallbacks
- source stat, skill, spellcasting, and defense bonuses from equipped items instead of full inventories
- refresh related unit tests to exercise equipment-based workflows

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js client/src/components/Zombies/attributes/Stats.test.js client/src/components/Zombies/attributes/Skills.test.js client/src/components/Zombies/attributes/HealthDefense.test.js client/src/components/Zombies/attributes/InventoryModal.test.js client/src/components/Zombies/attributes/EquipmentRack.test.js client/src/components/Zombies/attributes/SpellSelector.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cef0438094832e8f420bc380831a0a