### PR TITLE
Add enemy health tracking and display in combat tracker

### DIFF
--- a/server/utils/monsters.js
+++ b/server/utils/monsters.js
@@ -151,6 +151,7 @@ const buildEnemyRecord = (monsterDetail, enemyId, nameOverride) => {
     ...normalized,
     enemyId,
     name: trimmedName || normalized.name,
+    currentHp: normalized.hitPoints,
     addedAt: new Date().toISOString(),
   };
 };


### PR DESCRIPTION
## Summary
- Add server-side helpers to persist enemy hit points and expose a PUT endpoint for updating monster health while keeping combat participants in sync.
- Enhance the DM combat tracker UI with enemy health controls and display logic that reflects current/max HP for each monster.
- Consume the new combat participant HP fields on the player sheet so combat headers show monster health bars for enemies.

## Testing
- npm --prefix server test
- npm --prefix client test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d491486c38832eb9037f8012ea787c