### PR TITLE
Fix armor normalization fallback

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -133,7 +133,7 @@ const getItemName = (item) => {
   if (!item) return '';
   if (typeof item === 'string') return item;
   if (typeof item !== 'object') return String(item);
-  return item.displayName || item.name || item.title || '';
+  return item.displayName || item.name || item.armorName || item.title || '';
 };
 
 const getItemSource = (item) => {

--- a/client/src/components/Zombies/attributes/EquipmentRack.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EquipmentRack from './EquipmentRack';
+import { normalizeArmor } from './inventoryNormalization';
 
 describe('EquipmentRack', () => {
   test('shows slot names and allows assigning and clearing equipment', async () => {
@@ -134,5 +135,32 @@ describe('EquipmentRack', () => {
     expect(onEquipmentChange).toHaveBeenLastCalledWith(
       expect.objectContaining({ mainHand: null })
     );
+  });
+
+  test('includes armor entries that only define armorName', () => {
+    const inventory = {
+      armor: normalizeArmor([
+        {
+          armorName: 'Guardian Shield',
+          category: 'shield',
+        },
+      ]),
+    };
+
+    render(
+      <EquipmentRack
+        equipment={{}}
+        inventory={inventory}
+        onEquipmentChange={() => {}}
+        onSlotChange={() => {}}
+      />
+    );
+
+    const offHandSelect = screen.getByLabelText('Off Hand slot selection');
+    const offHandOptions = within(offHandSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+
+    expect(offHandOptions).toEqual(['Unequipped', 'Guardian Shield (Armor)']);
   });
 });

--- a/client/src/components/Zombies/attributes/inventoryNormalization.js
+++ b/client/src/components/Zombies/attributes/inventoryNormalization.js
@@ -134,6 +134,8 @@ export const normalizeArmor = (armor, { includeUnowned = false } = {}) => {
       if (typeof piece === 'object') {
         const {
           name,
+          armorName,
+          displayName,
           acBonus = '',
           maxDex = null,
           strength = null,
@@ -144,10 +146,11 @@ export const normalizeArmor = (armor, { includeUnowned = false } = {}) => {
           owned: ownedProp,
           ...rest
         } = piece;
-        if (!name) return null;
+        const resolvedName = name || armorName;
+        if (!resolvedName) return null;
         if (!includeUnowned && ownedProp === false) return null;
         const normalized = {
-          name,
+          name: resolvedName,
           acBonus,
           maxDex,
           strength,
@@ -155,8 +158,13 @@ export const normalizeArmor = (armor, { includeUnowned = false } = {}) => {
           weight,
           cost,
           ...(type !== undefined ? { type } : {}),
+          ...(displayName !== undefined ? { displayName } : {}),
+          ...(armorName !== undefined ? { armorName } : {}),
           ...rest,
         };
+        if (!name && armorName && normalized.displayName === undefined) {
+          normalized.displayName = armorName;
+        }
         if (ownedProp !== undefined) normalized.owned = ownedProp;
         return normalized;
       }


### PR DESCRIPTION
## Summary
- allow armor normalization to fallback to armorName when name is absent, preserving display names
- ensure equipment rack naming considers armorName values
- cover armorName-only armor entries with a regression test

## Testing
- CI=true npm test -- EquipmentRack.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf30695cb8832e9e08a2461d5b1c24