### PR TITLE
Make combat turn header horizontally scrollable

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8,6 +8,31 @@
   padding-right: 1rem;
 }
 
+.combat-turn-header {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 12px;
+  justify-content: flex-start;
+  align-items: stretch;
+  margin-bottom: 12px;
+  padding-bottom: 0.25rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.combat-turn-header__card {
+  flex: 0 0 auto;
+  width: clamp(160px, 22vw, 240px);
+  min-width: clamp(160px, 22vw, 240px);
+}
+
+@media (max-width: 576px) {
+  .combat-turn-header__card {
+    width: clamp(100px, 32vw, 33.333%);
+    min-width: clamp(100px, 32vw, 33.333%);
+  }
+}
+
 .zombies-dm-container--spaced {
   padding-bottom: 2rem;
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -139,15 +139,7 @@ function CombatTurnHeader({ participants }) {
   }
 
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        flexWrap: "wrap",
-        gap: "12px",
-        marginBottom: "12px",
-      }}
-    >
+    <div className="combat-turn-header">
       {participants.map((participant) => {
         const { characterId, name, hpDisplay, hpCurrent, hpMax, isActive } = participant;
 
@@ -166,6 +158,7 @@ function CombatTurnHeader({ participants }) {
         return (
           <div
             key={characterId}
+            className="combat-turn-header__card"
             style={{
               background: isActive
                 ? "linear-gradient(135deg, rgba(37, 31, 26, 0.96), rgba(18, 15, 12, 0.94))"
@@ -173,7 +166,6 @@ function CombatTurnHeader({ participants }) {
               color: "#FFFFFF",
               borderRadius: "12px",
               padding: "10px 16px",
-              minWidth: "160px",
               boxShadow: isActive
                 ? "0 0 18px rgba(214, 178, 86, 0.7), 0 0 8px rgba(214, 178, 86, 0.4) inset"
                 : "0 0 8px rgba(0, 0, 0, 0.45)",


### PR DESCRIPTION
## Summary
- replace the combat turn header container inline styles with semantic classes
- add responsive scrollable header styles that clamp card widths for desktop and mobile viewports

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6b35c9d6c832ebc72dd4d419e6d54