### PR TITLE
Restore scrollable structure for stats modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -226,6 +226,13 @@
   }
 }
 
+.stats-modal-body {
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+}
+
 .stat-card-grid {
   display: grid;
   grid-template-columns: 1fr;

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, Modal, Button } from "react-bootstrap";
+import { Modal, Button } from "react-bootstrap";
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
@@ -137,48 +137,44 @@ export default function Stats({ form, showStats, handleCloseStats }) {
         centered
         className="dnd-modal modern-modal"
       >
-        <div className="text-center">
-          <Card className="modern-card">
-            <Card.Header className="modal-header">
-              <Card.Title className="modal-title">Stats</Card.Title>
-            </Card.Header>
-            <Card.Body>
-              <div className="stat-card-grid">
-                {STATS.map(({ key, label }) => (
-                  <div className="stat-card" key={key}>
-                    <div className="stat-card-header">
-                      <div className="stat-card-title">
-                        <span className="stat-card-key">{key.toUpperCase()}</span>
-                        {label && <span className="stat-card-label">{label}</span>}
-                      </div>
-                      <Button
-                        onClick={() => handleView(key)}
-                        variant="link"
-                        aria-label={`View ${label || key} details`}
-                        className="stat-card-view"
-                      >
-                        <i className="fa-solid fa-eye"></i>
-                      </Button>
-                    </div>
-                    <div className="stat-card-body">
-                      <div className="stat-card-metric">
-                        <span className="stat-card-metric-label">Total</span>
-                        <span className="stat-card-metric-value">{computedStats[key]}</span>
-                      </div>
-                      <div className="stat-card-metric">
-                        <span className="stat-card-metric-label">Modifier</span>
-                        <span className="stat-card-metric-value">{statMods[key]}</span>
-                      </div>
-                    </div>
+        <Modal.Header className="modal-header">
+          <Modal.Title className="modal-title">Stats</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="stats-modal-body">
+          <div className="stat-card-grid">
+            {STATS.map(({ key, label }) => (
+              <div className="stat-card" key={key}>
+                <div className="stat-card-header">
+                  <div className="stat-card-title">
+                    <span className="stat-card-key">{key.toUpperCase()}</span>
+                    {label && <span className="stat-card-label">{label}</span>}
                   </div>
-                ))}
+                  <Button
+                    onClick={() => handleView(key)}
+                    variant="link"
+                    aria-label={`View ${label || key} details`}
+                    className="stat-card-view"
+                  >
+                    <i className="fa-solid fa-eye"></i>
+                  </Button>
+                </div>
+                <div className="stat-card-body">
+                  <div className="stat-card-metric">
+                    <span className="stat-card-metric-label">Total</span>
+                    <span className="stat-card-metric-value">{computedStats[key]}</span>
+                  </div>
+                  <div className="stat-card-metric">
+                    <span className="stat-card-metric-label">Modifier</span>
+                    <span className="stat-card-metric-value">{statMods[key]}</span>
+                  </div>
+                </div>
               </div>
-            </Card.Body>
-            <Card.Footer className="modal-footer">
-              <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>
-            </Card.Footer>
-          </Card>
-        </div>
+            ))}
+          </div>
+        </Modal.Body>
+        <Modal.Footer className="modal-footer">
+          <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>
+        </Modal.Footer>
       </Modal>
       <StatBreakdownModal
         show={showBreakdown}


### PR DESCRIPTION
## Summary
- switch the stats modal back to Bootstrap's header/body/footer layout so the scrollable container works again
- restyle the modal body to preserve the dark card styling around the stats grid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d73d4a33a4832e8828f1db0565984c