### PR TITLE
Add responsive padding around Zombies DM tabs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3,6 +3,25 @@
 @import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
 
+.zombies-dm-container {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+@media (min-width: 768px) {
+  .zombies-dm-container {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .zombies-dm-container {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
 .spell-slot-tabs {
   display: flex;
   overflow-x: auto;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1197,34 +1197,47 @@ const resolveIcon = (category, iconMap, fallback) => {
 
 
 // -----------------------------------Display-----------------------------------------------------------------------------
- return (
-    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${loginbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
-          <div style={{paddingTop: '150px'}}></div>
-{status && (
-  <Alert variant={status.type} dismissible onClose={() => setStatus(null)}>
-    {status.message}
-  </Alert>
-)}
+  return (
+    <div
+      className="pt-2 text-center"
+      style={{
+        fontFamily: 'Raleway, sans-serif',
+        backgroundImage: `url(${loginbg})`,
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        height: '100vh',
+      }}
+    >
+      <div style={{ paddingTop: '150px' }}></div>
+      {status && (
+        <Alert variant={status.type} dismissible onClose={() => setStatus(null)}>
+          {status.message}
+        </Alert>
+      )}
 
-<Tab.Container activeKey={activeResourceTab || null} onSelect={handleSelectResourceTab}>
-  <div
-    className="d-flex justify-content-center mb-2"
-    style={{ position: 'relative', zIndex: '4' }}
-  >
-    <h2 className="text-white text-center mb-0">
-      {campaignDM.campaignName ?? params.campaign}
-    </h2>
-  </div>
-  <div className="d-flex justify-content-center mb-3" style={{ position: 'relative', zIndex: '4' }}>
-    <Nav variant="tabs" className="flex-wrap">
-      {RESOURCE_TABS.map(({ key, title }) => (
-        <Nav.Item key={key}>
-          <Nav.Link eventKey={key}>{title}</Nav.Link>
-        </Nav.Item>
-      ))}
-    </Nav>
-  </div>
-  <Tab.Content>
+      <Container className="zombies-dm-container">
+        <Tab.Container activeKey={activeResourceTab || null} onSelect={handleSelectResourceTab}>
+          <div
+            className="d-flex justify-content-center mb-2"
+            style={{ position: 'relative', zIndex: '4' }}
+          >
+            <h2 className="text-white text-center mb-0">
+              {campaignDM.campaignName ?? params.campaign}
+            </h2>
+          </div>
+          <div
+            className="d-flex justify-content-center mb-3"
+            style={{ position: 'relative', zIndex: '4' }}
+          >
+            <Nav variant="tabs" className="flex-wrap">
+              {RESOURCE_TABS.map(({ key, title }) => (
+                <Nav.Item key={key}>
+                  <Nav.Link eventKey={key}>{title}</Nav.Link>
+                </Nav.Item>
+              ))}
+            </Nav>
+          </div>
+          <Tab.Content>
     <Tab.Pane eventKey="characters">
       {activeResourceTab === 'characters' && (
         <div className="text-center">
@@ -2431,9 +2444,10 @@ const resolveIcon = (category, iconMap, fallback) => {
       )}
     </Tab.Pane>
   </Tab.Content>
-</Tab.Container>
+        </Tab.Container>
+      </Container>
 
-    <Modal
+      <Modal
       className="dnd-modal"
       size="sm"
       centered


### PR DESCRIPTION
## Summary
- wrap the Zombies DM tab layout in a Bootstrap Container to introduce horizontal padding
- add a responsive `.zombies-dm-container` helper so larger viewports get increased gutters while remaining mobile-friendly

## Testing
- npm test -- --watchAll=false *(fails: pre-existing ZombiesCharacterSheet and related component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d05eb92ba0832eba4fe78a8a765c17