### PR TITLE
Add accessory inventory handling

### DIFF
--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -3,10 +3,12 @@ import { Modal, Card, Tab, Nav, Button } from 'react-bootstrap';
 import WeaponList from '../../Weapons/WeaponList';
 import ArmorList from '../../Armor/ArmorList';
 import ItemList from '../../Items/ItemList';
+import AccessoryList from '../../Accessories/AccessoryList';
 import {
   normalizeArmor,
   normalizeItems,
   normalizeWeapons,
+  normalizeAccessories,
 } from './inventoryNormalization';
 
 const DEFAULT_TAB = 'weapons';
@@ -45,6 +47,11 @@ export default function InventoryModal({
   const normalizedItems = useMemo(
     () => normalizeItems(form.item || []),
     [form.item]
+  );
+  const normalizedAccessories = useMemo(
+    () =>
+      normalizeAccessories(form.accessories || form.accessory || []),
+    [form.accessories, form.accessory]
   );
 
   const handleSelectTab = (key) => {
@@ -114,12 +121,31 @@ export default function InventoryModal({
             />
           ),
       },
+      {
+        key: 'accessories',
+        title: 'Accessories',
+        render: (isActive) =>
+          !isActive ? null : normalizedAccessories.length === 0 ? (
+            <div className="text-center text-muted py-3">
+              No accessories in inventory.
+            </div>
+          ) : (
+            <AccessoryList
+              campaign={form.campaign}
+              initialAccessories={normalizedAccessories}
+              show={isActive}
+              embedded
+              ownedOnly
+            />
+          ),
+      },
     ],
     [
       characterId,
       form.campaign,
       normalizedArmor,
       normalizedItems,
+      normalizedAccessories,
       normalizedWeapons,
     ]
   );

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -651,6 +651,91 @@ describe('Equipment routes', () => {
     });
   });
 
+  describe('update-accessories', () => {
+    const baseAccessory = {
+      name: 'Ring of Protection',
+      category: 'ring',
+      targetSlots: [ACCESSORY_SLOT_KEYS[0]],
+      statBonuses: { str: 1 },
+    };
+
+    test('update success', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({ accessories: [baseAccessory] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Accessories updated');
+    });
+
+    test('update not found', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 0 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({ accessories: [baseAccessory] });
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Accessory not found');
+    });
+
+    test('update accessories invalid id', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/123')
+        .send({ accessories: [baseAccessory] });
+      expect(res.status).toBe(400);
+    });
+
+    test('update accessories invalid body', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({ accessories: 'bad' });
+      expect(res.status).toBe(400);
+    });
+
+    test('update accessories invalid structure', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({ accessories: ['bad'] });
+      expect(res.status).toBe(400);
+    });
+
+    test('update accessories invalid slot', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, targetSlots: ['invalid-slot'] }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    test('update accessories invalid bonuses', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, statBonuses: 'bad' }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    test('update accessories invalid weight', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, weight: 'heavy' }],
+        });
+      expect(res.status).toBe(400);
+    });
+  });
+
   describe('update-equipment', () => {
     test('update success', async () => {
       const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });


### PR DESCRIPTION
## Summary
- add accessory normalization utilities and expose them to the inventory modal
- load, persist, and display accessories on the zombies character sheet alongside updated stat calculations
- provide an equipment route and Jest coverage for updating a character's accessories

## Testing
- npm --prefix server test -- equipment.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf53dbbf98832ebf3ec709cbaa1327