### PR TITLE
Revamp equipment rack silhouette styling

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.module.scss
+++ b/client/src/components/Zombies/attributes/EquipmentRack.module.scss
@@ -32,17 +32,52 @@
 }
 
 .silhouette {
+  position: relative;
   width: 100%;
   max-width: 220px;
   aspect-ratio: 3 / 5;
   border-radius: 1.75rem;
-  background-color: rgba(173, 181, 189, 0.18);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 300'%3E%3Cpath fill='%239aa0a6' fill-opacity='0.65' d='M90 24c26 0 48 24 48 62 0 28-14 50-33 58l4 42 48 30c12 8 20 21 20 36v40H3v-40c0-15 8-28 20-36l48-30 4-42C56 136 42 114 42 86c0-38 22-62 48-62z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 82%;
-  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.06);
-  filter: grayscale(0.85) contrast(0.9);
+  background:
+    radial-gradient(circle at 50% 22%, rgba(173, 181, 189, 0.32), rgba(173, 181, 189, 0) 54%),
+    radial-gradient(circle at 50% 84%, rgba(96, 112, 130, 0.42), rgba(15, 19, 28, 0.92) 70%),
+    linear-gradient(165deg, rgba(21, 26, 34, 0.96), rgba(9, 12, 19, 0.98));
+  background-color: rgba(8, 11, 16, 0.92);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.06),
+    inset 0 0 28px rgba(82, 99, 122, 0.18),
+    0 22px 38px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  filter: saturate(0.85) contrast(1.12);
+}
+
+.silhouette::before {
+  content: '';
+  position: absolute;
+  inset: 12% 18% 10%;
+  background: radial-gradient(circle at 50% 18%, rgba(235, 242, 248, 0.92), rgba(186, 203, 218, 0.88) 42%, rgba(113, 133, 152, 0.92) 100%);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-position: center;
+  mask-repeat: no-repeat;
+  filter: drop-shadow(0 16px 28px rgba(4, 6, 10, 0.7));
+  pointer-events: none;
+}
+
+.silhouette::after {
+  content: '';
+  position: absolute;
+  inset: 6%;
+  border-radius: calc(1.75rem - 0.35rem);
+  background:
+    radial-gradient(circle at 50% 16%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 62%),
+    radial-gradient(circle at 50% 95%, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 70%);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+  pointer-events: none;
 }
 
 .bottomRow {


### PR DESCRIPTION
## Summary
- replace the equipment rack silhouette data URI with layered gradients and a masked SVG for a sharper outline
- add pseudo-element lighting treatments for inner glow, drop shadow, and highlight accents while preserving responsiveness

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cefff34f0c832e855d8ebf38213a27