### PR TITLE
Restrict equipment rack slot options based on metadata

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.test.js
@@ -10,11 +10,18 @@ describe('EquipmentRack', () => {
 
     const inventory = {
       weapons: [
-        { name: 'Dagger' },
-        { name: 'Longsword' },
+        { name: 'Dagger', category: 'simple melee weapon' },
+        { name: 'Longbow', category: 'martial ranged weapon' },
       ],
-      armor: [{ name: 'Chain Mail' }],
-      items: [{ name: 'Ring of Protection' }],
+      armor: [
+        { name: 'Chain Mail', category: 'heavy' },
+        { name: 'Shield', category: 'shield' },
+      ],
+      items: [
+        { name: 'Ring of Protection', category: 'Ring' },
+        { name: 'Circlet of Wisdom', category: 'Head' },
+        { name: 'Belt of Giant Strength', category: 'Belt' },
+      ],
     };
 
     let equipmentState = {
@@ -49,20 +56,71 @@ describe('EquipmentRack', () => {
     };
 
     expect(screen.getByText('Head')).toBeInTheDocument();
+
+    const headSelect = screen.getByLabelText('Head slot selection');
+    const headOptions = within(headSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(headOptions).toEqual([
+      'Unequipped',
+      'Circlet of Wisdom (Item)',
+    ]);
+
+    const waistSelect = screen.getByLabelText('Waist slot selection');
+    const waistOptions = within(waistSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(waistOptions).toEqual([
+      'Unequipped',
+      'Belt of Giant Strength (Item)',
+    ]);
+
+    const ringSelect = screen.getByLabelText('Ring I slot selection');
+    const ringOptions = within(ringSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(ringOptions).toEqual(['Unequipped', 'Ring of Protection (Item)']);
+
     const mainHandSelect = screen.getByLabelText('Main Hand slot selection');
-    const longSwordOption = within(mainHandSelect).getByRole('option', {
-      name: /Longsword/,
+    const mainHandOptions = within(mainHandSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(mainHandOptions).toEqual([
+      'Unequipped',
+      'Dagger (Weapon)',
+      'Longbow (Weapon)',
+    ]);
+
+    const rangedSelect = screen.getByLabelText('Ranged slot selection');
+    const rangedOptions = within(rangedSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(rangedOptions).toEqual(['Unequipped', 'Longbow (Weapon)']);
+
+    const offHandSelect = screen.getByLabelText('Off Hand slot selection');
+    const offHandOptions = within(offHandSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(offHandOptions).toEqual([
+      'Unequipped',
+      'Dagger (Weapon)',
+      'Longbow (Weapon)',
+      'Shield (Armor)',
+    ]);
+
+    const longbowOption = within(mainHandSelect).getByRole('option', {
+      name: /Longbow/,
     });
 
-    await userEvent.selectOptions(mainHandSelect, longSwordOption);
+    await userEvent.selectOptions(mainHandSelect, longbowOption);
 
     expect(onSlotChange).toHaveBeenLastCalledWith(
       'mainHand',
-      expect.objectContaining({ name: 'Longsword', source: 'weapon' })
+      expect.objectContaining({ name: 'Longbow', source: 'weapon' })
     );
     expect(onEquipmentChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        mainHand: expect.objectContaining({ name: 'Longsword', source: 'weapon' }),
+        mainHand: expect.objectContaining({ name: 'Longbow', source: 'weapon' }),
       })
     );
 

--- a/client/src/components/Zombies/attributes/equipmentSlots.js
+++ b/client/src/components/Zombies/attributes/equipmentSlots.js
@@ -1,28 +1,170 @@
+const createSlot = (key, label, config = {}) => ({
+  key,
+  label,
+  allowedSources: config.allowedSources,
+  filters: config.filters || {},
+});
+
 export const EQUIPMENT_SLOT_LAYOUT = [
   [
-    { key: 'head', label: 'Head' },
-    { key: 'eyes', label: 'Eyes' },
-    { key: 'neck', label: 'Neck' },
-    { key: 'shoulders', label: 'Shoulders' },
+    createSlot('head', 'Head', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['head', 'helm', 'helmet', 'hat', 'circlet', 'crown'],
+        },
+        armor: {
+          categories: ['helm', 'helmet', 'head'],
+        },
+      },
+    }),
+    createSlot('eyes', 'Eyes', {
+      allowedSources: ['item'],
+      filters: {
+        item: {
+          categories: ['eye', 'eyes', 'goggles', 'lens', 'visor', 'glasses'],
+        },
+      },
+    }),
+    createSlot('neck', 'Neck', {
+      allowedSources: ['item'],
+      filters: {
+        item: {
+          categories: ['neck', 'amulet', 'necklace', 'pendant', 'torc'],
+        },
+      },
+    }),
+    createSlot('shoulders', 'Shoulders', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['shoulder', 'cloak', 'cape', 'mantle'],
+        },
+        armor: {
+          categories: ['shoulder', 'cloak', 'cape', 'mantle'],
+        },
+      },
+    }),
   ],
   [
-    { key: 'chest', label: 'Chest' },
-    { key: 'back', label: 'Back' },
-    { key: 'arms', label: 'Arms' },
-    { key: 'wrists', label: 'Wrists' },
+    createSlot('chest', 'Chest', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['armor', 'chest', 'vest', 'robe', 'mail', 'shirt', 'plate'],
+        },
+      },
+    }),
+    createSlot('back', 'Back', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['back', 'cloak', 'cape', 'mantle'],
+        },
+        armor: {
+          categories: ['back', 'cloak', 'cape', 'mantle'],
+        },
+      },
+    }),
+    createSlot('arms', 'Arms', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['arm', 'arms', 'bracer', 'sleeve'],
+        },
+        armor: {
+          categories: ['arm', 'arms', 'bracer', 'vambrace'],
+        },
+      },
+    }),
+    createSlot('wrists', 'Wrists', {
+      allowedSources: ['item'],
+      filters: {
+        item: {
+          categories: ['wrist', 'bracelet', 'bracer', 'cuff'],
+        },
+      },
+    }),
   ],
   [
-    { key: 'hands', label: 'Hands' },
-    { key: 'waist', label: 'Waist' },
-    { key: 'legs', label: 'Legs' },
-    { key: 'feet', label: 'Feet' },
+    createSlot('hands', 'Hands', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['hand', 'hands', 'glove', 'gauntlet', 'mitt'],
+        },
+        armor: {
+          categories: ['hand', 'hands', 'glove', 'gauntlet', 'mitt'],
+        },
+      },
+    }),
+    createSlot('waist', 'Waist', {
+      allowedSources: ['item'],
+      filters: {
+        item: {
+          categories: ['belt', 'waist', 'sash', 'girdle'],
+        },
+      },
+    }),
+    createSlot('legs', 'Legs', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['leg', 'legs', 'greaves', 'leggings', 'pants', 'skirt'],
+        },
+        armor: {
+          categories: ['leg', 'legs', 'greaves', 'leggings', 'pants', 'skirt'],
+        },
+      },
+    }),
+    createSlot('feet', 'Feet', {
+      allowedSources: ['armor', 'item'],
+      filters: {
+        item: {
+          categories: ['feet', 'foot', 'boot', 'boots', 'shoe', 'sandals', 'slippers'],
+        },
+        armor: {
+          categories: ['feet', 'foot', 'boot', 'boots', 'shoe', 'sandals', 'slippers'],
+        },
+      },
+    }),
   ],
   [
-    { key: 'mainHand', label: 'Main Hand' },
-    { key: 'offHand', label: 'Off Hand' },
-    { key: 'ranged', label: 'Ranged' },
-    { key: 'ringLeft', label: 'Ring I' },
-    { key: 'ringRight', label: 'Ring II' },
+    createSlot('mainHand', 'Main Hand', {
+      allowedSources: ['weapon'],
+    }),
+    createSlot('offHand', 'Off Hand', {
+      allowedSources: ['weapon', 'armor'],
+      filters: {
+        armor: {
+          categories: ['shield'],
+        },
+      },
+    }),
+    createSlot('ranged', 'Ranged', {
+      allowedSources: ['weapon'],
+      filters: {
+        weapon: {
+          categories: ['ranged', 'bow', 'crossbow', 'thrown', 'gun'],
+        },
+      },
+    }),
+    createSlot('ringLeft', 'Ring I', {
+      allowedSources: ['item'],
+      filters: {
+        item: {
+          categories: ['ring', 'band', 'signet'],
+        },
+      },
+    }),
+    createSlot('ringRight', 'Ring II', {
+      allowedSources: ['item'],
+      filters: {
+        item: {
+          categories: ['ring', 'band', 'signet'],
+        },
+      },
+    }),
   ],
 ];
 


### PR DESCRIPTION
## Summary
- add source and category metadata to each equipment slot so the rack knows which inventory to offer
- filter equipment rack select options per slot using the metadata-driven lookup instead of the global list
- expand the equipment rack test inventory and assertions to cover allowed and disallowed items per slot

## Testing
- CI=true npm test -- EquipmentRack
- CI=true npm test -- InventoryModal

------
https://chatgpt.com/codex/tasks/task_e_68cef928af84832e9d421948138ecb00