### PR TITLE
Limit armor slots to armor-friendly equipment

### DIFF
--- a/server/constants/equipmentSlots.js
+++ b/server/constants/equipmentSlots.js
@@ -28,6 +28,21 @@ const EQUIPMENT_SLOT_LAYOUT = [
 
 const EQUIPMENT_SLOT_KEYS = EQUIPMENT_SLOT_LAYOUT.flat().map((slot) => slot.key);
 
+const ARMOR_SLOT_KEYS = new Set([
+  'head',
+  'shoulders',
+  'chest',
+  'arms',
+  'hands',
+  'legs',
+  'feet',
+  'offHand',
+]);
+
+const ARMOR_SLOT_OPTIONS = EQUIPMENT_SLOT_LAYOUT.flat().filter((slot) =>
+  ARMOR_SLOT_KEYS.has(slot.key)
+);
+
 const createEmptyEquipmentMap = () => {
   const map = {};
   EQUIPMENT_SLOT_KEYS.forEach((slot) => {
@@ -109,6 +124,7 @@ const normalizeEquipmentMap = (equipment, { fallback } = {}) => {
 module.exports = {
   EQUIPMENT_SLOT_LAYOUT,
   EQUIPMENT_SLOT_KEYS,
+  ARMOR_SLOT_OPTIONS,
   createEmptyEquipmentMap,
   normalizeEquipmentMap,
 };

--- a/server/routes/armor.js
+++ b/server/routes/armor.js
@@ -1,11 +1,6 @@
 const express = require('express');
 const { armors, types, categories } = require('../data/armor');
-const { EQUIPMENT_SLOT_LAYOUT } = require('../constants/equipmentSlots');
-
-const SLOT_OPTIONS = EQUIPMENT_SLOT_LAYOUT.flat().map(({ key, label }) => ({
-  key,
-  label,
-}));
+const { ARMOR_SLOT_OPTIONS } = require('../constants/equipmentSlots');
 
 /** @typedef {import('../../types/armor').Armor} Armor */
 
@@ -17,7 +12,7 @@ module.exports = (router) => {
   });
 
   armorRouter.get('/options', (_req, res) => {
-    res.json({ types, categories, slots: SLOT_OPTIONS });
+    res.json({ types, categories, slots: ARMOR_SLOT_OPTIONS });
   });
 
   armorRouter.get('/:name', (req, res) => {


### PR DESCRIPTION
## Summary
- add an `ARMOR_SLOT_OPTIONS` helper that filters equipment slots down to armor-friendly positions
- update the `/armor/options` route to return the armor-only slot options
- refresh the Zombies DM tests to expect the trimmed slot list

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf2af18ad0832eb938644cf6b854ce