### PR TITLE
Reorder equipment button in zombies footer

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -958,6 +958,17 @@ return (
               </Button>
             )}
             <Button
+              onClick={handleShowEquipment}
+              style={{
+                color: 'black',
+                backgroundColor: '#6C757D',
+              }}
+              className="footer-btn"
+              variant="secondary"
+            >
+              <i className="fas fa-toolbox" aria-hidden="true"></i>
+            </Button>
+            <Button
               onClick={() => handleShowInventory()}
               style={{
                 color: "black",
@@ -988,17 +999,6 @@ return (
               <i className="fas fa-info" aria-hidden="true"></i>
             </Button>
           </div>
-          <Button
-            onClick={handleShowEquipment}
-            style={{
-              color: "black",
-              backgroundColor: "#6C757D",
-            }}
-            className="footer-btn ms-auto"
-            variant="secondary"
-          >
-            <i className="fas fa-toolbox" aria-hidden="true"></i>
-          </Button>
         </Nav>
       </Container>
     </Navbar>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import hasteIcon from '../../../images/spell-haste-icon.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
@@ -165,6 +165,76 @@ test('warlock character renders spells button', async () => {
   const buttons = await screen.findAllByRole('button');
   const spellButton = buttons.find((btn) => btn.querySelector('.fa-hat-wizard'));
   expect(spellButton).toBeInTheDocument();
+});
+
+test('footer renders equipment button after spells button for spellcasters', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const nav = await screen.findByRole('navigation');
+  const navButtons = within(nav).getAllByRole('button');
+  const indexOf = (iconClass) =>
+    navButtons.findIndex((btn) => btn.querySelector(`.${iconClass}`));
+
+  expect(indexOf('fa-hat-wizard')).toBeGreaterThan(-1);
+  expect(indexOf('fa-toolbox')).toBeGreaterThan(-1);
+  expect(indexOf('fa-box-open')).toBeGreaterThan(-1);
+  expect(indexOf('fa-hat-wizard')).toBeLessThan(indexOf('fa-toolbox'));
+  expect(indexOf('fa-toolbox')).toBeLessThan(indexOf('fa-box-open'));
+});
+
+test('footer renders equipment button before inventory for non-spellcasters', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Fighter', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const nav = await screen.findByRole('navigation');
+  const navButtons = within(nav).getAllByRole('button');
+  const indexOf = (iconClass) =>
+    navButtons.findIndex((btn) => btn.querySelector(`.${iconClass}`));
+
+  expect(indexOf('fa-hat-wizard')).toBe(-1);
+  expect(indexOf('fa-toolbox')).toBeGreaterThan(-1);
+  expect(indexOf('fa-box-open')).toBeGreaterThan(-1);
+  expect(indexOf('fa-toolbox')).toBeLessThan(indexOf('fa-box-open'));
 });
 
 test('renders SpellSlots for non-spellcasting characters', async () => {


### PR DESCRIPTION
## Summary
- move the equipment button into the footer button group so it sits with the other controls
- ensure the equipment button follows the spells button when present and precedes inventory otherwise
- add regression tests covering the footer ordering for spellcasters and non-spellcasters

## Testing
- npm test -- ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf20a2046c832e97d2de7fc2e20749