### PR TITLE
Show enemy names on combat tracker

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -60,9 +60,16 @@ const normalizeCombatState = (state) => {
           }
 
           const initiativeValue = Number(participant.initiative);
+          const displayName =
+            typeof participant.displayName === "string" &&
+            participant.displayName.trim() !== ""
+              ? participant.displayName.trim()
+              : null;
+
           return {
             characterId: participant.characterId.trim(),
             initiative: Number.isFinite(initiativeValue) ? initiativeValue : 0,
+            ...(displayName ? { displayName } : {}),
           };
         })
         .filter(Boolean)
@@ -289,7 +296,18 @@ export default function ZombiesCharacterSheet() {
       .sort((a, b) => b.initiative - a.initiative)
       .map((participant) => {
         const char = characterMap[participant.characterId];
-        const name = char?.characterName || participant.characterId;
+        const participantName =
+          (typeof char?.characterName === "string" && char.characterName.trim() !== ""
+            ? char.characterName.trim()
+            : null) ||
+          (typeof char?.name === "string" && char.name.trim() !== ""
+            ? char.name.trim()
+            : null) ||
+          (typeof participant.displayName === "string" &&
+          participant.displayName.trim() !== ""
+            ? participant.displayName.trim()
+            : null);
+        const name = participantName || participant.characterId;
         const { currentHp, maxHp } = calculateCharacterHitPoints(char);
 
         const normalizedCurrentHp = Number.isFinite(currentHp) ? currentHp : null;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -66,6 +66,8 @@ const STAT_LABELS = STATS.reduce((acc, { key, label }) => {
   return acc;
 }, {});
 
+const STAT_KEYS_ORDER = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
 const SKILL_LOOKUP = SKILLS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
   acc[key.toLowerCase()] = key;
@@ -108,9 +110,16 @@ const normalizeCombatState = (state) => {
           }
 
           const initiativeValue = Number(participant.initiative);
+          const displayName =
+            typeof participant.displayName === 'string' &&
+            participant.displayName.trim() !== ''
+              ? participant.displayName.trim()
+              : null;
+
           return {
             characterId: participant.characterId.trim(),
             initiative: Number.isFinite(initiativeValue) ? initiativeValue : 0,
+            ...(displayName ? { displayName } : {}),
           };
         })
         .filter(Boolean)
@@ -205,6 +214,18 @@ export default function ZombiesDM() {
     const navigate = useNavigate();
     const params = useParams();
     const [records, setRecords] = useState([]);
+    const [enemies, setEnemies] = useState([]);
+    const [monsterCatalog, setMonsterCatalog] = useState([]);
+    const [monsterCatalogLoading, setMonsterCatalogLoading] = useState(false);
+    const [monsterCatalogLoaded, setMonsterCatalogLoaded] = useState(false);
+    const [monsterCatalogError, setMonsterCatalogError] = useState(null);
+    const [monsterSearch, setMonsterSearch] = useState('');
+    const [selectedMonsterIndex, setSelectedMonsterIndex] = useState('');
+    const [selectedMonster, setSelectedMonster] = useState(null);
+    const [monsterDetailLoading, setMonsterDetailLoading] = useState(false);
+    const [addingEnemy, setAddingEnemy] = useState(false);
+    const [customEnemyName, setCustomEnemyName] = useState('');
+    const [removingEnemyId, setRemovingEnemyId] = useState(null);
     const [status, setStatus] = useState(null);
     const [combatState, setCombatState] = useState(createEmptyCombatState());
     const socketRef = useRef(null);
@@ -218,25 +239,39 @@ export default function ZombiesDM() {
     const fetchRecords = useCallback(async () => {
       if (!campaignId || !encodedCampaign) {
         setRecords([]);
+        setEnemies([]);
         setCombatState(createEmptyCombatState());
         return;
       }
 
       try {
-        const [charactersResponse, combatResponse] = await Promise.all([
+        const [charactersResponse, combatResponse, enemiesResponse] = await Promise.all([
           apiFetch(`/campaigns/${encodedCampaign}/characters`),
           apiFetch(`/campaigns/${encodedCampaign}/combat`),
+          apiFetch(`/campaigns/${encodedCampaign}/enemies`),
         ]);
 
         if (!charactersResponse.ok) {
           const message = `An error occurred: ${charactersResponse.statusText}`;
           setStatus({ type: 'danger', message });
           setRecords([]);
+          setEnemies([]);
           return;
         }
 
         const characters = await charactersResponse.json();
         setRecords(characters);
+
+        if (enemiesResponse.ok) {
+          const enemiesData = await enemiesResponse.json();
+          setEnemies(Array.isArray(enemiesData) ? enemiesData : []);
+        } else if (enemiesResponse.status === 404) {
+          setEnemies([]);
+        } else {
+          setEnemies([]);
+          const message = `An error occurred: ${enemiesResponse.statusText}`;
+          setStatus({ type: 'danger', message });
+        }
 
         if (combatResponse.ok) {
           const combatJson = await combatResponse.json();
@@ -251,9 +286,169 @@ export default function ZombiesDM() {
       } catch (error) {
         console.error(error);
         setStatus({ type: 'danger', message: error.message || 'Failed to fetch records.' });
+        setEnemies([]);
         setCombatState(createEmptyCombatState());
       }
     }, [campaignId, encodedCampaign]);
+
+    const fetchMonsterCatalog = useCallback(async () => {
+      if (monsterCatalogLoading) {
+        return;
+      }
+
+      setMonsterCatalogLoading(true);
+      try {
+        setMonsterCatalogError(null);
+        const response = await apiFetch('/monsters');
+        if (!response.ok) {
+          throw new Error(response.statusText || 'Failed to load monsters.');
+        }
+        const data = await response.json();
+        const catalog = Array.isArray(data)
+          ? data
+              .slice()
+              .sort((a, b) => (a?.name || '').localeCompare(b?.name || ''))
+          : [];
+        setMonsterCatalog(catalog);
+      } catch (error) {
+        console.error(error);
+        setMonsterCatalog([]);
+        setMonsterCatalogError(error.message || 'Failed to load monsters.');
+        setStatus({ type: 'danger', message: error.message || 'Failed to load monsters.' });
+      } finally {
+        setMonsterCatalogLoaded(true);
+        setMonsterCatalogLoading(false);
+      }
+    }, [monsterCatalogLoading]);
+
+    const updateSelectedMonster = useCallback(
+      async (index) => {
+        const normalizedIndex = typeof index === 'string' ? index.trim() : '';
+        setSelectedMonsterIndex(normalizedIndex);
+        if (!normalizedIndex) {
+          setSelectedMonster(null);
+          return;
+        }
+
+        setMonsterDetailLoading(true);
+        try {
+          const response = await apiFetch(`/monsters/${normalizedIndex}`);
+          if (!response.ok) {
+            throw new Error(response.statusText || 'Failed to load monster.');
+          }
+          const detail = await response.json();
+          setSelectedMonster(detail);
+        } catch (error) {
+          console.error(error);
+          setSelectedMonster(null);
+          setStatus({ type: 'danger', message: error.message || 'Failed to load monster.' });
+        } finally {
+          setMonsterDetailLoading(false);
+        }
+      },
+      [setStatus]
+    );
+
+    const handleMonsterSelectChange = useCallback(
+      (event) => {
+        const { value } = event.target;
+        setCustomEnemyName('');
+        updateSelectedMonster(value);
+      },
+      [updateSelectedMonster]
+    );
+
+    const handleAddEnemy = useCallback(
+      async (event) => {
+        event.preventDefault();
+        if (!selectedMonsterIndex || !encodedCampaign) {
+          return;
+        }
+
+        setAddingEnemy(true);
+        try {
+          const payload = { index: selectedMonsterIndex };
+          const trimmedName = customEnemyName.trim();
+          if (trimmedName) {
+            payload.name = trimmedName;
+          }
+
+          const response = await apiFetch(`/campaigns/${encodedCampaign}/enemies`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            let message = response.statusText || 'Failed to add enemy.';
+            try {
+              const errorData = await response.json();
+              message = errorData?.message || message;
+            } catch (jsonError) {
+              // Ignore JSON parsing errors
+            }
+            throw new Error(message);
+          }
+
+          const addedEnemy = await response.json();
+          setStatus({ type: 'success', message: `${addedEnemy?.name || 'Enemy'} added to campaign.` });
+          setCustomEnemyName('');
+          await fetchRecords();
+        } catch (error) {
+          console.error(error);
+          setStatus({ type: 'danger', message: error.message || 'Failed to add enemy.' });
+        } finally {
+          setAddingEnemy(false);
+        }
+      },
+      [selectedMonsterIndex, encodedCampaign, customEnemyName, fetchRecords]
+    );
+
+    const handleRemoveEnemy = useCallback(
+      async (enemyId) => {
+        if (!enemyId || !encodedCampaign) {
+          return;
+        }
+
+        setRemovingEnemyId(enemyId);
+        try {
+          const response = await apiFetch(`/campaigns/${encodedCampaign}/enemies/${enemyId}`, {
+            method: 'DELETE',
+          });
+
+          if (!response.ok) {
+            let message = response.statusText || 'Failed to remove enemy.';
+            try {
+              const errorData = await response.json();
+              message = errorData?.message || message;
+            } catch (jsonError) {
+              // Ignore JSON parsing errors
+            }
+            throw new Error(message);
+          }
+
+          await fetchRecords();
+          setStatus({ type: 'success', message: 'Enemy removed.' });
+        } catch (error) {
+          console.error(error);
+          setStatus({ type: 'danger', message: error.message || 'Failed to remove enemy.' });
+        } finally {
+          setRemovingEnemyId(null);
+        }
+      },
+      [encodedCampaign, fetchRecords]
+    );
+
+    const filteredMonsterCatalog = useMemo(() => {
+      if (!Array.isArray(monsterCatalog) || monsterCatalog.length === 0) {
+        return [];
+      }
+      const query = monsterSearch.trim().toLowerCase();
+      if (!query) {
+        return monsterCatalog;
+      }
+      return monsterCatalog.filter((monster) => monster?.name?.toLowerCase().includes(query));
+    }, [monsterCatalog, monsterSearch]);
 
     useEffect(() => {
       fetchRecords();
@@ -394,26 +589,125 @@ export default function ZombiesDM() {
       [campaignId, encodedCampaign, fetchRecords]
     );
 
-    const characterInitiativeMap = useMemo(() => {
+    const getEntityId = useCallback((entity) => {
+      if (!entity || typeof entity !== 'object') {
+        return null;
+      }
+      if (entity.entityType === 'enemy' && typeof entity.enemyId === 'string') {
+        return entity.enemyId;
+      }
+      if (typeof entity._id === 'string' && entity._id) {
+        return entity._id;
+      }
+      if (typeof entity.characterId === 'string' && entity.characterId) {
+        return entity.characterId;
+      }
+      if (typeof entity.token === 'string' && entity.token) {
+        return entity.token;
+      }
+      return null;
+    }, []);
+
+    const normalizedEnemies = useMemo(() => {
+      if (!Array.isArray(enemies)) {
+        return [];
+      }
+
+      return enemies.map((enemy) => {
+        const typeLabel = [enemy?.size, enemy?.type].filter(Boolean).join(' ');
+        return {
+          ...enemy,
+          entityType: 'enemy',
+          _id: enemy.enemyId,
+          characterName: enemy.name,
+          token: typeLabel || 'Enemy',
+          displayType: typeLabel,
+        };
+      });
+    }, [enemies]);
+
+    const combinedRecords = useMemo(() => {
+      const characterRecords = Array.isArray(records)
+        ? records.map((character) => ({ ...character, entityType: 'character' }))
+        : [];
+      return [...characterRecords, ...normalizedEnemies];
+    }, [records, normalizedEnemies]);
+
+    const characterLookup = useMemo(() => {
       const map = new Map();
-      if (Array.isArray(records)) {
-        records.forEach((character) => {
-          if (!character) {
-            return;
-          }
-          const id =
-            (typeof character._id === 'string' && character._id) ||
-            (typeof character.characterId === 'string' && character.characterId) ||
-            (typeof character.token === 'string' && character.token);
+      if (Array.isArray(combinedRecords)) {
+        combinedRecords.forEach((entity) => {
+          const id = getEntityId(entity);
           if (!id) {
             return;
           }
-          const initiative = calculateCharacterInitiative(character);
+          map.set(id, entity);
+        });
+      }
+      return map;
+    }, [combinedRecords, getEntityId]);
+
+    const resolveDisplayName = useCallback(
+      (characterId) => {
+        if (typeof characterId !== 'string' || characterId.trim() === '') {
+          return null;
+        }
+
+        const entity = characterLookup.get(characterId);
+        if (!entity || typeof entity !== 'object') {
+          return null;
+        }
+
+        if (
+          typeof entity.characterName === 'string' &&
+          entity.characterName.trim() !== ''
+        ) {
+          return entity.characterName.trim();
+        }
+
+        if (typeof entity.name === 'string' && entity.name.trim() !== '') {
+          return entity.name.trim();
+        }
+
+        return null;
+      },
+      [characterLookup]
+    );
+
+    const calculateEntityInitiative = useCallback(
+      (entity) => {
+        if (!entity || typeof entity !== 'object') {
+          return 0;
+        }
+
+        if (entity.entityType === 'enemy') {
+          const dexScore =
+            Number(entity?.abilityScores?.dex) ||
+            Number(entity?.dexterity) ||
+            0;
+          const modifier = Math.floor((dexScore - 10) / 2);
+          return Number.isFinite(modifier) ? modifier : 0;
+        }
+
+        return calculateCharacterInitiative(entity);
+      },
+      [calculateCharacterInitiative]
+    );
+
+    const characterInitiativeMap = useMemo(() => {
+      const map = new Map();
+      if (Array.isArray(combinedRecords)) {
+        combinedRecords.forEach((entity) => {
+          const id = getEntityId(entity);
+          if (!id) {
+            return;
+          }
+          const initiative = calculateEntityInitiative(entity);
           map.set(id, initiative);
         });
       }
       return map;
-    }, [records]);
+    }, [combinedRecords, calculateEntityInitiative, getEntityId]);
 
     useEffect(() => {
       if (!characterInitiativeMap.size) {
@@ -465,8 +759,14 @@ export default function ZombiesDM() {
           const derivedInitiative = characterInitiativeMap.get(characterId);
           const initiative =
             derivedInitiative !== undefined ? derivedInitiative : 0;
+          const displayName = resolveDisplayName(characterId);
+          const participant = {
+            characterId,
+            initiative,
+            ...(displayName ? { displayName } : {}),
+          };
           nextState = normalizeCombatState({
-            participants: [...participants, { characterId, initiative }],
+            participants: [...participants, participant],
             activeTurn: combatState.activeTurn,
           });
         } else {
@@ -493,7 +793,7 @@ export default function ZombiesDM() {
         setCombatState(nextState);
         persistCombatState(nextState);
       },
-      [combatState, persistCombatState, characterInitiativeMap]
+      [combatState, persistCombatState, characterInitiativeMap, resolveDisplayName]
     );
 
     const handleSetTurn = useCallback(
@@ -544,6 +844,7 @@ export default function ZombiesDM() {
           return {
             characterId: participant.characterId,
             initiative: numericBase + roll,
+            ...(participant.displayName ? { displayName: participant.displayName } : {}),
           };
         })
         .filter(Boolean);
@@ -637,28 +938,16 @@ export default function ZombiesDM() {
       return map;
     }, [combatState.participants]);
 
-    const characterLookup = useMemo(() => {
-      const map = new Map();
-      if (Array.isArray(records)) {
-        records.forEach((character) => {
-          if (character && typeof character._id === 'string') {
-            map.set(character._id, character);
-          }
-        });
-      }
-      return map;
-    }, [records]);
-
     const orderedCombatRecords = useMemo(() => {
-      if (!Array.isArray(records) || records.length === 0) {
+      if (!Array.isArray(combinedRecords) || combinedRecords.length === 0) {
         return [];
       }
 
-      return records
-        .map((character, recordIndex) => {
-          if (!character || typeof character !== 'object') {
+      return combinedRecords
+        .map((entity, recordIndex) => {
+          if (!entity || typeof entity !== 'object') {
             return {
-              character,
+              character: entity,
               rowId: '',
               participantInfo: undefined,
               initiativeValue: undefined,
@@ -667,12 +956,7 @@ export default function ZombiesDM() {
             };
           }
 
-          const rowId =
-            (typeof character._id === 'string' && character._id) ||
-            (typeof character.characterId === 'string' && character.characterId) ||
-            (typeof character.token === 'string' && character.token) ||
-            '';
-
+          const rowId = getEntityId(entity) || '';
           const participantInfo = rowId ? participantLookup.get(rowId) : undefined;
           const derivedInitiative = rowId ? characterInitiativeMap.get(rowId) : undefined;
 
@@ -689,7 +973,7 @@ export default function ZombiesDM() {
                 : Number.NEGATIVE_INFINITY;
 
           return {
-            character,
+            character: entity,
             rowId,
             participantInfo,
             initiativeValue,
@@ -718,7 +1002,64 @@ export default function ZombiesDM() {
 
           return a.recordIndex - b.recordIndex;
         });
-    }, [records, participantLookup, characterInitiativeMap]);
+    }, [combinedRecords, participantLookup, characterInitiativeMap, getEntityId]);
+
+    const formatArmorClass = useCallback((armorClass) => {
+      if (!Array.isArray(armorClass) || armorClass.length === 0) {
+        return '—';
+      }
+
+      const parts = armorClass
+        .map((entry) => {
+          if (!entry || (entry.value === undefined && entry.value !== 0)) {
+            return null;
+          }
+          const numeric = Number(entry.value);
+          if (!Number.isFinite(numeric)) {
+            return null;
+          }
+          const suffix = entry.type ? ` (${entry.type})` : '';
+          return `${numeric}${suffix}`;
+        })
+        .filter(Boolean);
+
+      return parts.length > 0 ? parts.join(', ') : '—';
+    }, []);
+
+    const formatSpeed = useCallback((speed) => {
+      if (!speed) {
+        return '—';
+      }
+
+      if (typeof speed === 'string') {
+        return speed;
+      }
+
+      if (typeof speed === 'object') {
+        const entries = Object.entries(speed)
+          .map(([mode, value]) => {
+            if (value === undefined || value === null || value === '') {
+              return null;
+            }
+            return `${mode}: ${value}`;
+          })
+          .filter(Boolean);
+        return entries.length > 0 ? entries.join(', ') : '—';
+      }
+
+      return '—';
+    }, []);
+
+    const formatAbilityScore = useCallback((key, value) => {
+      const label = STAT_LABELS[key] || key.toUpperCase();
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return `${label}: —`;
+      }
+      const modifier = Math.floor((numeric - 10) / 2);
+      const modifierText = modifier >= 0 ? `+${modifier}` : `${modifier}`;
+      return `${label}: ${numeric} (${modifierText})`;
+    }, []);
 
     const activeParticipant = useMemo(() => {
       if (!Array.isArray(combatState.participants)) {
@@ -747,6 +1088,7 @@ export default function ZombiesDM() {
       if (character) {
         return (
           character.characterName ||
+          character.name ||
           character.token ||
           activeParticipant.characterId
         );
@@ -767,12 +1109,13 @@ export default function ZombiesDM() {
       () => [
         { key: 'characters', title: 'Characters' },
         { key: 'players', title: 'Players' },
+        { key: 'enemies', title: 'Enemies' },
         { key: 'weapons', title: 'Weapons' },
         { key: 'armor', title: 'Armor' },
         { key: 'items', title: 'Items' },
         { key: 'accessories', title: 'Accessories' },
       ],
-      []
+      [calculateCharacterInitiative]
     );
     const [activeResourceTab, setActiveResourceTab] = useState('characters');
 
@@ -785,6 +1128,16 @@ export default function ZombiesDM() {
       },
       [activeResourceTab]
     );
+
+    useEffect(() => {
+      if (
+        activeResourceTab === 'enemies' &&
+        !monsterCatalogLoaded &&
+        !monsterCatalogLoading
+      ) {
+        fetchMonsterCatalog();
+      }
+    }, [activeResourceTab, monsterCatalogLoaded, monsterCatalogLoading, fetchMonsterCatalog]);
     //--------------------------------------------Currency Adjustments------------------------------
     const [currencyModalState, setCurrencyModalState] = useState({ show: false, character: null });
     const [currencyInputs, setCurrencyInputs] = useState({ cp: '0', sp: '0', gp: '0', pp: '0' });
@@ -1950,9 +2303,11 @@ const resolveIcon = (category, iconMap, fallback) => {
                                 isParticipant &&
                                 Number.isInteger(combatState.activeTurn) &&
                                 participantInfo.index === combatState.activeTurn;
+                              const displayName = character?.characterName || character?.name || '—';
                               const playerName = character?.token || '—';
                               const checkboxLabel =
                                 character?.characterName ||
+                                character?.name ||
                                 character?.token ||
                                 participantInfo?.characterId ||
                                 'this character';
@@ -1962,7 +2317,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                                   key={resolvedRowId || playerName}
                                   className={isActive ? 'table-success text-dark' : undefined}
                                 >
-                                  <td className="fw-semibold">{character?.characterName || '—'}</td>
+                                  <td className="fw-semibold">{displayName}</td>
                                   <td>{playerName}</td>
                                   <td className="text-center">
                                     <Form.Check
@@ -2225,6 +2580,293 @@ const resolveIcon = (category, iconMap, fallback) => {
                     </Card.Body>
                   </Card>
                 )}
+              />
+            </Card.Body>
+          </Card>
+        </div>
+      )}
+    </Tab.Pane>
+    <Tab.Pane eventKey="enemies">
+      {activeResourceTab === 'enemies' && (
+        <div className="text-center">
+          <Card className="modern-card" data-testid="resource-enemies-card">
+            <Card.Header className="modal-header">
+              <div className="d-flex align-items-center justify-content-center w-100">
+                <div className="d-flex flex-grow-1 justify-content-center">
+                  <CloseButton
+                    className="ms-auto"
+                    variant="white"
+                    onClick={() => handleCloseResourceTab('enemies')}
+                    aria-label="Close enemies tab"
+                  />
+                </div>
+              </div>
+            </Card.Header>
+            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+              <Container className="mt-3">
+                <Form onSubmit={handleAddEnemy}>
+                  <Row className="g-3 align-items-end">
+                    <Col md={6}>
+                      <Form.Group className="mb-3 mb-md-0">
+                        <Form.Label className="text-light">Search Monsters</Form.Label>
+                        <Form.Control
+                          type="text"
+                          value={monsterSearch}
+                          onChange={(e) => setMonsterSearch(e.target.value)}
+                          placeholder="Search by name"
+                          disabled={monsterCatalogLoading && !monsterCatalogLoaded}
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={6}>
+                      <Form.Group>
+                        <Form.Label className="text-light">Select Monster</Form.Label>
+                        <Form.Select
+                          value={selectedMonsterIndex}
+                          onChange={handleMonsterSelectChange}
+                          disabled={monsterCatalogLoading && !monsterCatalogLoaded}
+                        >
+                          <option value="" disabled>
+                            {monsterCatalogLoading && !monsterCatalogLoaded
+                              ? 'Loading monsters...'
+                              : 'Select Monster'}
+                          </option>
+                          {filteredMonsterCatalog.length > 0 ? (
+                            filteredMonsterCatalog.map((monster) => (
+                              <option key={monster.index} value={monster.index}>
+                                {monster.name}
+                              </option>
+                            ))
+                          ) : (
+                            monsterCatalogLoaded && (
+                              <option value="" disabled>
+                                No monsters match your search
+                              </option>
+                            )
+                          )}
+                        </Form.Select>
+                      </Form.Group>
+                    </Col>
+                  </Row>
+                  <Row className="g-3 align-items-end mt-0">
+                    <Col md={6}>
+                      <Form.Group>
+                        <Form.Label className="text-light">Custom Name (optional)</Form.Label>
+                        <Form.Control
+                          type="text"
+                          value={customEnemyName}
+                          onChange={(e) => setCustomEnemyName(e.target.value)}
+                          placeholder="Override monster name"
+                          disabled={!selectedMonsterIndex}
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={6} className="d-flex justify-content-center justify-content-md-end">
+                      <Button
+                        type="submit"
+                        variant="outline-light"
+                        className="rounded-pill mt-3 mt-md-0"
+                        disabled={!selectedMonsterIndex || addingEnemy}
+                      >
+                        {addingEnemy && (
+                          <Spinner
+                            animation="border"
+                            size="sm"
+                            role="status"
+                            aria-hidden="true"
+                            className="me-2"
+                          />
+                        )}
+                        Add Enemy
+                      </Button>
+                    </Col>
+                  </Row>
+                </Form>
+                {monsterCatalogError && (
+                  <div className="text-warning small mt-3">
+                    {monsterCatalogError}{' '}
+                    <Button
+                      variant="outline-light"
+                      size="sm"
+                      onClick={() => fetchMonsterCatalog()}
+                      disabled={monsterCatalogLoading}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                )}
+                <div className="mt-3">
+                  {monsterDetailLoading ? (
+                    <div className="text-light text-center">
+                      <Spinner animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+                      Loading monster details...
+                    </div>
+                  ) : selectedMonster ? (
+                    <Card className="bg-dark bg-opacity-75 border border-secondary text-start text-light mt-3">
+                      <Card.Body>
+                        <Card.Title className="h5 mb-1">{selectedMonster.name}</Card.Title>
+                        <Card.Subtitle className="text-muted small mb-3">
+                          {[selectedMonster.size, selectedMonster.type].filter(Boolean).join(' ') || '—'}
+                          {selectedMonster.challengeRating !== null && selectedMonster.challengeRating !== undefined
+                            ? ` • CR ${selectedMonster.challengeRating}`
+                            : ''}
+                        </Card.Subtitle>
+                        <div className="d-grid gap-1">
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              AC:
+                            </span>
+                            <span aria-hidden="true">{formatArmorClass(selectedMonster.armorClass)}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              HP:
+                            </span>
+                            <span aria-hidden="true">{selectedMonster.hitPoints ?? '—'}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Hit Dice:
+                            </span>
+                            <span aria-hidden="true">{selectedMonster.hitDice || '—'}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Speed:
+                            </span>
+                            <span aria-hidden="true">{formatSpeed(selectedMonster.speed)}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Alignment:
+                            </span>
+                            <span aria-hidden="true">{selectedMonster.alignment || '—'}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Languages:
+                            </span>
+                            <span aria-hidden="true">
+                              {Array.isArray(selectedMonster.languages)
+                                ? selectedMonster.languages.join(', ')
+                                : selectedMonster.languages || '—'}
+                            </span>
+                          </Card.Text>
+                        </div>
+                        <div className="mt-3">
+                          <h6 className="text-uppercase text-muted small fw-semibold mb-1">Abilities</h6>
+                          <div className="d-flex flex-wrap gap-2">
+                            {STAT_KEYS_ORDER.map((key) => (
+                              <span key={`preview-${key}`} className="badge bg-secondary">
+                                {formatAbilityScore(key, selectedMonster?.abilityScores?.[key])}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      </Card.Body>
+                    </Card>
+                  ) : null}
+                </div>
+              </Container>
+              <ResourceGrid
+                dataTestId="enemies-resource-grid"
+                items={Array.isArray(normalizedEnemies) ? normalizedEnemies : []}
+                emptyMessage="No enemies added yet."
+                getKey={(enemy) => enemy.enemyId}
+                renderItem={(enemy) => {
+                  const participantInfo = enemy.enemyId ? participantLookup.get(enemy.enemyId) : undefined;
+                  const inCombat = Boolean(participantInfo);
+                  const challengeText =
+                    enemy.challengeRating !== null && enemy.challengeRating !== undefined
+                      ? `CR ${enemy.challengeRating}`
+                      : null;
+                  const languagesDisplay = Array.isArray(enemy.languages)
+                    ? enemy.languages.join(', ')
+                    : enemy.languages || '—';
+
+                  return (
+                    <Card className="resource-card h-100 w-100 text-start">
+                      <Card.Body className="d-flex flex-column">
+                        <Card.Title className="mb-1">{enemy.name || 'Unnamed Enemy'}</Card.Title>
+                        <Card.Subtitle className="text-muted small mb-2">
+                          {[enemy.displayType, challengeText].filter(Boolean).join(' • ') || '—'}
+                        </Card.Subtitle>
+                        <div className="d-grid gap-1">
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              AC:
+                            </span>
+                            <span aria-hidden="true">{formatArmorClass(enemy.armorClass)}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              HP:
+                            </span>
+                            <span aria-hidden="true">{enemy.hitPoints ?? '—'}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Speed:
+                            </span>
+                            <span aria-hidden="true">{formatSpeed(enemy.speed)}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Alignment:
+                            </span>
+                            <span aria-hidden="true">{enemy.alignment || '—'}</span>
+                          </Card.Text>
+                          <Card.Text className="small mb-1 text-body fw-semibold text-break">
+                            <span className="text-muted text-uppercase fw-semibold me-1" aria-hidden="true">
+                              Languages:
+                            </span>
+                            <span aria-hidden="true">{languagesDisplay}</span>
+                          </Card.Text>
+                        </div>
+                        <div className="mt-2">
+                          <h6 className="text-uppercase text-muted small fw-semibold mb-1">Abilities</h6>
+                          <div className="d-flex flex-wrap gap-2">
+                            {STAT_KEYS_ORDER.map((key) => (
+                              <span key={`${enemy.enemyId}-${key}`} className="badge bg-secondary">
+                                {formatAbilityScore(key, enemy?.abilityScores?.[key])}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      </Card.Body>
+                      <Card.Footer className="d-flex flex-wrap gap-2 justify-content-end">
+                        <Button
+                          variant={inCombat ? 'success' : 'outline-light'}
+                          size="sm"
+                          onClick={() => handleToggleParticipant(enemy.enemyId)}
+                        >
+                          {inCombat ? 'Remove from Combat' : 'Add to Combat'}
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => handleRemoveEnemy(enemy.enemyId)}
+                          disabled={removingEnemyId === enemy.enemyId}
+                        >
+                          {removingEnemyId === enemy.enemyId ? (
+                            <>
+                              <Spinner
+                                animation="border"
+                                size="sm"
+                                role="status"
+                                aria-hidden="true"
+                                className="me-2"
+                              />
+                              Removing
+                            </>
+                          ) : (
+                            'Remove'
+                          )}
+                        </Button>
+                      </Card.Footer>
+                    </Card>
+                  );
+                }}
               />
             </Card.Body>
           </Card>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -88,6 +88,16 @@ describe('ZombiesDM AI generation', () => {
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/campaigns/Camp1/combat':
           return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
         case '/equipment/armor/Camp1':
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/armor/options':
@@ -166,6 +176,10 @@ describe('ZombiesDM AI generation', () => {
           return Promise.resolve({ ok: true, json: async () => [] });
         case '/campaigns/Camp1/combat':
           return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
         case '/equipment/armor/Camp1':
           return Promise.resolve({ ok: true, json: async () => armorRecords });
         case '/armor/options':
@@ -561,6 +575,8 @@ describe('ZombiesDM AI generation', () => {
             return Promise.resolve({ ok: true, json: async () => combatState });
           }
           return Promise.resolve({ ok: true, json: async () => combatState });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
         case '/campaigns/dm/dm/Camp1':
           return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
         case '/users':
@@ -602,7 +618,9 @@ describe('ZombiesDM AI generation', () => {
 
     await waitFor(() => expect(combatUpdates).toHaveLength(1));
     expect(combatUpdates[0]).toMatchObject({
-      participants: [{ characterId: 'char1', initiative: 3 }],
+      participants: [
+        { characterId: 'char1', initiative: 3, displayName: 'Hero' },
+      ],
       activeTurn: null,
     });
 

--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -37,6 +37,9 @@ jest.mock(
         optional() {
           return makeSchema((v) => v === undefined || check(v));
         },
+        nullable() {
+          return makeSchema((v) => v === null || check(v));
+        },
       };
     }
     const z = {

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -15,7 +15,15 @@ jest.mock('../middleware/auth', () => (req, res, next) => {
 jest.mock('../utils/socket', () => ({
   emitCombatUpdate: jest.fn(),
 }));
+jest.mock('../utils/dnd5eApi', () => ({
+  getMonsterByIndex: jest.fn(),
+}));
+jest.mock('../utils/monsters', () => ({
+  buildEnemyRecord: jest.fn(),
+}));
 const { emitCombatUpdate } = require('../utils/socket');
+const { getMonsterByIndex } = require('../utils/dnd5eApi');
+const { buildEnemyRecord } = require('../utils/monsters');
 const registerCampaignRoutes = require('../routes/campaigns');
 
 const app = express();
@@ -41,6 +49,8 @@ describe('Campaign routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     dbo.mockReset();
+    getMonsterByIndex.mockReset();
+    buildEnemyRecord.mockReset();
     mockUser = { username: 'DM' };
   });
 
@@ -59,6 +69,7 @@ describe('Campaign routes', () => {
     expect(insertOne).toHaveBeenCalledWith(
       expect.objectContaining({
         players: [],
+        enemies: [],
         combat: { participants: [], activeTurn: null },
       })
     );
@@ -171,6 +182,31 @@ describe('Campaign routes', () => {
     });
   });
 
+  test('get combat state populates enemy display names', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({
+          campaignName: 'Test',
+          dm: 'DM',
+          combat: {
+            participants: [{ characterId: 'enemy-1', initiative: 8 }],
+            activeTurn: 0,
+          },
+          enemies: [{ enemyId: 'enemy-1', name: 'Goblin' }],
+        }),
+      }),
+    });
+
+    const res = await request(app).get('/campaigns/Test/combat');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      participants: [
+        { characterId: 'enemy-1', initiative: 8, displayName: 'Goblin' },
+      ],
+      activeTurn: 0,
+    });
+  });
+
   test('get combat state not found', async () => {
     dbo.mockResolvedValue({
       collection: () => ({
@@ -264,4 +300,76 @@ describe('Campaign routes', () => {
     expect(res.status).toBe(400);
     expect(res.body.errors[0].param).toBe('participants');
   });
+
+  test('get enemies success', async () => {
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => ({ campaignName: 'Test', enemies: [{ enemyId: 'enemy-1', name: 'Goblin' }] }),
+      }),
+    });
+
+    const res = await request(app).get('/campaigns/Test/enemies');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ enemyId: 'enemy-1', name: 'Goblin' }]);
+  });
+
+  test('add enemy success', async () => {
+    getMonsterByIndex.mockResolvedValue({ index: 'goblin' });
+    buildEnemyRecord.mockImplementation((monster, enemyId, providedName) => ({ enemyId, name: 'Goblin', providedName }));
+    const findOneAndUpdate = jest.fn().mockResolvedValue({ value: { campaignName: 'Test' } });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOneAndUpdate,
+      }),
+    });
+
+    const res = await request(app)
+      .post('/campaigns/Test/enemies')
+      .send({ index: 'goblin' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Goblin');
+    expect(typeof res.body.enemyId).toBe('string');
+    expect(getMonsterByIndex).toHaveBeenCalledWith('goblin');
+    expect(buildEnemyRecord).toHaveBeenCalledWith({ index: 'goblin' }, res.body.enemyId, undefined);
+  });
+
+  test('delete enemy success', async () => {
+    const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+    const campaign = {
+      campaignName: 'Test',
+      enemies: [{ enemyId: 'enemy-1', name: 'Goblin' }],
+      combat: {
+        participants: [
+          { characterId: 'enemy-1', initiative: 14 },
+          { characterId: 'char-1', initiative: 12 },
+        ],
+        activeTurn: 0,
+      },
+    };
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: async () => campaign,
+        updateOne,
+      }),
+    });
+
+    const res = await request(app).delete('/campaigns/Test/enemies/enemy-1');
+    expect(res.status).toBe(200);
+    expect(updateOne).toHaveBeenCalledWith(
+      { campaignName: 'Test' },
+      {
+        $set: {
+          enemies: [],
+          combat: { participants: [{ characterId: 'char-1', initiative: 12 }], activeTurn: 0 },
+        },
+      }
+    );
+    expect(emitCombatUpdate).toHaveBeenCalledWith('Test', {
+      participants: [{ characterId: 'char-1', initiative: 12 }],
+      activeTurn: 0,
+    });
+    expect(res.body.success).toBe(true);
+  });
+
 });

--- a/server/data/monsters.json
+++ b/server/data/monsters.json
@@ -1,0 +1,697 @@
+{
+  "results": [
+    { "index": "bandit", "name": "Bandit", "url": "/api/monsters/bandit" },
+    { "index": "bugbear", "name": "Bugbear", "url": "/api/monsters/bugbear" },
+    { "index": "cultist", "name": "Cultist", "url": "/api/monsters/cultist" },
+    { "index": "ghoul", "name": "Ghoul", "url": "/api/monsters/ghoul" },
+    { "index": "giant-spider", "name": "Giant Spider", "url": "/api/monsters/giant-spider" },
+    { "index": "giant-wolf-spider", "name": "Giant Wolf Spider", "url": "/api/monsters/giant-wolf-spider" },
+    { "index": "goblin", "name": "Goblin", "url": "/api/monsters/goblin" },
+    { "index": "hobgoblin", "name": "Hobgoblin", "url": "/api/monsters/hobgoblin" },
+    { "index": "kobold", "name": "Kobold", "url": "/api/monsters/kobold" },
+    { "index": "ogre", "name": "Ogre", "url": "/api/monsters/ogre" },
+    { "index": "orc", "name": "Orc", "url": "/api/monsters/orc" },
+    { "index": "skeleton", "name": "Skeleton", "url": "/api/monsters/skeleton" },
+    { "index": "wolf", "name": "Wolf", "url": "/api/monsters/wolf" },
+    { "index": "worg", "name": "Worg", "url": "/api/monsters/worg" },
+    { "index": "zombie", "name": "Zombie", "url": "/api/monsters/zombie" }
+  ],
+  "monsters": {
+    "bandit": {
+      "index": "bandit",
+      "name": "Bandit",
+      "size": "Medium",
+      "type": "humanoid",
+      "subtype": "any race",
+      "alignment": "any non-lawful alignment",
+      "armor_class": [
+        { "type": "leather armor", "value": 12 }
+      ],
+      "hit_points": 11,
+      "hit_dice": "2d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 11,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 10,
+      "skills": { "athletics": 3 },
+      "senses": { "passive_perception": 10 },
+      "languages": "Common",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "actions": [
+        {
+          "name": "Scimitar",
+          "type": "melee",
+          "attack_bonus": 3,
+          "damage_dice": "1d6+1",
+          "damage_type": { "name": "slashing" },
+          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+        },
+        {
+          "name": "Light Crossbow",
+          "type": "ranged",
+          "attack_bonus": 3,
+          "damage_dice": "1d8+1",
+          "damage_type": { "name": "piercing" },
+          "desc": "Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        }
+      ]
+    },
+    "bugbear": {
+      "index": "bugbear",
+      "name": "Bugbear",
+      "size": "Medium",
+      "type": "humanoid",
+      "subtype": "goblinoid",
+      "alignment": "chaotic evil",
+      "armor_class": [
+        { "type": "hide armor", "value": 16 }
+      ],
+      "hit_points": 27,
+      "hit_dice": "5d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 15,
+      "dexterity": 14,
+      "constitution": 13,
+      "intelligence": 8,
+      "wisdom": 11,
+      "charisma": 9,
+      "skills": { "stealth": 6 },
+      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
+      "languages": "Common, Goblin",
+      "challenge_rating": 1,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Brute",
+          "desc": "A melee weapon deals one extra die of its damage when the bugbear hits with it (included in the attack)."
+        },
+        {
+          "name": "Surprise Attack",
+          "desc": "If the bugbear surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 7 (2d6) damage from the attack."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Morningstar",
+          "attack_bonus": 4,
+          "damage_dice": "2d8+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 11 (2d8 + 2) piercing damage."
+        },
+        {
+          "name": "Javelin",
+          "attack_bonus": 4,
+          "damage_dice": "2d6+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 9 (2d6 + 2) piercing damage in melee or 7 (2d4 + 2) piercing damage at range."
+        }
+      ]
+    },
+    "cultist": {
+      "index": "cultist",
+      "name": "Cultist",
+      "size": "Medium",
+      "type": "humanoid",
+      "subtype": "any race",
+      "alignment": "any non-good alignment",
+      "armor_class": [
+        { "type": "leather armor", "value": 12 }
+      ],
+      "hit_points": 9,
+      "hit_dice": "2d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 11,
+      "dexterity": 12,
+      "constitution": 10,
+      "intelligence": 10,
+      "wisdom": 11,
+      "charisma": 10,
+      "skills": { "deception": 2, "religion": 2 },
+      "senses": { "passive_perception": 10 },
+      "languages": "Common",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "actions": [
+        {
+          "name": "Scimitar",
+          "attack_bonus": 3,
+          "damage_dice": "1d6+1",
+          "damage_type": { "name": "slashing" },
+          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+        }
+      ],
+      "special_abilities": [
+        {
+          "name": "Dark Devotion",
+          "desc": "The cultist has advantage on saving throws against being charmed or frightened."
+        }
+      ]
+    },
+    "ghoul": {
+      "index": "ghoul",
+      "name": "Ghoul",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "chaotic evil",
+      "armor_class": 12,
+      "hit_points": 22,
+      "hit_dice": "5d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 13,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 7,
+      "wisdom": 10,
+      "charisma": 6,
+      "damage_resistances": [],
+      "damage_immunities": [],
+      "condition_immunities": [
+        { "name": "charmed" },
+        { "name": "exhaustion" },
+        { "name": "poisoned" }
+      ],
+      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
+      "languages": "Common",
+      "challenge_rating": 1,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Keen Smell",
+          "desc": "The ghoul has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Turning Defiance",
+          "desc": "The ghoul and any ghouls within 30 feet of it have advantage on saving throws against effects that turn undead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "attack_bonus": 2,
+          "damage_dice": "2d6+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "attack_bonus": 4,
+          "damage_dice": "2d4+2",
+          "damage_type": { "name": "slashing" },
+          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage, and if the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute."
+        }
+      ]
+    },
+    "giant-spider": {
+      "index": "giant-spider",
+      "name": "Giant Spider",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "unaligned",
+      "armor_class": 14,
+      "hit_points": 26,
+      "hit_dice": "4d10",
+      "speed": { "walk": "30 ft.", "climb": "30 ft." },
+      "strength": 14,
+      "dexterity": 16,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 4,
+      "skills": { "stealth": 7 },
+      "senses": { "blindsight": "10 ft.", "darkvision": "60 ft.", "passive_perception": 10 },
+      "languages": "--",
+      "challenge_rating": 1,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The spider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "attack_bonus": 5,
+          "damage_dice": "1d8+3",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 7 (1d8 + 3) piercing damage plus 7 (2d6) poison damage, or half as much on a successful DC 11 Constitution saving throw."
+        },
+        {
+          "name": "Web (Recharge 5-6)",
+          "desc": "Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing. As an action, the restrained target can make a DC 12 Strength check to burst the webbing."
+        }
+      ]
+    },
+    "giant-wolf-spider": {
+      "index": "giant-wolf-spider",
+      "name": "Giant Wolf Spider",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "unaligned",
+      "armor_class": 13,
+      "hit_points": 11,
+      "hit_dice": "2d8",
+      "speed": { "walk": "40 ft.", "climb": "40 ft." },
+      "strength": 12,
+      "dexterity": 16,
+      "constitution": 13,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 4,
+      "skills": { "perception": 3, "stealth": 7 },
+      "senses": { "blindsight": "10 ft.", "darkvision": "60 ft.", "passive_perception": 13 },
+      "languages": "--",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The spider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "attack_bonus": 5,
+          "damage_dice": "1d6+3",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d6 + 3) piercing damage plus 7 (2d6) poison damage, or half as much on a successful DC 11 Constitution saving throw."
+        }
+      ]
+    },
+    "goblin": {
+      "index": "goblin",
+      "name": "Goblin",
+      "size": "Small",
+      "type": "humanoid",
+      "subtype": "goblinoid",
+      "alignment": "neutral evil",
+      "armor_class": [
+        { "type": "leather armor", "value": 15 }
+      ],
+      "hit_points": 7,
+      "hit_dice": "2d6",
+      "speed": { "walk": "30 ft." },
+      "strength": 8,
+      "dexterity": 14,
+      "constitution": 10,
+      "intelligence": 10,
+      "wisdom": 8,
+      "charisma": 8,
+      "skills": { "stealth": 6 },
+      "senses": { "darkvision": "60 ft.", "passive_perception": 9 },
+      "languages": "Common, Goblin",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Nimble Escape",
+          "desc": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Scimitar",
+          "attack_bonus": 4,
+          "damage_dice": "1d6+2",
+          "damage_type": { "name": "slashing" },
+          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+        },
+        {
+          "name": "Shortbow",
+          "attack_bonus": 4,
+          "damage_dice": "1d6+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ]
+    },
+    "hobgoblin": {
+      "index": "hobgoblin",
+      "name": "Hobgoblin",
+      "size": "Medium",
+      "type": "humanoid",
+      "subtype": "goblinoid",
+      "alignment": "lawful evil",
+      "armor_class": [
+        { "type": "chain mail", "value": 18 }
+      ],
+      "hit_points": 11,
+      "hit_dice": "2d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 13,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 9,
+      "skills": { "martial": 0 },
+      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
+      "languages": "Common, Goblin",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Martial Advantage",
+          "desc": "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 feet of an ally of the hobgoblin that isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Longsword",
+          "attack_bonus": 3,
+          "damage_dice": "1d8+1",
+          "damage_type": { "name": "slashing" },
+          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage or 6 (1d10 + 1) slashing damage if used with two hands."
+        },
+        {
+          "name": "Longbow",
+          "attack_bonus": 3,
+          "damage_dice": "1d8+1",
+          "damage_type": { "name": "piercing" },
+          "desc": "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        }
+      ]
+    },
+    "kobold": {
+      "index": "kobold",
+      "name": "Kobold",
+      "size": "Small",
+      "type": "humanoid",
+      "subtype": "kobold",
+      "alignment": "lawful evil",
+      "armor_class": 12,
+      "hit_points": 5,
+      "hit_dice": "2d6",
+      "speed": { "walk": "30 ft." },
+      "strength": 7,
+      "dexterity": 15,
+      "constitution": 9,
+      "intelligence": 8,
+      "wisdom": 7,
+      "charisma": 8,
+      "skills": { "stealth": 4 },
+      "senses": { "darkvision": "60 ft.", "passive_perception": 8 },
+      "languages": "Common, Draconic",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Sunlight Sensitivity",
+          "desc": "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        },
+        {
+          "name": "Pack Tactics",
+          "desc": "The kobold has advantage on an attack roll against a creature if at least one of the kobold's allies is within 5 feet of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Dagger",
+          "attack_bonus": 4,
+          "damage_dice": "1d4+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        },
+        {
+          "name": "Sling",
+          "attack_bonus": 4,
+          "damage_dice": "1d4+2",
+          "damage_type": { "name": "bludgeoning" },
+          "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage."
+        }
+      ]
+    },
+    "ogre": {
+      "index": "ogre",
+      "name": "Ogre",
+      "size": "Large",
+      "type": "giant",
+      "alignment": "chaotic evil",
+      "armor_class": 11,
+      "hit_points": 59,
+      "hit_dice": "7d10",
+      "speed": { "walk": "40 ft." },
+      "strength": 19,
+      "dexterity": 8,
+      "constitution": 16,
+      "intelligence": 5,
+      "wisdom": 7,
+      "charisma": 7,
+      "senses": { "darkvision": "60 ft.", "passive_perception": 8 },
+      "languages": "Common, Giant",
+      "challenge_rating": 2,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "actions": [
+        {
+          "name": "Greatclub",
+          "attack_bonus": 6,
+          "damage_dice": "2d8+4",
+          "damage_type": { "name": "bludgeoning" },
+          "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Javelin",
+          "attack_bonus": 6,
+          "damage_dice": "2d6+4",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 11 (2d6 + 4) piercing damage."
+        }
+      ]
+    },
+    "orc": {
+      "index": "orc",
+      "name": "Orc",
+      "size": "Medium",
+      "type": "humanoid",
+      "subtype": "orc",
+      "alignment": "chaotic evil",
+      "armor_class": 13,
+      "hit_points": 15,
+      "hit_dice": "2d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 16,
+      "dexterity": 12,
+      "constitution": 16,
+      "intelligence": 7,
+      "wisdom": 11,
+      "charisma": 10,
+      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
+      "languages": "Common, Orc",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Aggressive",
+          "desc": "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Greataxe",
+          "attack_bonus": 5,
+          "damage_dice": "1d12+3",
+          "damage_type": { "name": "slashing" },
+          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage."
+        },
+        {
+          "name": "Javelin",
+          "attack_bonus": 5,
+          "damage_dice": "1d6+3",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 8 (1d6 + 3) piercing damage."
+        }
+      ]
+    },
+    "skeleton": {
+      "index": "skeleton",
+      "name": "Skeleton",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "lawful evil",
+      "armor_class": 13,
+      "hit_points": 13,
+      "hit_dice": "2d8",
+      "speed": { "walk": "30 ft." },
+      "strength": 10,
+      "dexterity": 14,
+      "constitution": 15,
+      "intelligence": 6,
+      "wisdom": 8,
+      "charisma": 5,
+      "damage_vulnerabilities": ["bludgeoning"],
+      "damage_resistances": ["piercing", "slashing"],
+      "damage_immunities": ["poison"],
+      "condition_immunities": [
+        { "name": "poisoned" }
+      ],
+      "senses": { "darkvision": "60 ft.", "passive_perception": 9 },
+      "languages": "Understands all languages it spoke in life but can't speak",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "actions": [
+        {
+          "name": "Shortsword",
+          "attack_bonus": 4,
+          "damage_dice": "1d6+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Shortbow",
+          "attack_bonus": 4,
+          "damage_dice": "1d6+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ]
+    },
+    "wolf": {
+      "index": "wolf",
+      "name": "Wolf",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "unaligned",
+      "armor_class": 13,
+      "hit_points": 11,
+      "hit_dice": "2d8",
+      "speed": { "walk": "40 ft." },
+      "strength": 12,
+      "dexterity": 15,
+      "constitution": 12,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 6,
+      "skills": { "perception": 3, "stealth": 4 },
+      "senses": { "passive_perception": 13 },
+      "languages": "--",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Keen Hearing and Smell",
+          "desc": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "desc": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 feet of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "attack_bonus": 4,
+          "damage_dice": "2d4+2",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        }
+      ]
+    },
+    "worg": {
+      "index": "worg",
+      "name": "Worg",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "neutral evil",
+      "armor_class": 13,
+      "hit_points": 26,
+      "hit_dice": "4d10",
+      "speed": { "walk": "50 ft." },
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 13,
+      "intelligence": 7,
+      "wisdom": 11,
+      "charisma": 8,
+      "skills": { "perception": 4, "stealth": 3 },
+      "senses": { "darkvision": "60 ft.", "passive_perception": 14 },
+      "languages": "Goblin, Worg",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "actions": [
+        {
+          "name": "Bite",
+          "attack_bonus": 5,
+          "damage_dice": "2d6+3",
+          "damage_type": { "name": "piercing" },
+          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        }
+      ]
+    },
+    "zombie": {
+      "index": "zombie",
+      "name": "Zombie",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "neutral evil",
+      "armor_class": 8,
+      "hit_points": 22,
+      "hit_dice": "3d8",
+      "speed": { "walk": "20 ft." },
+      "strength": 13,
+      "dexterity": 6,
+      "constitution": 16,
+      "intelligence": 3,
+      "wisdom": 6,
+      "charisma": 5,
+      "damage_immunities": ["poison"],
+      "condition_immunities": [
+        { "name": "poisoned" }
+      ],
+      "senses": { "darkvision": "60 ft.", "passive_perception": 8 },
+      "languages": "Understands the languages it knew in life but can't speak",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "special_abilities": [
+        {
+          "name": "Undead Fortitude",
+          "desc": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Slam",
+          "attack_bonus": 3,
+          "damage_dice": "1d6+1",
+          "damage_type": { "name": "bludgeoning" },
+          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage."
+        }
+      ]
+    }
+  }
+}

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1,5 +1,8 @@
 const { param, body } = require('express-validator');
 const express = require('express');
+const { randomUUID } = require('crypto');
+const { getMonsterByIndex } = require('../utils/dnd5eApi');
+const { buildEnemyRecord } = require('../utils/monsters');
 const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 const logger = require('../utils/logger');
@@ -13,6 +16,13 @@ module.exports = (router) => {
     activeTurn: null,
   });
 
+  const generateEnemyId = () => {
+    if (typeof randomUUID === 'function') {
+      return randomUUID();
+    }
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  };
+
   const parseInitiative = (value) => {
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
@@ -23,7 +33,37 @@ module.exports = (router) => {
     return Number.isInteger(parsed) ? parsed : null;
   };
 
-  const sanitizeParticipants = (participants) => {
+  const createEnemyLookup = (enemies) => {
+    const map = new Map();
+
+    if (!Array.isArray(enemies)) {
+      return map;
+    }
+
+    enemies.forEach((enemy) => {
+      if (
+        !enemy ||
+        typeof enemy.enemyId !== 'string' ||
+        enemy.enemyId.trim() === ''
+      ) {
+        return;
+      }
+
+      const trimmedId = enemy.enemyId.trim();
+      const rawName =
+        typeof enemy.name === 'string' && enemy.name.trim() !== ''
+          ? enemy.name.trim()
+          : null;
+
+      if (rawName) {
+        map.set(trimmedId, rawName);
+      }
+    });
+
+    return map;
+  };
+
+  const sanitizeParticipants = (participants, enemyLookup = new Map()) => {
     if (!Array.isArray(participants)) {
       return [];
     }
@@ -43,9 +83,19 @@ module.exports = (router) => {
           return null;
         }
 
+        const trimmedId = participant.characterId.trim();
+        const rawDisplayName =
+          typeof participant.displayName === 'string' &&
+          participant.displayName.trim() !== ''
+            ? participant.displayName.trim()
+            : null;
+
+        const displayName = rawDisplayName || enemyLookup.get(trimmedId) || null;
+
         return {
-          characterId: participant.characterId.trim(),
+          characterId: trimmedId,
           initiative,
+          ...(displayName ? { displayName } : {}),
         };
       })
       .filter(Boolean);
@@ -56,7 +106,11 @@ module.exports = (router) => {
       return campaign;
     }
 
-    const participants = sanitizeParticipants(campaign.combat?.participants);
+    const enemyLookup = createEnemyLookup(campaign.enemies);
+    const participants = sanitizeParticipants(
+      campaign.combat?.participants,
+      enemyLookup
+    );
     const requestedTurn = parseTurnIndex(campaign.combat?.activeTurn);
     const activeTurn =
       requestedTurn !== null &&
@@ -71,6 +125,7 @@ module.exports = (router) => {
         participants,
         activeTurn,
       },
+      enemies: Array.isArray(campaign.enemies) ? campaign.enemies : [],
     };
   };
 
@@ -166,6 +221,7 @@ module.exports = (router) => {
       dm: req.body.dm,
       players: Array.isArray(req.body.players) ? req.body.players : [],
       combat: createDefaultCombatState(),
+      enemies: [],
     };
     try {
       const result = await db_connect.collection("Campaigns").insertOne(myobj);
@@ -188,6 +244,124 @@ module.exports = (router) => {
       next(err);
     }
   });
+
+  campaignRouter
+    .route('/:campaign/enemies')
+    .get(
+      [param('campaign').trim().notEmpty().withMessage('campaign is required')],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const db_connect = req.db;
+          const campaign = await db_connect
+            .collection('Campaigns')
+            .findOne({ campaignName: req.params.campaign });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          res.json(Array.isArray(campaign.enemies) ? campaign.enemies : []);
+        } catch (err) {
+          next(err);
+        }
+      }
+    )
+    .post(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        body('index').trim().notEmpty().withMessage('index is required'),
+        body('name').optional().isString().withMessage('name must be a string'),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        const campaignName = req.params.campaign;
+        const { index, name } = req.body;
+
+        try {
+          const monster = await getMonsterByIndex(index);
+          const enemyId = generateEnemyId();
+          const enemyRecord = buildEnemyRecord(monster, enemyId, name);
+
+          if (!enemyRecord) {
+            return res.status(500).json({ message: 'Failed to create enemy record' });
+          }
+
+          const db_connect = req.db;
+          const result = await db_connect.collection('Campaigns').findOneAndUpdate(
+            { campaignName },
+            { $push: { enemies: enemyRecord } },
+            { returnDocument: 'after' }
+          );
+
+          if (!result.value) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          res.json(enemyRecord);
+        } catch (err) {
+          if (err.statusCode === 404) {
+            return res.status(404).json({ message: 'Monster not found' });
+          }
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/enemies/:enemyId')
+    .delete(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        param('enemyId').trim().notEmpty().withMessage('enemyId is required'),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const { enemyId } = req.params;
+          const db_connect = req.db;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const existingEnemies = Array.isArray(campaign.enemies) ? campaign.enemies : [];
+          if (!existingEnemies.some((enemy) => enemy.enemyId === enemyId)) {
+            return res.status(404).json({ message: 'Enemy not found' });
+          }
+
+          const updatedEnemies = existingEnemies.filter((enemy) => enemy.enemyId !== enemyId);
+          const enemyLookup = createEnemyLookup(updatedEnemies);
+          const participants = sanitizeParticipants(
+            campaign.combat?.participants,
+            enemyLookup
+          ).filter(
+            (participant) => participant.characterId !== enemyId
+          );
+
+          let activeTurn = parseTurnIndex(campaign.combat?.activeTurn);
+          if (activeTurn !== null && activeTurn >= participants.length) {
+            activeTurn = participants.length > 0 ? Math.min(activeTurn, participants.length - 1) : null;
+          }
+
+          const combatState = { participants, activeTurn };
+
+          await collection.updateOne(
+            { campaignName },
+            { $set: { enemies: updatedEnemies, combat: combatState } }
+          );
+
+          emitCombatUpdate(campaignName, combatState);
+
+          res.json({ success: true, enemies: updatedEnemies, combat: combatState });
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
 
   campaignRouter
     .route('/:campaign/combat')
@@ -272,7 +446,11 @@ module.exports = (router) => {
             return res.status(403).json({ message: 'Forbidden' });
           }
 
-          const participants = sanitizeParticipants(req.body.participants);
+          const enemyLookup = createEnemyLookup(campaign.enemies);
+          const participants = sanitizeParticipants(
+            req.body.participants,
+            enemyLookup
+          );
 
           if (participants.length !== req.body.participants.length) {
             return res

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -22,6 +22,7 @@ const weapons = require('./weapons');
 const armor = require('./armor');
 const items = require('./items');
 const accessories = require('./accessories');
+const monsters = require('./monsters');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
 const ai = require('./ai');
@@ -46,6 +47,7 @@ weapons(routes);
 armor(routes);
 items(routes);
 accessories(routes);
+monsters(routes);
 ai(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.

--- a/server/routes/monsters.js
+++ b/server/routes/monsters.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const { getMonsterList, getMonsterByIndex } = require('../utils/dnd5eApi');
+const { normalizeMonsterDetail } = require('../utils/monsters');
+
+module.exports = (router) => {
+  const monstersRouter = express.Router();
+
+  monstersRouter.get('/monsters', async (req, res, next) => {
+    try {
+      const list = await getMonsterList();
+      const results = Array.isArray(list?.results) ? list.results : [];
+      const search = typeof req.query.search === 'string' ? req.query.search.trim().toLowerCase() : '';
+
+      let filtered = results;
+      if (search) {
+        filtered = results.filter((monster) => monster?.name?.toLowerCase().includes(search));
+      }
+
+      res.json(filtered.map((monster) => ({
+        index: monster.index,
+        name: monster.name,
+        url: monster.url,
+      })));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  monstersRouter.get('/monsters/:index', async (req, res, next) => {
+    try {
+      const monster = await getMonsterByIndex(req.params.index);
+      const normalized = normalizeMonsterDetail(monster);
+      if (!normalized) {
+        return res.status(404).json({ message: 'Monster not found' });
+      }
+      res.json(normalized);
+    } catch (err) {
+      if (err.statusCode === 404) {
+        return res.status(404).json({ message: 'Monster not found' });
+      }
+      next(err);
+    }
+  });
+
+  router.use(monstersRouter);
+};

--- a/server/utils/dnd5eApi.js
+++ b/server/utils/dnd5eApi.js
@@ -1,0 +1,149 @@
+const https = require('https');
+const logger = require('./logger');
+const localMonsterData = require('../data/monsters.json');
+
+const API_BASE = 'https://www.dnd5eapi.co';
+
+const localMonsterList =
+  localMonsterData && Array.isArray(localMonsterData.results)
+    ? localMonsterData.results.map((monster) => ({
+        index: monster.index,
+        name: monster.name,
+        url: monster.url,
+      }))
+    : [];
+
+const localMonsterMap = new Map();
+if (localMonsterData && localMonsterData.monsters && typeof localMonsterData.monsters === 'object') {
+  Object.entries(localMonsterData.monsters).forEach(([index, monster]) => {
+    if (!monster || typeof monster !== 'object') {
+      return;
+    }
+
+    const normalizedIndex = typeof index === 'string' ? index.trim().toLowerCase() : '';
+    if (!normalizedIndex) {
+      return;
+    }
+
+    localMonsterMap.set(normalizedIndex, {
+      ...monster,
+      index: monster.index || normalizedIndex,
+    });
+  });
+}
+
+function fetchJson(path) {
+  return new Promise((resolve, reject) => {
+    if (!path || typeof path !== 'string') {
+      reject(new Error('A valid path is required to fetch data from the 5e SRD API.'));
+      return;
+    }
+
+    const request = https.get(`${API_BASE}${path}`, (response) => {
+      const { statusCode } = response;
+
+      if (statusCode < 200 || statusCode >= 300) {
+        response.resume();
+        const error = new Error(`Request to 5e SRD API failed with status code ${statusCode}`);
+        error.statusCode = statusCode;
+        reject(error);
+        return;
+      }
+
+      let raw = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        raw += chunk;
+      });
+      response.on('end', () => {
+        try {
+          const parsed = JSON.parse(raw);
+          resolve(parsed);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+
+    request.on('error', (err) => {
+      logger.error('Error fetching data from 5e SRD API', { error: err.message });
+      reject(err);
+    });
+  });
+}
+
+let monsterListCache = localMonsterList.length
+  ? { count: localMonsterList.length, results: localMonsterList }
+  : null;
+const monsterDetailCache = new Map(localMonsterMap);
+
+async function getMonsterList() {
+  if (monsterListCache) {
+    return monsterListCache;
+  }
+
+  try {
+    monsterListCache = await fetchJson('/api/monsters');
+  } catch (err) {
+    if (localMonsterList.length) {
+      logger.warn('Falling back to bundled 5e SRD monster list', { error: err.message });
+      monsterListCache = { count: localMonsterList.length, results: localMonsterList };
+    } else {
+      throw err;
+    }
+  }
+
+  return monsterListCache;
+}
+
+async function getMonsterByIndex(index) {
+  if (!index || typeof index !== 'string') {
+    const error = new Error('Monster index is required');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const normalized = index.trim().toLowerCase();
+  if (!normalized) {
+    const error = new Error('Monster index is required');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  if (monsterDetailCache.has(normalized)) {
+    return monsterDetailCache.get(normalized);
+  }
+
+  try {
+    const monster = await fetchJson(`/api/monsters/${encodeURIComponent(normalized)}`);
+    monsterDetailCache.set(normalized, monster);
+    return monster;
+  } catch (err) {
+    if (localMonsterMap.has(normalized)) {
+      logger.warn('Falling back to bundled 5e SRD monster detail', {
+        error: err.message,
+        monster: normalized,
+      });
+      const monster = localMonsterMap.get(normalized);
+      monsterDetailCache.set(normalized, monster);
+      return monster;
+    }
+    throw err;
+  }
+}
+
+function clearMonsterCache() {
+  monsterListCache = localMonsterList.length
+    ? { count: localMonsterList.length, results: localMonsterList }
+    : null;
+  monsterDetailCache.clear();
+  localMonsterMap.forEach((monster, index) => {
+    monsterDetailCache.set(index, monster);
+  });
+}
+
+module.exports = {
+  getMonsterList,
+  getMonsterByIndex,
+  clearMonsterCache,
+};

--- a/server/utils/monsters.js
+++ b/server/utils/monsters.js
@@ -1,0 +1,163 @@
+const normalizeArmorClass = (armorClass) => {
+  if (Array.isArray(armorClass)) {
+    return armorClass
+      .map((entry) => {
+        if (entry && typeof entry === 'object') {
+          return {
+            value: Number(entry.value) || 0,
+            type: entry.type || null,
+            desc: entry.desc || null,
+          };
+        }
+        const numeric = Number(entry);
+        if (Number.isFinite(numeric)) {
+          return { value: numeric, type: null, desc: null };
+        }
+        return null;
+      })
+      .filter((entry) => entry && entry.value);
+  }
+
+  const numeric = Number(armorClass);
+  if (Number.isFinite(numeric)) {
+    return [{ value: numeric, type: null, desc: null }];
+  }
+
+  return [];
+};
+
+const normalizeSpeed = (speed) => {
+  if (!speed) {
+    return {};
+  }
+
+  if (typeof speed === 'string') {
+    return { walk: speed };
+  }
+
+  if (typeof speed === 'object') {
+    return Object.entries(speed).reduce((acc, [key, value]) => {
+      acc[key] = String(value);
+      return acc;
+    }, {});
+  }
+
+  return {};
+};
+
+const normalizeConditionImmunities = (conditionImmunities) => {
+  if (!Array.isArray(conditionImmunities)) {
+    return [];
+  }
+
+  return conditionImmunities
+    .map((entry) => {
+      if (!entry) {
+        return null;
+      }
+      if (typeof entry === 'string') {
+        return entry;
+      }
+      if (typeof entry === 'object' && entry.name) {
+        return entry.name;
+      }
+      return null;
+    })
+    .filter(Boolean);
+};
+
+const normalizeProficiencies = (proficiencies) => {
+  if (!Array.isArray(proficiencies)) {
+    return [];
+  }
+
+  return proficiencies
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const name = entry.proficiency?.name || entry.name || null;
+      const value = Number(entry.value);
+      return {
+        name,
+        value: Number.isFinite(value) ? value : null,
+      };
+    })
+    .filter((entry) => entry && entry.name);
+};
+
+const normalizeMonsterDetail = (monster) => {
+  if (!monster || typeof monster !== 'object') {
+    return null;
+  }
+
+  return {
+    index: monster.index,
+    slug: monster.slug || null,
+    name: monster.name,
+    size: monster.size || null,
+    type: monster.type || null,
+    subtype: monster.subtype || null,
+    alignment: monster.alignment || null,
+    armorClass: normalizeArmorClass(monster.armor_class),
+    hitPoints: Number(monster.hit_points) || 0,
+    hitDice: monster.hit_dice || null,
+    speed: normalizeSpeed(monster.speed),
+    abilityScores: {
+      str: Number(monster.strength) || 0,
+      dex: Number(monster.dexterity) || 0,
+      con: Number(monster.constitution) || 0,
+      int: Number(monster.intelligence) || 0,
+      wis: Number(monster.wisdom) || 0,
+      cha: Number(monster.charisma) || 0,
+    },
+    savingThrows: monster.saving_throws || [],
+    skills: monster.skills || {},
+    proficiencies: normalizeProficiencies(monster.proficiencies),
+    senses: monster.senses || {},
+    languages: monster.languages || '',
+    challengeRating: monster.challenge_rating ?? null,
+    xp: monster.xp ?? null,
+    proficiencyBonus: monster.proficiency_bonus ?? monster.prof_bonus ?? null,
+    damageVulnerabilities: monster.damage_vulnerabilities || [],
+    damageResistances: monster.damage_resistances || [],
+    damageImmunities: monster.damage_immunities || [],
+    conditionImmunities: normalizeConditionImmunities(monster.condition_immunities),
+    actions: monster.actions || [],
+    bonusActions: monster.bonus_actions || [],
+    reactions: monster.reactions || [],
+    legendaryActions: monster.legendary_actions || [],
+    specialAbilities: monster.special_abilities || [],
+    lairActions: monster.lair_actions || [],
+    regionalEffects: monster.regional_effects || [],
+    image: monster.image || null,
+    source: '5e-srd',
+  };
+};
+
+const buildEnemyRecord = (monsterDetail, enemyId, nameOverride) => {
+  if (!monsterDetail) {
+    return null;
+  }
+
+  const normalized = normalizeMonsterDetail(monsterDetail);
+  if (!normalized) {
+    return null;
+  }
+
+  const trimmedName = typeof nameOverride === 'string' ? nameOverride.trim() : '';
+
+  return {
+    ...normalized,
+    enemyId,
+    name: trimmedName || normalized.name,
+    addedAt: new Date().toISOString(),
+  };
+};
+
+module.exports = {
+  normalizeArmorClass,
+  normalizeSpeed,
+  normalizeMonsterDetail,
+  buildEnemyRecord,
+};


### PR DESCRIPTION
## Summary
- propagate optional displayName values through combat participants, deriving enemy names on the server so combat updates always include readable labels
- teach the DM combat management UI to capture participant display names when adding enemies or rolling initiative
- have the player character sheet and campaign tests respect the new displayName data so combat trackers render enemy names instead of raw ids

## Testing
- npm test --prefix server
- CI=true npm test --prefix client
- CI=true npm test --prefix client -- --testPathPattern=ZombiesDM.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4768b95c4832e836c9aa09eda8842