### PR TITLE
Make shop and inventory tab headers sticky

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1322,6 +1322,20 @@ h1 {
   overflow: visible;
 }
 
+.modern-card .modal-body {
+  position: relative;
+}
+
+.modern-card .modal-tab-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: rgba(0, 0, 0, 0.95);
+  padding: 0.75rem 0;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 /* Modal Header */
 .modal-header {
   background: none !important;

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -169,7 +169,7 @@ export default function InventoryModal({
           style={{ maxHeight: '80vh', overflowY: 'auto' }}
         >
           <Tab.Container activeKey={currentTab} onSelect={handleSelectTab}>
-            <div className="d-flex justify-content-between align-items-center mb-3">
+            <div className="modal-tab-header d-flex justify-content-between align-items-center mb-3">
               <Nav variant="tabs" className="mb-0">
                 {tabConfigs.map(({ key, title }) => (
                   <Nav.Item key={key}>

--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -660,7 +660,7 @@ export default function ShopModal({
           style={{ maxHeight: '80vh', overflowY: 'auto' }}
         >
           <Tab.Container activeKey={currentTab} onSelect={handleSelectTab}>
-            <div className="d-flex justify-content-between align-items-center mb-3">
+            <div className="modal-tab-header d-flex justify-content-between align-items-center mb-3">
               <Nav variant="tabs" className="mb-0">
                 {tabConfigs.map(({ key, title }) => (
                   <Nav.Item key={key}>


### PR DESCRIPTION
## Summary
- add a reusable `modal-tab-header` wrapper around the shop and inventory tab rows so they can be targeted for styling
- style `modal-tab-header` within modern modals to stay sticky with matching background and spacing while scrolling

## Testing
- npm --prefix client start


------
https://chatgpt.com/codex/tasks/task_e_68d1c08e0558832e858eebc5ade2ded4