### PR TITLE
Fix socket.io mock for ZombiesDM tests

### DIFF
--- a/client/__mocks__/socket.io-client.js
+++ b/client/__mocks__/socket.io-client.js
@@ -1,0 +1,29 @@
+const mockSockets = [];
+
+const io = jest.fn(() => {
+  const socket = {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+    disconnect: jest.fn(),
+  };
+  mockSockets.push(socket);
+  return socket;
+});
+
+const __resetMockSocket = () => {
+  mockSockets.length = 0;
+};
+
+const __getMockSockets = () => mockSockets;
+
+const __getIoMock = () => io;
+
+module.exports = {
+  __esModule: true,
+  default: io,
+  io,
+  __resetMockSocket,
+  __getMockSockets,
+  __getIoMock,
+};


### PR DESCRIPTION
## Summary
- add a manual `socket.io-client` mock that builds tracked socket stubs
- update `ZombiesDM.test` to use the shared mock helpers, reset the socket factory in `beforeEach`, and await the rendered combat row before interacting

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d318872590832e90f4ccc03e984ff5