### PR TITLE
Add accessory stat overrides and enforce ability minimums

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentModal.test.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.test.js
@@ -63,6 +63,41 @@ describe('EquipmentModal', () => {
     );
   });
 
+  test('preserves accessory stat overrides when normalizing inventory', async () => {
+    const form = {
+      weapon: [],
+      armor: [],
+      item: [],
+      accessories: [
+        {
+          name: 'Belt of Hill Giant Strength',
+          targetSlots: ['waist'],
+          statOverrides: { str: 21 },
+        },
+      ],
+      equipment: {},
+    };
+
+    render(
+      <EquipmentModal
+        show
+        onHide={jest.fn()}
+        form={form}
+        onEquipmentChange={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByTestId('equipment-rack')).toBeInTheDocument();
+    const accessories = mockEquipmentRackProps.current?.inventory?.accessories;
+    expect(accessories).toBeTruthy();
+    expect(accessories?.[0]).toEqual(
+      expect.objectContaining({
+        name: 'Belt of Hill Giant Strength',
+        statOverrides: { str: 21 },
+      })
+    );
+  });
+
   test('close button triggers onHide handler', async () => {
     const handleHide = jest.fn();
 

--- a/client/src/components/Zombies/attributes/StatBreakdownModal.js
+++ b/client/src/components/Zombies/attributes/StatBreakdownModal.js
@@ -59,6 +59,12 @@ export default function StatBreakdownModal({ show, onHide, statKey, breakdown })
                     <td>Item</td>
                     <td>{breakdown.item}</td>
                   </tr>
+                  {breakdown.override !== undefined && (
+                    <tr>
+                      <td>Override</td>
+                      <td>{breakdown.override}</td>
+                    </tr>
+                  )}
                   <tr>
                     <td>Total</td>
                     <td>{breakdown.total}</td>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -4,6 +4,17 @@ import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
 
+const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
+const createEmptyStatMap = () => ({
+  str: 0,
+  dex: 0,
+  con: 0,
+  int: 0,
+  wis: 0,
+  cha: 0,
+});
+
 export default function Stats({ form, showStats, handleCloseStats }) {
   const [stats] = useState({
     str: form.str || 0,
@@ -24,16 +35,26 @@ export default function Stats({ form, showStats, handleCloseStats }) {
     return Array.isArray(form.item) ? form.item.filter(Boolean) : [];
   }, [form.equipment, form.item]);
 
-  const totalItemBonus = equippedItems.reduce(
-    (acc, el) => ({
-      str: acc.str + Number(el.statBonuses?.str || 0),
-      dex: acc.dex + Number(el.statBonuses?.dex || 0),
-      con: acc.con + Number(el.statBonuses?.con || 0),
-      int: acc.int + Number(el.statBonuses?.int || 0),
-      wis: acc.wis + Number(el.statBonuses?.wis || 0),
-      cha: acc.cha + Number(el.statBonuses?.cha || 0),
-    }),
-    { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 }
+  const { bonuses: totalItemBonus, overrides: itemOverrides } = equippedItems.reduce(
+    (acc, el) => {
+      STAT_KEYS.forEach((key) => {
+        const bonusValue = Number(el.statBonuses?.[key] || 0);
+        if (!Number.isNaN(bonusValue)) {
+          acc.bonuses[key] += bonusValue;
+        }
+        const overrideRaw = el.statOverrides?.[key];
+        if (overrideRaw !== undefined && overrideRaw !== null) {
+          const overrideValue = Number(overrideRaw);
+          if (!Number.isNaN(overrideValue)) {
+            const current = acc.overrides[key];
+            acc.overrides[key] =
+              current === undefined ? overrideValue : Math.max(current, overrideValue);
+          }
+        }
+      });
+      return acc;
+    },
+    { bonuses: createEmptyStatMap(), overrides: {} }
   );
 
   const totalFeatBonus = (form.feat || []).reduce(
@@ -67,14 +88,25 @@ export default function Stats({ form, showStats, handleCloseStats }) {
     const feat = totalFeatBonus[key];
     const item = totalItemBonus[key];
     const cls = classBonus[key];
-    acc[key] = {
+    const totalWithoutOverride = base + cls + race + feat + item;
+    const overrideValue = itemOverrides[key];
+    const breakdown = {
       base,
       class: cls,
       race,
       feat,
       item,
-      total: base + cls + race + feat + item,
+      total: totalWithoutOverride,
     };
+    if (
+      overrideValue !== undefined &&
+      overrideValue !== null &&
+      overrideValue > totalWithoutOverride
+    ) {
+      breakdown.override = overrideValue;
+      breakdown.total = overrideValue;
+    }
+    acc[key] = breakdown;
     return acc;
   }, {});
 

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -46,3 +46,83 @@ test('clicking view shows description and breakdown', async () => {
   const totalRow = screen.getByText('Total').closest('tr');
   expect(within(totalRow).getByText('14')).toBeInTheDocument();
 });
+
+test('equipped stat overrides raise ability score to minimum value', async () => {
+  const form = {
+    str: 10,
+    dex: 0,
+    con: 0,
+    int: 0,
+    wis: 0,
+    cha: 0,
+    race: { abilities: {} },
+    feat: [],
+    equipment: {
+      waist: {
+        name: 'Belt of Hill Giant Strength',
+        statOverrides: { str: 21 },
+        source: 'accessory',
+      },
+    },
+    item: [],
+    occupation: [],
+  };
+
+  render(<Stats form={form} showStats={true} handleCloseStats={() => {}} />);
+
+  const strengthRow = screen.getByText('STR').closest('tr');
+  const cells = within(strengthRow).getAllByRole('cell');
+  expect(cells[1]).toHaveTextContent('21');
+  expect(cells[2]).toHaveTextContent('5');
+
+  await act(async () => {
+    await userEvent.click(
+      within(strengthRow).getByRole('button', { name: /view/i })
+    );
+  });
+
+  const overrideRow = await screen.findByText('Override');
+  const overrideCells = within(overrideRow.closest('tr')).getAllByRole('cell');
+  expect(overrideCells[1]).toHaveTextContent('21');
+  const totalRow = screen.getByText('Total').closest('tr');
+  expect(within(totalRow).getByText('21')).toBeInTheDocument();
+});
+
+test('stat overrides do not lower higher native scores', async () => {
+  const form = {
+    str: 22,
+    dex: 0,
+    con: 0,
+    int: 0,
+    wis: 0,
+    cha: 0,
+    race: { abilities: {} },
+    feat: [],
+    equipment: {
+      waist: {
+        name: 'Belt of Hill Giant Strength',
+        statOverrides: { str: 21 },
+        source: 'accessory',
+      },
+    },
+    item: [],
+    occupation: [],
+  };
+
+  render(<Stats form={form} showStats={true} handleCloseStats={() => {}} />);
+
+  const strengthRow = screen.getByText('STR').closest('tr');
+  const cells = within(strengthRow).getAllByRole('cell');
+  expect(cells[1]).toHaveTextContent('22');
+  expect(cells[2]).toHaveTextContent('6');
+
+  await act(async () => {
+    await userEvent.click(
+      within(strengthRow).getByRole('button', { name: /view/i })
+    );
+  });
+
+  expect(screen.queryByText('Override')).not.toBeInTheDocument();
+  const totalRow = screen.getByText('Total').closest('tr');
+  expect(within(totalRow).getByText('22')).toBeInTheDocument();
+});

--- a/client/src/components/Zombies/attributes/inventoryNormalization.js
+++ b/client/src/components/Zombies/attributes/inventoryNormalization.js
@@ -29,6 +29,11 @@ const normalizeAccessoryBonuses = (bonuses) =>
     ? bonuses
     : {};
 
+const normalizeAccessoryOverrides = (overrides) =>
+  overrides && typeof overrides === 'object' && !Array.isArray(overrides)
+    ? overrides
+    : {};
+
 export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
   if (!Array.isArray(weapons)) return [];
   return weapons
@@ -305,6 +310,7 @@ export const normalizeAccessories = (
           notes,
           statBonuses,
           skillBonuses,
+          statOverrides,
         ] = accessory;
         if (!name) return null;
         const normalized = {
@@ -316,6 +322,7 @@ export const normalizeAccessories = (
           cost: cost ?? '',
           statBonuses: normalizeAccessoryBonuses(statBonuses),
           skillBonuses: normalizeAccessoryBonuses(skillBonuses),
+          statOverrides: normalizeAccessoryOverrides(statOverrides),
         };
         if (notes !== undefined) normalized.notes = notes;
         if (owned !== undefined) normalized.owned = owned;
@@ -331,6 +338,7 @@ export const normalizeAccessories = (
           cost: '',
           statBonuses: {},
           skillBonuses: {},
+          statOverrides: {},
         };
       }
       if (isObjectLike(accessory)) {
@@ -345,6 +353,7 @@ export const normalizeAccessories = (
           cost = '',
           statBonuses,
           skillBonuses,
+          statOverrides,
           notes,
           owned: ownedProp,
           ...rest
@@ -361,6 +370,7 @@ export const normalizeAccessories = (
           cost,
           statBonuses: normalizeAccessoryBonuses(statBonuses),
           skillBonuses: normalizeAccessoryBonuses(skillBonuses),
+          statOverrides: normalizeAccessoryOverrides(statOverrides),
           ...rest,
         };
         if (!name && accessoryName && normalized.displayName === undefined) {

--- a/server/data/accessories.js
+++ b/server/data/accessories.js
@@ -44,6 +44,7 @@ const accessories = {
     targetSlots: ['neck'],
     weight: 1,
     cost: '5000 gp',
+    statOverrides: { con: 19 },
     notes: 'While attuned to this amulet, your Constitution score is 19.',
   },
   'amulet-of-proof-against-detection-and-location': {
@@ -105,6 +106,7 @@ const accessories = {
     targetSlots: ['waist'],
     weight: 3,
     cost: '5000 gp',
+    statOverrides: { str: 21 },
     notes: 'While wearing this belt, your Strength score is 21.',
   },
   'belt-of-stone-giant-strength': {
@@ -115,6 +117,7 @@ const accessories = {
     targetSlots: ['waist'],
     weight: 3,
     cost: '50000 gp',
+    statOverrides: { str: 23 },
     notes: 'While wearing this belt, your Strength score is 23.',
   },
   'bracers-of-archery': {


### PR DESCRIPTION
## Summary
- add structured stat overrides for items like the Amulet of Health and hill giant belts and keep them through accessory normalization
- clamp computed ability scores in stats, the character sheet, and the spell selector to respect equipped overrides while surfacing the override in the breakdown modal
- cover the new behavior with equipment and stats tests for the Belt of Hill Giant Strength

## Testing
- `CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Stats.test.js client/src/components/Zombies/attributes/EquipmentModal.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d024fac460832ebe0eb0f2b6a92168