### PR TITLE
Support equipping accessories

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentModal.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.js
@@ -6,6 +6,7 @@ import {
   normalizeArmor,
   normalizeItems,
   normalizeWeapons,
+  normalizeAccessories,
 } from './inventoryNormalization';
 
 export default function EquipmentModal({
@@ -26,6 +27,10 @@ export default function EquipmentModal({
   const normalizedItems = useMemo(
     () => normalizeItems(form.item || []),
     [form.item]
+  );
+  const normalizedAccessories = useMemo(
+    () => normalizeAccessories(form.accessories || form.accessory || []),
+    [form.accessories, form.accessory]
   );
   const normalizedEquipment = useMemo(
     () => normalizeEquipmentMap(form.equipment),
@@ -57,6 +62,7 @@ export default function EquipmentModal({
                 weapons: normalizedWeapons,
                 armor: normalizedArmor,
                 items: normalizedItems,
+                accessories: normalizedAccessories,
               }}
               onEquipmentChange={onEquipmentChange}
               onSlotChange={onEquipmentSlotChange}

--- a/client/src/components/Zombies/attributes/EquipmentModal.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.test.js
@@ -24,6 +24,7 @@ describe('EquipmentModal', () => {
       weapon: [['Longsword']],
       armor: [['Shield']],
       item: [['Potion']],
+      accessories: [['Belt of Dwarvenkind']],
       equipment: {
         mainHand: { name: 'Longsword', source: 'weapon' },
       },
@@ -44,6 +45,7 @@ describe('EquipmentModal', () => {
       weapons: [expect.objectContaining({ name: 'Longsword' })],
       armor: [expect.objectContaining({ name: 'Shield' })],
       items: [expect.objectContaining({ name: 'Potion' })],
+      accessories: [expect.objectContaining({ name: 'Belt of Dwarvenkind' })],
     });
 
     const equipment = mockEquipmentRackProps.current?.equipment;

--- a/client/src/components/Zombies/attributes/EquipmentRack.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.test.js
@@ -205,4 +205,46 @@ describe('EquipmentRack', () => {
       .map((option) => option.textContent);
     expect(feetOptions).toEqual(['Unequipped']);
   });
+
+  test('accessories only appear in compatible slots', () => {
+    const inventory = {
+      accessories: [
+        {
+          name: 'Belt of Hill Giant Strength',
+          category: 'belt',
+          targetSlots: ['waist'],
+        },
+      ],
+    };
+
+    render(
+      <EquipmentRack
+        equipment={{}}
+        inventory={inventory}
+        onEquipmentChange={() => {}}
+        onSlotChange={() => {}}
+      />
+    );
+
+    const waistSelect = screen.getByLabelText('Waist slot selection');
+    const waistOptions = within(waistSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(waistOptions).toEqual([
+      'Unequipped',
+      'Belt of Hill Giant Strength (Accessory)',
+    ]);
+
+    const headSelect = screen.getByLabelText('Head slot selection');
+    const headOptions = within(headSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(headOptions).toEqual(['Unequipped']);
+
+    const ringSelect = screen.getByLabelText('Ring I slot selection');
+    const ringOptions = within(ringSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(ringOptions).toEqual(['Unequipped']);
+  });
 });

--- a/client/src/components/Zombies/attributes/equipmentSlots.js
+++ b/client/src/components/Zombies/attributes/equipmentSlots.js
@@ -8,55 +8,91 @@ const createSlot = (key, label, config = {}) => ({
 export const EQUIPMENT_SLOT_LAYOUT = [
   [
     createSlot('head', 'Head', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
-          categories: ['head', 'helm', 'helmet', 'hat', 'circlet', 'crown'],
+          categories: [
+            'head',
+            'helm',
+            'helmet',
+            'hat',
+            'circlet',
+            'crown',
+            'headband',
+          ],
         },
         armor: {
           categories: ['helm', 'helmet', 'head'],
         },
+        accessory: {
+          categories: [
+            'head',
+            'helm',
+            'helmet',
+            'hat',
+            'circlet',
+            'crown',
+            'headband',
+          ],
+          targetSlots: ['head'],
+        },
       },
     }),
     createSlot('eyes', 'Eyes', {
-      allowedSources: ['item'],
+      allowedSources: ['item', 'accessory'],
       filters: {
         item: {
           categories: ['eye', 'eyes', 'goggles', 'lens', 'visor', 'glasses'],
         },
+        accessory: {
+          categories: ['eye', 'eyes', 'goggles', 'lens', 'visor', 'glasses'],
+          targetSlots: ['eyes'],
+        },
       },
     }),
     createSlot('neck', 'Neck', {
-      allowedSources: ['item'],
+      allowedSources: ['item', 'accessory'],
       filters: {
         item: {
           categories: ['neck', 'amulet', 'necklace', 'pendant', 'torc'],
         },
+        accessory: {
+          categories: ['neck', 'amulet', 'necklace', 'pendant', 'torc'],
+          targetSlots: ['neck'],
+        },
       },
     }),
     createSlot('shoulders', 'Shoulders', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['shoulder', 'cloak', 'cape', 'mantle'],
         },
         armor: {
           categories: ['shoulder', 'cloak', 'cape', 'mantle'],
+        },
+        accessory: {
+          categories: ['shoulder', 'cloak', 'cape', 'mantle'],
+          targetSlots: ['shoulders', 'back'],
         },
       },
     }),
   ],
   [
     createSlot('chest', 'Chest', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['armor', 'chest', 'vest', 'robe', 'mail', 'shirt', 'plate'],
         },
+        accessory: {
+          categories: ['armor', 'chest', 'vest', 'robe', 'mail', 'shirt', 'plate'],
+          targetSlots: ['chest'],
+        },
       },
     }),
     createSlot('back', 'Back', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['back', 'cloak', 'cape', 'mantle'],
@@ -64,10 +100,14 @@ export const EQUIPMENT_SLOT_LAYOUT = [
         armor: {
           categories: ['back', 'cloak', 'cape', 'mantle'],
         },
+        accessory: {
+          categories: ['back', 'cloak', 'cape', 'mantle', 'wings'],
+          targetSlots: ['back', 'shoulders'],
+        },
       },
     }),
     createSlot('arms', 'Arms', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['arm', 'arms', 'bracer', 'sleeve'],
@@ -75,56 +115,80 @@ export const EQUIPMENT_SLOT_LAYOUT = [
         armor: {
           categories: ['arm', 'arms', 'bracer', 'vambrace'],
         },
+        accessory: {
+          categories: ['arm', 'arms', 'bracer', 'sleeve', 'vambrace'],
+          targetSlots: ['arms'],
+        },
       },
     }),
     createSlot('wrists', 'Wrists', {
-      allowedSources: ['item'],
+      allowedSources: ['item', 'accessory'],
       filters: {
         item: {
           categories: ['wrist', 'bracelet', 'bracer', 'cuff'],
+        },
+        accessory: {
+          categories: ['wrist', 'bracelet', 'bracer', 'cuff'],
+          targetSlots: ['wrists'],
         },
       },
     }),
   ],
   [
     createSlot('hands', 'Hands', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['hand', 'hands', 'glove', 'gauntlet', 'mitt'],
         },
         armor: {
           categories: ['hand', 'hands', 'glove', 'gauntlet', 'mitt'],
+        },
+        accessory: {
+          categories: ['hand', 'hands', 'glove', 'gauntlet', 'mitt'],
+          targetSlots: ['hands'],
         },
       },
     }),
     createSlot('waist', 'Waist', {
-      allowedSources: ['item'],
+      allowedSources: ['item', 'accessory'],
       filters: {
         item: {
           categories: ['belt', 'waist', 'sash', 'girdle'],
         },
+        accessory: {
+          categories: ['belt', 'waist', 'sash', 'girdle'],
+          targetSlots: ['waist'],
+        },
       },
     }),
     createSlot('legs', 'Legs', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['leg', 'legs', 'greaves', 'leggings', 'pants', 'skirt'],
         },
         armor: {
           categories: ['leg', 'legs', 'greaves', 'leggings', 'pants', 'skirt'],
+        },
+        accessory: {
+          categories: ['leg', 'legs', 'greaves', 'leggings', 'pants', 'skirt'],
+          targetSlots: ['legs'],
         },
       },
     }),
     createSlot('feet', 'Feet', {
-      allowedSources: ['armor', 'item'],
+      allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
           categories: ['feet', 'foot', 'boot', 'boots', 'shoe', 'sandals', 'slippers'],
         },
         armor: {
           categories: ['feet', 'foot', 'boot', 'boots', 'shoe', 'sandals', 'slippers'],
+        },
+        accessory: {
+          categories: ['feet', 'foot', 'boot', 'boots', 'shoe', 'sandals', 'slippers'],
+          targetSlots: ['feet'],
         },
       },
     }),
@@ -150,18 +214,26 @@ export const EQUIPMENT_SLOT_LAYOUT = [
       },
     }),
     createSlot('ringLeft', 'Ring I', {
-      allowedSources: ['item'],
+      allowedSources: ['item', 'accessory'],
       filters: {
         item: {
           categories: ['ring', 'band', 'signet'],
         },
+        accessory: {
+          categories: ['ring', 'band', 'signet'],
+          targetSlots: ['ring', 'ringleft'],
+        },
       },
     }),
     createSlot('ringRight', 'Ring II', {
-      allowedSources: ['item'],
+      allowedSources: ['item', 'accessory'],
       filters: {
         item: {
           categories: ['ring', 'band', 'signet'],
+        },
+        accessory: {
+          categories: ['ring', 'band', 'signet'],
+          targetSlots: ['ring', 'ringright'],
         },
       },
     }),


### PR DESCRIPTION
## Summary
- pass normalized accessories into the equipment rack so they can be slotted
- allow the rack to surface accessory inventory with slot-aware filtering
- extend equipment slot definitions and tests to cover accessories

## Testing
- CI=true npm test -- EquipmentRack
- CI=true npm test -- EquipmentModal

------
https://chatgpt.com/codex/tasks/task_e_68cff8b2f828832e83426376ce1b6607