### PR TITLE
Refine spell casting damage logging

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -263,14 +263,18 @@ const [pendingSpell, setPendingSpell] = useState(null);
       diff > 0 ? diff : 0
     );
     if (!value) return;
+    if (onCastSpell) {
+      onCastSpell({
+        level,
+        slotType,
+        damage: value.total,
+        breakdown: value.breakdown,
+        castingTime: spell.castingTime,
+        name: spell.name,
+      });
+      return;
+    }
     updateDamageValueWithAnimation(value.total, value.breakdown, spell.name);
-    onCastSpell?.({
-      level,
-      slotType,
-      damage: value.total,
-      castingTime: spell.castingTime,
-      name: spell.name,
-    });
   };
 
   const handleSpellsButtonClick = (spell, crit = false) => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -492,6 +492,7 @@ describe('PlayerTurnActions spell casting', () => {
         level: spell.level,
         slotType: undefined,
         damage: expect.any(Number),
+        breakdown: expect.any(String),
         castingTime: spell.castingTime,
         name: spell.name,
       })

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -388,6 +388,7 @@ export default function ZombiesCharacterSheet() {
         const {
           level,
           damage,
+          breakdown,
           extraDice,
           levelsAbove,
           slotLevel,
@@ -402,7 +403,7 @@ export default function ZombiesCharacterSheet() {
         else if (castingTime?.includes('1 bonus action')) consumeCircle('bonus');
         let result;
         if (typeof damage === 'number') {
-          result = { total: damage };
+          result = { total: damage, breakdown };
         } else if (damage) {
           const calc = calculateDamage(
             damage,
@@ -416,6 +417,9 @@ export default function ZombiesCharacterSheet() {
             calc && typeof calc === 'object'
               ? calc
               : { total: calc };
+          if (!result?.breakdown && breakdown) {
+            result = { ...result, breakdown };
+          }
         } else {
           const spellLabel = name || altName;
           result = { total: spellLabel || 'Spell Cast' };


### PR DESCRIPTION
## Summary
- include rolled damage totals and breakdowns in PlayerTurnActions spell cast payloads when an onCastSpell handler is present
- forward the new breakdown data through ZombiesCharacterSheet so damage animations use the shared payload
- update spell casting test coverage to expect the breakdown field

## Testing
- npm test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1c94762a8832e876733ff128e5aff