### PR TITLE
Increase safe area padding for resource tab

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13,7 +13,9 @@
 }
 
 .resource-tab-safe-area {
-  padding-bottom: calc(env(safe-area-inset-bottom, 0) + var(--bs-card-spacer-y, 1rem));
+  padding-bottom: calc(
+    env(safe-area-inset-bottom, 0) + max(var(--bs-card-spacer-y, 1rem), 2.75rem)
+  );
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- increase the resource tab safe area padding to include a larger baseline cushion while preserving support for device safe-area insets

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve 'socket.io-client' in '/workspace/DnD/client/src/components/Zombies/pages')*


------
https://chatgpt.com/codex/tasks/task_e_68d5c0865fb8832ebca946cf8dfac584