### PR TITLE
Add accessory creation support across client and server

### DIFF
--- a/server/data/accessories.js
+++ b/server/data/accessories.js
@@ -1,0 +1,27 @@
+const { EQUIPMENT_SLOT_LAYOUT } = require('../constants/equipmentSlots');
+
+const categories = [
+  'amulet',
+  'belt',
+  'bracelet',
+  'brooch',
+  'cape',
+  'cloak',
+  'goggles',
+  'mask',
+  'ring',
+  'sash',
+  'wrap',
+];
+
+const slotKeys = ['eyes', 'wrists', 'neck', 'waist', 'back', 'ringLeft', 'ringRight'];
+
+const slotMap = new Map(EQUIPMENT_SLOT_LAYOUT.flat().map((slot) => [slot.key, slot]));
+
+const slots = slotKeys.map((key) => slotMap.get(key) || { key, label: key });
+
+module.exports = {
+  categories,
+  slots,
+  slotKeys,
+};

--- a/server/routes/accessories.js
+++ b/server/routes/accessories.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { categories, slots } = require('../data/accessories');
+
+module.exports = (router) => {
+  const accessoryRouter = express.Router();
+
+  accessoryRouter.get('/options', (_req, res) => {
+    res.json({ categories, slots });
+  });
+
+  router.use('/accessories', accessoryRouter);
+};

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -24,6 +24,10 @@ const {
 } = require('../data/armor');
 const { ARMOR_SLOT_OPTIONS } = require('../constants/equipmentSlots');
 const { categories: itemCategories } = require('../data/items');
+const {
+  categories: accessoryCategories,
+  slotKeys: accessorySlotKeys,
+} = require('../data/accessories');
 const { skillNames } = require('./fieldConstants');
 
 module.exports = (router) => {
@@ -168,6 +172,61 @@ module.exports = (router) => {
       const parsed = ItemSchema.safeParse(data);
       if (!parsed.success) {
         return res.status(500).json({ message: parsed.error.message });
+      }
+      return res.json(parsed.data);
+    } catch (err) {
+      return res.status(500).json({ message: err.message });
+    }
+  });
+
+  aiRouter.post('/accessory', async (req, res) => {
+    const { prompt } = req.body || {};
+    if (!prompt) {
+      return res.status(400).json({ message: 'Prompt is required' });
+    }
+    if (!OpenAI || !z || !zodResponseFormat) {
+      return res.status(500).json({ message: 'OpenAI not configured' });
+    }
+
+    const AccessorySchema = z.object({
+      name: z.string(),
+      category: z.enum(accessoryCategories),
+      targetSlots: z.array(z.enum(accessorySlotKeys)),
+      rarity: z.string().optional(),
+      weight: z.number().optional(),
+      cost: z.string().optional(),
+      notes: z.string().optional(),
+      statBonuses: z.object({}).catchall(z.number()).optional(),
+      skillBonuses: z.object({}).catchall(z.number()).optional(),
+    });
+
+    try {
+      const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const { json_schema, ...rest } = zodResponseFormat(AccessorySchema);
+      const format = { name: 'accessory', schema: json_schema.schema, ...rest };
+      const slotList = accessorySlotKeys.join(', ');
+      const categoryList = accessoryCategories.join(', ');
+      const skillsList = skillNames.join(', ');
+
+      const response = await openai.responses.parse({
+        model: 'gpt-4o-2024-08-06',
+        input: [
+          {
+            role: 'system',
+            content: `Create a Dungeons and Dragons accessory. Always include a non-empty "targetSlots" array using only these slots: ${slotList}. Choose a "category" from the following list: ${categoryList}. Include "statBonuses" or "skillBonuses" only if the description suggests bonuses to ability scores (str, dex, con, int, wis, cha) or skills (${skillsList}).`,
+          },
+          { role: 'user', content: prompt },
+        ],
+        text: { format },
+      });
+
+      const data = response.output?.[0]?.content?.[0]?.parsed;
+      const parsed = AccessorySchema.safeParse(data);
+      if (!parsed.success) {
+        return res.status(500).json({ message: parsed.error.message });
+      }
+      if (!Array.isArray(parsed.data.targetSlots) || parsed.data.targetSlots.length === 0) {
+        return res.status(500).json({ message: 'targetSlots must be a non-empty array' });
       }
       return res.json(parsed.data);
     } catch (err) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -21,6 +21,7 @@ const spells = require('./spells');
 const weapons = require('./weapons');
 const armor = require('./armor');
 const items = require('./items');
+const accessories = require('./accessories');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
 const ai = require('./ai');
@@ -44,6 +45,7 @@ spells(routes);
 weapons(routes);
 armor(routes);
 items(routes);
+accessories(routes);
 ai(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.


### PR DESCRIPTION
## Summary
- add accessory management to the Zombies DM page including AI-assisted generation, slot selection, and CRUD actions
- introduce accessory data, routes, and validation on the server plus AI generation support and dedicated tests
- extend existing equipment tests to cover accessories and update client tests for the new workflow

## Testing
- npm --prefix server test
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf4bcb68b8832ea971abe62fa32ffd