### PR TITLE
Fix legacy itemName normalization and add regression test

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -171,7 +171,14 @@ const getItemName = (item) => {
   if (!item) return '';
   if (typeof item === 'string') return item;
   if (typeof item !== 'object') return String(item);
-  return item.displayName || item.name || item.armorName || item.title || '';
+  return (
+    item.displayName ||
+    item.name ||
+    item.itemName ||
+    item.armorName ||
+    item.title ||
+    ''
+  );
 };
 
 const getItemSource = (item) => {

--- a/client/src/components/Zombies/attributes/inventoryNormalization.js
+++ b/client/src/components/Zombies/attributes/inventoryNormalization.js
@@ -222,6 +222,8 @@ export const normalizeItems = (items, { includeUnowned = false } = {}) => {
       if (isObjectLike(item)) {
         const {
           name,
+          itemName,
+          displayName,
           category = '',
           weight = '',
           cost = '',
@@ -231,10 +233,11 @@ export const normalizeItems = (items, { includeUnowned = false } = {}) => {
           owned: ownedProp,
           ...rest
         } = item;
-        if (!name) return null;
+        const resolvedName = name || itemName || displayName;
+        if (!resolvedName) return null;
         if (!includeUnowned && ownedProp === false) return null;
         const normalized = {
-          name,
+          name: resolvedName,
           category,
           weight,
           cost,
@@ -246,6 +249,12 @@ export const normalizeItems = (items, { includeUnowned = false } = {}) => {
               : {},
           ...rest,
         };
+        if (itemName !== undefined) normalized.itemName = itemName;
+        if (displayName !== undefined) {
+          normalized.displayName = displayName;
+        } else if (!name && itemName) {
+          normalized.displayName = itemName;
+        }
         if (notes !== undefined) normalized.notes = notes;
         if (ownedProp !== undefined) normalized.owned = ownedProp;
         return normalized;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -121,7 +121,7 @@ test('spells button glows when spellPoints absent but spells remain', async () =
         startStatTotal: 60,
         proficiencyPoints: 0,
         skills: {},
-        item: [],
+        item: [{ itemName: 'Legacy Keepsake' }],
         feat: [],
         weapon: [],
         armor: [],
@@ -549,7 +549,7 @@ test('purchasing from shop updates currency and inventory', async () => {
         startStatTotal: 60,
         proficiencyPoints: 0,
         skills: {},
-        item: [],
+        item: [{ itemName: 'Legacy Keepsake' }],
         feat: [],
         weapon: [],
         armor: [],
@@ -571,6 +571,11 @@ test('purchasing from shop updates currency and inventory', async () => {
 
   await waitFor(() => expect(mockShopModalProps.current).not.toBeNull());
   await waitFor(() => expect(mockShopModalProps.current.form).toBeTruthy());
+  await waitFor(() =>
+    expect(mockShopModalProps.current.form.item).toEqual([
+      { itemName: 'Legacy Keepsake' },
+    ])
+  );
 
   const cartItems = [
     {
@@ -666,15 +671,21 @@ test('purchasing from shop updates currency and inventory', async () => {
       headers: { 'Content-Type': 'application/json' },
     })
   );
-  expect(JSON.parse(apiFetch.mock.calls[4][1].body)).toEqual({
-    item: [
-      expect.objectContaining({
-        name: 'Torch',
-        cost: '3 sp',
-        type: 'gear',
-      }),
-    ],
-  });
+  const updatedItemsPayload = JSON.parse(apiFetch.mock.calls[4][1].body).item;
+  expect(updatedItemsPayload).toHaveLength(2);
+  expect(updatedItemsPayload[0]).toEqual(
+    expect.objectContaining({
+      name: 'Legacy Keepsake',
+      displayName: 'Legacy Keepsake',
+    })
+  );
+  expect(updatedItemsPayload[1]).toEqual(
+    expect.objectContaining({
+      name: 'Torch',
+      cost: '3 sp',
+      type: 'gear',
+    })
+  );
 
   await waitFor(() =>
     expect(mockShopModalProps.current.currency).toMatchObject({


### PR DESCRIPTION
## Summary
- update item normalization helpers to fall back to legacy itemName values and keep display labels
- ensure cart keying and equipment name resolution recognize itemName entries
- add a regression test covering purchases when inventory contains legacy itemName-only entries

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/attributes/EquipmentRack.test.js src/components/Zombies/attributes/ShopModal.test.js
- CI=1 npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --testNamePattern "purchasing from shop updates currency and inventory"


------
https://chatgpt.com/codex/tasks/task_e_68cf3abbbd40832e8d649900cb1ce318