### PR TITLE
Prevent redundant combat header auto-scroll

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -138,6 +138,7 @@ function CombatTurnHeader({ participants }) {
   const isDraggingRef = useRef(false);
   const startXRef = useRef(0);
   const startScrollLeftRef = useRef(0);
+  const lastAutoScrollTargetRef = useRef(null);
   const [isDragging, setIsDragging] = useState(false);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -279,7 +280,24 @@ function CombatTurnHeader({ participants }) {
     }
 
     const container = headerRef.current;
-    if (!container || activeIndex < 0) {
+    const participantsList = Array.isArray(participants) ? participants : null;
+    const activeParticipant =
+      activeIndex >= 0 && participantsList ? participantsList[activeIndex] : null;
+
+    if (activeIndex < 0 || !activeParticipant) {
+      if (lastAutoScrollTargetRef.current !== null) {
+        lastAutoScrollTargetRef.current = null;
+      }
+      return;
+    }
+
+    if (!container) {
+      return;
+    }
+
+    const identifier = activeParticipant.characterId ?? activeIndex;
+
+    if (lastAutoScrollTargetRef.current === identifier) {
       return;
     }
 
@@ -322,6 +340,8 @@ function CombatTurnHeader({ participants }) {
       adjustScrollManually();
       updateOverflowHints();
     });
+
+    lastAutoScrollTargetRef.current = identifier;
   }, [activeIndex, participants, isDragging, updateOverflowHints]);
 
   if (!participantsCount) {


### PR DESCRIPTION
## Summary
- track the last combat participant that was auto-centered to avoid redundant scrollIntoView calls
- reset the tracking ref whenever there is no active participant so the next valid turn change auto-centers again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70b3e2f34832eabf7f3079d12161c