### PR TITLE
Refactor skills modal to card layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -190,6 +190,18 @@
   }
 }
 
+.skills-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .skills-card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+}
+
 .feature-card-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -262,6 +274,87 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.skill-card {
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: var(--bs-light);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skill-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.skill-card-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.skill-card-name {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.skill-card-ability {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.skill-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.skill-card-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.skill-card-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 90px;
+}
+
+.skill-card-metric-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.skill-card-metric-value {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.skill-card-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.skill-card .form-check {
+  margin: 0;
+}
+
+.skill-card .form-check-label {
+  font-weight: 500;
 }
 
 .feature-card {

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button, Form, Alert } from 'react-bootstrap';
+import { Modal, Card, Button, Form, Alert } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 
 import { SKILLS } from '../skillSchema';
@@ -317,96 +317,101 @@ export default function Skills({
               <span className="points-label text-light">Expertise Left:</span>
               <span className="points-value">{expertisePointsLeft}</span>
             </div>
-            <Table striped bordered hover size="sm" className="modern-table">
-              <thead>
-                <tr>
-                  <th>Skill</th>
-                  <th>View</th>
-                  <th>Total</th>
-                  <th>Mod</th>
-                  <th>Prof</th>
-                  <th>Exp</th>
-                  <th>Roll</th>
-                </tr>
-              </thead>
-              <tbody>
-                {SKILLS.map(({
-                  key,
-                  label,
-                  ability,
-                  armorPenalty = 0,
-                }) => {
-                  const { proficient = false, expertise = false } =
-                    skills[key] || {};
-                  const penalty = armorPenalty
-                    ? armorPenalty * totalCheckPenalty
-                    : 0;
-                  const isProficient =
-                    proficient || lockedProficiencies.has(key);
-                  const multiplier = expertise ? 2 : isProficient ? 1 : 0;
-                  const total =
-                    modMap[ability] +
-                    profBonus * multiplier +
-                    penalty +
-                    itemTotals[key] +
-                    featTotals[key] +
-                    raceTotals[key];
-                  const isSelectable = selectableSkills.has(key);
-                  const isRaceSkill = raceProficiencies.has(key);
-                  const isBackgroundSkill = backgroundProficiencies.has(key);
-                  return (
-                    <tr key={key}>
-                      <td>{label}</td>
-                      <td>
+            <div className="skills-card-grid">
+              {SKILLS.map(({
+                key,
+                label,
+                ability,
+                armorPenalty = 0,
+              }) => {
+                const { proficient = false, expertise = false } =
+                  skills[key] || {};
+                const penalty = armorPenalty
+                  ? armorPenalty * totalCheckPenalty
+                  : 0;
+                const isProficient = proficient || lockedProficiencies.has(key);
+                const multiplier = expertise ? 2 : isProficient ? 1 : 0;
+                const total =
+                  modMap[ability] +
+                  profBonus * multiplier +
+                  penalty +
+                  itemTotals[key] +
+                  featTotals[key] +
+                  raceTotals[key];
+                const isSelectable = selectableSkills.has(key);
+                const isRaceSkill = raceProficiencies.has(key);
+                const isBackgroundSkill = backgroundProficiencies.has(key);
+                const abilityLabel = ability?.toUpperCase();
+                const proficiencyId = `skill-${key}-proficiency`;
+                const expertiseId = `skill-${key}-expertise`;
+
+                return (
+                  <div key={key} className="skill-card">
+                    <div className="skill-card-header">
+                      <div className="skill-card-title">
+                        <span className="skill-card-name">{label}</span>
+                        <span className="skill-card-ability">{abilityLabel}</span>
+                      </div>
+                      <div className="skill-card-actions">
                         <Button
                           onClick={() => handleView(key)}
                           variant="link"
-                          aria-label="view"
+                          aria-label={`view ${label}`}
                         >
                           <i className="fa-solid fa-eye"></i>
                         </Button>
-                      </td>
-                      <td>{total}</td>
-                      <td>{modMap[ability]}</td>
-                      <td>
-                        <Form.Check
-                          className="skill-checkbox"
-                          type="checkbox"
-                          checked={proficient}
-                          disabled={!isSelectable || isRaceSkill || isBackgroundSkill}
-                          onChange={() => toggleProficient(key)}
-                        />
-                      </td>
-                      <td>
-                        <Form.Check
-                          className="skill-checkbox"
-                          type="checkbox"
-                          checked={expertise}
-                          disabled={
-                            !isProficient ||
-                            !selectableExpertise.has(key) ||
-                            lockedExpertise.has(key) ||
-                            (!expertise && expertisePointsLeft <= 0)
-                          }
-                          onChange={() => toggleExpertise(key)}
-                        />
-                      </td>
-                      <td>
                         <Button
                           onClick={() =>
                             handleRoll(key, ability, isProficient, expertise)
                           }
                           variant="link"
-                          aria-label="roll"
+                          aria-label={`roll ${label}`}
                         >
                           <i className="fa-solid fa-dice-d20"></i>
                         </Button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </Table>
+                      </div>
+                    </div>
+                    <div className="skill-card-metrics">
+                      <div className="skill-card-metric">
+                        <span className="skill-card-metric-label">Total</span>
+                        <span className="skill-card-metric-value">{total}</span>
+                      </div>
+                      <div className="skill-card-metric">
+                        <span className="skill-card-metric-label">Mod</span>
+                        <span className="skill-card-metric-value">
+                          {modMap[ability]}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="skill-card-toggles">
+                      <Form.Check
+                        id={proficiencyId}
+                        className="skill-checkbox"
+                        type="checkbox"
+                        label="Proficient"
+                        checked={proficient}
+                        disabled={!isSelectable || isRaceSkill || isBackgroundSkill}
+                        onChange={() => toggleProficient(key)}
+                      />
+                      <Form.Check
+                        id={expertiseId}
+                        className="skill-checkbox"
+                        type="checkbox"
+                        label="Expertise"
+                        checked={expertise}
+                        disabled={
+                          !isProficient ||
+                          !selectableExpertise.has(key) ||
+                          lockedExpertise.has(key) ||
+                          (!expertise && expertisePointsLeft <= 0)
+                        }
+                        onChange={() => toggleExpertise(key)}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           </Card.Body>
           <Card.Footer className="modal-footer d-flex">
             <Button


### PR DESCRIPTION
## Summary
- replace the skills table with responsive cards that keep existing actions accessible
- add shared styling for the new skills card grid so it matches other modal card layouts

## Testing
- `npm --prefix client test -- --watchAll=false` *(fails: pre-existing act() warnings in ZombiesCharacterSheet, ArmorList, and WeaponList tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d73946cf48832e8ce00630ecb6c4c2