### PR TITLE
Add SRD enemy management for DM view

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -88,6 +88,16 @@ describe('ZombiesDM AI generation', () => {
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/campaigns/Camp1/combat':
           return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
         case '/equipment/armor/Camp1':
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/armor/options':
@@ -166,6 +176,10 @@ describe('ZombiesDM AI generation', () => {
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/campaigns/Camp1/combat':
           return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
         case '/equipment/armor/Camp1':
           return Promise.resolve({ ok: true, json: async () => armorRecords });
         case '/armor/options':
@@ -561,6 +575,8 @@ describe('ZombiesDM AI generation', () => {
             return Promise.resolve({ ok: true, json: async () => combatState });
           }
           return Promise.resolve({ ok: true, json: async () => combatState });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
         case '/campaigns/dm/dm/Camp1':
           return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
         case '/users':

--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -37,6 +37,9 @@ jest.mock(
         optional() {
           return makeSchema((v) => v === undefined || check(v));
         },
+        nullable() {
+          return makeSchema((v) => v === null || check(v));
+        },
       };
     }
     const z = {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -22,6 +22,7 @@ const weapons = require('./weapons');
 const armor = require('./armor');
 const items = require('./items');
 const accessories = require('./accessories');
+const monsters = require('./monsters');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
 const ai = require('./ai');
@@ -46,6 +47,7 @@ weapons(routes);
 armor(routes);
 items(routes);
 accessories(routes);
+monsters(routes);
 ai(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.

--- a/server/routes/monsters.js
+++ b/server/routes/monsters.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const { getMonsterList, getMonsterByIndex } = require('../utils/dnd5eApi');
+const { normalizeMonsterDetail } = require('../utils/monsters');
+
+module.exports = (router) => {
+  const monstersRouter = express.Router();
+
+  monstersRouter.get('/monsters', async (req, res, next) => {
+    try {
+      const list = await getMonsterList();
+      const results = Array.isArray(list?.results) ? list.results : [];
+      const search = typeof req.query.search === 'string' ? req.query.search.trim().toLowerCase() : '';
+
+      let filtered = results;
+      if (search) {
+        filtered = results.filter((monster) => monster?.name?.toLowerCase().includes(search));
+      }
+
+      res.json(filtered.map((monster) => ({
+        index: monster.index,
+        name: monster.name,
+        url: monster.url,
+      })));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  monstersRouter.get('/monsters/:index', async (req, res, next) => {
+    try {
+      const monster = await getMonsterByIndex(req.params.index);
+      const normalized = normalizeMonsterDetail(monster);
+      if (!normalized) {
+        return res.status(404).json({ message: 'Monster not found' });
+      }
+      res.json(normalized);
+    } catch (err) {
+      if (err.statusCode === 404) {
+        return res.status(404).json({ message: 'Monster not found' });
+      }
+      next(err);
+    }
+  });
+
+  router.use(monstersRouter);
+};

--- a/server/utils/dnd5eApi.js
+++ b/server/utils/dnd5eApi.js
@@ -1,0 +1,90 @@
+const https = require('https');
+const logger = require('./logger');
+
+const API_BASE = 'https://www.dnd5eapi.co';
+
+function fetchJson(path) {
+  return new Promise((resolve, reject) => {
+    if (!path || typeof path !== 'string') {
+      reject(new Error('A valid path is required to fetch data from the 5e SRD API.'));
+      return;
+    }
+
+    const request = https.get(`${API_BASE}${path}`, (response) => {
+      const { statusCode } = response;
+
+      if (statusCode < 200 || statusCode >= 300) {
+        response.resume();
+        const error = new Error(`Request to 5e SRD API failed with status code ${statusCode}`);
+        error.statusCode = statusCode;
+        reject(error);
+        return;
+      }
+
+      let raw = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        raw += chunk;
+      });
+      response.on('end', () => {
+        try {
+          const parsed = JSON.parse(raw);
+          resolve(parsed);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+
+    request.on('error', (err) => {
+      logger.error('Error fetching data from 5e SRD API', { error: err.message });
+      reject(err);
+    });
+  });
+}
+
+let monsterListCache = null;
+const monsterDetailCache = new Map();
+
+async function getMonsterList() {
+  if (monsterListCache) {
+    return monsterListCache;
+  }
+
+  monsterListCache = await fetchJson('/api/monsters');
+  return monsterListCache;
+}
+
+async function getMonsterByIndex(index) {
+  if (!index || typeof index !== 'string') {
+    const error = new Error('Monster index is required');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const normalized = index.trim().toLowerCase();
+  if (!normalized) {
+    const error = new Error('Monster index is required');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  if (monsterDetailCache.has(normalized)) {
+    return monsterDetailCache.get(normalized);
+  }
+
+  const monster = await fetchJson(`/api/monsters/${encodeURIComponent(normalized)}`);
+  monsterDetailCache.set(normalized, monster);
+  return monster;
+}
+
+function clearMonsterCache() {
+  monsterListCache = null;
+  monsterDetailCache.clear();
+}
+
+module.exports = {
+  getMonsterList,
+  getMonsterByIndex,
+  clearMonsterCache,
+};

--- a/server/utils/monsters.js
+++ b/server/utils/monsters.js
@@ -1,0 +1,163 @@
+const normalizeArmorClass = (armorClass) => {
+  if (Array.isArray(armorClass)) {
+    return armorClass
+      .map((entry) => {
+        if (entry && typeof entry === 'object') {
+          return {
+            value: Number(entry.value) || 0,
+            type: entry.type || null,
+            desc: entry.desc || null,
+          };
+        }
+        const numeric = Number(entry);
+        if (Number.isFinite(numeric)) {
+          return { value: numeric, type: null, desc: null };
+        }
+        return null;
+      })
+      .filter((entry) => entry && entry.value);
+  }
+
+  const numeric = Number(armorClass);
+  if (Number.isFinite(numeric)) {
+    return [{ value: numeric, type: null, desc: null }];
+  }
+
+  return [];
+};
+
+const normalizeSpeed = (speed) => {
+  if (!speed) {
+    return {};
+  }
+
+  if (typeof speed === 'string') {
+    return { walk: speed };
+  }
+
+  if (typeof speed === 'object') {
+    return Object.entries(speed).reduce((acc, [key, value]) => {
+      acc[key] = String(value);
+      return acc;
+    }, {});
+  }
+
+  return {};
+};
+
+const normalizeConditionImmunities = (conditionImmunities) => {
+  if (!Array.isArray(conditionImmunities)) {
+    return [];
+  }
+
+  return conditionImmunities
+    .map((entry) => {
+      if (!entry) {
+        return null;
+      }
+      if (typeof entry === 'string') {
+        return entry;
+      }
+      if (typeof entry === 'object' && entry.name) {
+        return entry.name;
+      }
+      return null;
+    })
+    .filter(Boolean);
+};
+
+const normalizeProficiencies = (proficiencies) => {
+  if (!Array.isArray(proficiencies)) {
+    return [];
+  }
+
+  return proficiencies
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const name = entry.proficiency?.name || entry.name || null;
+      const value = Number(entry.value);
+      return {
+        name,
+        value: Number.isFinite(value) ? value : null,
+      };
+    })
+    .filter((entry) => entry && entry.name);
+};
+
+const normalizeMonsterDetail = (monster) => {
+  if (!monster || typeof monster !== 'object') {
+    return null;
+  }
+
+  return {
+    index: monster.index,
+    slug: monster.slug || null,
+    name: monster.name,
+    size: monster.size || null,
+    type: monster.type || null,
+    subtype: monster.subtype || null,
+    alignment: monster.alignment || null,
+    armorClass: normalizeArmorClass(monster.armor_class),
+    hitPoints: Number(monster.hit_points) || 0,
+    hitDice: monster.hit_dice || null,
+    speed: normalizeSpeed(monster.speed),
+    abilityScores: {
+      str: Number(monster.strength) || 0,
+      dex: Number(monster.dexterity) || 0,
+      con: Number(monster.constitution) || 0,
+      int: Number(monster.intelligence) || 0,
+      wis: Number(monster.wisdom) || 0,
+      cha: Number(monster.charisma) || 0,
+    },
+    savingThrows: monster.saving_throws || [],
+    skills: monster.skills || {},
+    proficiencies: normalizeProficiencies(monster.proficiencies),
+    senses: monster.senses || {},
+    languages: monster.languages || '',
+    challengeRating: monster.challenge_rating ?? null,
+    xp: monster.xp ?? null,
+    proficiencyBonus: monster.proficiency_bonus ?? monster.prof_bonus ?? null,
+    damageVulnerabilities: monster.damage_vulnerabilities || [],
+    damageResistances: monster.damage_resistances || [],
+    damageImmunities: monster.damage_immunities || [],
+    conditionImmunities: normalizeConditionImmunities(monster.condition_immunities),
+    actions: monster.actions || [],
+    bonusActions: monster.bonus_actions || [],
+    reactions: monster.reactions || [],
+    legendaryActions: monster.legendary_actions || [],
+    specialAbilities: monster.special_abilities || [],
+    lairActions: monster.lair_actions || [],
+    regionalEffects: monster.regional_effects || [],
+    image: monster.image || null,
+    source: '5e-srd',
+  };
+};
+
+const buildEnemyRecord = (monsterDetail, enemyId, nameOverride) => {
+  if (!monsterDetail) {
+    return null;
+  }
+
+  const normalized = normalizeMonsterDetail(monsterDetail);
+  if (!normalized) {
+    return null;
+  }
+
+  const trimmedName = typeof nameOverride === 'string' ? nameOverride.trim() : '';
+
+  return {
+    ...normalized,
+    enemyId,
+    name: trimmedName || normalized.name,
+    addedAt: new Date().toISOString(),
+  };
+};
+
+module.exports = {
+  normalizeArmorClass,
+  normalizeSpeed,
+  normalizeMonsterDetail,
+  buildEnemyRecord,
+};


### PR DESCRIPTION
## Summary
- add cached 5e SRD monster utilities plus monsters router and campaign enemy endpoints
- extend the DM Zombies UI with SRD enemy catalog browsing, detail preview, and add/remove/combat controls
- allow AI schemas to accept null optional fields and update the jest zod mock accordingly

## Testing
- npm test --prefix server
- CI=true npm test --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d4768b95c4832e836c9aa09eda8842