### PR TITLE
Ensure AI armor responses include slot metadata

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -54,6 +54,7 @@ describe('ZombiesDM AI generation', () => {
             name: 'AI Armor',
             type: 'Light',
             category: 'Shield',
+            slot: 'chest',
             armorBonus: 2,
             maxDex: 4,
             strength: 10,
@@ -95,6 +96,9 @@ describe('ZombiesDM AI generation', () => {
     await waitFor(() => expect(screen.getByDisplayValue('AI Armor')).toBeInTheDocument());
     expect(screen.getByDisplayValue('Light')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Shield')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText('Slot')).toHaveValue('chest')
+    );
     expect(screen.getByLabelText('Stealth')).toHaveValue('false');
     expect(screen.getByLabelText('Cost')).toHaveValue('100');
     expect(screen.getByLabelText('Max Dex Bonus')).toHaveValue('4');

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -18,7 +18,11 @@ try {
   zodResponseFormat = null;
 }
 const { types: weaponTypes, categories: weaponCategories } = require('../data/weapons');
-const { types: armorTypes, categories: armorCategories } = require('../data/armor');
+const {
+  types: armorTypes,
+  categories: armorCategories,
+} = require('../data/armor');
+const { ARMOR_SLOT_OPTIONS } = require('../constants/equipmentSlots');
 const { categories: itemCategories } = require('../data/items');
 const { skillNames } = require('./fieldConstants');
 
@@ -77,10 +81,14 @@ module.exports = (router) => {
       return res.status(500).json({ message: 'OpenAI not configured' });
     }
 
+    const armorSlotKeys = ARMOR_SLOT_OPTIONS.map((slot) => slot.key);
+
     const ArmorSchema = z.object({
       name: z.string(),
       type: z.enum(armorTypes),
       category: z.enum(armorCategories),
+      slot: z.enum(armorSlotKeys),
+      equipmentSlot: z.enum(armorSlotKeys).optional(),
       armorBonus: z.number().optional(),
       acBonus: z.number().optional(),
       maxDex: z.number().optional(),
@@ -97,7 +105,12 @@ module.exports = (router) => {
       const response = await openai.responses.parse({
         model: 'gpt-4o-2024-08-06',
         input: [
-          { role: 'system', content: 'Create a Dungeons and Dragons armor.' },
+          {
+            role: 'system',
+            content: `Create a Dungeons and Dragons armor. Always include a "slot" field matching one of the following equipment slots: ${armorSlotKeys.join(
+              ', '
+            )}. If the armor occupies a different equipment slot than it is worn on, include an "equipmentSlot" field set to a value from the same list.`,
+          },
           { role: 'user', content: prompt },
         ],
         text: { format },


### PR DESCRIPTION
## Summary
- validate AI armor output includes a slot/equipmentSlot from the armor slot enum and update the prompt accordingly
- return the selected slot from the AI response so the armor form can autopopulate it
- extend the ZombiesDM AI test payload and assertions to cover slot population

## Testing
- npm test -- ZombiesDM

------
https://chatgpt.com/codex/tasks/task_e_68cf2c9e3018832e95ab6b6905a4aab1