### PR TITLE
Refactor stats modal into responsive cards

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -226,6 +226,90 @@
   }
 }
 
+.stat-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .stat-card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+}
+
+.stat-card {
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: var(--bs-light);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.stat-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.stat-card-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat-card-key {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.stat-card-label {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.stat-card-view {
+  color: rgba(255, 255, 255, 0.85);
+  padding: 0.25rem;
+  font-size: 1.1rem;
+}
+
+.stat-card-view:hover,
+.stat-card-view:focus {
+  color: #fff;
+  text-decoration: none;
+}
+
+.stat-card-body {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.stat-card-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 90px;
+}
+
+.stat-card-metric-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.stat-card-metric-value {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
 .spell-card {
   background: rgba(17, 16, 19, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.1);

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, Table, Modal, Button } from "react-bootstrap";
+import { Card, Modal, Button } from "react-bootstrap";
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
@@ -143,34 +143,36 @@ export default function Stats({ form, showStats, handleCloseStats }) {
               <Card.Title className="modal-title">Stats</Card.Title>
             </Card.Header>
             <Card.Body>
-              <Table striped bordered hover size="sm" responsive className="modern-table">
-                <thead>
-                  <tr>
-                    <th>Stat</th>
-                    <th>Level</th>
-                    <th>Mod</th>
-                    <th>View</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {STATS.map(({ key }) => (
-                    <tr key={key}>
-                      <td>{key.toUpperCase()}</td>
-                      <td>{computedStats[key]}</td>
-                      <td>{statMods[key]}</td>
-                      <td>
-                          <Button
-                            onClick={() => handleView(key)}
-                            variant="link"
-                            aria-label="view"
-                          >
-                            <i className="fa-solid fa-eye"></i>
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </Table>
+              <div className="stat-card-grid">
+                {STATS.map(({ key, label }) => (
+                  <div className="stat-card" key={key}>
+                    <div className="stat-card-header">
+                      <div className="stat-card-title">
+                        <span className="stat-card-key">{key.toUpperCase()}</span>
+                        {label && <span className="stat-card-label">{label}</span>}
+                      </div>
+                      <Button
+                        onClick={() => handleView(key)}
+                        variant="link"
+                        aria-label={`View ${label || key} details`}
+                        className="stat-card-view"
+                      >
+                        <i className="fa-solid fa-eye"></i>
+                      </Button>
+                    </div>
+                    <div className="stat-card-body">
+                      <div className="stat-card-metric">
+                        <span className="stat-card-metric-label">Total</span>
+                        <span className="stat-card-metric-value">{computedStats[key]}</span>
+                      </div>
+                      <div className="stat-card-metric">
+                        <span className="stat-card-metric-label">Modifier</span>
+                        <span className="stat-card-metric-value">{statMods[key]}</span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </Card.Body>
             <Card.Footer className="modal-footer">
               <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>


### PR DESCRIPTION
## Summary
- replace the stats table in the modal with card-based tiles that surface totals, modifiers, and the breakdown trigger
- add responsive styling for the stat card grid so it stacks on small screens and fills multiple columns on larger viewports

## Testing
- npm --prefix client start *(fails: Module not found: Error: Can't resolve 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_68d73b1d161c832e8b5b3e8c33f10532