### PR TITLE
Adjust dragonborn breath weapon scaling

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -324,9 +324,9 @@ const [isFumble, setIsFumble] = useState(false);
     if (!dragonbornAncestry) return null;
 
     const diceCount =
-      totalLevel >= 16 ? 5 : totalLevel >= 11 ? 4 : totalLevel >= 6 ? 3 : 2;
+      totalLevel >= 17 ? 4 : totalLevel >= 11 ? 3 : totalLevel >= 5 ? 2 : 1;
     const damageType = dragonbornAncestry.damageType || '';
-    const damageString = `${diceCount}d6${damageType ? ` ${damageType}` : ''}`;
+    const damageString = `${diceCount}d10${damageType ? ` ${damageType}` : ''}`;
     const breathWeapon = dragonbornAncestry.breathWeapon || {};
     const numericConMod = Number(conMod) || 0;
 


### PR DESCRIPTION
## Summary
- update the dragonborn breath weapon damage string to use d10s with the new level thresholds

## Testing
- npm --prefix client test -- --watch=false *(fails: existing ZombiesCharacterSheet tests require wrapping updates in act)*

------
https://chatgpt.com/codex/tasks/task_e_68d828043d6c83239a353b70895b5387