### PR TITLE
Restore stat modal icon color

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1472,6 +1472,12 @@ max-width: 300px;
   color: initial;
 }
 
+.dnd-modal .modal-body .stat-card-view,
+.dnd-modal .modal-body .stat-card-view:hover,
+.dnd-modal .modal-body .stat-card-view:focus {
+  color: var(--bs-info);
+}
+
 //vars
 $fg: linear-gradient(135deg, #3e8e41, #2e7d32);
 $fgDM: linear-gradient(135deg, #979940b6, #fffb00);


### PR DESCRIPTION
## Summary
- restore the stat modal eye icon color after the modal reset by reapplying the info hue, including hover and focus states

## Testing
- npm --prefix client start *(fails: Module not found: Error: Can't resolve 'socket.io-client')*


------
https://chatgpt.com/codex/tasks/task_e_68d7409c0238832eaa36bf141798736b