### PR TITLE
Format breath weapon damage segments

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -856,7 +856,7 @@ const showSparklesEffect = () => {
                       <div className="attack-card__row">
                         <span className="attack-card__label">Damage</span>
                         <span className="attack-card__value">
-                          {breathWeaponDetails.damageString}
+                          {formatDamageSegments(breathWeaponDetails.damageString)}
                         </span>
                       </div>
                       {(breathWeaponDetails.shape || breathWeaponDetails.save) && (

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -172,6 +172,41 @@ describe('PlayerTurnActions weapon damage display', () => {
     ).toBeInTheDocument();
   });
 
+  test('breath attack damage segments include type classes', () => {
+    const ancestry = {
+      label: 'Blue (Lightning)',
+      damageType: 'lightning',
+      breathWeapon: { shape: '5 by 30 ft. line', save: 'Dexterity' },
+    };
+    const race = {
+      name: 'Dragonborn',
+      dragonAncestries: { blue: ancestry },
+      selectedAncestryKey: 'blue',
+      selectedAncestry: ancestry,
+    };
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          race,
+          equipment: {},
+          spells: [],
+          occupation: [{ Level: '6' }],
+        }}
+        strMod={0}
+        dexMod={0}
+        conMod={2}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const breathCard = screen.getByText('Blue (Lightning)').closest('.attack-card');
+    expect(breathCard).toBeInTheDocument();
+    const damage = within(breathCard).getByText('3d6 lightning');
+    expect(damage).toHaveClass('damage-lightning');
+  });
+
   test('does not render breath attack card for non-dragonborn characters', () => {
     render(
       <PlayerTurnActions


### PR DESCRIPTION
## Summary
- render dragonborn breath weapon damage via formatDamageSegments so elemental types receive styling classes
- add a PlayerTurnActions test ensuring lightning ancestry damage gets the damage-lightning class

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8153e2efc83238201e4271db267b3