### PR TITLE
Add dragonborn ancestry selection support

### DIFF
--- a/server/data/races.js
+++ b/server/data/races.js
@@ -45,6 +45,68 @@ const races = {
     abilities: { str: 2, cha: 1 },
     skills: {},
     languages: ["Common", "Draconic"],
+    dragonAncestries: {
+      black: {
+        label: "Black (Acid)",
+        damageType: "Acid",
+        breathWeapon: { shape: "5 by 30 ft. line", save: "Dexterity" },
+        moralAlignment: "evil",
+      },
+      blue: {
+        label: "Blue (Lightning)",
+        damageType: "Lightning",
+        breathWeapon: { shape: "5 by 30 ft. line", save: "Dexterity" },
+        moralAlignment: "evil",
+      },
+      brass: {
+        label: "Brass (Fire)",
+        damageType: "Fire",
+        breathWeapon: { shape: "5 by 30 ft. line", save: "Dexterity" },
+        moralAlignment: "good",
+      },
+      bronze: {
+        label: "Bronze (Lightning)",
+        damageType: "Lightning",
+        breathWeapon: { shape: "5 by 30 ft. line", save: "Dexterity" },
+        moralAlignment: "good",
+      },
+      copper: {
+        label: "Copper (Acid)",
+        damageType: "Acid",
+        breathWeapon: { shape: "5 by 30 ft. line", save: "Dexterity" },
+        moralAlignment: "good",
+      },
+      gold: {
+        label: "Gold (Fire)",
+        damageType: "Fire",
+        breathWeapon: { shape: "15 ft. cone", save: "Dexterity" },
+        moralAlignment: "good",
+      },
+      green: {
+        label: "Green (Poison)",
+        damageType: "Poison",
+        breathWeapon: { shape: "15 ft. cone", save: "Constitution" },
+        moralAlignment: "evil",
+      },
+      red: {
+        label: "Red (Fire)",
+        damageType: "Fire",
+        breathWeapon: { shape: "15 ft. cone", save: "Dexterity" },
+        moralAlignment: "evil",
+      },
+      silver: {
+        label: "Silver (Cold)",
+        damageType: "Cold",
+        breathWeapon: { shape: "15 ft. cone", save: "Constitution" },
+        moralAlignment: "good",
+      },
+      white: {
+        label: "White (Cold)",
+        damageType: "Cold",
+        breathWeapon: { shape: "15 ft. cone", save: "Constitution" },
+        moralAlignment: "evil",
+      },
+    },
   },
   gnome: {
     name: "Gnome",


### PR DESCRIPTION
## Summary
- add structured dragon ancestry metadata to the Dragonborn race definition
- surface dragon ancestry selection in the zombies character form and persist the choice through ability/skill flows and database writes
- update the random character generator to pick a Dragonborn ancestry that matches the character alignment and store the result

## Testing
- npm --prefix client start *(fails: existing lint warnings and missing socket.io-client dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d80ba76ad483238de591e15776dce0