### PR TITLE
Adjust zombie DM enemy health controls for mobile

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -119,6 +119,27 @@
   background-color: #fff;
 }
 
+.health-adjustment-group {
+  width: 100%;
+}
+
+.health-adjustment-group .health-adjustment-input {
+  min-width: 0;
+}
+
+@media (max-width: 575.98px) {
+  .health-adjustment-group .health-adjustment-button,
+  .health-adjustment-group .health-adjustment-input {
+    width: 100%;
+  }
+}
+
+@media (min-width: 576px) {
+  .health-adjustment-group .health-adjustment-input {
+    flex: 1 1 auto;
+  }
+}
+
 .weapon-card .form-check-label {
   font-size: 0.9rem;
   color: var(--bs-body-color);

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -13,7 +13,6 @@ import {
   Nav,
   Tab,
   CloseButton,
-  InputGroup,
 } from "react-bootstrap";
 import Modal from 'react-bootstrap/Modal';
 import { useNavigate, useParams } from "react-router-dom";
@@ -3079,10 +3078,11 @@ const resolveIcon = (category, iconMap, fallback) => {
                               <span>Current:</span>
                               <span>{healthSummary}</span>
                             </div>
-                            <InputGroup size="sm">
+                            <div className="health-adjustment-group d-flex flex-column flex-sm-row gap-2 gap-sm-0 w-100">
                               <Button
                                 variant="outline-danger"
                                 size="sm"
+                                className="health-adjustment-button"
                                 onClick={() => handleApplyEnemyHealthAdjustment(enemy.enemyId, -1)}
                                 disabled={isSavingHealth}
                               >
@@ -3098,16 +3098,19 @@ const resolveIcon = (category, iconMap, fallback) => {
                                 min="0"
                                 aria-label={`Adjust ${enemy.name || 'enemy'} health amount`}
                                 disabled={isSavingHealth}
+                                size="sm"
+                                className="health-adjustment-input flex-sm-grow-1"
                               />
                               <Button
                                 variant="outline-success"
                                 size="sm"
+                                className="health-adjustment-button"
                                 onClick={() => handleApplyEnemyHealthAdjustment(enemy.enemyId, 1)}
                                 disabled={isSavingHealth}
                               >
                                 Heal
                               </Button>
-                            </InputGroup>
+                            </div>
                             <div className="d-flex justify-content-end">
                               <Button
                                 variant="outline-light"


### PR DESCRIPTION
## Summary
- refactor the enemy health adjustment controls to stack vertically on extra-small viewports while keeping the horizontal layout on larger screens
- add responsive styling so the damage and heal buttons expand to full width on narrow devices

## Testing
- CI=true npm --prefix client test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d5b81a13dc832e8af9f1124edd7aa6