### PR TITLE
Add bottom spacing to Zombies DM tabs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8,6 +8,10 @@
   padding-right: 1rem;
 }
 
+.zombies-dm-container--spaced {
+  padding-bottom: 2rem;
+}
+
 @media (min-width: 768px) {
   .zombies-dm-container {
     padding-left: 1.5rem;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1215,7 +1215,7 @@ const resolveIcon = (category, iconMap, fallback) => {
         </Alert>
       )}
 
-      <Container className="zombies-dm-container">
+      <Container className="zombies-dm-container zombies-dm-container--spaced">
         <Tab.Container activeKey={activeResourceTab || null} onSelect={handleSelectResourceTab}>
           <div
             className="d-flex justify-content-center mb-2"


### PR DESCRIPTION
## Summary
- add a reusable modifier class that supplies bottom padding for the Zombies DM container
- apply the new spacing class to the Zombies DM page container so the tabs clear the viewport edge

## Testing
- not run (styling-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0632ed3b8832eab89664638cbba70