### PR TITLE
Add campaign combat state management and tests

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -7,12 +7,26 @@ const express = require('express');
 
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
-jest.mock('../middleware/auth', () => (req, res, next) => next());
-const campaignsRouter = require('../routes');
+let mockUser = { username: 'DM' };
+jest.mock('../middleware/auth', () => (req, res, next) => {
+  req.user = mockUser;
+  next();
+});
+const registerCampaignRoutes = require('../routes/campaigns');
 
 const app = express();
 app.use(express.json());
-app.use(campaignsRouter);
+const router = express.Router();
+router.use(async (req, res, next) => {
+  try {
+    req.db = await dbo();
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+registerCampaignRoutes(router);
+app.use(router);
 app.use((err, req, res, next) => {
   const status = err.status || 500;
   const message = status === 500 ? 'Internal Server Error' : err.message;
@@ -20,17 +34,30 @@ app.use((err, req, res, next) => {
 });
 
 describe('Campaign routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbo.mockReset();
+    mockUser = { username: 'DM' };
+  });
+
   test('create campaign success', async () => {
+    const insertOne = jest.fn().mockResolvedValue({ acknowledged: true });
     dbo.mockResolvedValue({
       collection: () => ({
-        insertOne: async () => ({ acknowledged: true })
-      })
+        insertOne,
+      }),
     });
     const res = await request(app)
       .post('/campaigns/add')
       .send({ campaignName: 'Test', dm: 'DM' });
     expect(res.status).toBe(200);
     expect(res.body.acknowledged).toBe(true);
+    expect(insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        players: [],
+        combat: { participants: [], activeTurn: null },
+      })
+    );
   });
 
   test('create campaign failure', async () => {
@@ -55,6 +82,7 @@ describe('Campaign routes', () => {
     const res = await request(app).get('/campaigns/Test');
     expect(res.status).toBe(200);
     expect(res.body.dm).toBe('DM');
+    expect(res.body.combat).toEqual({ participants: [], activeTurn: null });
   });
 
   test('get campaign by name failure', async () => {
@@ -76,6 +104,7 @@ describe('Campaign routes', () => {
     const res = await request(app).get('/campaigns/dm/DM');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
+    expect(res.body[0].combat).toEqual({ participants: [], activeTurn: null });
   });
 
   test('get campaigns by dm failure', async () => {
@@ -97,6 +126,7 @@ describe('Campaign routes', () => {
     const res = await request(app).get('/campaigns/dm/DM/Test');
     expect(res.status).toBe(200);
     expect(res.body.campaignName).toBe('Test');
+    expect(res.body.combat).toEqual({ participants: [], activeTurn: null });
   });
 
   test('get campaign by dm and name failure', async () => {
@@ -107,5 +137,120 @@ describe('Campaign routes', () => {
     });
     const res = await request(app).get('/campaigns/dm/DM/Test');
     expect(res.status).toBe(500);
+  });
+
+  test('get combat state success', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({
+          campaignName: 'Test',
+          dm: 'DM',
+          combat: {
+            participants: [
+              { characterId: 'char1', initiative: 15 },
+              { characterId: 'char2', initiative: 12 },
+            ],
+            activeTurn: 1,
+          },
+        }),
+      }),
+    });
+
+    const res = await request(app).get('/campaigns/Test/combat');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      participants: [
+        { characterId: 'char1', initiative: 15 },
+        { characterId: 'char2', initiative: 12 },
+      ],
+      activeTurn: 1,
+    });
+  });
+
+  test('get combat state not found', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => null,
+      }),
+    });
+
+    const res = await request(app).get('/campaigns/Unknown/combat');
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Campaign not found');
+  });
+
+  test('update combat success', async () => {
+    const findOne = jest.fn().mockResolvedValue({ campaignName: 'Test', dm: 'DM' });
+    const updateOne = jest.fn().mockResolvedValue({ acknowledged: true, modifiedCount: 1 });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne,
+        updateOne,
+      }),
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/combat')
+      .send({
+        participants: [
+          { characterId: 'char1', initiative: 15 },
+          { characterId: 'char2', initiative: 12 },
+        ],
+        activeTurn: 0,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      participants: [
+        { characterId: 'char1', initiative: 15 },
+        { characterId: 'char2', initiative: 12 },
+      ],
+      activeTurn: 0,
+    });
+    expect(updateOne).toHaveBeenCalledWith(
+      { campaignName: 'Test' },
+      {
+        $set: {
+          combat: {
+            participants: [
+              { characterId: 'char1', initiative: 15 },
+              { characterId: 'char2', initiative: 12 },
+            ],
+            activeTurn: 0,
+          },
+        },
+      }
+    );
+  });
+
+  test('update combat forbidden for non-DM', async () => {
+    mockUser = { username: 'NotDM' };
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+      }),
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/combat')
+      .send({ participants: [], activeTurn: null });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('Forbidden');
+  });
+
+  test('update combat validation failure', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+      }),
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/combat')
+      .send({ participants: 'invalid' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].param).toBe('participants');
   });
 });


### PR DESCRIPTION
## Summary
- add a combat state helper to campaign routes to normalize data and default the new subdocument
- expose authenticated GET/PUT /campaigns/:campaign/combat endpoints with validation and DM-only write access
- expand campaign route tests to cover combat defaults and CRUD while isolating the router under test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3096a42c0832e999013bc9cebb9a4