### PR TITLE
Improve combat tracker nav scrolling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12,6 +12,47 @@
   padding-bottom: 2rem;
 }
 
+.combat-tracker-nav {
+  flex-wrap: nowrap !important;
+  overflow-x: auto;
+  overflow-y: hidden;
+  gap: 0.5rem;
+  padding-bottom: 0.25rem;
+  -ms-overflow-style: none; // IE and Edge
+  scrollbar-width: none; // Firefox
+  -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-item {
+    flex: 1 0 clamp(6.5rem, 24vw, 11rem);
+    min-width: clamp(6.5rem, 24vw, 11rem);
+  }
+
+  .nav-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    white-space: nowrap;
+    font-size: clamp(0.75rem, 2.6vw, 1rem);
+    padding: 0.5rem 0.75rem;
+  }
+}
+
+@media (max-width: 576px) {
+  .combat-tracker-nav {
+    gap: 0.25rem;
+
+    .nav-link {
+      font-size: clamp(0.7rem, 3.2vw, 0.9rem);
+      padding: 0.45rem 0.5rem;
+    }
+  }
+}
+
 @media (min-width: 768px) {
   .zombies-dm-container {
     padding-left: 1.5rem;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1258,7 +1258,7 @@ const resolveIcon = (category, iconMap, fallback) => {
             className="d-flex justify-content-center mb-3"
             style={{ position: 'relative', zIndex: '4' }}
           >
-            <Nav variant="tabs" className="flex-wrap">
+            <Nav variant="tabs" className="combat-tracker-nav">
               {RESOURCE_TABS.map(({ key, title }) => (
                 <Nav.Item key={key}>
                   <Nav.Link eventKey={key}>{title}</Nav.Link>


### PR DESCRIPTION
## Summary
- replace the combat tracker tab navigation flex-wrap class with a dedicated hook for styling
- add combat tracker navigation styles to enforce a single-row scrolling layout with responsive sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a0359134832eb8a423c1dd6841d0