### PR TITLE
Refactor hit point calculations into shared helper

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -22,6 +22,7 @@ import {
   collectFeatAbilityBonuses,
   collectFeatNumericBonuses,
 } from "../utils/derivedStats";
+import { calculateCharacterHitPoints } from "../utils/characterMetrics";
 import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import StatusEffectBar from "../attributes/StatusEffectBar";
@@ -80,14 +81,6 @@ const normalizeCombatState = (state) => {
       : null;
 
   return { participants, activeTurn };
-};
-
-const parseHpValue = (value) => {
-  if (value === null || value === undefined || value === "") {
-    return null;
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
 };
 
 const mapCharactersById = (characters) => {
@@ -251,10 +244,7 @@ export default function ZombiesCharacterSheet() {
       .map((participant) => {
         const char = characterMap[participant.characterId];
         const name = char?.characterName || participant.characterId;
-        const parsedTemp = parseHpValue(char?.tempHealth);
-        const parsedHealth = parseHpValue(char?.health);
-        const currentHp = parsedTemp ?? parsedHealth;
-        const maxHp = parsedHealth;
+        const { currentHp, maxHp } = calculateCharacterHitPoints(char);
 
         let hpDisplay = '—';
         if (currentHp !== null && maxHp !== null) {

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -1,0 +1,144 @@
+import { aggregateStatEffects, collectFeatAbilityBonuses, collectFeatNumericBonuses, STAT_KEYS } from './derivedStats';
+
+const toFiniteNumberOrNull = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const toFiniteNumberOrZero = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const sumLevels = (occupation) => {
+  if (!Array.isArray(occupation)) {
+    return 0;
+  }
+  return occupation.reduce((total, entry) => total + toFiniteNumberOrZero(entry?.Level), 0);
+};
+
+const normalizeAccessoryCollection = (character) => {
+  if (Array.isArray(character?.accessories)) {
+    return character.accessories;
+  }
+  if (Array.isArray(character?.accessory)) {
+    return character.accessory;
+  }
+  return [];
+};
+
+const calculateEffectiveAbilityScores = (character) => {
+  if (!character || typeof character !== 'object') {
+    return STAT_KEYS.reduce((acc, key) => {
+      acc[key] = 0;
+      return acc;
+    }, {});
+  }
+
+  const baseStats = STAT_KEYS.reduce((acc, key) => {
+    acc[key] = toFiniteNumberOrZero(character?.[key]);
+    return acc;
+  }, {});
+
+  const { bonuses: itemBonuses, overrides: itemOverrides } = aggregateStatEffects(character?.item);
+  const { bonuses: accessoryBonuses, overrides: accessoryOverrides } = aggregateStatEffects(
+    normalizeAccessoryCollection(character)
+  );
+  const featAbilityBonuses = collectFeatAbilityBonuses(character?.feat);
+  const raceBonuses = character?.race?.abilities || {};
+
+  return STAT_KEYS.reduce((acc, key) => {
+    const total =
+      baseStats[key] +
+      itemBonuses[key] +
+      accessoryBonuses[key] +
+      featAbilityBonuses[key] +
+      toFiniteNumberOrZero(raceBonuses[key]);
+
+    const overrideCandidates = [itemOverrides?.[key], accessoryOverrides?.[key]];
+    const highestOverride = overrideCandidates.reduce((max, candidate) => {
+      const numeric = toFiniteNumberOrNull(candidate);
+      if (numeric === null) {
+        return max;
+      }
+      return max === null || numeric > max ? numeric : max;
+    }, null);
+
+    acc[key] = highestOverride !== null && highestOverride > total ? highestOverride : total;
+    return acc;
+  }, {});
+};
+
+const calculateConModifier = (character) => {
+  const abilities = calculateEffectiveAbilityScores(character);
+  return Math.floor((abilities.con - 10) / 2);
+};
+
+const resolveHpBonusFromSource = (character) => {
+  const featBonuses = collectFeatNumericBonuses(character?.feat);
+
+  const directHpBonus = toFiniteNumberOrNull(character?.hpMaxBonus);
+  const directHpBonusPerLevel = toFiniteNumberOrNull(character?.hpMaxBonusPerLevel);
+
+  return {
+    hpMaxBonus:
+      directHpBonus !== null ? directHpBonus : toFiniteNumberOrZero(featBonuses.hpMaxBonus),
+    hpMaxBonusPerLevel:
+      directHpBonusPerLevel !== null
+        ? directHpBonusPerLevel
+        : toFiniteNumberOrZero(featBonuses.hpMaxBonusPerLevel),
+  };
+};
+
+export const calculateCharacterHitPoints = (character, overrides = {}) => {
+  if (!character || typeof character !== 'object') {
+    return { currentHp: null, maxHp: null };
+  }
+
+  const totalLevel = Number.isFinite(overrides.totalLevel)
+    ? overrides.totalLevel
+    : sumLevels(character?.occupation);
+
+  const conMod = Number.isFinite(overrides.conMod)
+    ? overrides.conMod
+    : calculateConModifier(character);
+
+  const baseHealth = toFiniteNumberOrNull(
+    overrides.baseHealth !== undefined ? overrides.baseHealth : character?.health
+  );
+
+  const currentHp = toFiniteNumberOrNull(
+    overrides.currentHp !== undefined ? overrides.currentHp : character?.tempHealth
+  );
+
+  const { hpMaxBonus: fallbackBonus, hpMaxBonusPerLevel: fallbackPerLevel } =
+    resolveHpBonusFromSource(character);
+
+  const hpMaxBonus = Number.isFinite(overrides.hpMaxBonus)
+    ? overrides.hpMaxBonus
+    : fallbackBonus;
+
+  const hpMaxBonusPerLevel = Number.isFinite(overrides.hpMaxBonusPerLevel)
+    ? overrides.hpMaxBonusPerLevel
+    : fallbackPerLevel;
+
+  const resolvedCurrent =
+    currentHp !== null
+      ? currentHp
+      : toFiniteNumberOrNull(overrides.fallbackCurrentHp ?? character?.health);
+
+  const maxHp =
+    baseHealth === null
+      ? null
+      : baseHealth + conMod * totalLevel + hpMaxBonus + hpMaxBonusPerLevel * totalLevel;
+
+  return {
+    currentHp: resolvedCurrent,
+    maxHp: Number.isFinite(maxHp) ? maxHp : null,
+  };
+};
+
+export default calculateCharacterHitPoints;

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -1,0 +1,55 @@
+import { calculateCharacterHitPoints } from './characterMetrics';
+
+describe('calculateCharacterHitPoints', () => {
+  it('calculates current and max hp using con and level', () => {
+    const character = {
+      health: 10,
+      tempHealth: 8,
+      con: 14,
+      occupation: [{ Level: 1 }],
+    };
+
+    const result = calculateCharacterHitPoints(character);
+
+    expect(result).toEqual({ currentHp: 8, maxHp: 12 });
+  });
+
+  it('includes feat bonuses when available', () => {
+    const character = {
+      health: 20,
+      tempHealth: '35',
+      con: 16,
+      occupation: [{ Level: 3 }],
+      feat: [{ hpMaxBonus: 5, hpMaxBonusPerLevel: 2 }],
+    };
+
+    const result = calculateCharacterHitPoints(character);
+
+    expect(result).toEqual({ currentHp: 35, maxHp: 40 });
+  });
+
+  it('respects override values when provided', () => {
+    const character = {
+      health: 1,
+      tempHealth: 0,
+      occupation: [],
+    };
+
+    const result = calculateCharacterHitPoints(character, {
+      baseHealth: 15,
+      currentHp: 9,
+      conMod: 4,
+      totalLevel: 2,
+      hpMaxBonus: 3,
+      hpMaxBonusPerLevel: 1,
+    });
+
+    expect(result).toEqual({ currentHp: 9, maxHp: 28 });
+  });
+
+  it('returns nulls when data is missing', () => {
+    const result = calculateCharacterHitPoints({}, {});
+
+    expect(result).toEqual({ currentHp: null, maxHp: null });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared hit point calculator that aggregates health, CON, levels, and feat bonuses
- use the shared helper for participant HP displays and the HealthDefense widget to keep numbers in sync
- add unit coverage for the new helper and tighten HealthDefense handling of missing HP data

## Testing
- `CI=true npm test -- --runTestsByPath client/src/components/Zombies/utils/characterMetrics.test.js client/src/components/Zombies/attributes/HealthDefense.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` *(fails: jest cannot resolve optional dependency socket.io-client in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d32d780c38832ea8b94285975c1869