### PR TITLE
Add armor slot options and update DM armor tooling

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -555,7 +555,7 @@ describe('Character routes', () => {
     dbo.mockResolvedValue({
       collection: () => ({ insertOne: async () => ({ insertedId: 'abc123' }) })
     });
-    const payload = { campaign: 'Camp1', armorName: 'Plate' };
+    const payload = { campaign: 'Camp1', armorName: 'Plate', slot: EQUIPMENT_SLOT_KEYS[0] };
     const res = await request(app)
       .post('/equipment/armor/add')
       .send(payload);

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -162,11 +162,14 @@ describe('Equipment routes', () => {
       dbo.mockResolvedValue({
         collection: () => ({ insertOne: async () => ({ insertedId: 'abc123' }) })
       });
+      const slotKey = EQUIPMENT_SLOT_KEYS[0];
       const payload = {
         campaign: 'Camp1',
         armorName: 'Plate',
         type: 'heavy',
         category: 'martial',
+        slot: slotKey,
+        equipmentSlot: slotKey,
         strength: 15,
         stealth: true,
         weight: 65,

--- a/server/routes/armor.js
+++ b/server/routes/armor.js
@@ -1,5 +1,11 @@
 const express = require('express');
 const { armors, types, categories } = require('../data/armor');
+const { EQUIPMENT_SLOT_LAYOUT } = require('../constants/equipmentSlots');
+
+const SLOT_OPTIONS = EQUIPMENT_SLOT_LAYOUT.flat().map(({ key, label }) => ({
+  key,
+  label,
+}));
 
 /** @typedef {import('../../types/armor').Armor} Armor */
 
@@ -11,7 +17,7 @@ module.exports = (router) => {
   });
 
   armorRouter.get('/options', (_req, res) => {
-    res.json({ types, categories });
+    res.json({ types, categories, slots: SLOT_OPTIONS });
   });
 
   armorRouter.get('/:name', (req, res) => {

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -171,6 +171,18 @@ module.exports = (router) => {
       body('maxDex').optional({ checkFalsy: true }).isInt().toInt(),
       body('type').optional().isString().trim().toLowerCase(),
       body('category').optional().isString().trim().toLowerCase(),
+      body('slot')
+        .optional({ checkFalsy: true })
+        .isString()
+        .trim()
+        .isIn(EQUIPMENT_SLOT_KEYS)
+        .withMessage('slot must be a valid equipment slot'),
+      body('equipmentSlot')
+        .optional({ checkFalsy: true })
+        .isString()
+        .trim()
+        .isIn(EQUIPMENT_SLOT_KEYS)
+        .withMessage('equipmentSlot must be a valid equipment slot'),
       body('strength').optional().isInt().toInt(),
       body('stealth').optional().isBoolean().toBoolean(),
       body('weight').optional().isFloat().toFloat(),


### PR DESCRIPTION
## Summary
- expose available equipment slots from the armor options endpoint so slot metadata can be chosen on the client
- allow optional slot/equipmentSlot values through armor creation validation and persist them when saving
- surface slot selection in the DM armor form/table and extend automated coverage for the new field shape

## Testing
- npm test (server)
- npm --prefix client test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cf2778d5e0832e8f66ee557510a8f6