### PR TITLE
Derive combat initiatives from character data

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -531,8 +531,14 @@ describe('ZombiesDM AI generation', () => {
 
   test('allows the DM to manage combat participants', async () => {
     const characters = [
-      { _id: 'char1', characterName: 'Hero', token: 'Player1' },
-      { _id: 'char2', characterName: 'Rogue', token: 'Player2' },
+      {
+        _id: 'char1',
+        characterName: 'Hero',
+        token: 'Player1',
+        dex: 14,
+        feat: [{ initiative: 1 }],
+      },
+      { _id: 'char2', characterName: 'Rogue', token: 'Player2', dex: 12 },
     ];
     let combatState = { participants: [], activeTurn: null };
     const combatUpdates = [];
@@ -585,6 +591,10 @@ describe('ZombiesDM AI generation', () => {
       throw new Error('Hero row not found in combat table');
     }
 
+    const cells = within(heroRow).getAllByRole('cell');
+    const initiativeCell = cells[3];
+    expect(initiativeCell).toHaveTextContent('3');
+
     const heroCheckbox = within(heroRow).getByRole('checkbox', {
       name: /Toggle Hero in combat/i,
     });
@@ -592,7 +602,7 @@ describe('ZombiesDM AI generation', () => {
 
     await waitFor(() => expect(combatUpdates).toHaveLength(1));
     expect(combatUpdates[0]).toMatchObject({
-      participants: [{ characterId: 'char1', initiative: 0 }],
+      participants: [{ characterId: 'char1', initiative: 3 }],
       activeTurn: null,
     });
 

--- a/client/src/components/Zombies/utils/derivedStats.js
+++ b/client/src/components/Zombies/utils/derivedStats.js
@@ -1,0 +1,215 @@
+import { SKILLS } from '../skillSchema';
+
+export const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
+const toNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const createEmptyStatMap = () => ({
+  str: 0,
+  dex: 0,
+  con: 0,
+  int: 0,
+  wis: 0,
+  cha: 0,
+});
+
+export const aggregateStatEffects = (collection) => {
+  const entries = Array.isArray(collection) ? collection : [];
+  return entries.reduce(
+    (acc, el) => {
+      STAT_KEYS.forEach((key) => {
+        const bonusValue = toNumber(el?.statBonuses?.[key]);
+        if (!Number.isNaN(bonusValue)) {
+          acc.bonuses[key] += bonusValue;
+        }
+        const overrideRaw = el?.statOverrides?.[key];
+        if (overrideRaw !== undefined && overrideRaw !== null) {
+          const overrideValue = Number(overrideRaw);
+          if (!Number.isNaN(overrideValue)) {
+            const current = acc.overrides[key];
+            acc.overrides[key] =
+              current === undefined ? overrideValue : Math.max(current, overrideValue);
+          }
+        }
+      });
+      return acc;
+    },
+    { bonuses: createEmptyStatMap(), overrides: {} }
+  );
+};
+
+const extractFeatBonuses = (feat) => {
+  const abilityBonuses = createEmptyStatMap();
+  const result = {
+    abilityBonuses,
+    initiative: 0,
+    speed: 0,
+    ac: 0,
+    hpMaxBonus: 0,
+    hpMaxBonusPerLevel: 0,
+  };
+
+  if (!feat) {
+    return result;
+  }
+
+  if (Array.isArray(feat)) {
+    const [, , ...rest] = feat;
+    const abilityValues = rest.slice(SKILLS.length, SKILLS.length + STAT_KEYS.length);
+    abilityValues.forEach((value, index) => {
+      abilityBonuses[STAT_KEYS[index]] = toNumber(value);
+    });
+    const numericValues = rest.slice(SKILLS.length + STAT_KEYS.length);
+    [
+      result.initiative,
+      result.ac,
+      result.speed,
+      result.hpMaxBonus,
+      result.hpMaxBonusPerLevel,
+    ] = numericValues.map(toNumber);
+    return result;
+  }
+
+  if (typeof feat === 'object') {
+    STAT_KEYS.forEach((key) => {
+      abilityBonuses[key] = toNumber(feat[key]);
+    });
+    result.initiative = toNumber(feat.initiative);
+    result.speed = toNumber(feat.speed);
+    result.ac = toNumber(feat.ac);
+    result.hpMaxBonus = toNumber(feat.hpMaxBonus);
+    result.hpMaxBonusPerLevel = toNumber(feat.hpMaxBonusPerLevel);
+  }
+
+  return result;
+};
+
+const mergeAbilityBonuses = (target, source) => {
+  STAT_KEYS.forEach((key) => {
+    target[key] += toNumber(source[key]);
+  });
+};
+
+export const collectFeatAbilityBonuses = (feats) => {
+  const total = createEmptyStatMap();
+  (Array.isArray(feats) ? feats : []).forEach((feat) => {
+    const { abilityBonuses } = extractFeatBonuses(feat);
+    mergeAbilityBonuses(total, abilityBonuses);
+  });
+  return total;
+};
+
+export const collectFeatNumericBonuses = (feats) =>
+  (Array.isArray(feats) ? feats : []).reduce(
+    (acc, feat) => {
+      const { initiative, speed, ac, hpMaxBonus, hpMaxBonusPerLevel } = extractFeatBonuses(feat);
+      acc.initiative += initiative;
+      acc.speed += speed;
+      acc.ac += ac;
+      acc.hpMaxBonus += hpMaxBonus;
+      acc.hpMaxBonusPerLevel += hpMaxBonusPerLevel;
+      return acc;
+    },
+    { initiative: 0, speed: 0, ac: 0, hpMaxBonus: 0, hpMaxBonusPerLevel: 0 }
+  );
+
+const extractInitiativeFromSource = (source) => {
+  if (!source) return 0;
+  if (Array.isArray(source)) {
+    return source.reduce((sum, entry) => sum + extractInitiativeFromSource(entry), 0);
+  }
+  if (typeof source !== 'object') {
+    return 0;
+  }
+  let total = 0;
+  if (source.initiative !== undefined) {
+    total += toNumber(source.initiative);
+  }
+  if (source.initiativeBonus !== undefined) {
+    total += toNumber(source.initiativeBonus);
+  }
+  if (source.bonuses) {
+    total += extractInitiativeFromSource(source.bonuses);
+  }
+  if (source.statBonuses) {
+    total += extractInitiativeFromSource(source.statBonuses);
+  }
+  if (source.numericBonuses) {
+    total += extractInitiativeFromSource(source.numericBonuses);
+  }
+  if (source.effects) {
+    total += extractInitiativeFromSource(source.effects);
+  }
+  return total;
+};
+
+const getHighestOverride = (candidates) => {
+  return candidates.reduce((max, value) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return max;
+    }
+    return max === null || numeric > max ? numeric : max;
+  }, null);
+};
+
+export const calculateCharacterInitiative = (character) => {
+  if (!character || typeof character !== 'object') {
+    return 0;
+  }
+
+  const baseStats = STAT_KEYS.reduce((acc, key) => {
+    acc[key] = toNumber(character[key]);
+    return acc;
+  }, {});
+
+  const { bonuses: itemBonuses, overrides: itemOverrides } = aggregateStatEffects(
+    character?.item
+  );
+  const accessorySource = Array.isArray(character?.accessories)
+    ? character.accessories
+    : Array.isArray(character?.accessory)
+      ? character.accessory
+      : [];
+  const { bonuses: accessoryBonuses, overrides: accessoryOverrides } = aggregateStatEffects(
+    accessorySource
+  );
+  const featAbilityBonuses = collectFeatAbilityBonuses(character?.feat);
+  const raceAbilityBonuses = STAT_KEYS.reduce((acc, key) => {
+    acc[key] = toNumber(character?.race?.abilities?.[key]);
+    return acc;
+  }, createEmptyStatMap());
+
+  const totalDex =
+    baseStats.dex +
+    itemBonuses.dex +
+    accessoryBonuses.dex +
+    featAbilityBonuses.dex +
+    raceAbilityBonuses.dex;
+
+  const dexOverride = getHighestOverride([itemOverrides?.dex, accessoryOverrides?.dex]);
+  const effectiveDex = dexOverride !== null && dexOverride > totalDex ? dexOverride : totalDex;
+  const dexMod = Math.floor((effectiveDex - 10) / 2);
+
+  const featNumericBonuses = collectFeatNumericBonuses(character?.feat);
+
+  let initiativeTotal = dexMod + featNumericBonuses.initiative + toNumber(character?.initiative);
+
+  initiativeTotal += extractInitiativeFromSource(character?.race);
+  initiativeTotal += extractInitiativeFromSource(character?.background);
+  initiativeTotal += extractInitiativeFromSource(character?.item);
+  initiativeTotal += extractInitiativeFromSource(character?.items);
+  initiativeTotal += extractInitiativeFromSource(character?.armor);
+  initiativeTotal += extractInitiativeFromSource(character?.weapon);
+  initiativeTotal += extractInitiativeFromSource(
+    Array.isArray(character?.accessories) ? character.accessories : character?.accessory
+  );
+  initiativeTotal += extractInitiativeFromSource(character?.equipment);
+  initiativeTotal += extractInitiativeFromSource(character?.miscBonuses);
+  initiativeTotal += extractInitiativeFromSource(character?.bonuses);
+
+  return initiativeTotal;
+};

--- a/client/src/components/Zombies/utils/derivedStats.test.js
+++ b/client/src/components/Zombies/utils/derivedStats.test.js
@@ -1,0 +1,31 @@
+import { calculateCharacterInitiative } from './derivedStats';
+
+describe('calculateCharacterInitiative', () => {
+  it('combines dexterity modifier with feat initiative bonuses', () => {
+    const character = {
+      dex: 14,
+      feat: [{ initiative: 2 }],
+    };
+
+    expect(calculateCharacterInitiative(character)).toBe(4);
+  });
+
+  it('includes race ability bonuses when determining the dex modifier', () => {
+    const character = {
+      dex: 10,
+      race: { abilities: { dex: 2 } },
+    };
+
+    expect(calculateCharacterInitiative(character)).toBe(1);
+  });
+
+  it('applies overrides and flat initiative bonuses from the character record', () => {
+    const character = {
+      dex: 10,
+      accessories: [{ statOverrides: { dex: 18 } }],
+      initiative: 1,
+    };
+
+    expect(calculateCharacterInitiative(character)).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared stat aggregation helpers and expose an initiative calculation utility
- update the Zombies DM combat tracker to seed and sync initiatives from derived character data while rendering them read-only
- adjust the character sheet to reuse the shared helpers and extend tests for initiative calculations

## Testing
- npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js src/components/Zombies/utils/derivedStats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d328336308832e893b002548b3dea0