### PR TITLE
Maintain Zombies combat header layout when idle

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9,6 +9,7 @@
 }
 
 .combat-turn-header {
+  --combat-turn-header-height: clamp(112px, 20vw, 148px);
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
@@ -62,16 +63,44 @@
   &.combat-turn-header--fade-right::after {
     opacity: 1;
   }
+
+  &.combat-turn-header--empty {
+    min-height: var(--combat-turn-header-height);
+    cursor: default;
+    gap: 0;
+
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
 }
 
 .combat-turn-header__card {
   flex: 0 0 auto;
   width: clamp(160px, 22vw, 240px);
   min-width: clamp(160px, 22vw, 240px);
+  min-height: var(--combat-turn-header-height);
 }
 
 @media (max-width: 576px) {
   .combat-turn-header__card {
+    width: clamp(100px, 32vw, 33.333%);
+    min-width: clamp(100px, 32vw, 33.333%);
+    min-height: var(--combat-turn-header-height);
+  }
+}
+
+.combat-turn-header__placeholder {
+  flex: 0 0 auto;
+  width: clamp(160px, 22vw, 240px);
+  min-width: clamp(160px, 22vw, 240px);
+  min-height: var(--combat-turn-header-height);
+  pointer-events: none;
+}
+
+@media (max-width: 576px) {
+  .combat-turn-header__placeholder {
     width: clamp(100px, 32vw, 33.333%);
     min-width: clamp(100px, 32vw, 33.333%);
   }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -195,9 +195,12 @@ function CombatTurnHeader({ participants }) {
     if (canScrollRight) {
       classes.push('combat-turn-header--fade-right');
     }
+    if (!participantsCount) {
+      classes.push('combat-turn-header--empty');
+    }
 
     return classes.join(' ');
-  }, [isDragging, canScrollLeft, canScrollRight]);
+  }, [isDragging, canScrollLeft, canScrollRight, participantsCount]);
 
   const finishDrag = useCallback((event) => {
     if (!isDraggingRef.current) {
@@ -344,113 +347,113 @@ function CombatTurnHeader({ participants }) {
     lastAutoScrollTargetRef.current = identifier;
   }, [activeIndex, participants, isDragging, updateOverflowHints]);
 
-  if (!participantsCount) {
-    return null;
-  }
-
   return (
     <div
       ref={headerRef}
       className={headerClassName}
       role="group"
       aria-label="Combat turn order"
-      touchAction="pan-x"
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerLeave={handlePointerLeave}
-      onPointerCancel={handlePointerCancel}
-      onScroll={handleScroll}
+      touchAction={participantsCount ? 'pan-x' : 'auto'}
+      onPointerDown={participantsCount ? handlePointerDown : undefined}
+      onPointerMove={participantsCount ? handlePointerMove : undefined}
+      onPointerUp={participantsCount ? handlePointerUp : undefined}
+      onPointerLeave={participantsCount ? handlePointerLeave : undefined}
+      onPointerCancel={participantsCount ? handlePointerCancel : undefined}
+      onScroll={participantsCount ? handleScroll : undefined}
     >
-      {participants.map((participant, index) => {
-        const { characterId, name, hpDisplay, hpCurrent, hpMax, isActive } = participant;
+      {participantsCount ? (
+        participants.map((participant, index) => {
+          const { characterId, name, hpDisplay, hpCurrent, hpMax, isActive } = participant;
 
-        const hasHpData = hpCurrent !== null || hpMax !== null;
-        const computedPercentage =
-          hpCurrent !== null && hpMax !== null && hpMax > 0
-            ? Math.max(0, Math.min(100, (hpCurrent / hpMax) * 100))
-            : null;
-        const hpPercentage = computedPercentage !== null ? computedPercentage : 0;
-        const hpColorHue = computedPercentage !== null ? (hpPercentage / 100) * 120 : 0;
-        const hpFillColor =
-          computedPercentage !== null
-            ? `hsl(${Math.round(hpColorHue)}, 70%, 45%)`
-            : "rgba(220, 220, 220, 0.35)";
+          const hasHpData = hpCurrent !== null || hpMax !== null;
+          const computedPercentage =
+            hpCurrent !== null && hpMax !== null && hpMax > 0
+              ? Math.max(0, Math.min(100, (hpCurrent / hpMax) * 100))
+              : null;
+          const hpPercentage = computedPercentage !== null ? computedPercentage : 0;
+          const hpColorHue = computedPercentage !== null ? (hpPercentage / 100) * 120 : 0;
+          const hpFillColor =
+            computedPercentage !== null
+              ? `hsl(${Math.round(hpColorHue)}, 70%, 45%)`
+              : "rgba(220, 220, 220, 0.35)";
 
-        return (
-          <div
-            key={characterId}
-            className="combat-turn-header__card"
-            data-participant-id={characterId}
-            data-participant-index={index}
-            style={{
-              background: isActive
-                ? "linear-gradient(135deg, rgba(37, 31, 26, 0.96), rgba(18, 15, 12, 0.94))"
-                : "rgba(28, 25, 22, 0.82)",
-              color: "#FFFFFF",
-              borderRadius: "12px",
-              padding: "10px 16px",
-              boxShadow: isActive
-                ? "0 0 18px rgba(214, 178, 86, 0.7), 0 0 8px rgba(214, 178, 86, 0.4) inset"
-                : "0 0 8px rgba(0, 0, 0, 0.45)",
-              border: isActive
-                ? "1px solid rgba(214, 178, 86, 0.85)"
-                : "1px solid rgba(255, 255, 255, 0.18)",
-              transition: "transform 0.2s ease, box-shadow 0.2s ease",
-              transform: isActive ? "scale(1.03)" : "scale(1)",
-            }}
-          >
+          return (
             <div
+              key={characterId}
+              className="combat-turn-header__card"
+              data-participant-id={characterId}
+              data-participant-index={index}
               style={{
-                fontWeight: 600,
-                fontSize: "14px",
-                letterSpacing: "0.5px",
+                background: isActive
+                  ? "linear-gradient(135deg, rgba(37, 31, 26, 0.96), rgba(18, 15, 12, 0.94))"
+                  : "rgba(28, 25, 22, 0.82)",
+                color: "#FFFFFF",
+                borderRadius: "12px",
+                padding: "10px 16px",
+                boxShadow: isActive
+                  ? "0 0 18px rgba(214, 178, 86, 0.7), 0 0 8px rgba(214, 178, 86, 0.4) inset"
+                  : "0 0 8px rgba(0, 0, 0, 0.45)",
+                border: isActive
+                  ? "1px solid rgba(214, 178, 86, 0.85)"
+                  : "1px solid rgba(255, 255, 255, 0.18)",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                transform: isActive ? "scale(1.03)" : "scale(1)",
               }}
             >
-              {name}
-            </div>
-            <div style={{ marginTop: "6px" }}>
               <div
                 style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  fontSize: "12px",
-                  opacity: 0.9,
-                  marginBottom: "4px",
+                  fontWeight: 600,
+                  fontSize: "14px",
+                  letterSpacing: "0.5px",
                 }}
               >
-                <span>HP</span>
-                <span>{hasHpData ? hpDisplay : "—"}</span>
+                {name}
               </div>
-              <div
-                style={{
-                  position: "relative",
-                  width: "100%",
-                  height: "8px",
-                  borderRadius: "6px",
-                  background: "rgba(0, 0, 0, 0.45)",
-                  overflow: "hidden",
-                  border: "1px solid rgba(255, 255, 255, 0.12)",
-                }}
-              >
+              <div style={{ marginTop: "6px" }}>
                 <div
                   style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    height: "100%",
-                    width: `${hpPercentage}%`,
-                    background: computedPercentage !== null
-                      ? `linear-gradient(90deg, ${hpFillColor} 0%, ${hpFillColor} 100%)`
-                      : "transparent",
-                    transition: "width 0.3s ease, background-color 0.3s ease",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontSize: "12px",
+                    opacity: 0.9,
+                    marginBottom: "4px",
                   }}
-                />
+                >
+                  <span>HP</span>
+                  <span>{hasHpData ? hpDisplay : "—"}</span>
+                </div>
+                <div
+                  style={{
+                    position: "relative",
+                    width: "100%",
+                    height: "8px",
+                    borderRadius: "6px",
+                    background: "rgba(0, 0, 0, 0.45)",
+                    overflow: "hidden",
+                    border: "1px solid rgba(255, 255, 255, 0.12)",
+                  }}
+                >
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      height: "100%",
+                      width: `${hpPercentage}%`,
+                      background: computedPercentage !== null
+                        ? `linear-gradient(90deg, ${hpFillColor} 0%, ${hpFillColor} 100%)`
+                        : "transparent",
+                      transition: "width 0.3s ease, background-color 0.3s ease",
+                    }}
+                  />
+                </div>
               </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })
+      ) : (
+        <div className="combat-turn-header__placeholder" aria-hidden="true" />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep the combat turn header mounted and supply an empty-state placeholder so the layout stays stable when combat is inactive
- add empty-state styling that reserves the tracker height without rendering participant cards and hide overflow fades during downtime

## Testing
- npm --prefix client start *(fails: missing socket.io-client dependency in local node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d74c3b8340832ead776154b0b59c71