### PR TITLE
Expand resource card safe area padding

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -19,7 +19,9 @@
 }
 
 .resource-card-footer-safe-area {
-  padding-bottom: calc(env(safe-area-inset-bottom, 0) + var(--bs-card-spacer-y, 0.75rem));
+  padding-bottom: calc(
+    env(safe-area-inset-bottom, 0) + max(var(--bs-card-spacer-y, 0.75rem), 2.75rem)
+  );
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- increase the resource card footer safe area padding to provide a larger bottom cushion while retaining the safe-area inset

## Testing
- npm --prefix client run build *(fails: Module not found: Error: Can't resolve 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_68d5c7426540832e8133bb38aad23382