### PR TITLE
Fix ability modifier application for multi-part damage rolls

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -71,8 +71,10 @@ export function calculateDamage(
 
     const type = rest.join(' ').trim();
 
+    const abilityBonus = i === 0 ? ability : 0;
+
     if (!match[2]) {
-      const baseValue = parseInt(match[1], 10) + ability;
+      const baseValue = parseInt(match[1], 10) + abilityBonus;
       results.push({ value: baseValue, type });
       continue;
     }
@@ -102,7 +104,7 @@ export function calculateDamage(
       }
     }
 
-    results.push({ value: damageSum + modifier + ability, type });
+    results.push({ value: damageSum + modifier + abilityBonus, type });
   }
 
   const total = results.reduce((sum, r) => sum + r.value, 0);
@@ -350,11 +352,12 @@ const [isFumble, setIsFumble] = useState(false);
       .map((part, i, arr) => {
         const [token, ...rest] = part.trim().split(' ');
         const type = rest.join(' ').trim();
+        const showAbility = ability !== undefined && ability !== null && i === 0;
         return (
           <React.Fragment key={i}>
             <span className={type ? `damage-${type}` : ''}>
               {token}
-              {ability !== undefined ? `+${ability}` : ''}
+              {showAbility ? `+${ability}` : ''}
               {type ? ` ${type}` : ''}
             </span>
             {i < arr.length - 1 ? ' + ' : ''}

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -55,7 +55,7 @@ describe('calculateDamage parser', () => {
   test('handles multi-type damage and returns breakdown string', () => {
     expect(
       calculateDamage('1d4 cold + 1d6 slashing', 2, false, fixedRoll)
-    ).toEqual({ total: 6, breakdown: '3 cold + 3 slashing' });
+    ).toEqual({ total: 4, breakdown: '3 cold + 1 slashing' });
   });
 });
 
@@ -102,9 +102,45 @@ describe('PlayerTurnActions weapon damage display', () => {
     const card = screen.getByText('Frost Brand').closest('.attack-card');
     expect(card).not.toBeNull();
     const cold = within(card).getByText(/1d4\+2 cold/);
-    const slashing = within(card).getByText(/1d6\+2 slashing/);
+    const slashing = within(card).getByText(/1d6 slashing/);
     expect(cold).toHaveClass('damage-cold');
     expect(slashing).toHaveClass('damage-slashing');
+    expect(slashing.textContent).toBe('1d6 slashing');
+  });
+
+  test('multi-part weapon damage applies ability modifier once', () => {
+    const weapon = {
+      name: 'Storm Blade',
+      damage: '2d8 slashing + 1d6 lightning',
+      category: 'melee',
+      source: 'weapon',
+    };
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          spells: [],
+        }}
+        strMod={3}
+        atkBonus={0}
+        dexMod={0}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const card = screen.getByText('Storm Blade').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const slashing = within(card).getByText(/2d8\+3 slashing/);
+    const lightning = within(card).getByText(/1d6 lightning/);
+    expect(slashing.textContent).toBe('2d8+3 slashing');
+    expect(lightning.textContent).toBe('1d6 lightning');
+
+    const deterministicRoll = (count, sides) => Array(count).fill(1);
+    expect(
+      calculateDamage(weapon.damage, 3, false, deterministicRoll)
+    ).toEqual({ total: 6, breakdown: '5 slashing + 1 lightning' });
   });
 
   test('spell damage segments include type classes', () => {
@@ -227,7 +263,7 @@ describe('PlayerTurnActions damage log', () => {
       const el = document.getElementById('damageValue');
       if (!el || el.textContent === '0') throw new Error('waiting');
     });
-    expect(document.getElementById('damageValue').textContent).toBe('6');
+    expect(document.getElementById('damageValue').textContent).toBe('4');
 
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: '⚔️ Log' }));
@@ -238,11 +274,11 @@ describe('PlayerTurnActions damage log', () => {
       .filter((li) => !li.classList.contains('roll-separator'));
     const item = items[0];
     const [totalLine, breakdownDiv] = item.querySelectorAll('div');
-    expect(totalLine).toHaveTextContent('Frost Brand (6)');
+    expect(totalLine).toHaveTextContent('Frost Brand (4)');
     const breakdownLines = Array.from(breakdownDiv.querySelectorAll('div')).map(
       (d) => d.textContent.trim()
     );
-    expect(breakdownLines).toEqual(['- 3 cold', '- 3 slashing']);
+    expect(breakdownLines).toEqual(['- 3 cold', '- 1 slashing']);
     Math.random = orig;
   });
 
@@ -285,13 +321,13 @@ describe('PlayerTurnActions damage log', () => {
         cold.classList.contains('damage-cold')
     ).toBe(true);
 
-    const fire = within(modal).getByText('3 fire');
+    const fire = within(modal).getByText('1 fire');
     expect(
       fire.style.color === damageTypeColors.fire ||
         fire.classList.contains('damage-fire')
     ).toBe(true);
 
-    const lightning = within(modal).getByText('3 lightning');
+    const lightning = within(modal).getByText('1 lightning');
     expect(
       lightning.style.color === damageTypeColors.lightning ||
         lightning.classList.contains('damage-lightning')
@@ -394,7 +430,7 @@ describe('PlayerTurnActions damage log', () => {
     const fixedRoll = (count, sides) => Array(count).fill(1);
     expect(
       calculateDamage('1d4 cold + 1d6 slashing', 2, false, fixedRoll)
-    ).toEqual({ total: 6, breakdown: '3 cold + 3 slashing' });
+    ).toEqual({ total: 4, breakdown: '3 cold + 1 slashing' });
   });
 });
 
@@ -424,9 +460,10 @@ describe('PlayerTurnActions weapon damage display', () => {
     const card = screen.getByText('Frost Brand').closest('.attack-card');
     expect(card).not.toBeNull();
     const cold = within(card).getByText(/1d4\+2 cold/);
-    const slashing = within(card).getByText(/1d6\+2 slashing/);
+    const slashing = within(card).getByText(/1d6 slashing/);
     expect(cold).toHaveClass('damage-cold');
     expect(slashing).toHaveClass('damage-slashing');
+    expect(slashing.textContent).toBe('1d6 slashing');
   });
 
   test('spell damage segments include type classes', () => {


### PR DESCRIPTION
## Summary
- ensure calculateDamage only applies the ability modifier to the first damage segment or flat value
- update damage formatting so only the initial segment shows the +ability tag
- expand PlayerTurnActions tests to cover multi-part damage with a single applied modifier

## Testing
- CI=true npm test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8151f60348323a579444ded1531a7