### PR TITLE
Add ranged equipment slot support

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -296,6 +296,7 @@ describe('Character routes', () => {
       }],
       equipment: {
         mainHand: { name: 'Longsword', source: 'weapon' },
+        ranged: { name: 'Shortbow', source: 'weapon' },
         ringLeft: 'Ring of Protection',
         tail: { name: 'Tail Blade' },
       },
@@ -322,10 +323,16 @@ describe('Character routes', () => {
       name: 'Longsword',
       source: 'weapon',
     });
+    expect(res.body.equipment.ranged).toMatchObject({
+      name: 'Shortbow',
+      source: 'weapon',
+    });
     expect(res.body.equipment.ringLeft).toMatchObject({
       name: 'Ring of Protection',
     });
-    EQUIPMENT_SLOT_KEYS.filter((slot) => !['mainHand', 'ringLeft'].includes(slot)).forEach(
+    EQUIPMENT_SLOT_KEYS.filter((slot) =>
+      !['mainHand', 'ranged', 'ringLeft'].includes(slot)
+    ).forEach(
       (slot) => {
         expect(res.body.equipment[slot]).toBeNull();
       }

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -515,6 +515,7 @@ describe('Equipment routes', () => {
         equipment: {
           mainHand: { name: 'Longsword', source: 'weapon' },
           offHand: { name: 'Longsword', source: 'weapon' },
+          ranged: { name: 'Shortbow', source: 'weapon' },
           ringLeft: 'Ring of Protection',
         },
       };
@@ -533,6 +534,10 @@ describe('Equipment routes', () => {
       expect(updatedEquipment.mainHand).toBeNull();
       expect(updatedEquipment.offHand).toMatchObject({
         name: 'Longsword',
+        source: 'weapon',
+      });
+      expect(updatedEquipment.ranged).toMatchObject({
+        name: 'Shortbow',
         source: 'weapon',
       });
       expect(updatedEquipment.ringLeft).toMatchObject({

--- a/server/constants/equipmentSlots.js
+++ b/server/constants/equipmentSlots.js
@@ -20,6 +20,7 @@ const EQUIPMENT_SLOT_LAYOUT = [
   [
     { key: 'mainHand', label: 'Main Hand' },
     { key: 'offHand', label: 'Off Hand' },
+    { key: 'ranged', label: 'Ranged' },
     { key: 'ringLeft', label: 'Ring I' },
     { key: 'ringRight', label: 'Ring II' },
   ],


### PR DESCRIPTION
## Summary
- add the missing ranged equipment slot to the server equipment slot layout
- extend equipment- and character-related tests to cover ranged assignments

## Testing
- npm test -- equipment.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf2440e54c832ebb590fdf3781873e