### PR TITLE
Align view buttons with link styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -280,17 +280,32 @@
   color: rgba(255, 255, 255, 0.7);
 }
 
-.stat-card-view {
-  color: #0dcaf0;
-  color: var(--bs-info);
+.view-link-btn {
+  color: var(--bs-link-color);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
   padding: 0.25rem;
+}
+
+.view-link-btn:hover,
+.view-link-btn:focus,
+.view-link-btn:focus-visible {
+  color: var(--bs-link-hover-color);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-decoration: none;
+  outline: none;
+}
+
+.stat-card-view {
+  @extend .view-link-btn;
   font-size: 1.1rem;
 }
 
 .stat-card-view:hover,
 .stat-card-view:focus {
-  color: #3dd5f3;
-  color: color-mix(in srgb, var(--bs-info) 85%, white 15%);
   text-decoration: none;
 }
 
@@ -1472,10 +1487,13 @@ max-width: 300px;
   color: initial;
 }
 
-.dnd-modal .modal-body .stat-card-view,
+.dnd-modal .modal-body .stat-card-view {
+  color: var(--bs-link-color);
+}
+
 .dnd-modal .modal-body .stat-card-view:hover,
 .dnd-modal .modal-body .stat-card-view:focus {
-  color: var(--bs-info);
+  color: var(--bs-link-hover-color);
 }
 
 //vars

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -346,8 +346,9 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                           style={{ display: showDeleteFeatBtn }}
                         >
                           <Button
-                            variant="outline-light"
+                            variant="link"
                             size="sm"
+                            className="view-link-btn"
                             onClick={() => {
                               handleShowFeatNotes();
                               setModalFeatData(el);
@@ -424,6 +425,7 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
                         </Form.Select>
                         <Button
                           variant="link"
+                          className="view-link-btn"
                           disabled={!selectedFeatData}
                           onClick={() => {
                             setModalFeatData(selectedFeatData);

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -126,8 +126,9 @@ export default function Features({
                             )}
                             <Button
                               aria-label="view feature"
-                              variant="outline-light"
+                              variant="link"
                               size="sm"
+                              className="view-link-btn"
                               onClick={() => {
                                 setModalFeature(feat);
                                 setShowModal(true);


### PR DESCRIPTION
## Summary
- update the stat card view styling to reuse Bootstrap link colors and provide a shared utility class
- apply the shared styling to feature and feat view buttons so their icons match the skills controls

## Testing
- Not Run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7437ecda4832ebf3888dfa2b0424a