### PR TITLE
Clamp dice offset on short viewports

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -567,7 +567,7 @@ $rotateX: -$angle;
     height: $containerHeight;
     perspective: 1500px;
 
-    @media (max-width: 576px) {
+    @media (max-width: 576px), (max-height: 600px) {
       top: calc(#{$containerHeight} * -0.06);
     }
   }


### PR DESCRIPTION
## Summary
- adjust the dice mixin so the content top offset relaxes on narrow widths or short viewports
- ensure the dice remains centered below the attack button on landscape devices by clamping the upward offset

## Testing
- npm start *(fails: missing optional dependency `socket.io-client` in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d71fc73e7c832e9577034f7c483457