### PR TITLE
feat: refresh zombies DM resource header buttons

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1429,6 +1429,45 @@ h1 {
   transition: all 0.2s ease-in-out;
 }
 
+.action-btn.create-btn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background-image: linear-gradient(135deg, var(--bs-primary), #6610f2);
+  border: 0;
+  color: #fff;
+  text-transform: none;
+  box-shadow: 0 0.5rem 1.25rem rgba(13, 110, 253, 0.25);
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out,
+    background-image 0.2s ease-in-out;
+
+  &:hover,
+  &:focus-visible {
+    color: #fff;
+    background-image: linear-gradient(135deg, #4aa3ff, #5a21ff);
+    box-shadow: 0 0.75rem 1.5rem rgba(13, 110, 253, 0.35);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.7);
+    outline-offset: 2px;
+  }
+
+  &:active {
+    transform: translateY(1px);
+    box-shadow: 0 0.35rem 1rem rgba(13, 110, 253, 0.3);
+  }
+
+  svg {
+    font-size: 1.1rem;
+  }
+}
+
 .save-btn {
   background: #ffc107;
   margin-right: 5px;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -39,6 +39,7 @@ import {
   GiSailboat,
   GiTreasureMap,
 } from "react-icons/gi";
+import { FiList, FiPlus } from "react-icons/fi";
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -1398,11 +1399,21 @@ const resolveIcon = (category, iconMap, fallback) => {
               </Card.Title>
               <div className="d-flex align-items-center gap-2">
                 <Button
-                  variant="outline-light"
-                  size="sm"
+                  className="action-btn create-btn"
                   onClick={() => setIsCreatingWeapon((prev) => !prev)}
                 >
-                  {isCreatingWeapon ? "View Weapons" : "Create"}
+                  {isCreatingWeapon ? (
+                    <>
+                      <FiList aria-hidden="true" />
+                      View Weapons
+                    </>
+                  ) : (
+                    <>
+                      <FiPlus aria-hidden="true" />
+                      <span>Create</span>
+                      <span aria-hidden="true"> Weapon</span>
+                    </>
+                  )}
                 </Button>
                 <CloseButton variant="white" onClick={() => handleCloseResourceTab('weapons')} />
               </div>
@@ -1616,11 +1627,21 @@ const resolveIcon = (category, iconMap, fallback) => {
               </Card.Title>
               <div className="d-flex align-items-center gap-2">
                 <Button
-                  variant="outline-light"
-                  size="sm"
+                  className="action-btn create-btn"
                   onClick={() => setIsCreatingArmor((prev) => !prev)}
                 >
-                  {isCreatingArmor ? "View Armor" : "Create"}
+                  {isCreatingArmor ? (
+                    <>
+                      <FiList aria-hidden="true" />
+                      View Armor
+                    </>
+                  ) : (
+                    <>
+                      <FiPlus aria-hidden="true" />
+                      <span>Create</span>
+                      <span aria-hidden="true"> Armor</span>
+                    </>
+                  )}
                 </Button>
                 <CloseButton variant="white" onClick={() => handleCloseResourceTab('armor')} />
               </div>
@@ -1865,11 +1886,21 @@ const resolveIcon = (category, iconMap, fallback) => {
               </Card.Title>
               <div className="d-flex align-items-center gap-2">
                 <Button
-                  variant="outline-light"
-                  size="sm"
+                  className="action-btn create-btn"
                   onClick={() => setIsCreatingAccessory((prev) => !prev)}
                 >
-                  {isCreatingAccessory ? "View Accessories" : "Create"}
+                  {isCreatingAccessory ? (
+                    <>
+                      <FiList aria-hidden="true" />
+                      View Accessories
+                    </>
+                  ) : (
+                    <>
+                      <FiPlus aria-hidden="true" />
+                      <span>Create</span>
+                      <span aria-hidden="true"> Accessory</span>
+                    </>
+                  )}
                 </Button>
                 <CloseButton variant="white" onClick={() => handleCloseResourceTab('accessories')} />
               </div>
@@ -2118,11 +2149,21 @@ const resolveIcon = (category, iconMap, fallback) => {
               </Card.Title>
               <div className="d-flex align-items-center gap-2">
                 <Button
-                  variant="outline-light"
-                  size="sm"
+                  className="action-btn create-btn"
                   onClick={() => setIsCreatingItem((prev) => !prev)}
                 >
-                  {isCreatingItem ? "View Items" : "Create"}
+                  {isCreatingItem ? (
+                    <>
+                      <FiList aria-hidden="true" />
+                      View Items
+                    </>
+                  ) : (
+                    <>
+                      <FiPlus aria-hidden="true" />
+                      <span>Create</span>
+                      <span aria-hidden="true"> Item</span>
+                    </>
+                  )}
                 </Button>
                 <CloseButton variant="white" onClick={() => handleCloseResourceTab('items')} />
               </div>


### PR DESCRIPTION
## Summary
- swap the Zombies DM resource header toggles to the modern action button styling with plus/list icons
- add a reusable create button style with gradient fill and hover/focus treatments in App.scss

## Testing
- `CI=true npm test -- --watch=false` *(fails: existing ZombiesCharacterSheet, ArmorList, Feats warnings/errors in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d054dcc4c8832ebdf7fac06d8014ef