### PR TITLE
Normalize damage type classes

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -346,16 +346,22 @@ const [isFumble, setIsFumble] = useState(false);
     abilityForWeapon(weapon) +
     Number(weapon?.attackBonus ?? weapon?.bonus ?? 0);
     
+  const normalizeDamageTypeForClass = (type) => {
+    const trimmed = (type || '').trim();
+    return trimmed ? trimmed.toLowerCase().replace(/\s+/g, '-') : '';
+  };
+
   const formatDamageSegments = (damage, ability) =>
     damage
       .split(/\s+\+\s+/)
       .map((part, i, arr) => {
         const [token, ...rest] = part.trim().split(' ');
         const type = rest.join(' ').trim();
+        const normalizedType = normalizeDamageTypeForClass(type);
         const showAbility = ability !== undefined && ability !== null && i === 0;
         return (
           <React.Fragment key={i}>
-            <span className={type ? `damage-${type}` : ''}>
+            <span className={normalizedType ? `damage-${normalizedType}` : ''}>
               {token}
               {showAbility ? `+${ability}` : ''}
               {type ? ` ${type}` : ''}
@@ -719,13 +725,14 @@ const showSparklesEffect = () => {
                   {entry.breakdown && (
                     <div>
                       {entry.breakdown.split(' + ').map((segment, i) => {
-                        const match = segment.match(/(\d+)(?:\s+(\w+))?/);
-                        const value = match ? match[1] : segment;
-                        const type = match ? match[2] : '';
+                        const [valueToken, ...typeParts] = segment.trim().split(/\s+/);
+                        const value = valueToken || segment;
+                        const type = typeParts.join(' ');
+                        const normalizedType = normalizeDamageTypeForClass(type);
                         return (
                           <div key={i}>
                             -{' '}
-                            <span className={type ? `damage-${type}` : ''}>
+                            <span className={normalizedType ? `damage-${normalizedType}` : ''}>
                               {value}
                               {type ? ` ${type}` : ''}
                             </span>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -202,7 +202,9 @@ describe('PlayerTurnActions weapon damage display', () => {
     expect(breathCard).toBeInTheDocument();
     expect(within(breathCard).getByText('Save DC')).toBeInTheDocument();
     expect(within(breathCard).getByText('13')).toBeInTheDocument();
-    expect(within(breathCard).getByText('3d6 Fire')).toBeInTheDocument();
+    const fireDamage = within(breathCard).getByText('3d6 Fire');
+    expect(fireDamage).toBeInTheDocument();
+    expect(fireDamage).toHaveClass('damage-fire');
     expect(
       within(breathCard).getByText('15 ft. cone • Dexterity Save')
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- normalize damage-type CSS classes by lowercasing and hyphenating whitespace before applying the damage- prefix
- ensure the damage log uses the same normalization logic as inline damage segments
- extend the dragonborn breath weapon test to cover title-cased damage types

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8181a18c0832395e4987cdadc5ca7