### PR TITLE
Adjust create button spacing in Zombies DM tabs

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1453,6 +1453,7 @@ h1 {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  margin-top: 0.5rem;
   padding: 0.4rem 1rem;
   font-size: 0.95rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add a top margin to the global create button style so the control sits below the card header border in Zombies DM resource tabs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d06330184c832eadf88e98170852d3