### PR TITLE
Adjust modal footer layout spacing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1603,6 +1603,9 @@ h1 {
 .modal-footer {
   display: flex;
   justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  column-gap: 0.75rem;
   padding: 10px;
 }
 


### PR DESCRIPTION
## Summary
- keep modal footer buttons on a single row by preventing wrapping
- add horizontal gaps so actions have breathing room while shrinking as needed

## Testing
- npm --prefix client start *(fails: missing dependency socket.io-client in Zombies pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d71ce76620832e8237e1706d3bddf7