### PR TITLE
Adjust ResourceGrid responsive columns

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -205,10 +205,14 @@ function ResourceGrid({
     return <div className="text-center text-muted py-3">{emptyMessage}</div>;
   }
 
+  const hasRowColsOverride =
+    typeof rowClassName === 'string' && /\brow-cols[\w-]*/.test(rowClassName);
+
   const rowClasses = [
     'resource-grid',
-    'row-cols-2',
-    'row-cols-lg-3',
+    !hasRowColsOverride && 'row-cols-1',
+    !hasRowColsOverride && 'row-cols-sm-2',
+    !hasRowColsOverride && 'row-cols-xl-3',
     'g-3',
     rowClassName,
   ]


### PR DESCRIPTION
## Summary
- default the Zombies DM resource grid to a single column on extra-small screens while keeping other breakpoints responsive
- preserve row class overrides by skipping the default column classes when callers supply their own

## Testing
- Manual verification blocked: `npm start` (client build fails: missing dependency `socket.io-client`)

------
https://chatgpt.com/codex/tasks/task_e_68d59e5497fc832ea4293f826b354d64