### PR TITLE
Redesign equipment rack layout

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback } from 'react';
 import { Form, Button } from 'react-bootstrap';
 import { EQUIPMENT_SLOT_LAYOUT } from './equipmentSlots';
+import styles from './EquipmentRack.module.scss';
 
 const FLAT_SLOTS = EQUIPMENT_SLOT_LAYOUT.flat();
 
@@ -102,54 +103,30 @@ const buildSlotOptions = (slot, optionsBySource) => {
   return options;
 };
 
-const rackStyles = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-  gap: '1rem',
+const SLOT_LAYOUT = {
+  leftColumn: ['head', 'eyes', 'neck', 'shoulders', 'chest', 'back'],
+  rightColumn: ['arms', 'wrists', 'hands', 'waist', 'legs', 'feet'],
+  bottomRow: ['mainHand', 'offHand', 'ranged', 'ringLeft', 'ringRight'],
 };
 
-const slotStyles = {
-  border: '1px solid rgba(108, 117, 125, 0.5)',
-  borderRadius: '0.75rem',
-  padding: '0.75rem',
-  minHeight: '180px',
-  background: 'linear-gradient(135deg, rgba(33,37,41,0.85), rgba(73,80,87,0.65))',
-  color: 'var(--bs-light, #f8f9fa)',
-  boxShadow: '0 8px 16px rgba(0,0,0,0.15)',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-};
-
-const labelStyles = {
-  fontSize: '0.75rem',
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-  fontWeight: 700,
-  opacity: 0.85,
-  marginBottom: '0.5rem',
-};
-
-const itemStyles = {
-  flex: 1,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  textAlign: 'center',
-  borderRadius: '0.5rem',
-  background: 'rgba(255, 255, 255, 0.05)',
-  marginBottom: '0.75rem',
-  padding: '0.5rem',
-  fontSize: '0.9rem',
-  fontWeight: 500,
-  minHeight: '3rem',
-  wordBreak: 'break-word',
-};
-
-const controlsStyles = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '0.5rem',
+const SLOT_ICONS = {
+  head: '🪖',
+  eyes: '👁️',
+  neck: '🧿',
+  shoulders: '🛡️',
+  chest: '👕',
+  back: '🎒',
+  arms: '💪',
+  wrists: '⛓️',
+  hands: '🧤',
+  waist: '🧷',
+  legs: '🦵',
+  feet: '🥾',
+  mainHand: '⚔️',
+  offHand: '🛡️',
+  ranged: '🏹',
+  ringLeft: '💍',
+  ringRight: '💍',
 };
 
 const getItemName = (item) => {
@@ -175,6 +152,13 @@ export default function EquipmentRack({
   disabled = false,
 }) {
   const { weapons = [], armor = [], items = [] } = inventory || {};
+  const slotLookup = useMemo(() => {
+    const map = new Map();
+    FLAT_SLOTS.forEach((slot) => {
+      map.set(slot.key, slot);
+    });
+    return map;
+  }, []);
   const inventoryOptions = useMemo(() => {
     const options = [];
     const bySource = {};
@@ -269,6 +253,7 @@ export default function EquipmentRack({
   );
 
   const renderSlot = (slot) => {
+    if (!slot) return null;
     const current = equipment?.[slot.key];
     const optionsForSlot = slotOptionsMap.get(slot.key) || [];
     const selectedOption = optionsForSlot.find((opt) => {
@@ -286,14 +271,27 @@ export default function EquipmentRack({
     const displayName = getItemName(current) || '—';
 
     return (
-      <div key={slot.key} style={slotStyles}>
-        <div style={labelStyles}>{slot.label}</div>
-        <div style={itemStyles}>{displayName}</div>
-        <div style={controlsStyles}>
+      <div key={slot.key} className={styles.slot}>
+        <div className={styles.slotHeader}>
+          {SLOT_ICONS[slot.key] ? (
+            <span aria-hidden="true" className={styles.slotIcon}>
+              {SLOT_ICONS[slot.key]}
+            </span>
+          ) : null}
+          <span className={styles.slotLabel}>{slot.label}</span>
+        </div>
+        <div
+          className={current ? styles.slotItem : styles.slotItemEmpty}
+          data-testid={`${slot.key}-item-display`}
+        >
+          {displayName}
+        </div>
+        <div className={styles.slotControls}>
           <Form.Select
             aria-label={`${slot.label} slot selection`}
             value={selectedValue}
             disabled={disabled}
+            className={styles.slotSelect}
             onChange={(event) => handleAssign(slot.key, event.target.value)}
           >
             <option value="">Unequipped</option>
@@ -309,6 +307,7 @@ export default function EquipmentRack({
             size="sm"
             disabled={disabled || !current}
             onClick={() => handleAssign(slot.key, '')}
+            className={styles.clearButton}
           >
             Clear Slot
           </Button>
@@ -318,14 +317,33 @@ export default function EquipmentRack({
   };
 
   return (
-    <div>
+    <div className={styles.rackWrapper}>
       <p className="text-muted small mb-3">
         {hasOptions
           ? "Assign owned items to equipment slots. Selecting an option will update the character's loadout immediately."
           : "You do not have any owned inventory to assign yet. Equip gear from the inventory tabs to populate this rack."}
       </p>
-      <div style={rackStyles}>
-        {FLAT_SLOTS.map((slot) => renderSlot(slot))}
+      <div className={styles.rackLayout}>
+        <div className={styles.columns}>
+          <div className={styles.leftColumn}>
+            {SLOT_LAYOUT.leftColumn.map((slotKey) =>
+              renderSlot(slotLookup.get(slotKey))
+            )}
+          </div>
+          <div className={styles.centerColumn}>
+            <div className={styles.silhouette} aria-hidden="true" />
+          </div>
+          <div className={styles.rightColumn}>
+            {SLOT_LAYOUT.rightColumn.map((slotKey) =>
+              renderSlot(slotLookup.get(slotKey))
+            )}
+          </div>
+        </div>
+        <div className={styles.bottomRow}>
+          {SLOT_LAYOUT.bottomRow.map((slotKey) =>
+            renderSlot(slotLookup.get(slotKey))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/Zombies/attributes/EquipmentRack.module.scss
+++ b/client/src/components/Zombies/attributes/EquipmentRack.module.scss
@@ -1,0 +1,207 @@
+.rackWrapper {
+  --rack-border: rgba(255, 255, 255, 0.08);
+  --rack-shadow: rgba(0, 0, 0, 0.35);
+}
+
+.rackLayout {
+  background: radial-gradient(circle at top, rgba(73, 80, 87, 0.25), rgba(33, 37, 41, 0.85));
+  border: 1px solid var(--rack-border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 36px var(--rack-shadow);
+}
+
+.columns {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(180px, 1fr) minmax(200px, 240px) minmax(180px, 1fr);
+  align-items: stretch;
+}
+
+.leftColumn,
+.rightColumn {
+  display: grid;
+  grid-auto-rows: minmax(0, auto);
+  gap: 1rem;
+}
+
+.centerColumn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.silhouette {
+  width: 100%;
+  max-width: 220px;
+  aspect-ratio: 3 / 5;
+  border-radius: 1.75rem;
+  background-color: rgba(173, 181, 189, 0.18);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 300'%3E%3Cpath fill='%239aa0a6' fill-opacity='0.65' d='M90 24c26 0 48 24 48 62 0 28-14 50-33 58l4 42 48 30c12 8 20 21 20 36v40H3v-40c0-15 8-28 20-36l48-30 4-42C56 136 42 114 42 86c0-38 22-62 48-62z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 82%;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.06);
+  filter: grayscale(0.85) contrast(0.9);
+}
+
+.bottomRow {
+  margin-top: 1.75rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(5, minmax(140px, 1fr));
+}
+
+.slot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 180px;
+  padding: 0.9rem;
+  border-radius: 0.85rem;
+  background: linear-gradient(135deg, rgba(33, 37, 41, 0.92), rgba(73, 80, 87, 0.7));
+  color: var(--bs-light, #f8f9fa);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.slot::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.slotHeader {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: rgba(248, 249, 250, 0.9);
+}
+
+.slotIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  font-size: 1.1rem;
+}
+
+.slotLabel {
+  flex: 1;
+}
+
+%slotItemBase {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border-radius: 0.65rem;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  min-height: 3rem;
+  word-break: break-word;
+}
+
+.slotItem {
+  @extend %slotItemBase;
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+.slotItemEmpty {
+  @extend %slotItemBase;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(248, 249, 250, 0.7);
+  font-style: italic;
+}
+
+.slotControls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: auto;
+}
+
+.slotSelect {
+  background: rgba(8, 12, 20, 0.75);
+  color: var(--bs-light, #f8f9fa);
+  border-radius: 0.6rem;
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.slotSelect:focus {
+  border-color: rgba(173, 181, 189, 0.8);
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.35);
+}
+
+.clearButton {
+  font-weight: 600;
+}
+
+@media (max-width: 992px) {
+  .columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .centerColumn {
+    grid-column: span 2;
+    order: -1;
+  }
+
+  .silhouette {
+    margin: 0 auto;
+    max-width: 260px;
+  }
+
+  .bottomRow {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .rackLayout {
+    padding: 1rem;
+  }
+
+  .columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .centerColumn {
+    order: 0;
+  }
+
+  .leftColumn,
+  .rightColumn {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .silhouette {
+    aspect-ratio: 3 / 4;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slot,
+  .rackLayout {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- reorganize equipment rack into dedicated columns flanking a central character silhouette with a bottom weapon row
- add icon-enhanced slot tiles with updated styling hooks for selects and clear buttons
- introduce SCSS module that defines the rack grid, decorative slot treatments, and responsive behavior

## Testing
- CI=true npm test -- EquipmentRack

------
https://chatgpt.com/codex/tasks/task_e_68cefd684014832eb5dcfa358547092f