### PR TITLE
Increase padding on Zombies DM page

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1233,7 +1233,7 @@ const resolveIcon = (category, iconMap, fallback) => {
         backgroundSize: 'cover',
         backgroundRepeat: 'no-repeat',
         minHeight: '100vh',
-        paddingBottom: '2rem',
+        paddingBottom: '5rem',
       }}
     >
       <div style={{ paddingTop: '150px' }}></div>


### PR DESCRIPTION
## Summary
- increase the Zombies DM page wrapper's bottom padding to provide additional breathing room below the tab set

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d06be82f68832e911007dbcec01be6