### PR TITLE
Restrict armor options to matching equipment slots

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.test.js
@@ -170,10 +170,10 @@ describe('EquipmentRack', () => {
         {
           name: 'Crown of Insight',
           category: 'head',
-          slot: 'head',
-          equipmentSlot: 'head',
-          slots: ['head'],
-          equipmentSlots: ['head'],
+          slot: 'Head',
+          equipmentSlot: ' head ',
+          slots: ['head', 'Headgear'],
+          equipmentSlots: ['HEAD'],
         },
       ]),
     };
@@ -192,6 +192,12 @@ describe('EquipmentRack', () => {
       .getAllByRole('option')
       .map((option) => option.textContent);
     expect(headOptions).toEqual(['Unequipped', 'Crown of Insight (Armor)']);
+
+    const chestSelect = screen.getByLabelText('Chest slot selection');
+    const chestOptions = within(chestSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(chestOptions).toEqual(['Unequipped']);
 
     const feetSelect = screen.getByLabelText('Feet slot selection');
     const feetOptions = within(feetSelect)


### PR DESCRIPTION
## Summary
- normalize slot metadata and ensure armor options respect their declared equipment slots
- add guards so slot dropdowns skip armor entries that don't match their slot metadata
- extend EquipmentRack tests to cover slot-aware filtering for armor

## Testing
- CI=true npm --prefix client test -- EquipmentRack.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf358b7aec832e81f2d2c067a5499d