### PR TITLE
Add combat header with live updates for Zombies character sheet

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.8.2",
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
+    "socket.io-client": "^4.7.5",
     "web-vitals": "^2.1.4",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
## Summary
- fetch the campaign combat state and relevant character data when loading a Zombies character to derive a sorted participant list
- add a combat turn header that surfaces each participant's name and HP with active turn highlighting above the sheet
- integrate socket.io-client so the header updates whenever combat data changes and declare the new dependency

## Testing
- not run (socket.io-client install blocked by npm registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68d315b7b04c832eb22ba2cbe87408be