### PR TITLE
Fix skill and expertise point tracking

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1710,19 +1710,20 @@ export default function ZombiesCharacterSheet() {
   // Characters no longer receive stat points from leveling
   const statPointsLeft = form.startStatTotal - statTotal;
 
-  const skillPointsLeft =
-    (form.proficiencyPoints || 0) -
-    Object.entries(form.skills || {}).filter(
-      ([key, s]) => s.proficient && !form.race?.skills?.[key]?.proficient
-    ).length;
-  const expertisePointsLeft =
-    (form.expertisePoints || 0) -
-    Object.entries(form.skills || {}).filter(
-      ([key, s]) =>
-        s.expertise &&
-        !form.race?.skills?.[key]?.expertise &&
-        !form.background?.skills?.[key]?.expertise
-    ).length;
+  const proficientSkillsCount = Object.values(form.skills || {}).filter(
+    (skill) => skill?.proficient
+  ).length;
+  const expertiseSkillsCount = Object.values(form.skills || {}).filter(
+    (skill) => skill?.expertise
+  ).length;
+  const skillPointsLeft = Math.max(
+    0,
+    (form.proficiencyPoints || 0) - proficientSkillsCount
+  );
+  const expertisePointsLeft = Math.max(
+    0,
+    (form.expertisePoints || 0) - expertiseSkillsCount
+  );
   const skillsGold =
     skillPointsLeft > 0 || expertisePointsLeft > 0 ? 'gold' : '#6C757D';
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -330,6 +330,50 @@ test('skills button includes points-glow when expertise points available', async
   await waitFor(() => expect(skillButton).toHaveClass('points-glow'));
 });
 
+test('skills button does not glow when granted proficiencies meet totals', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Rogue', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 2,
+      expertisePoints: 1,
+      skills: {
+        stealth: { proficient: true, expertise: true },
+        perception: { proficient: true },
+      },
+      race: {
+        skills: {
+          stealth: { proficient: true, expertise: true },
+          perception: { proficient: true },
+        },
+      },
+      background: {
+        skills: {
+          stealth: { expertise: true },
+          perception: { proficient: true },
+        },
+      },
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  const buttons = await screen.findAllByRole('button');
+  const skillButton = buttons.find((btn) => btn.querySelector('.fa-book-open'));
+  await waitFor(() => expect(skillButton).not.toHaveClass('points-glow'));
+});
+
 test('casting spells consumes action and bonus circles based on casting time', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- count every proficient and expertise-marked skill when calculating remaining points on the character sheet
- clamp the remaining skill and expertise totals to zero to avoid negative counts
- add a regression test ensuring granted proficiencies do not trigger the skills button glow

## Testing
- npm test -- ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d800010ddc8323a7badb6865be2558