### PR TITLE
Adjust Zombies DM layout height and padding

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1205,7 +1205,8 @@ const resolveIcon = (category, iconMap, fallback) => {
         backgroundImage: `url(${loginbg})`,
         backgroundSize: 'cover',
         backgroundRepeat: 'no-repeat',
-        height: '100vh',
+        minHeight: '100vh',
+        paddingBottom: '2rem',
       }}
     >
       <div style={{ paddingTop: '150px' }}></div>


### PR DESCRIPTION
## Summary
- update the Zombies DM page wrapper to use a min-height viewport fill
- add bottom padding so the interface can extend beneath the viewport edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d06761af44832ea22609a1f16a1fd1