### PR TITLE
Add safe-area padding for enemy resource card footer

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -18,6 +18,10 @@
   );
 }
 
+.resource-card-footer-safe-area {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0) + var(--bs-card-spacer-y, 0.75rem));
+}
+
 @media (min-width: 768px) {
   .zombies-dm-container {
     padding-left: 1.5rem;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -3134,7 +3134,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           </div>
                         </div>
                       </Card.Body>
-                      <Card.Footer className="d-flex flex-wrap gap-2 justify-content-end">
+                      <Card.Footer className="resource-card-footer-safe-area d-flex flex-wrap gap-2 justify-content-end">
                         <Button
                           variant={inCombat ? 'success' : 'outline-primary'}
                           size="sm"


### PR DESCRIPTION
## Summary
- add a helper class on the enemy resource card footer so it can receive safe-area padding on mobile
- define the helper class in App.scss to add extra bottom padding that accounts for the device safe area

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5c2e121a4832e8bd9dba8c5f7fdc5