### PR TITLE
Refactor equipment handling into dedicated modal

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentModal.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.js
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import { Modal, Card, Button } from 'react-bootstrap';
+import EquipmentRack from './EquipmentRack';
+import { normalizeEquipmentMap } from './equipmentNormalization';
+import {
+  normalizeArmor,
+  normalizeItems,
+  normalizeWeapons,
+} from './inventoryNormalization';
+
+export default function EquipmentModal({
+  show,
+  onHide,
+  form = {},
+  onEquipmentChange,
+  onEquipmentSlotChange,
+}) {
+  const normalizedWeapons = useMemo(
+    () => normalizeWeapons(form.weapon || []),
+    [form.weapon]
+  );
+  const normalizedArmor = useMemo(
+    () => normalizeArmor(form.armor || []),
+    [form.armor]
+  );
+  const normalizedItems = useMemo(
+    () => normalizeItems(form.item || []),
+    [form.item]
+  );
+  const normalizedEquipment = useMemo(
+    () => normalizeEquipmentMap(form.equipment),
+    [form.equipment]
+  );
+
+  return (
+    <Modal
+      className="dnd-modal modern-modal"
+      show={show}
+      onHide={onHide}
+      size="lg"
+      centered
+      scrollable
+      fullscreen="sm-down"
+    >
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Equipment</Card.Title>
+        </Card.Header>
+        <Card.Body
+          className="modal-body"
+          style={{ maxHeight: '80vh', overflowY: 'auto' }}
+        >
+          {show && (
+            <EquipmentRack
+              equipment={normalizedEquipment}
+              inventory={{
+                weapons: normalizedWeapons,
+                armor: normalizedArmor,
+                items: normalizedItems,
+              }}
+              onEquipmentChange={onEquipmentChange}
+              onSlotChange={onEquipmentSlotChange}
+            />
+          )}
+        </Card.Body>
+        <Card.Footer className="modal-footer">
+          <Button className="action-btn close-btn" onClick={onHide}>
+            Close
+          </Button>
+        </Card.Footer>
+      </Card>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/attributes/EquipmentModal.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.test.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EquipmentModal from './EquipmentModal';
+import { EQUIPMENT_SLOT_KEYS } from './equipmentSlots';
+
+const mockEquipmentRackProps = { current: null };
+
+jest.mock('./EquipmentRack', () => {
+  const React = require('react');
+  return (props) => {
+    mockEquipmentRackProps.current = props;
+    return <div data-testid="equipment-rack" />;
+  };
+});
+
+describe('EquipmentModal', () => {
+  beforeEach(() => {
+    mockEquipmentRackProps.current = null;
+  });
+
+  test('renders equipment rack with normalized inventory and equipment data', async () => {
+    const form = {
+      weapon: [['Longsword']],
+      armor: [['Shield']],
+      item: [['Potion']],
+      equipment: {
+        mainHand: { name: 'Longsword', source: 'weapon' },
+      },
+    };
+    const handleEquipmentChange = jest.fn();
+
+    render(
+      <EquipmentModal
+        show
+        onHide={jest.fn()}
+        form={form}
+        onEquipmentChange={handleEquipmentChange}
+      />
+    );
+
+    expect(await screen.findByTestId('equipment-rack')).toBeInTheDocument();
+    expect(mockEquipmentRackProps.current?.inventory).toMatchObject({
+      weapons: [expect.objectContaining({ name: 'Longsword' })],
+      armor: [expect.objectContaining({ name: 'Shield' })],
+      items: [expect.objectContaining({ name: 'Potion' })],
+    });
+
+    const equipment = mockEquipmentRackProps.current?.equipment;
+    expect(equipment).toBeTruthy();
+    const equipmentKeys = Object.keys(equipment || {}).sort();
+    expect(equipmentKeys).toEqual([...EQUIPMENT_SLOT_KEYS].sort());
+    expect(equipment?.mainHand).toEqual(
+      expect.objectContaining({ name: 'Longsword', source: 'weapon' })
+    );
+    EQUIPMENT_SLOT_KEYS.filter((key) => key !== 'mainHand').forEach((slot) => {
+      expect(equipment?.[slot]).toBeNull();
+    });
+    expect(mockEquipmentRackProps.current.onEquipmentChange).toBe(
+      handleEquipmentChange
+    );
+  });
+
+  test('close button triggers onHide handler', async () => {
+    const handleHide = jest.fn();
+
+    render(
+      <EquipmentModal
+        show
+        onHide={handleHide}
+        form={{ weapon: [], armor: [], item: [], equipment: {} }}
+      />
+    );
+
+    expect(await screen.findByTestId('equipment-rack')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(handleHide).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -3,8 +3,6 @@ import { Modal, Card, Tab, Nav, Button } from 'react-bootstrap';
 import WeaponList from '../../Weapons/WeaponList';
 import ArmorList from '../../Armor/ArmorList';
 import ItemList from '../../Items/ItemList';
-import EquipmentRack from './EquipmentRack';
-import { normalizeEquipmentMap } from './equipmentNormalization';
 import {
   normalizeArmor,
   normalizeItems,
@@ -20,8 +18,6 @@ export default function InventoryModal({
   onTabChange,
   form = {},
   characterId,
-  onEquipmentChange,
-  onEquipmentSlotChange,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -49,11 +45,6 @@ export default function InventoryModal({
   const normalizedItems = useMemo(
     () => normalizeItems(form.item || []),
     [form.item]
-  );
-
-  const normalizedEquipment = useMemo(
-    () => normalizeEquipmentMap(form.equipment),
-    [form.equipment]
   );
 
   const handleSelectTab = (key) => {
@@ -123,30 +114,10 @@ export default function InventoryModal({
             />
           ),
       },
-      {
-        key: 'equipment',
-        title: 'Equipment',
-        render: (isActive) =>
-          !isActive ? null : (
-            <EquipmentRack
-              equipment={normalizedEquipment}
-              inventory={{
-                weapons: normalizedWeapons,
-                armor: normalizedArmor,
-                items: normalizedItems,
-              }}
-              onEquipmentChange={onEquipmentChange}
-              onSlotChange={onEquipmentSlotChange}
-            />
-          ),
-      },
     ],
     [
       characterId,
       form.campaign,
-      normalizedEquipment,
-      onEquipmentChange,
-      onEquipmentSlotChange,
       normalizedArmor,
       normalizedItems,
       normalizedWeapons,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -25,6 +25,7 @@ import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import hasteIcon from "../../../images/spell-haste-icon.png";
 import ShopModal from "../attributes/ShopModal";
 import InventoryModal from "../attributes/InventoryModal";
+import EquipmentModal from "../attributes/EquipmentModal";
 import { normalizeItems as normalizeInventoryItems } from "../attributes/inventoryNormalization";
 import { normalizeEquipmentMap } from "../attributes/equipmentNormalization";
 
@@ -53,6 +54,7 @@ export default function ZombiesCharacterSheet() {
   const [shopTab, setShopTab] = useState('weapons');
   const [showInventory, setShowInventory] = useState(false);
   const [inventoryTab, setInventoryTab] = useState('weapons');
+  const [showEquipment, setShowEquipment] = useState(false);
   const [showSpells, setShowSpells] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showBackground, setShowBackground] = useState(false);
@@ -255,6 +257,8 @@ export default function ZombiesCharacterSheet() {
     setShowInventory(true);
   };
   const handleCloseInventory = () => setShowInventory(false);
+  const handleShowEquipment = () => setShowEquipment(true);
+  const handleCloseEquipment = () => setShowEquipment(false);
   const handleShowSpells = () => setShowSpells(true);
   const handleCloseSpells = () => setShowSpells(false);
   const handleShowHelpModal = () => setShowHelpModal(true);
@@ -873,105 +877,127 @@ return (
     >
       <Container style={{ backgroundColor: 'transparent' }}>
         <Nav
-          className="me-auto mx-auto"
+          className="w-100 align-items-center"
           style={{ backgroundColor: 'transparent' }}
         >
-          <Button
-            onClick={handleShowCharacterInfo}
-            style={{ color: "black" }}
-            className="footer-btn"
-            variant="secondary"
+          <div
+            className="d-flex justify-content-center flex-wrap flex-grow-1"
+            style={{ backgroundColor: 'transparent' }}
           >
-            <i className="fas fa-image-portrait" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={handleShowStats}
-            style={{
-              color: "black",
-              backgroundColor: statPointsLeft > 0 ? "gold" : "#6C757D",
-            }}
-            className="footer-btn"
-            variant="secondary"
-          >
-            <i className="fas fa-scroll" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={handleShowSkill}
-            style={{
-              color: "black",
-              backgroundColor: skillsGold,
-            }}
-            className={`footer-btn ${
-              skillPointsLeft > 0 || expertisePointsLeft > 0 ? 'points-glow' : ''
-            }`}
-            variant="secondary"
-          >
-            <i className="fas fa-book-open" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={handleShowFeats}
-            style={{
-              color: "black",
-              backgroundColor: featsGold,
-            }}
-            className={`footer-btn ${featPointsLeft > 0 ? 'points-glow' : ''}`}
-            variant="secondary"
-          >
-            <i className="fas fa-hand-fist" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={handleShowFeatures}
-            style={{
-              color: "black",
-              backgroundColor: "#6C757D",
-            }}
-            className="footer-btn"
-            variant="secondary"
-          >
-            <i className="fas fa-star" aria-hidden="true"></i>
-          </Button>
-          {hasSpellcasting && (
             <Button
-              onClick={handleShowSpells}
-              style={{
-                color: 'black',
-                backgroundColor: spellsGold,
-              }}
-              className={`footer-btn ${spellPointsLeft > 0 ? 'points-glow' : ''}`}
+              onClick={handleShowCharacterInfo}
+              style={{ color: "black" }}
+              className="footer-btn"
               variant="secondary"
             >
-              <i className="fas fa-hat-wizard" aria-hidden="true"></i>
+              <i className="fas fa-image-portrait" aria-hidden="true"></i>
             </Button>
-          )}
+            <Button
+              onClick={handleShowStats}
+              style={{
+                color: "black",
+                backgroundColor: statPointsLeft > 0 ? "gold" : "#6C757D",
+              }}
+              className="footer-btn"
+              variant="secondary"
+            >
+              <i className="fas fa-scroll" aria-hidden="true"></i>
+            </Button>
+            <Button
+              onClick={handleShowSkill}
+              style={{
+                color: "black",
+                backgroundColor: skillsGold,
+              }}
+              className={`footer-btn ${
+                skillPointsLeft > 0 || expertisePointsLeft > 0
+                  ? 'points-glow'
+                  : ''
+              }`}
+              variant="secondary"
+            >
+              <i className="fas fa-book-open" aria-hidden="true"></i>
+            </Button>
+            <Button
+              onClick={handleShowFeats}
+              style={{
+                color: "black",
+                backgroundColor: featsGold,
+              }}
+              className={`footer-btn ${
+                featPointsLeft > 0 ? 'points-glow' : ''
+              }`}
+              variant="secondary"
+            >
+              <i className="fas fa-hand-fist" aria-hidden="true"></i>
+            </Button>
+            <Button
+              onClick={handleShowFeatures}
+              style={{
+                color: "black",
+                backgroundColor: "#6C757D",
+              }}
+              className="footer-btn"
+              variant="secondary"
+            >
+              <i className="fas fa-star" aria-hidden="true"></i>
+            </Button>
+            {hasSpellcasting && (
+              <Button
+                onClick={handleShowSpells}
+                style={{
+                  color: 'black',
+                  backgroundColor: spellsGold,
+                }}
+                className={`footer-btn ${
+                  spellPointsLeft > 0 ? 'points-glow' : ''
+                }`}
+                variant="secondary"
+              >
+                <i className="fas fa-hat-wizard" aria-hidden="true"></i>
+              </Button>
+            )}
+            <Button
+              onClick={() => handleShowInventory()}
+              style={{
+                color: "black",
+                backgroundColor: "#6C757D",
+              }}
+              className="footer-btn"
+              variant="secondary"
+            >
+              <i className="fas fa-box-open" aria-hidden="true"></i>
+            </Button>
+            <Button
+              onClick={() => handleShowShop()}
+              style={{
+                color: "black",
+                backgroundColor: "#6C757D",
+              }}
+              className="footer-btn"
+              variant="secondary"
+            >
+              <i className="fas fa-store" aria-hidden="true"></i>
+            </Button>
+            <Button
+              onClick={handleShowHelpModal}
+              style={{ color: "white" }}
+              className="footer-btn"
+              variant="primary"
+            >
+              <i className="fas fa-info" aria-hidden="true"></i>
+            </Button>
+          </div>
           <Button
-            onClick={() => handleShowInventory()}
+            onClick={handleShowEquipment}
             style={{
               color: "black",
               backgroundColor: "#6C757D",
             }}
-            className="footer-btn"
+            className="footer-btn ms-auto"
             variant="secondary"
           >
-            <i className="fas fa-box-open" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={() => handleShowShop()}
-            style={{
-              color: "black",
-              backgroundColor: "#6C757D",
-            }}
-            className="footer-btn"
-            variant="secondary"
-          >
-            <i className="fas fa-store" aria-hidden="true"></i>
-          </Button>
-          <Button
-            onClick={handleShowHelpModal}
-            style={{ color: "white" }}
-            className="footer-btn"
-            variant="primary"
-          >
-            <i className="fas fa-info" aria-hidden="true"></i>
+            <i className="fas fa-toolbox" aria-hidden="true"></i>
           </Button>
         </Nav>
       </Container>
@@ -1021,6 +1047,11 @@ return (
       onTabChange={setInventoryTab}
       form={form}
       characterId={characterId}
+    />
+    <EquipmentModal
+      show={showEquipment}
+      onHide={handleCloseEquipment}
+      form={form}
       onEquipmentChange={handleEquipmentChange}
     />
     <ShopModal


### PR DESCRIPTION
## Summary
- add a standalone EquipmentModal component that wraps the equipment rack
- simplify InventoryModal to only handle inventory tabs
- wire the new equipment modal and trigger button into the zombies character sheet with updated tests

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/InventoryModal.test.js client/src/components/Zombies/attributes/EquipmentModal.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf0d6e5f5c832ea6f098ade24dfae0