### PR TITLE
Convert feat table to responsive cards

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -202,6 +202,18 @@
   }
 }
 
+.feat-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .feat-card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+}
+
 .spell-card {
   background: rgba(17, 16, 19, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -304,6 +316,79 @@
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.85);
   line-height: 1.45;
+}
+
+.feat-card {
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: var(--bs-light);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.feat-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.feat-card-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.feat-card-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.feat-card-actions .btn-outline-light {
+  color: var(--bs-light);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.feat-card-actions .btn-outline-light:hover,
+.feat-card-actions .btn-outline-light:focus {
+  color: var(--bs-dark);
+  background-color: var(--bs-light);
+}
+
+.feat-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.feat-card-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.feat-card-section-title {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.feat-card-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.feat-card-list li {
+  line-height: 1.4;
 }
 
 .weapon-checkbox .form-check-input:checked {

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button, Form, Col, Row, Alert } from 'react-bootstrap';
+import { Modal, Card, Button, Form, Col, Row, Alert } from 'react-bootstrap';
 import { useNavigate, useParams } from "react-router-dom";
 import { SKILLS } from "../skillSchema";
 import { calculateFeatPointsLeft } from '../../../utils/featUtils';
@@ -305,103 +305,102 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                 <span className="points-label text-light">Points Left:</span>
                 <span className="points-value" id="featPointLeft">{featPointsLeft}</span>
               </div>
-              <Table striped bordered hover size="sm" className="modern-table">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Notes</th>
-                    <th>Skills</th>
-                    <th>Abilities</th>
+              <div className="feat-card-grid">
+                {form.feat.map((el, index) => {
+                  const skillValues = [];
+                  if (el.skills) {
+                    Object.keys(el.skills).forEach((key) => {
+                      const skill = ALL_SKILLS.find((s) => s.key === key);
+                      const label = skill ? skill.label : key;
+                      skillValues.push(`${label}: proficient`);
+                    });
+                  }
+                  SKILLS.forEach(({ label, key }) => {
+                    const val = el[key];
+                    if (val && val !== "0" && val !== "") {
+                      skillValues.push(`${label}: ${val}`);
+                    }
+                  });
 
-                    <th>Delete</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {form.feat.map((el, index) => (
-                    <tr key={`${el.featName}-${index}`}>
-                      <td>{el.featName}</td>
-                      <td style={{ display: showDeleteFeatBtn }}>
-                        <Button
-                          variant="link"
-                          onClick={() => {
-                            handleShowFeatNotes();
-                            setModalFeatData(el);
-                          }}
-                        >
-                          <i className="fa-solid fa-eye"></i>
-                        </Button>
-                      </td>
-                      <td style={{ display: showDeleteFeatBtn }}>
-                        {(() => {
-                          const skillValues = [];
-                          if (el.skills) {
-                            Object.keys(el.skills).forEach((key) => {
-                              const skill = ALL_SKILLS.find((s) => s.key === key);
-                              const label = skill ? skill.label : key;
-                              skillValues.push(`${label}: proficient`);
-                            });
-                          }
-                          SKILLS.forEach(({ label, key }) => {
-                            const val = el[key];
-                            if (val && val !== "0" && val !== "") {
-                              skillValues.push(`${label}: ${val} `);
-                            }
-                          });
-                          return (
-                            <div>
-                              {skillValues.map((skill, index) => (
-                                <div key={index}>{skill}</div>
-                              ))}
-                            </div>
-                          );
-                        })()}
-                      </td>
-                      <td
-                        style={{
-                          display: showDeleteFeatBtn,
-                          textAlign: "left",
-                          verticalAlign: "top",
-                          whiteSpace: "pre-wrap",
-                        }}
-                      >
-                        {(() => {
-                          const abilityValues = [];
-                          abilityLabels.forEach((label) => {
-                            const prop = label.toLowerCase();
-                            const val = el[prop];
-                            if (val && val !== "0" && val !== "") {
-                              abilityValues.push(`${label}: ${val}`);
-                            }
-                          });
-                          extraAbilityLabels.forEach(({ label, key }) => {
-                            const val = el[key];
-                            if (val && val !== "0" && val !== "") {
-                              abilityValues.push(`${label}: ${val}`);
-                            }
-                          });
-                          return (
-                            <div>
-                              {abilityValues.map((ab, index) => (
-                                <div key={index}>{ab}</div>
-                              ))}
-                            </div>
-                          );
-                        })()}
-                      </td>
-                      <td>
-                        <Button
-                          size="sm"
+                  const abilityValues = [];
+                  abilityLabels.forEach((label) => {
+                    const prop = label.toLowerCase();
+                    const val = el[prop];
+                    if (val && val !== "0" && val !== "") {
+                      abilityValues.push(`${label}: ${val}`);
+                    }
+                  });
+                  extraAbilityLabels.forEach(({ label, key }) => {
+                    const val = el[key];
+                    if (val && val !== "0" && val !== "") {
+                      abilityValues.push(`${label}: ${val}`);
+                    }
+                  });
+
+                  return (
+                    <div className="feat-card" key={`${el.featName}-${index}`}>
+                      <div className="feat-card-header">
+                        <div className="feat-card-name">{el.featName}</div>
+                        <div
+                          className="feat-card-actions"
                           style={{ display: showDeleteFeatBtn }}
-                          className="btn-danger action-btn fa-solid fa-trash"
-                          onClick={() => {
-                            deleteFeats(index);
-                          }}
-                        ></Button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Table>
+                        >
+                          <Button
+                            variant="outline-light"
+                            size="sm"
+                            onClick={() => {
+                              handleShowFeatNotes();
+                              setModalFeatData(el);
+                            }}
+                          >
+                            <i className="fa-solid fa-eye" aria-hidden="true"></i>
+                            <span className="visually-hidden">View notes</span>
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="danger"
+                            className="action-btn"
+                            onClick={() => {
+                              deleteFeats(index);
+                            }}
+                          >
+                            <i className="fa-solid fa-trash" aria-hidden="true"></i>
+                            <span className="visually-hidden">Delete feat</span>
+                          </Button>
+                        </div>
+                      </div>
+                      <div className="feat-card-body">
+                        {skillValues.length > 0 && (
+                          <div
+                            className="feat-card-section"
+                            style={{ display: showDeleteFeatBtn }}
+                          >
+                            <div className="feat-card-section-title">Skills &amp; Tools</div>
+                            <ul className="feat-card-list">
+                              {skillValues.map((skill) => (
+                                <li key={skill}>{skill}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                        {abilityValues.length > 0 && (
+                          <div
+                            className="feat-card-section"
+                            style={{ display: showDeleteFeatBtn }}
+                          >
+                            <div className="feat-card-section-title">Ability Bonuses</div>
+                            <ul className="feat-card-list">
+                              {abilityValues.map((ab) => (
+                                <li key={ab}>{ab}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
               <Row>
                 <Col style={{ display: showFeatBtn }}>
                   <Form onSubmit={addFeatToDb}>


### PR DESCRIPTION
## Summary
- replace the feat management table with a responsive card layout that keeps existing actions
- add shared card styling so feats stack on mobile and form a grid on wider screens

## Testing
- Manual verification of feat modal responsiveness at mobile and desktop breakpoints

------
https://chatgpt.com/codex/tasks/task_e_68d73801c54c832eaf3a508d82b807e4