### PR TITLE
Improve mobile card legibility

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -147,35 +147,35 @@
   .armor-card,
   .item-card,
   .resource-card {
-    font-size: 0.6rem;
+    font-size: 0.9rem;
   }
   .weapon-card .card-title,
   .armor-card .card-title,
   .item-card .card-title,
   .resource-card .card-title {
-    font-size: 0.85rem;
+    font-size: 1rem;
   }
   .weapon-card .card-text,
   .armor-card .card-text,
   .item-card .card-text,
   .resource-card .card-text {
-    font-size: 0.6rem;
+    font-size: 0.85rem;
   }
   .weapon-card .btn,
   .armor-card .btn,
   .item-card .btn,
   .resource-card .btn {
-    font-size: 0.6rem;
-    padding: 0.25rem 0.5rem;
+    font-size: 0.9rem;
+    padding: 0.4rem 0.75rem;
   }
   .weapon-card .form-check-label {
-    font-size: 0.65rem;
+    font-size: 0.85rem;
   }
   .armor-card .form-check-label {
-    font-size: 0.65rem;
+    font-size: 0.85rem;
   }
   .item-card .form-check-label {
-    font-size: 0.65rem;
+    font-size: 0.85rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- increase font sizing for resource and equipment cards on extra-small viewports
- expand button padding to maintain touch-friendly targets on phones

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve 'socket.io-client' in '/workspace/DnD/client/src/components/Zombies/pages')*

------
https://chatgpt.com/codex/tasks/task_e_68d5a4f3dfc8832ebf59531fb81935bd