### PR TITLE
Ensure dragonborn ancestry features rely on description field

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -68,7 +68,6 @@ export default function Features({
       id: 'dragonborn-damage-resistance',
       name: 'Damage Resistance',
       meta: `Dragon Subrace (${ancestryLabel})`,
-      desc: resistanceDescription,
       description: resistanceDescription,
       hideUseButton: true,
     };
@@ -82,7 +81,6 @@ export default function Features({
         id: 'dragonborn-draconic-flight',
         name: 'Draconic Flight',
         meta: `Dragon Subrace (${ancestryLabel})`,
-        desc: draconicFlightDescription,
         description: draconicFlightDescription,
         hideUseButton: true,
       });


### PR DESCRIPTION
## Summary
- remove the legacy `desc` field from dragonborn damage resistance and draconic flight features so only `description` is populated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82f3b01308323a0424160f6757421