### PR TITLE
Enable drag-to-scroll combat turn header

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -18,6 +18,50 @@
   margin-bottom: 12px;
   padding-bottom: 0.25rem;
   -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  cursor: grab;
+  user-select: none;
+  touch-action: pan-x;
+  position: relative;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  &.combat-turn-header--dragging {
+    cursor: grabbing;
+  }
+
+  &::before,
+  &::after {
+    content: '';
+    position: sticky;
+    top: 0;
+    bottom: 0;
+    width: 1.25rem;
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  &::before {
+    left: 0;
+    background: linear-gradient(90deg, rgba(12, 10, 8, 0.65), rgba(12, 10, 8, 0));
+  }
+
+  &::after {
+    right: 0;
+    background: linear-gradient(270deg, rgba(12, 10, 8, 0.65), rgba(12, 10, 8, 0));
+  }
+
+  &.combat-turn-header--fade-left::before {
+    opacity: 1;
+  }
+
+  &.combat-turn-header--fade-right::after {
+    opacity: 1;
+  }
 }
 
 .combat-turn-header__card {


### PR DESCRIPTION
## Summary
- add pointer-driven drag scrolling and accessibility attributes to the combat turn header
- hide the scrollbar, add grab cursors, and show subtle edge fades while preserving touch momentum

## Testing
- npm --prefix client run build *(fails: Module not found: Error: Can't resolve 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_68d70676fe78832e99aed3d689bc3d18