### PR TITLE
Add dragonborn ancestry damage resistance feature card

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Modal, Card, Button, Spinner } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
@@ -18,6 +18,56 @@ export default function Features({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [surgeUsed, setSurgeUsed] = useState(false);
+
+  const dragonbornAncestry = useMemo(() => {
+    const race = form?.race;
+    if (!race) return null;
+
+    const raceName =
+      typeof race?.name === 'string' ? race.name.toLowerCase() : '';
+    if (raceName !== 'dragonborn') return null;
+
+    if (race.selectedAncestry) return race.selectedAncestry;
+
+    if (race.selectedAncestryKey && race.dragonAncestries) {
+      const selected = race.dragonAncestries[race.selectedAncestryKey];
+      if (selected) return selected;
+    }
+
+    if (form?.dragonAncestry) return form.dragonAncestry;
+
+    if (form?.dragonAncestryKey && race.dragonAncestries) {
+      return race.dragonAncestries[form.dragonAncestryKey] || null;
+    }
+
+    return null;
+  }, [form?.race, form?.dragonAncestry, form?.dragonAncestryKey]);
+
+  const ancestryFeature = useMemo(() => {
+    if (!dragonbornAncestry) return null;
+
+    const ancestryLabel =
+      dragonbornAncestry.label || dragonbornAncestry.name || 'Dragonborn';
+    const damageType = dragonbornAncestry.damageType || '';
+    const damageTypeLower = damageType.toLowerCase();
+    const resistanceDescription = damageTypeLower
+      ? `You have resistance to ${damageTypeLower} damage.`
+      : 'You have resistance to the damage type associated with your draconic ancestry.';
+
+    return {
+      id: 'dragonborn-damage-resistance',
+      name: 'Damage Resistance',
+      meta: `Dragon Subrace (${ancestryLabel})`,
+      desc: resistanceDescription,
+      description: resistanceDescription,
+      hideUseButton: true,
+    };
+  }, [dragonbornAncestry]);
+
+  const displayFeatures = useMemo(() => {
+    if (!ancestryFeature) return features;
+    return [ancestryFeature, ...features];
+  }, [ancestryFeature, features]);
 
   useEffect(() => {
     if (!showFeatures) return;
@@ -83,10 +133,10 @@ export default function Features({
                 <div className="d-flex justify-content-center py-4">
                   <Spinner animation="border" role="status" />
                 </div>
-              ) : features.length > 0 ? (
+              ) : displayFeatures.length > 0 ? (
                 <div className="feature-card-grid">
-                  {features.map((feat, idx) => {
-                    const featKey = `${feat.class}-${feat.level}-${idx}`;
+                  {displayFeatures.map((feat, idx) => {
+                    const featKey = feat.id || `${feat.name}-${idx}`;
                     const isActionSurge = feat.name?.includes('Action Surge');
                     return (
                       <div className="feature-card" key={featKey}>
@@ -94,8 +144,16 @@ export default function Features({
                           <div>
                             <div className="feature-card-name">{feat.name}</div>
                             <div className="feature-card-meta">
-                              <span>{feat.class}</span>
-                              <span>Level {feat.level}</span>
+                              {feat.meta ? (
+                                <span>{feat.meta}</span>
+                              ) : (
+                                <>
+                                  {feat.class && <span>{feat.class}</span>}
+                                  {feat.level != null && (
+                                    <span>Level {feat.level}</span>
+                                  )}
+                                </>
+                              )}
                             </div>
                           </div>
                           <div className="feature-card-actions">
@@ -119,11 +177,11 @@ export default function Features({
                                   height={36}
                                 />
                               </Button>
-                            ) : (
+                            ) : !feat.hideUseButton ? (
                               <Button aria-label="use feature" variant="outline-light" size="sm">
                                 Use
                               </Button>
-                            )}
+                            ) : null}
                             <Button
                               aria-label="view feature"
                               variant="link"


### PR DESCRIPTION
## Summary
- detect a selected dragonborn ancestry when opening the features modal
- surface a synthetic "Damage Resistance" card that reflects the ancestry metadata and feeds the feature modal
- adjust the feature grid rendering to gracefully handle custom feature metadata and hide the use button when appropriate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d812fb98e48323b4b1069fce90ed24