### PR TITLE
Convert spell selector tables into responsive cards

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -178,6 +178,68 @@
   opacity: 1;
 }
 
+.spell-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .spell-card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+}
+
+.spell-card {
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: var(--bs-light);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spell-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.spell-card-header .form-check {
+  margin: 0;
+}
+
+.spell-card .form-check-label {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.spell-card-details {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.spell-card-details span {
+  display: flex;
+  gap: 0.35rem;
+  align-items: baseline;
+}
+
+.spell-card-details strong {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.spell-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .weapon-checkbox .form-check-input:checked {
   background-color: var(--bs-primary);
   border-color: var(--bs-primary);

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Button, Form, Tabs, Tab, Table } from 'react-bootstrap';
+import { Modal, Card, Button, Form, Tabs, Tab } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 import UpcastModal from './UpcastModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
@@ -400,6 +400,82 @@ export default function SpellSelector({
     saveSpells(updatedSpells, updatedCasters);
   }
 
+  const renderSpellCards = (cls) => {
+    const spells = spellsForClass(cls);
+    if (!spells.length) {
+      return <div className="text-light">No spells available.</div>;
+    }
+
+    return (
+      <div className="spell-card-grid">
+        {spells.map((spell) => {
+          const isSelected = selectedSpells.includes(spell.name);
+          const disableSelection = !isSelected && (pointsLeft[cls] || 0) <= 0;
+
+          return (
+            <div key={spell.name} className="spell-card">
+              <div className="spell-card-header">
+                <Form.Check
+                  id={`spell-${cls}-${spell.name}`}
+                  type="checkbox"
+                  label={spell.name}
+                  checked={isSelected}
+                  disabled={disableSelection}
+                  onChange={() => toggleSpell(spell.name, cls)}
+                />
+                <div className="spell-card-actions">
+                  <Button
+                    variant="link"
+                    onClick={() => setViewSpell(spell)}
+                  >
+                    <i className="fa-solid fa-eye"></i>
+                  </Button>
+                  <Button
+                    variant="link"
+                    disabled={!isSelected}
+                    className={!isSelected ? 'text-secondary' : ''}
+                    onClick={() => {
+                      if (!isSelected) return;
+                      if (spell.higherLevels) {
+                        setPendingSpell(spell);
+                        setShowUpcast(true);
+                      } else {
+                        const damage = getScaledDamage(spell);
+                        onCastSpell?.({
+                          level: spell.level,
+                          damage,
+                          castingTime: spell.castingTime,
+                          name: spell.name,
+                        });
+                        handleClose();
+                      }
+                    }}
+                  >
+                    <i className="fa-solid fa-wand-sparkles" />
+                  </Button>
+                </div>
+              </div>
+              <div className="spell-card-details">
+                <span>
+                  <strong>School:</strong> {spell.school}
+                </span>
+                <span>
+                  <strong>Casting Time:</strong> {spell.castingTime}
+                </span>
+                <span>
+                  <strong>Range:</strong> {spell.range}
+                </span>
+                <span>
+                  <strong>Duration:</strong> {spell.duration}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   async function saveSpells(
     spells = selectedSpells,
     casters = spellCasters
@@ -510,83 +586,7 @@ export default function SpellSelector({
                           : pointsLeft[cls] || 0}
                       </span>
                     </div>
-                    <Table
-                      striped
-                      bordered
-                      hover
-                      size="sm"
-                      className="modern-table"
-                    >
-                      <thead>
-                        <tr>
-                          <th></th>
-                          <th>Name</th>
-                          <th>School</th>
-                          <th>Casting Time</th>
-                          <th>Range</th>
-                          <th>Duration</th>
-                          <th></th>
-                          <th></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {spellsForClass(cls).map((spell) => {
-                          const isSelected = selectedSpells.includes(spell.name);
-                          return (
-                            <tr key={spell.name}>
-                              <td>
-                                <Form.Check
-                                  id={`spell-${spell.name}`}
-                                  type="checkbox"
-                                  checked={isSelected}
-                                  disabled={
-                                    !isSelected && (pointsLeft[cls] || 0) <= 0
-                                  }
-                                  onChange={() => toggleSpell(spell.name, cls)}
-                                />
-                              </td>
-                              <td>{spell.name}</td>
-                              <td>{spell.school}</td>
-                              <td>{spell.castingTime}</td>
-                              <td>{spell.range}</td>
-                              <td>{spell.duration}</td>
-                              <td>
-                                <Button
-                                  variant="link"
-                                  onClick={() => setViewSpell(spell)}
-                                >
-                                  <i className="fa-solid fa-eye"></i>
-                                </Button>
-                              </td>
-                              <td>
-                                <Button
-                                  variant="link"
-                                  disabled={!isSelected}
-                                  className={!isSelected ? 'text-secondary' : ''}
-                                  onClick={() => {
-                                    if (spell.higherLevels) {
-                                      setPendingSpell(spell);
-                                      setShowUpcast(true);
-                                    } else {
-                                      const damage = getScaledDamage(spell);
-                                      onCastSpell?.({
-                                        level: spell.level,
-                                        damage,
-                                        castingTime: spell.castingTime,
-                                        name: spell.name,
-                                      });
-                                      handleClose();
-                                    }
-                                  }}
-                                >
-                                  <i className="fa-solid fa-wand-sparkles" />
-                                </Button>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </Table>
+                    {renderSpellCards(cls)}
                   </>
                 );
               })()
@@ -631,83 +631,7 @@ export default function SpellSelector({
                           : pointsLeft[name] || 0}
                       </span>
                     </div>
-                    <Table
-                      striped
-                      bordered
-                      hover
-                      size="sm"
-                      className="modern-table"
-                    >
-                      <thead>
-                        <tr>
-                          <th></th>
-                          <th>Name</th>
-                          <th>School</th>
-                          <th>Casting Time</th>
-                          <th>Range</th>
-                          <th>Duration</th>
-                          <th></th>
-                          <th></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {spellsForClass(name).map((spell) => {
-                          const isSelected = selectedSpells.includes(spell.name);
-                          return (
-                            <tr key={spell.name}>
-                              <td>
-                                <Form.Check
-                                  id={`spell-${spell.name}`}
-                                  type="checkbox"
-                                  checked={isSelected}
-                                  disabled={
-                                    !isSelected && (pointsLeft[name] || 0) <= 0
-                                  }
-                                  onChange={() => toggleSpell(spell.name, name)}
-                                />
-                              </td>
-                              <td>{spell.name}</td>
-                              <td>{spell.school}</td>
-                              <td>{spell.castingTime}</td>
-                              <td>{spell.range}</td>
-                              <td>{spell.duration}</td>
-                              <td>
-                                <Button
-                                  variant="link"
-                                  onClick={() => setViewSpell(spell)}
-                                >
-                                  <i className="fa-solid fa-eye"></i>
-                                </Button>
-                              </td>
-                              <td>
-                                <Button
-                                  variant="link"
-                                  disabled={!isSelected}
-                                  className={!isSelected ? 'text-secondary' : ''}
-                                  onClick={() => {
-                                    if (spell.higherLevels) {
-                                      setPendingSpell(spell);
-                                      setShowUpcast(true);
-                                    } else {
-                                      const damage = getScaledDamage(spell);
-                                      onCastSpell?.({
-                                        level: spell.level,
-                                        damage,
-                                        castingTime: spell.castingTime,
-                                        name: spell.name,
-                                      });
-                                      handleClose();
-                                    }
-                                  }}
-                                >
-                                  <i className="fa-solid fa-wand-sparkles" />
-                                </Button>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </Table>
+                    {renderSpellCards(name)}
                   </Tab>
                 ))}
               </Tabs>


### PR DESCRIPTION
## Summary
- replace the SpellSelector tables with a shared card renderer that keeps view and cast flows intact
- add responsive styling so spell cards stack on small screens and form a grid on larger breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d730f588bc832e96dec0245c21920e