### PR TITLE
Restrict cloaks to back equipment slot

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentRack.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.test.js
@@ -247,4 +247,60 @@ describe('EquipmentRack', () => {
       .map((option) => option.textContent);
     expect(ringOptions).toEqual(['Unequipped']);
   });
+
+  test('cloaks only appear in the back slot', () => {
+    const inventory = {
+      armor: normalizeArmor([
+        { name: 'Cloak of Protection', category: 'cloak' },
+        { name: 'Steel Pauldron', category: 'shoulder' },
+      ]),
+      items: [
+        { name: 'Cape of Billowing', category: 'Cape' },
+        { name: 'Spaulders of Might', category: 'Shoulder' },
+      ],
+      accessories: [
+        {
+          name: 'Shadowed Capelet',
+          category: 'Cloak',
+          targetSlots: ['back'],
+        },
+        {
+          name: 'Silver Epaulette',
+          category: 'Shoulder',
+          targetSlots: ['shoulders'],
+        },
+      ],
+    };
+
+    render(
+      <EquipmentRack
+        equipment={{}}
+        inventory={inventory}
+        onEquipmentChange={() => {}}
+        onSlotChange={() => {}}
+      />
+    );
+
+    const shouldersSelect = screen.getByLabelText('Shoulders slot selection');
+    const shouldersOptions = within(shouldersSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(shouldersOptions).toEqual([
+      'Unequipped',
+      'Steel Pauldron (Armor)',
+      'Spaulders of Might (Item)',
+      'Silver Epaulette (Accessory)',
+    ]);
+
+    const backSelect = screen.getByLabelText('Back slot selection');
+    const backOptions = within(backSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+    expect(backOptions).toEqual([
+      'Unequipped',
+      'Cloak of Protection (Armor)',
+      'Cape of Billowing (Item)',
+      'Shadowed Capelet (Accessory)',
+    ]);
+  });
 });

--- a/client/src/components/Zombies/attributes/equipmentSlots.js
+++ b/client/src/components/Zombies/attributes/equipmentSlots.js
@@ -66,14 +66,38 @@ export const EQUIPMENT_SLOT_LAYOUT = [
       allowedSources: ['armor', 'item', 'accessory'],
       filters: {
         item: {
-          categories: ['shoulder', 'cloak', 'cape', 'mantle'],
+          categories: [
+            'shoulder',
+            'shoulders',
+            'pauldron',
+            'spauldron',
+            'epaulet',
+            'epaulette',
+            'mantle',
+          ],
         },
         armor: {
-          categories: ['shoulder', 'cloak', 'cape', 'mantle'],
+          categories: [
+            'shoulder',
+            'shoulders',
+            'pauldron',
+            'spauldron',
+            'epaulet',
+            'epaulette',
+            'mantle',
+          ],
         },
         accessory: {
-          categories: ['shoulder', 'cloak', 'cape', 'mantle'],
-          targetSlots: ['shoulders', 'back'],
+          categories: [
+            'shoulder',
+            'shoulders',
+            'pauldron',
+            'spauldron',
+            'epaulet',
+            'epaulette',
+            'mantle',
+          ],
+          targetSlots: ['shoulders'],
         },
       },
     }),
@@ -102,7 +126,7 @@ export const EQUIPMENT_SLOT_LAYOUT = [
         },
         accessory: {
           categories: ['back', 'cloak', 'cape', 'mantle', 'wings'],
-          targetSlots: ['back', 'shoulders'],
+          targetSlots: ['back'],
         },
       },
     }),


### PR DESCRIPTION
## Summary
- limit the shoulder slot filters to shoulder-focused categories and drop the back target option
- keep cloak-eligible accessories restricted to the back slot configuration
- add an EquipmentRack test that confirms cloaks populate the back slot but not the shoulder slot

## Testing
- CI=true npm test -- EquipmentRack.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d02408b8fc832ead6aaa53362924db