### PR TITLE
Reintroduce shared Zombies campaign actions

### DIFF
--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,11 +1,31 @@
 import React, { useState, useEffect, useRef } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button } from 'react-bootstrap'; // Adjust as per your actual UI library
+import { Modal, Card, Table, Button, Alert } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
+import CampaignModals from "../components/CampaignModals";
+import useCampaignActions from "../hooks/useCampaignActions";
 
-export default function Help({props, form, showHelpModal, handleCloseHelpModal}) {
+export default function Help({ form, showHelpModal, handleCloseHelpModal }) {
   const params = useParams();
   const navigate = useNavigate();
+  const {
+    notification: campaignNotification,
+    clearNotification,
+    playerCampaigns,
+    dmCampaigns,
+    showJoinCampaignModal,
+    showHostCampaignModal,
+    showCreateCampaignModal,
+    openJoinCampaignModal,
+    closeJoinCampaignModal,
+    openHostCampaignModal,
+    closeHostCampaignModal,
+    openCreateCampaignModal,
+    closeCreateCampaignModal,
+    createCampaignForm,
+    updateCreateCampaignForm,
+    submitCreateCampaign,
+  } = useCampaignActions();
   const [showDeleteCharacter, setShowDeleteCharacter] = useState(false);
   const handleCloseDeleteCharacter = () => setShowDeleteCharacter(false);
  const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
@@ -67,81 +87,140 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
    });
    navigate(0);
  } 
-return(
+  return (
     <div>
-        <Modal
+      <Modal
         className="dnd-modal modern-modal text-center"
         size="lg"
         aria-labelledby="contained-modal-title-vcenter"
         centered
         scrollable
-        show={showHelpModal} onHide={handleCloseHelpModal}>
-          <Card className="modern-card text-center">
-            <Card.Header className="modal-header">
-              <Card.Title className="modal-title">Help</Card.Title>
-            </Card.Header>
-            <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-              <div className="table-container">
-                <Table striped bordered hover size="sm" className="custom-table">
-                  <thead>
-                    <tr>
-                      <td className="center-td">
-                        <strong className='text-light'>Change Dice Color:</strong>
-                      </td>
-                      <td className="center-td">
-                        <input
-                          type="color"
-                          id="colorPicker"
-                          ref={colorPickerRef}
-                          value={newColor}
-                          onChange={handleColorChange}
-                        />
-                      </td>
-                      <td className="center-td">
-                        <Button onClick={diceColorUpdate} className="action-btn save-btn fa-solid fa-floppy-disk"></Button>
-                      </td>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td className="center-td" colSpan="3">
-                        <Button onClick={handleLogout} className="action-btn close-btn">
-                          Logout
-                        </Button>
-                      </td>
-                    </tr>
-                  </tbody>
-                </Table>
-              </div>
-            </Card.Body>
-            <Card.Footer className="modal-footer justify-content-between">
-              <Button className="action-btn btn-danger" onClick={handleShowDeleteCharacter}>Delete Character</Button>
-              <Button className="action-btn close-btn" onClick={handleCloseHelpModal}>
-                Close
+        show={showHelpModal}
+        onHide={handleCloseHelpModal}
+      >
+        <Card className="modern-card text-center">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Help</Card.Title>
+          </Card.Header>
+          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+            {campaignNotification && (
+              <Alert
+                variant="danger"
+                dismissible
+                onClose={clearNotification}
+                className="mb-3"
+              >
+                {campaignNotification}
+              </Alert>
+            )}
+            <div className="table-container">
+              <Table striped bordered hover size="sm" className="custom-table">
+                <thead>
+                  <tr>
+                    <td className="center-td">
+                      <strong className="text-light">Change Dice Color:</strong>
+                    </td>
+                    <td className="center-td">
+                      <input
+                        type="color"
+                        id="colorPicker"
+                        ref={colorPickerRef}
+                        value={newColor}
+                        onChange={handleColorChange}
+                      />
+                    </td>
+                    <td className="center-td">
+                      <Button
+                        onClick={diceColorUpdate}
+                        className="action-btn save-btn fa-solid fa-floppy-disk"
+                      ></Button>
+                    </td>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className="center-td" colSpan="3">
+                      <Button onClick={handleLogout} className="action-btn close-btn">
+                        Logout
+                      </Button>
+                    </td>
+                  </tr>
+                </tbody>
+              </Table>
+            </div>
+            <div className="mt-3 d-flex flex-column flex-lg-row gap-2 justify-content-center align-items-center">
+              <Button
+                className="fantasy-button campaign-button"
+                style={{ borderColor: "transparent" }}
+                onClick={openJoinCampaignModal}
+              >
+                Join Campaign
               </Button>
-            </Card.Footer>
-          </Card>
-        </Modal>
-        <Modal
-          className="dnd-modal modern-modal text-center"
-          size="lg"
-          aria-labelledby="contained-modal-title-vcenter"
-          centered
-          scrollable
-          show={showDeleteCharacter} onHide={handleCloseDeleteCharacter}>
-          <Card className="modern-card text-center">
-            <Card.Header className="modal-header">
-              <Card.Title className="modal-title">Delete Character</Card.Title>
-            </Card.Header>
-            <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-              Are you sure you want to delete your character?
-            </Card.Body>
-            <Card.Footer className="modal-footer">
-              <Button className="btn-danger action-btn save-btn" onClick={deleteRecord}>Im Sure</Button>
-              <Button className="action-btn close-btn" onClick={handleCloseDeleteCharacter}>Close</Button>
-            </Card.Footer>
-          </Card>
-        </Modal>
+              <Button
+                className="fantasy-button campaign-button hostCampaign"
+                style={{ borderColor: "transparent" }}
+                onClick={openHostCampaignModal}
+              >
+                Host Campaign
+              </Button>
+              <Button
+                className="fantasy-button campaign-button create-button"
+                style={{ borderColor: "transparent" }}
+                onClick={openCreateCampaignModal}
+              >
+                Create Campaign
+              </Button>
+            </div>
+          </Card.Body>
+          <Card.Footer className="modal-footer justify-content-between">
+            <Button className="action-btn btn-danger" onClick={handleShowDeleteCharacter}>
+              Delete Character
+            </Button>
+            <Button className="action-btn close-btn" onClick={handleCloseHelpModal}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </Modal>
+      <Modal
+        className="dnd-modal modern-modal text-center"
+        size="lg"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        scrollable
+        show={showDeleteCharacter}
+        onHide={handleCloseDeleteCharacter}
+      >
+        <Card className="modern-card text-center">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Delete Character</Card.Title>
+          </Card.Header>
+          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+            Are you sure you want to delete your character?
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="btn-danger action-btn save-btn" onClick={deleteRecord}>
+              Im Sure
+            </Button>
+            <Button className="action-btn close-btn" onClick={handleCloseDeleteCharacter}>
+              Close
+            </Button>
+          </Card.Footer>
+        </Card>
+      </Modal>
+      <CampaignModals
+        playerCampaigns={playerCampaigns}
+        dmCampaigns={dmCampaigns}
+        showJoinCampaignModal={showJoinCampaignModal}
+        closeJoinCampaignModal={closeJoinCampaignModal}
+        showHostCampaignModal={showHostCampaignModal}
+        closeHostCampaignModal={closeHostCampaignModal}
+        showCreateCampaignModal={showCreateCampaignModal}
+        closeCreateCampaignModal={closeCreateCampaignModal}
+        createCampaignForm={createCampaignForm}
+        updateCreateCampaignForm={updateCreateCampaignForm}
+        submitCreateCampaign={submitCreateCampaign}
+      />
     </div>
-)
+  );
 }

--- a/client/src/components/Zombies/components/CampaignModals.js
+++ b/client/src/components/Zombies/components/CampaignModals.js
@@ -1,0 +1,169 @@
+import React from "react";
+import { Button, Card, Form, Modal, Table } from "react-bootstrap";
+import { Link } from "react-router-dom";
+
+export default function CampaignModals({
+  playerCampaigns,
+  dmCampaigns,
+  showJoinCampaignModal,
+  closeJoinCampaignModal,
+  showHostCampaignModal,
+  closeHostCampaignModal,
+  showCreateCampaignModal,
+  closeCreateCampaignModal,
+  createCampaignForm,
+  updateCreateCampaignForm,
+  submitCreateCampaign,
+}) {
+  return (
+    <>
+      <Modal
+        className="dnd-modal"
+        centered
+        show={showJoinCampaignModal}
+        onHide={closeJoinCampaignModal}
+      >
+        <div className="text-center">
+          <Card className="dnd-background">
+            <Card.Title>Join Campaign</Card.Title>
+
+            <Card.Body>
+              <Table striped bordered hover>
+                <thead>
+                  <tr>
+                    <th>Campaign Name</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {playerCampaigns.map((campaign) => (
+                    <tr key={campaign.campaignName}>
+                      <td>{campaign.campaignName}</td>
+                      <td>
+                        <Link
+                          className="btn btn-link"
+                          to={`/zombies-character-select/${campaign.campaignName}`}
+                        >
+                          <Button
+                            style={{ borderColor: "transparent" }}
+                            className="fantasy-button"
+                            type="button"
+                            onClick={closeJoinCampaignModal}
+                          >
+                            Join
+                          </Button>
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Card.Body>
+            <Modal.Footer>
+              <Button variant="secondary" onClick={closeJoinCampaignModal}>
+                Close
+              </Button>
+            </Modal.Footer>
+          </Card>
+        </div>
+      </Modal>
+
+      <Modal
+        className="dnd-modal"
+        centered
+        show={showHostCampaignModal}
+        onHide={closeHostCampaignModal}
+      >
+        <div className="text-center">
+          <Card className="dnd-background">
+            <Card.Title>Host Campaign</Card.Title>
+
+            <Card.Body>
+              <Table striped bordered hover>
+                <thead>
+                  <tr>
+                    <th>Campaign Name</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dmCampaigns.map((campaign) => (
+                    <tr key={campaign.campaignName}>
+                      <td>{campaign.campaignName}</td>
+                      <td>
+                        <Link
+                          className="btn btn-link"
+                          to={`/zombies-dm/${campaign.campaignName}`}
+                        >
+                          <Button
+                            style={{ borderColor: "transparent" }}
+                            className="hostCampaign"
+                            type="button"
+                            onClick={closeHostCampaignModal}
+                          >
+                            Host
+                          </Button>
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Card.Body>
+            <Modal.Footer>
+              <Button variant="secondary" onClick={closeHostCampaignModal}>
+                Close
+              </Button>
+            </Modal.Footer>
+          </Card>
+        </div>
+      </Modal>
+
+      <Modal
+        centered
+        className="dnd-modal"
+        show={showCreateCampaignModal}
+        onHide={closeCreateCampaignModal}
+      >
+        <div className="text-center">
+          <Card className="dnd-background">
+            <Card.Title>Create Campaign</Card.Title>
+            <Card.Body>
+              <div className="text-center">
+                <Form onSubmit={submitCreateCampaign} className="px-5">
+                  <Form.Group className="mb-3 pt-3">
+                    <Form.Label className="text-light">Campaign Name</Form.Label>
+                    <Form.Control
+                      className="mb-2"
+                      onChange={(e) =>
+                        updateCreateCampaignForm({
+                          campaignName: e.target.value,
+                        })
+                      }
+                      type="text"
+                      value={createCampaignForm.campaignName}
+                      placeholder="Enter campaign name"
+                    />
+                  </Form.Group>
+                  <div className="text-center">
+                    <Button variant="primary" type="submit">
+                      Create
+                    </Button>
+                    <Button
+                      className="ms-4"
+                      variant="secondary"
+                      type="button"
+                      onClick={closeCreateCampaignModal}
+                    >
+                      Close
+                    </Button>
+                  </div>
+                </Form>
+              </div>
+            </Card.Body>
+          </Card>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/client/src/components/Zombies/hooks/useCampaignActions.js
+++ b/client/src/components/Zombies/hooks/useCampaignActions.js
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import apiFetch from "../../../utils/apiFetch";
+import useUser from "../../../hooks/useUser";
+
+export default function useCampaignActions() {
+  const navigate = useNavigate();
+  const user = useUser();
+
+  const [playerCampaigns, setPlayerCampaigns] = useState([]);
+  const [dmCampaigns, setDmCampaigns] = useState([]);
+  const [notification, setNotification] = useState("");
+
+  const [showJoinCampaignModal, setShowJoinCampaignModal] = useState(false);
+  const [showHostCampaignModal, setShowHostCampaignModal] = useState(false);
+  const [showCreateCampaignModal, setShowCreateCampaignModal] = useState(false);
+
+  const [createCampaignForm, setCreateCampaignForm] = useState({
+    campaignName: "",
+    gameMode: "zombies",
+    dm: "",
+    players: [],
+  });
+
+  const username = user?.username ?? "";
+
+  useEffect(() => {
+    if (username) {
+      setCreateCampaignForm((prev) => ({ ...prev, dm: username }));
+    }
+  }, [username]);
+
+  const clearNotification = useCallback(() => setNotification(""), []);
+
+  const fetchPlayerCampaigns = useCallback(async () => {
+    if (!username) {
+      return [];
+    }
+
+    try {
+      const response = await apiFetch(`/campaigns/player/${username}`);
+
+      if (!response.ok) {
+        const message = `An error has occurred: ${response.statusText}`;
+        setNotification(message);
+        return [];
+      }
+
+      const record = await response.json();
+      if (!record) {
+        setNotification("Record not found");
+        navigate("/");
+        return [];
+      }
+
+      setPlayerCampaigns(record);
+      return record;
+    } catch (error) {
+      setNotification(error.message || "An unexpected error has occurred");
+      return [];
+    }
+  }, [navigate, username]);
+
+  const fetchDmCampaigns = useCallback(async () => {
+    if (!username) {
+      return [];
+    }
+
+    try {
+      const response = await apiFetch(`/campaigns/dm/${username}`);
+
+      if (!response.ok) {
+        const message = `An error has occurred: ${response.statusText}`;
+        setNotification(message);
+        return [];
+      }
+
+      const record = await response.json();
+      if (!record) {
+        setNotification("Record not found");
+        navigate("/");
+        return [];
+      }
+
+      setDmCampaigns(record);
+      return record;
+    } catch (error) {
+      setNotification(error.message || "An unexpected error has occurred");
+      return [];
+    }
+  }, [navigate, username]);
+
+  useEffect(() => {
+    fetchPlayerCampaigns();
+  }, [fetchPlayerCampaigns]);
+
+  const updateCreateCampaignForm = useCallback((value) => {
+    setCreateCampaignForm((prev) => ({ ...prev, ...value }));
+  }, []);
+
+  const submitCreateCampaign = useCallback(
+    async (event) => {
+      event?.preventDefault?.();
+
+      if (!username) {
+        setNotification("You must be logged in to create a campaign.");
+        return false;
+      }
+
+      const newCampaign = {
+        ...createCampaignForm,
+        dm: createCampaignForm.dm || username,
+      };
+
+      try {
+        const response = await apiFetch("/campaigns/add", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(newCampaign),
+        });
+
+        if (!response.ok) {
+          const message = `An error has occurred: ${response.statusText}`;
+          setNotification(message);
+          return false;
+        }
+
+        updateCreateCampaignForm({ campaignName: "" });
+        await Promise.all([fetchDmCampaigns(), fetchPlayerCampaigns()]);
+        setShowCreateCampaignModal(false);
+        return true;
+      } catch (error) {
+        setNotification(error.message || "An unexpected error has occurred");
+        return false;
+      }
+    },
+    [createCampaignForm, fetchDmCampaigns, fetchPlayerCampaigns, updateCreateCampaignForm, username]
+  );
+
+  const openJoinCampaignModal = useCallback(async () => {
+    await fetchPlayerCampaigns();
+    setShowJoinCampaignModal(true);
+  }, [fetchPlayerCampaigns]);
+
+  const closeJoinCampaignModal = useCallback(() => {
+    setShowJoinCampaignModal(false);
+  }, []);
+
+  const openHostCampaignModal = useCallback(async () => {
+    await fetchDmCampaigns();
+    setShowHostCampaignModal(true);
+  }, [fetchDmCampaigns]);
+
+  const closeHostCampaignModal = useCallback(() => {
+    setShowHostCampaignModal(false);
+  }, []);
+
+  const openCreateCampaignModal = useCallback(() => {
+    setShowCreateCampaignModal(true);
+  }, []);
+
+  const closeCreateCampaignModal = useCallback(() => {
+    setShowCreateCampaignModal(false);
+  }, []);
+
+  return useMemo(
+    () => ({
+      notification,
+      clearNotification,
+      playerCampaigns,
+      dmCampaigns,
+      showJoinCampaignModal,
+      showHostCampaignModal,
+      showCreateCampaignModal,
+      openJoinCampaignModal,
+      closeJoinCampaignModal,
+      openHostCampaignModal,
+      closeHostCampaignModal,
+      openCreateCampaignModal,
+      closeCreateCampaignModal,
+      createCampaignForm,
+      updateCreateCampaignForm,
+      submitCreateCampaign,
+    }),
+    [
+      clearNotification,
+      closeCreateCampaignModal,
+      closeHostCampaignModal,
+      closeJoinCampaignModal,
+      createCampaignForm,
+      dmCampaigns,
+      notification,
+      openCreateCampaignModal,
+      openHostCampaignModal,
+      openJoinCampaignModal,
+      playerCampaigns,
+      showCreateCampaignModal,
+      showHostCampaignModal,
+      showJoinCampaignModal,
+      submitCreateCampaign,
+      updateCreateCampaignForm,
+    ]
+  );
+}

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -1,260 +1,96 @@
-import React, { useState, useEffect, } from "react";
-import apiFetch from '../../../utils/apiFetch';
-import { Button, Form, Table, Card, Alert } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
-import Modal from 'react-bootstrap/Modal';
-import { Link } from "react-router-dom";
+import React from "react";
+import { Button, Alert } from "react-bootstrap";
 import loginbg from "../../../images/loginbg.png";
-import useUser from '../../../hooks/useUser';
-
+import apiFetch from "../../../utils/apiFetch";
+import CampaignModals from "../components/CampaignModals";
+import useCampaignActions from "../hooks/useCampaignActions";
 
 export default function Zombies() {
-  const navigate = useNavigate();
-  const user = useUser();
+  const {
+    notification: campaignNotification,
+    clearNotification,
+    playerCampaigns,
+    dmCampaigns,
+    showJoinCampaignModal,
+    showHostCampaignModal,
+    showCreateCampaignModal,
+    openJoinCampaignModal,
+    closeJoinCampaignModal,
+    openHostCampaignModal,
+    closeHostCampaignModal,
+    openCreateCampaignModal,
+    closeCreateCampaignModal,
+    createCampaignForm,
+    updateCreateCampaignForm,
+    submitCreateCampaign,
+  } = useCampaignActions();
 
   const handleLogout = async () => {
     await apiFetch("/logout", { method: "POST" });
     window.location.assign("/");
   };
 
-//--------------------------------------------Campaign Section------------------------------
-
-const [form1, setForm1] = useState({ 
-  campaignName: "", 
-  gameMode: "zombies",
-  dm: "",
-  players: [],
-});
-
-useEffect(() => {
-  // Update form1 state once the token is decoded
-    if (user) {
-      setForm1(prevForm1 => ({ ...prevForm1, dm: user.username }));
-    }
-  }, [user]);
-
-const [campaign, setCampaign] = useState({ 
-  campaign: [], 
-});
-
-const [campaignDM, setCampaignDM] = useState({
-  campaign: [],
-});
-
-const [show1, setShow1] = useState(false);
-const handleClose1 = () => setShow1(false);
-const handleShow1 = () => setShow1(true);
-
-const [showJoinCampaignModal, setShowJoinCampaignModal] = useState(false);
-const handleCloseJoinCampaign = () => setShowJoinCampaignModal(false);
-const handleShowJoinCampaign = () => setShowJoinCampaignModal(true);
-
-const [showHostCampaignModal, setShowHostCampaignModal] = useState(false);
-const handleCloseHostCampaign = () => setShowHostCampaignModal(false);
-
-const [notification, setNotification] = useState("");
-
-async function loadDmCampaigns() {
-  if (!user || !user.username) {
-    return;
-  }
-
-  const response = await apiFetch(`/campaigns/dm/${user.username}`);
-
-  if (!response.ok) {
-    const message = `An error has occurred: ${response.statusText}`;
-    setNotification(message);
-    return;
-  }
-
-  const record = await response.json();
-  if (!record) {
-    setNotification(`Record not found`);
-    navigate("/");
-    return;
-  }
-  setCampaignDM({ campaign: record });
-}
-
-const handleShowHostCampaign = async () => {
-  await loadDmCampaigns();
-  setShowHostCampaignModal(true);
-};
-
-// Fetch Campaigns
-  useEffect(() => {
-    if (!user || !user.username) {
-      return;
-    }
-  async function fetchData1() {
-    const response = await apiFetch(`/campaigns/player/${user.username}`);
-
-    if (!response.ok) {
-      const message = `An error has occurred: ${response.statusText}`;
-      setNotification(message);
-      return;
-    }
-
-    const record = await response.json();
-    if (!record) {
-      setNotification(`Record not found`);
-      navigate("/");
-      return;
-    }
-    setCampaign({campaign: record});
-  }
-  fetchData1();   
-  return;
-  
-  }, [navigate, user]);
-
-
-
-function updateForm1(value) {
-  return setForm1((prev) => {
-    return { ...prev, ...value };
-  });
-}
-
-async function onSubmit1(e) {
-  e.preventDefault();   
-   sendToDb1();
-}
- async function sendToDb1(){
-    const newCampaign = { ...form1 };
-      await apiFetch("/campaigns/add", {
-       method: "POST",
-       headers: {
-         "Content-Type": "application/json",
-       },
-       body: JSON.stringify(newCampaign),
-     })
-     .catch(error => {
-       setNotification(error.message || error);
-       return;
-     });
-
-     setForm1({
-      campaignName: "", 
-      gameMode: "zombies",
-    });
-     navigate(0);
-   }
-
-// -----------------------------------Display-----------------------------------------------------------------------------
-return (
-<div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${loginbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
-
-      {notification && (
-        <Alert variant="danger" dismissible onClose={() => setNotification("")}> 
-          {notification}
+  return (
+    <div
+      className="pt-2 text-center"
+      style={{
+        fontFamily: "Raleway, sans-serif",
+        backgroundImage: `url(${loginbg})`,
+        backgroundSize: "cover",
+        backgroundRepeat: "no-repeat",
+        height: "100vh",
+      }}
+    >
+      {campaignNotification && (
+        <Alert variant="danger" dismissible onClose={clearNotification}>
+          {campaignNotification}
         </Alert>
       )}
 
       <div className="d-flex flex-column justify-content-center align-items-center h-100">
-        <Button className="mb-3 fantasy-button campaign-button" style={{borderColor: "transparent"}} onClick={handleShowJoinCampaign}>Join Campaign</Button>
-        <Button className="mb-3 hostCampaign campaign-button" style={{borderColor: "transparent"}} onClick={handleShowHostCampaign}>Host Campaign</Button>
-        <Button className="create-button campaign-button" style={{borderColor: "transparent"}} onClick={handleShow1}>Create Campaign</Button>
-        <Button className="mt-3 fantasy-button campaign-button" style={{borderColor: "transparent"}} onClick={handleLogout}>Logout</Button>
+        <Button
+          className="mb-3 fantasy-button campaign-button"
+          style={{ borderColor: "transparent" }}
+          onClick={openJoinCampaignModal}
+        >
+          Join Campaign
+        </Button>
+        <Button
+          className="mb-3 hostCampaign campaign-button"
+          style={{ borderColor: "transparent" }}
+          onClick={openHostCampaignModal}
+        >
+          Host Campaign
+        </Button>
+        <Button
+          className="create-button campaign-button"
+          style={{ borderColor: "transparent" }}
+          onClick={openCreateCampaignModal}
+        >
+          Create Campaign
+        </Button>
+        <Button
+          className="mt-3 fantasy-button campaign-button"
+          style={{ borderColor: "transparent" }}
+          onClick={handleLogout}
+        >
+          Logout
+        </Button>
       </div>
 
-      <Modal className="dnd-modal" centered show={showJoinCampaignModal} onHide={handleCloseJoinCampaign}>
-   <div className="text-center">
-    <Card className="dnd-background">
-    <Card.Title>Join Campaign</Card.Title>
-
-  <Card.Body>
-    <Table striped bordered hover>
-      <thead>
-        <tr>
-          <th>Campaign Name</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {campaign.campaign.map((el) => (
-          <tr key={el.campaignName}>
-            <td>{el.campaignName}</td>
-            <td>
-              <Link className="btn btn-link" to={`/zombies-character-select/${el.campaignName}`}>
-              <Button style={{borderColor: "transparent"}} className="fantasy-button" type="submit">Join</Button>              </Link>
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </Table>
-  </Card.Body>
-  <Modal.Footer>
-    <Button variant="secondary" onClick={handleCloseJoinCampaign}>
-      Close
-    </Button>
-  </Modal.Footer>
-  </Card>
-  </div>
-</Modal>
-
-  <Modal className="dnd-modal" centered show={showHostCampaignModal} onHide={handleCloseHostCampaign}>
-   <div className="text-center">
-    <Card className="dnd-background">
-    <Card.Title>Host Campaign</Card.Title>
-
-  <Card.Body>
-    <Table striped bordered hover>
-      <thead>
-        <tr>
-          <th>Campaign Name</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {campaignDM.campaign.map((el) => (
-          <tr key={el.campaignName}>
-            <td>{el.campaignName}</td>
-            <td>
-              <Link className="btn btn-link" to={`/zombies-dm/${el.campaignName}`}>
-              <Button style={{borderColor: "transparent"}} className="hostCampaign" type="submit">Host</Button>              </Link>
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </Table>
-  </Card.Body>
-  <Modal.Footer>
-    <Button variant="secondary" onClick={handleCloseHostCampaign}>
-      Close
-    </Button>
-  </Modal.Footer>
-  </Card>
-  </div>
-</Modal>
-
-      {/* -----------------------------------Create Campaign--------------------------------------------- */}
-      <Modal centered className="dnd-modal" show={show1} onHide={handleClose1}>
-        <div className="text-center">
-        <Card className="dnd-background">
-          <Card.Title>Create Campaign</Card.Title>
-        <Card.Body>   
-        <div className="text-center">
-      <Form onSubmit={onSubmit1} className="px-5">
-      <Form.Group className="mb-3 pt-3">
-       <Form.Label className="text-light">Campaign Name</Form.Label>
-       <Form.Control className="mb-2" onChange={(e) => updateForm1({ campaignName: e.target.value })}
-        type="text" placeholder="Enter campaign name" />         
-     </Form.Group>
-     <div className="text-center">
-     <Button variant="primary" onClick={handleClose1} type="submit">
-            Create
-          </Button>
-          <Button className="ms-4" variant="secondary" onClick={handleClose1}>
-            Close
-          </Button>
-          </div>
-     </Form>
-     </div>
-     </Card.Body> 
-     </Card>   
-     </div>    
-      </Modal>
+      <CampaignModals
+        playerCampaigns={playerCampaigns}
+        dmCampaigns={dmCampaigns}
+        showJoinCampaignModal={showJoinCampaignModal}
+        closeJoinCampaignModal={closeJoinCampaignModal}
+        showHostCampaignModal={showHostCampaignModal}
+        closeHostCampaignModal={closeHostCampaignModal}
+        showCreateCampaignModal={showCreateCampaignModal}
+        closeCreateCampaignModal={closeCreateCampaignModal}
+        createCampaignForm={createCampaignForm}
+        updateCreateCampaignForm={updateCreateCampaignForm}
+        submitCreateCampaign={submitCreateCampaign}
+      />
     </div>
- )
+  );
 }


### PR DESCRIPTION
## Summary
- restore the Join, Host, and Create campaign buttons on the zombies landing page using shared modal logic
- integrate the help modal with the same campaign actions to reuse fetching and modal behaviour
- add reusable hook and modal component for campaign data management

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d729247518832ea1ef438827494a09