### PR TITLE
Condense equipment rack layout spacing

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -292,6 +292,7 @@ export default function EquipmentRack({
             value={selectedValue}
             disabled={disabled}
             className={styles.slotSelect}
+            size="sm"
             onChange={(event) => handleAssign(slot.key, event.target.value)}
           >
             <option value="">Unequipped</option>

--- a/client/src/components/Zombies/attributes/EquipmentRack.module.scss
+++ b/client/src/components/Zombies/attributes/EquipmentRack.module.scss
@@ -7,7 +7,7 @@
   background: radial-gradient(circle at top, rgba(73, 80, 87, 0.25), rgba(33, 37, 41, 0.85));
   border: 1px solid var(--rack-border);
   border-radius: 1rem;
-  padding: 1.5rem;
+  padding: clamp(0.85rem, 2vw, 1.15rem);
   box-shadow: 0 18px 36px var(--rack-shadow);
   position: relative;
   overflow: hidden;
@@ -61,7 +61,7 @@
 
 .columns {
   display: grid;
-  gap: clamp(1.2rem, 3vw, 3rem);
+  gap: clamp(0.75rem, 2.25vw, 2.25rem);
   grid-template-columns: repeat(2, minmax(140px, 1fr));
   align-items: start;
   position: relative;
@@ -72,13 +72,13 @@
 .rightColumn {
   display: grid;
   grid-auto-rows: minmax(0, auto);
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .bottomRow {
-  margin-top: 1.5rem;
+  margin-top: 1.1rem;
   display: grid;
-  gap: 0.9rem;
+  gap: clamp(0.65rem, 2vw, 0.9rem);
   grid-template-columns: repeat(5, minmax(120px, 1fr));
   position: relative;
   z-index: 1;
@@ -88,8 +88,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  min-height: 150px;
-  padding: 0.75rem;
+  min-height: 118px;
+  padding: 0.6rem;
   border-radius: 0.8rem;
   background: linear-gradient(135deg, rgba(33, 37, 41, 0.92), rgba(73, 80, 87, 0.7));
   color: var(--bs-light, #f8f9fa);
@@ -112,12 +112,12 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.72rem;
+  gap: 0.45rem;
+  font-size: 0.66rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-weight: 700;
-  margin-bottom: 0.65rem;
+  margin-bottom: 0.5rem;
   color: rgba(248, 249, 250, 0.9);
 }
 
@@ -125,12 +125,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 .slotLabel {
@@ -144,9 +144,9 @@
   justify-content: center;
   text-align: center;
   border-radius: 0.65rem;
-  padding: 0.65rem;
-  margin-bottom: 0.65rem;
-  min-height: 3rem;
+  padding: 0.55rem;
+  margin-bottom: 0.5rem;
+  min-height: 2.6rem;
   word-break: break-word;
 }
 
@@ -165,8 +165,9 @@
 
 .slotControls {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
   margin-top: auto;
 }
 
@@ -176,6 +177,9 @@
   border-radius: 0.55rem;
   border-color: rgba(255, 255, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+  padding: 0.35rem 0.65rem;
+  font-size: 0.88rem;
+  flex: 1 1 160px;
 }
 
 .slotSelect:focus {
@@ -185,12 +189,14 @@
 
 .clearButton {
   font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  white-space: nowrap;
 }
 
 @media (max-width: 992px) {
   .columns {
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: clamp(1rem, 2.5vw, 2rem);
+    gap: clamp(0.75rem, 2.75vw, 1.75rem);
   }
 
   .bottomRow {


### PR DESCRIPTION
## Summary
- tighten spacing, slot sizing, and typography in the equipment rack styles to reduce overall padding while keeping content legible
- lay out the slot controls horizontally with compact select and outline button variants to conserve vertical space

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cf0b3dd3d0832e8554540782d71db6