### PR TITLE
Add safe area padding to zombies enemy resource card

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12,6 +12,10 @@
   padding-bottom: 2rem;
 }
 
+.resource-tab-safe-area {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0) + var(--bs-card-spacer-y, 1rem));
+}
+
 @media (min-width: 768px) {
   .zombies-dm-container {
     padding-left: 1.5rem;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -2458,7 +2458,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                 </div>
               </div>
             </Card.Header>
-            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+            <Card.Body
+              className="resource-tab-safe-area"
+              style={{ overflowY: 'auto', maxHeight: '70vh' }}
+            >
               <Card className="mb-4 bg-dark bg-opacity-75 border border-secondary text-start">
                 <Card.Header className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 bg-transparent border-secondary text-light">
                   <h3 className="h5 mb-0">Combat Tracker</h3>
@@ -2737,7 +2740,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                 </div>
               </div>
             </Card.Header>
-            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+            <Card.Body
+              className="resource-tab-safe-area"
+              style={{ overflowY: 'auto', maxHeight: '70vh' }}
+            >
               <Container className="mt-3">
                 <Row className="justify-content-center">
                   <Col md={8} lg={6}>
@@ -2817,7 +2823,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                 </div>
               </div>
             </Card.Header>
-            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+            <Card.Body
+              className="resource-tab-safe-area"
+              style={{ overflowY: 'auto', maxHeight: '70vh' }}
+            >
               <Container className="mt-3">
                 <Form onSubmit={handleAddEnemy}>
                   <Row className="g-3 align-items-end">


### PR DESCRIPTION
## Summary
- add a reusable `.resource-tab-safe-area` helper that extends card padding with the device safe-area inset
- apply the helper to the DM characters, players, and enemies resource cards so their footers clear mobile browser chrome

## Testing
- npm --prefix client start *(fails: missing socket.io-client dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b69ef28c832ebb8659e550bbc795