### PR TITLE
Refine character info modal layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -245,7 +245,7 @@
   }
 }
 
-.stat-card {
+.stat-card { 
   background: rgba(17, 16, 19, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.75rem;
@@ -254,6 +254,60 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.character-info-body {
+  overflow-y: auto;
+}
+
+.character-info-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .character-info-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 992px) {
+  .character-info-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.character-info-item {
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: var(--bs-light);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.character-info-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.character-info-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.character-info-value--stacked {
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .stat-card-header {

--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Card, Table, Modal, Button } from "react-bootstrap";
+import { Card, Modal, Button } from "react-bootstrap";
 import levelup from "../../../images/levelup.png";
 import LevelUp from "./LevelUp"; // Import LevelUp component
 
@@ -39,63 +39,67 @@ export default function CharacterInfo({
         <Card.Header className="modal-header">
           <Card.Title className="modal-title">Character Info</Card.Title>
         </Card.Header>
-        <Card.Body style={{ overflowY: "auto", maxHeight: "60vh" }}>
-          <Table striped bordered hover size="sm" className="modern-table">
-            <tbody>
-              <tr>
-                <th>Level</th>
-                <td>{totalLevel}</td>
-              </tr>
-              <tr>
-                <th>Class</th>
-                <td>
-                  {form.occupation.map((el, i) => (
-                    <span key={i}>
-                      {el.Level} {el.Occupation}
-                      <br />
-                    </span>
-                  ))}
-                </td>
-              </tr>
-              <tr>
-                <th>Race</th>
-                <td>{form.race?.name || ''}</td>
-              </tr>
-              <tr>
-                <th>Background</th>
-                <td>
-                  {form.background?.name || ''}
-                  <Button
-                    onClick={onShowBackground}
-                    variant="link"
-                    aria-label="Show Background"
-                  >
-                    <i className="fa-solid fa-eye"></i>
-                  </Button>
-                </td>
-              </tr>
-              <tr>
-                <th>Languages</th>
-                <td>{raceLanguages}</td>
-              </tr>
-              <tr>
-                <th>Age</th>
-                <td>{form.age}</td>
-              </tr>
-              <tr>
-                <th>Sex</th>
-                <td>{form.sex}</td>
-              </tr>
-              <tr>
-                <th>Height</th>
-                <td>{form.height}</td>
-              </tr>
-              <tr>
-                <th>Weight</th>
-                <td>{form.weight} lbs</td>
-              </tr>
-            </tbody>
-          </Table>
+        <Card.Body className="modal-body character-info-body" style={{ maxHeight: "60vh" }}>
+          <div className="character-info-grid">
+            <div className="character-info-item">
+              <div className="character-info-label">Level</div>
+              <div className="character-info-value">{totalLevel}</div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Classes</div>
+              <div className="character-info-value character-info-value--stacked">
+                {form.occupation.length
+                  ? form.occupation.map((el, i) => (
+                      <span key={`${el.Occupation}-${i}`}>
+                        {el.Level} {el.Occupation}
+                      </span>
+                    ))
+                  : "—"}
+              </div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Race</div>
+              <div className="character-info-value">{form.race?.name || "—"}</div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Background</div>
+              <div className="character-info-value">
+                <span>{form.background?.name || "—"}</span>
+                <Button
+                  onClick={onShowBackground}
+                  variant="link"
+                  aria-label="Show Background"
+                  className="view-link-btn"
+                >
+                  <i className="fa-solid fa-eye"></i>
+                </Button>
+              </div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Languages</div>
+              <div className="character-info-value">
+                {raceLanguages || "—"}
+              </div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Age</div>
+              <div className="character-info-value">{form.age || "—"}</div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Sex</div>
+              <div className="character-info-value">{form.sex || "—"}</div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Height</div>
+              <div className="character-info-value">{form.height || "—"}</div>
+            </div>
+            <div className="character-info-item">
+              <div className="character-info-label">Weight</div>
+              <div className="character-info-value">
+                {form.weight ? `${form.weight} lbs` : "—"}
+              </div>
+            </div>
+          </div>
         </Card.Body>
         <Card.Footer className="modal-footer">
           <Button


### PR DESCRIPTION
## Summary
- replace the Character Info modal table with a responsive card-style layout that mirrors the other modern modals
- add SCSS helpers so the card grid stacks on small screens and aligns into multiple columns on wider viewports

## Testing
- CI=1 npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/CharacterInfo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d745172a40832eb7a9468125e2f22d