### PR TITLE
Relax password complexity requirements

### DIFF
--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -125,7 +125,7 @@ describe('Users routes', () => {
     dbo.mockResolvedValue({ collection: () => ({}) });
     const res = await request(app)
       .post('/users/add')
-      .send({ username: 'bob', password: 'weakpass' });
+      .send({ username: 'bob', password: 'short' });
     expect(res.status).toBe(400);
     expect(res.body.errors).toBeDefined();
   });

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -38,15 +38,7 @@ module.exports = (router) => {
       body('username').trim().notEmpty().withMessage('username is required'),
       body('password')
         .isLength({ min: 8 })
-        .withMessage('password must be at least 8 characters')
-        .matches(/[a-z]/)
-        .withMessage('password must contain at least one lowercase letter')
-        .matches(/[A-Z]/)
-        .withMessage('password must contain at least one uppercase letter')
-        .matches(/\d/)
-        .withMessage('password must contain at least one number')
-        .matches(/[^A-Za-z0-9]/)
-        .withMessage('password must contain at least one special character'),
+        .withMessage('password must be at least 8 characters'),
     ],
     handleValidationErrors,
     async (req, res, next) => {


### PR DESCRIPTION
## Summary
- simplify the user registration password validator to only require a minimum length of eight characters
- adjust the weak-password registration test to use a password shorter than eight characters

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68d7fad23c748323b5fb1392403991c4