### PR TITLE
Refactor Zombies DM resources to card layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -79,19 +79,14 @@
   border-color: var(--bs-primary);
 }
 
-.weapon-card {
-  height: 100%;
-  color: var(--bs-dark);
-  background-color: #fff;
+.resource-grid > [class*='col'] {
+  display: flex;
 }
 
-.armor-card {
-  height: 100%;
-  color: var(--bs-dark);
-  background-color: #fff;
-}
-
-.item-card {
+.weapon-card,
+.armor-card,
+.item-card,
+.resource-card {
   height: 100%;
   color: var(--bs-dark);
   background-color: #fff;
@@ -113,54 +108,40 @@
 }
 
 .weapon-card .card-title,
-.weapon-card .card-text {
-  margin-bottom: 0.25rem; // reduce vertical gap
-  line-height: 1.2;
-}
-
+.weapon-card .card-text,
 .armor-card .card-title,
-.armor-card .card-text {
+.armor-card .card-text,
+.item-card .card-title,
+.item-card .card-text,
+.resource-card .card-title,
+.resource-card .card-text {
   margin-bottom: 0.25rem; // reduce vertical gap
   line-height: 1.2;
 }
 
 @media (max-width: 576px) {
-  .weapon-card {
+  .weapon-card,
+  .armor-card,
+  .item-card,
+  .resource-card {
     font-size: 0.6rem;
   }
-  .armor-card {
-    font-size: 0.6rem;
-  }
-  .item-card {
-    font-size: 0.6rem;
-  }
-  .weapon-card .card-title {
+  .weapon-card .card-title,
+  .armor-card .card-title,
+  .item-card .card-title,
+  .resource-card .card-title {
     font-size: 0.85rem;
   }
-  .armor-card .card-title {
-    font-size: 0.85rem;
-  }
-  .item-card .card-title {
-    font-size: 0.85rem;
-  }
-  .weapon-card .card-text {
+  .weapon-card .card-text,
+  .armor-card .card-text,
+  .item-card .card-text,
+  .resource-card .card-text {
     font-size: 0.6rem;
   }
-  .armor-card .card-text {
-    font-size: 0.6rem;
-  }
-  .item-card .card-text {
-    font-size: 0.6rem;
-  }
-  .weapon-card .btn {
-    font-size: 0.6rem;
-    padding: 0.25rem 0.5rem;
-  }
-  .armor-card .btn {
-    font-size: 0.6rem;
-    padding: 0.25rem 0.5rem;
-  }
-  .item-card .btn {
+  .weapon-card .btn,
+  .armor-card .btn,
+  .item-card .btn,
+  .resource-card .btn {
     font-size: 0.6rem;
     padding: 0.25rem 0.5rem;
   }

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -99,9 +99,8 @@ describe('ZombiesDM AI generation', () => {
     await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/armor/options'));
 
     expect(
-      await within(card).findByRole('columnheader', { name: 'Slot' })
+      await within(card).findByText(/No armor created yet\./i)
     ).toBeInTheDocument();
-    expect(await within(card).findByText('Chest')).toBeInTheDocument();
 
     await openResourceCreateForm(card);
 
@@ -167,10 +166,13 @@ describe('ZombiesDM AI generation', () => {
 
     await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/armor/options'));
 
+    const armorGrid = await within(card).findByTestId('armor-resource-grid');
     expect(
-      await within(card).findByRole('columnheader', { name: 'Slot' })
+      within(armorGrid).getByText(/Custom Armor/i)
     ).toBeInTheDocument();
-    expect(await within(card).findByText('Chest')).toBeInTheDocument();
+    expect(
+      within(armorGrid).getByText(/Slot:\s*Chest/i)
+    ).toBeInTheDocument();
 
     await openResourceCreateForm(card);
 
@@ -411,8 +413,10 @@ describe('ZombiesDM AI generation', () => {
 
     render(<ZombiesDM />);
 
-    expect(await screen.findByRole('columnheader', { name: 'Currency' })).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: /Adjust/i })).toBeInTheDocument();
+    const grid = await screen.findByTestId('characters-resource-grid');
+    expect(
+      within(grid).getByRole('button', { name: /Adjust currency for Hero/i })
+    ).toBeInTheDocument();
   });
 
   test('submits normalized currency adjustments to the API', async () => {
@@ -451,7 +455,9 @@ describe('ZombiesDM AI generation', () => {
 
     render(<ZombiesDM />);
 
-    const adjustButton = await screen.findByRole('button', { name: /Adjust/i });
+    const adjustButton = await screen.findByRole('button', {
+      name: /Adjust currency for Hero/i,
+    });
     await userEvent.click(adjustButton);
 
     const copperInput = await screen.findByLabelText(/Copper/i);


### PR DESCRIPTION
## Summary
- replace table-based resource panes in the Zombies DM screen with a reusable ResourceGrid that renders cards for characters, players, weapons, armor, accessories, and items
- update shared styling to support the new resource card grid layout alongside existing inventory cards
- refresh the Zombies DM tests to assert against the card grids and new button labels

## Testing
- CI=true npm test -- ZombiesDM

------
https://chatgpt.com/codex/tasks/task_e_68d0451456e4832e90c9f0f1e2420507