### PR TITLE
Tighten equipment rack card sizing

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.module.scss
+++ b/client/src/components/Zombies/attributes/EquipmentRack.module.scss
@@ -13,8 +13,8 @@
 
 .columns {
   display: grid;
-  gap: 1.25rem;
-  grid-template-columns: minmax(180px, 1fr) minmax(200px, 240px) minmax(180px, 1fr);
+  gap: 1.1rem;
+  grid-template-columns: minmax(140px, 1fr) minmax(180px, 220px) minmax(140px, 1fr);
   align-items: stretch;
 }
 
@@ -81,19 +81,19 @@
 }
 
 .bottomRow {
-  margin-top: 1.75rem;
+  margin-top: 1.5rem;
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(5, minmax(140px, 1fr));
+  gap: 0.9rem;
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
 }
 
 .slot {
   position: relative;
   display: flex;
   flex-direction: column;
-  min-height: 180px;
-  padding: 0.9rem;
-  border-radius: 0.85rem;
+  min-height: 150px;
+  padding: 0.75rem;
+  border-radius: 0.8rem;
   background: linear-gradient(135deg, rgba(33, 37, 41, 0.92), rgba(73, 80, 87, 0.7));
   color: var(--bs-light, #f8f9fa);
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -115,12 +115,12 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  font-size: 0.75rem;
+  gap: 0.5rem;
+  font-size: 0.72rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-weight: 700;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65rem;
   color: rgba(248, 249, 250, 0.9);
 }
 
@@ -128,12 +128,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .slotLabel {
@@ -147,8 +147,8 @@
   justify-content: center;
   text-align: center;
   border-radius: 0.65rem;
-  padding: 0.75rem;
-  margin-bottom: 0.75rem;
+  padding: 0.65rem;
+  margin-bottom: 0.65rem;
   min-height: 3rem;
   word-break: break-word;
 }
@@ -169,14 +169,14 @@
 .slotControls {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.5rem;
   margin-top: auto;
 }
 
 .slotSelect {
   background: rgba(8, 12, 20, 0.75);
   color: var(--bs-light, #f8f9fa);
-  border-radius: 0.6rem;
+  border-radius: 0.55rem;
   border-color: rgba(255, 255, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
@@ -206,7 +206,7 @@
   }
 
   .bottomRow {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- shrink equipment rack column and bottom row minimum widths for a tighter layout footprint
- adjust slot card dimensions and inner spacing so icons, labels, and controls remain balanced
- tune responsive grid minimums to avoid overflow on smaller viewports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf01b7ddb0832eb65cd3e24ba933cc