### PR TITLE
Improve mobile spacing for attack dice

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -562,10 +562,14 @@ $rotateX: -$angle;
   .content {
     margin: 0 auto;
     position: relative;
-    top: -30px;
+    top: calc(#{$containerHeight} * -0.18);
     width: $containerWidth;
     height: $containerHeight;
     perspective: 1500px;
+
+    @media (max-width: 576px) {
+      top: calc(#{$containerHeight} * -0.06);
+    }
   }
 
   .die {
@@ -669,6 +673,51 @@ $rotateX: -$angle;
         }
       }
     }
+  }
+}
+
+// Layout helpers for the attack button and dice roller
+.attack-roll-controls {
+  --attack-die-size: min(25vw, 120px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: calc(var(--attack-die-size) * 0.25);
+  min-height: calc(var(--attack-die-size) + 88px);
+  padding-bottom: calc(var(--attack-die-size) * 0.35);
+}
+
+.attack-roll-controls__die {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: calc(var(--attack-die-size) * 0.2);
+}
+
+@media (max-height: 600px) {
+  .attack-roll-controls {
+    --attack-die-size: min(20vw, 100px);
+    gap: calc(var(--attack-die-size) * 0.25);
+    min-height: calc(var(--attack-die-size) + 88px);
+    padding-bottom: calc(var(--attack-die-size) * 0.35);
+  }
+
+  .attack-roll-controls__die {
+    margin-bottom: calc(var(--attack-die-size) * 0.2);
+  }
+}
+
+@media (max-width: 576px) {
+  .attack-roll-controls {
+    gap: calc(var(--attack-die-size) * 0.4);
+    min-height: calc(var(--attack-die-size) * 1.9);
+    padding-bottom: calc(var(--attack-die-size) * 0.5);
+  }
+
+  .attack-roll-controls__die {
+    margin-bottom: calc(var(--attack-die-size) * 0.3);
   }
 }
 

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -592,45 +592,41 @@ const showSparklesEffect = () => {
           paddingBottom: `${footerHeight}px`,
         }}
       >
-          <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px', alignItems: 'center' }}>
-            {/* Attack Button */}
-            <button
-              onClick={handleShowAttack}
-              style={{
-              width: "64px",
-              height: "64px",
+        <div className="attack-roll-controls">
+          {/* Attack Button */}
+          <button
+            onClick={handleShowAttack}
+            style={{
+              width: '64px',
+              height: '64px',
               backgroundImage: `url(${sword})`,
-              backgroundSize: "cover",
-              backgroundPosition: "center",
-              border: "none",
-              transition: "transform 0.2s ease",
-              cursor: "pointer",
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              border: 'none',
+              transition: 'transform 0.2s ease',
+              cursor: 'pointer',
               backgroundColor: 'transparent',
             }}
-            onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.1)")}
-            onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
+            onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
+            onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
             title="Attack"
           />
-        </div>
-        <div
-          style={{
-            flex: 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <div className="content">
-            {showSparkles && (
-              <div className="sparkle"></div>
-            )}
-            {showSparkles1 && (
-              <div className="sparkle1"></div>
-            )}
-            <div onClick={handleRandomizeClick}
-    className={`die ${rolling ? 'rolling' : ''}`} data-face={activeFace}>
-      {faceElements}
-    </div>
+          <div className="attack-roll-controls__die">
+            <div className="content">
+              {showSparkles && (
+                <div className="sparkle"></div>
+              )}
+              {showSparkles1 && (
+                <div className="sparkle1"></div>
+              )}
+              <div
+                onClick={handleRandomizeClick}
+                className={`die ${rolling ? 'rolling' : ''}`}
+                data-face={activeFace}
+              >
+                {faceElements}
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the dice layout mixin to use relative offsets and add a mobile tweak for centering
- introduce shared attack roll layout helpers to preserve spacing between the attack button, dice, and footer
- refactor PlayerTurnActions to use the new helpers so the die no longer overlaps nearby controls

## Testing
- npm start *(fails: missing socket.io-client in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d718fcad10832e9299d828ba5aa4b3