### PR TITLE
Add footer close button to features modal

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -152,6 +152,14 @@ export default function Features({
                 <div className="text-center text-muted">No features found</div>
               ) : null}
             </Card.Body>
+            <Card.Footer className="modal-footer">
+              <Button
+                className="action-btn close-btn"
+                onClick={handleCloseFeatures}
+              >
+                Close
+              </Button>
+            </Card.Footer>
           </Card>
         </div>
       </Modal>


### PR DESCRIPTION
## Summary
- add a modal footer with a close button to the features modal to match the styling of other modals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d736905350832e9288239619798ad0