### PR TITLE
Preserve armor slot metadata for custom entries

### DIFF
--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -126,8 +126,21 @@ function ArmorList({
 
         const customMap = Array.isArray(custom)
           ? custom.reduce((acc, a) => {
-              const key = (a.name || a.armorName || '').toLowerCase();
+              const key = (a?.name || a?.armorName || '').toLowerCase();
               if (!key) return acc;
+              const slotFields = Object.entries(a || {}).reduce(
+                (fields, [field, value]) => {
+                  if (
+                    typeof field === 'string' &&
+                    field.toLowerCase().includes('slot') &&
+                    value !== undefined
+                  ) {
+                    fields[field] = value;
+                  }
+                  return fields;
+                },
+                {}
+              );
               acc[key] = {
                 name: key,
                 displayName: a.name || a.armorName,
@@ -139,6 +152,7 @@ function ArmorList({
                 stealth: a.stealth ?? false,
                 weight: a.weight ?? '',
                 cost: a.cost ?? '',
+                ...slotFields,
               };
               return acc;
             }, {})

--- a/client/src/components/Armor/ArmorList.test.js
+++ b/client/src/components/Armor/ArmorList.test.js
@@ -39,6 +39,10 @@ const customData = [
     weight: 5,
     cost: '1000 gp',
     type: 'shield',
+    slot: 'head',
+    equipmentSlot: 'head',
+    slots: ['head'],
+    equipmentSlots: ['head'],
   },
 ];
 
@@ -122,6 +126,10 @@ test('fetches armor, handles add to cart, and displays cart count', async () => 
       cost: '1000 gp',
       acBonus: 8,
       category: 'special',
+      slot: 'head',
+      equipmentSlot: 'head',
+      slots: ['head'],
+      equipmentSlots: ['head'],
     })
   );
   expect(onAddToCart).toHaveBeenCalledTimes(2);

--- a/client/src/components/Zombies/attributes/EquipmentRack.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.test.js
@@ -163,4 +163,40 @@ describe('EquipmentRack', () => {
 
     expect(offHandOptions).toEqual(['Unequipped', 'Guardian Shield (Armor)']);
   });
+
+  test('displays custom armor with slot metadata only in matching slot', () => {
+    const inventory = {
+      armor: normalizeArmor([
+        {
+          name: 'Crown of Insight',
+          category: 'head',
+          slot: 'head',
+          equipmentSlot: 'head',
+          slots: ['head'],
+          equipmentSlots: ['head'],
+        },
+      ]),
+    };
+
+    render(
+      <EquipmentRack
+        equipment={{}}
+        inventory={inventory}
+        onEquipmentChange={() => {}}
+        onSlotChange={() => {}}
+      />
+    );
+
+    const headSelect = screen.getByLabelText('Head slot selection');
+    const headOptions = within(headSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(headOptions).toEqual(['Unequipped', 'Crown of Insight (Armor)']);
+
+    const feetSelect = screen.getByLabelText('Feet slot selection');
+    const feetOptions = within(feetSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(feetOptions).toEqual(['Unequipped']);
+  });
 });


### PR DESCRIPTION
## Summary
- carry through slot-related metadata when normalizing custom armor records in ArmorList
- ensure add-to-cart payloads and downstream inventory keep slot fields intact
- cover the equipment rack with a regression test that requires head-slot armor to appear only in the matching dropdown

## Testing
- CI=true npm test -- ArmorList.test
- CI=true npm test -- EquipmentRack.test

------
https://chatgpt.com/codex/tasks/task_e_68cf330d4254832e82242f67370867a5