### PR TITLE
Add weapon mastery selection workflow to class features

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import { Modal, Card, Button } from 'react-bootstrap';
+import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
 
 export default function FeatureModal({ show, onHide, feature }) {
   if (!show || !feature) return null;
   const description = Array.isArray(feature.desc)
     ? feature.desc.join('\n')
     : (feature.description || feature.desc);
+  const masterySelections = Array.isArray(feature.masterySelections)
+    ? feature.masterySelections
+    : [];
+  const masteryDetails = masterySelections
+    .map((selection) => WEAPON_MASTERY_OPTION_MAP[selection])
+    .filter(Boolean);
   return (
     <Modal
       show={show}
@@ -20,6 +27,19 @@ export default function FeatureModal({ show, onHide, feature }) {
           </Card.Header>
           <Card.Body>
             <p>{description || 'Feature details unavailable'}</p>
+            {masteryDetails.length > 0 && (
+              <div className="text-start mt-3">
+                <h5 className="fw-semibold">Weapon Mastery Selections</h5>
+                <ul className="mb-0">
+                  {masteryDetails.map((option) => (
+                    <li key={option.id} className="mb-2">
+                      <strong>{option.title}</strong>
+                      <div>{option.description}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </Card.Body>
           <Card.Footer className="modal-footer">
             <Button className="action-btn close-btn" onClick={onHide}>

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,8 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { Modal, Card, Button, Spinner } from 'react-bootstrap';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Card, Button, Spinner, Form } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import actionSurgeIcon from '../../../images/action-surge-icon.png';
+import {
+  WEAPON_MASTERY_OPTIONS,
+  WEAPON_MASTERY_OPTION_MAP,
+} from './weaponMasteryOptions';
 
 export default function Features({
   form,
@@ -11,6 +15,7 @@ export default function Features({
   onActionSurge,
   longRestCount,
   shortRestCount,
+  onFeatureStateChange,
 }) {
   const [features, setFeatures] = useState([]);
   const [modalFeature, setModalFeature] = useState(null);
@@ -18,6 +23,77 @@ export default function Features({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [surgeUsed, setSurgeUsed] = useState(false);
+  const [weaponMasterySelections, setWeaponMasterySelections] = useState(
+    () => form?.features?.weaponMastery || {}
+  );
+
+  const handleFeatureStateChange =
+    typeof onFeatureStateChange === 'function'
+      ? onFeatureStateChange
+      : () => {};
+
+  useEffect(() => {
+    setWeaponMasterySelections(form?.features?.weaponMastery || {});
+  }, [form?.features?.weaponMastery]);
+
+  const masteryOptionElements = useMemo(
+    () =>
+      WEAPON_MASTERY_OPTIONS.map((option) => (
+        <option value={option.id} key={option.id}>
+          {option.title}
+        </option>
+      )),
+    []
+  );
+
+  const buildFeatureKey = (feat) =>
+    [feat.class, feat.level, feat.name]
+      .map((part) => String(part || '').toLowerCase())
+      .join('::');
+
+  const getMasterySelections = (featureKey, picks) => {
+    const selections = weaponMasterySelections?.[featureKey] || [];
+    return Array.from({ length: picks }, (_, idx) => selections[idx] || '');
+  };
+
+  const handleMasterySelectionChange = (featureKey, picks, index, value) => {
+    setWeaponMasterySelections((prev) => {
+      const nextSelections = {
+        ...prev,
+        [featureKey]: Array.from({ length: picks }, (_, idx) =>
+          idx === index ? value : prev?.[featureKey]?.[idx] || ''
+        ),
+      };
+
+      const hasSelected = nextSelections[featureKey].some(Boolean);
+      if (!hasSelected) {
+        delete nextSelections[featureKey];
+      }
+
+      handleFeatureStateChange((prevFeatureState = {}) => {
+        const nextFeatureState = { ...prevFeatureState };
+        const existingWeaponMastery = {
+          ...(prevFeatureState.weaponMastery || {}),
+        };
+
+        if (hasSelected) {
+          existingWeaponMastery[featureKey] = nextSelections[featureKey];
+        } else {
+          delete existingWeaponMastery[featureKey];
+        }
+
+        if (Object.keys(existingWeaponMastery).length > 0) {
+          nextFeatureState.weaponMastery = existingWeaponMastery;
+        } else {
+          delete nextFeatureState.weaponMastery;
+        }
+
+        return nextFeatureState;
+      });
+
+      return nextSelections;
+    });
+  };
 
   useEffect(() => {
     if (!showFeatures) return;
@@ -88,8 +164,17 @@ export default function Features({
                   {features.map((feat, idx) => {
                     const featKey = `${feat.class}-${feat.level}-${idx}`;
                     const isActionSurge = feat.name?.includes('Action Surge');
+                    const isWeaponMastery = Boolean(feat.mastery?.picks);
+                    const featureKey = buildFeatureKey(feat);
+                    const masterySelections = isWeaponMastery
+                      ? getMasterySelections(featureKey, feat.mastery.picks)
+                      : [];
                     return (
-                      <div className="feature-card" key={featKey}>
+                      <div
+                        className="feature-card"
+                        key={featKey}
+                        data-testid="feature-card"
+                      >
                         <div className="feature-card-header">
                           <div>
                             <div className="feature-card-name">{feat.name}</div>
@@ -130,7 +215,13 @@ export default function Features({
                               size="sm"
                               className="view-link-btn"
                               onClick={() => {
-                                setModalFeature(feat);
+                                const selectedMasteries = masterySelections.filter(
+                                  Boolean
+                                );
+                                setModalFeature({
+                                  ...feat,
+                                  masterySelections: selectedMasteries,
+                                });
                                 setShowModal(true);
                               }}
                             >
@@ -138,13 +229,63 @@ export default function Features({
                             </Button>
                           </div>
                         </div>
-                        {feat.desc && (
-                          <div className="feature-card-body">
-                            {Array.isArray(feat.desc)
-                              ? feat.desc.join(' ')
-                              : feat.desc}
-                          </div>
-                        )}
+                        <div className="feature-card-body">
+                          {(feat.description || feat.desc) && (
+                            <div className="mb-2">
+                              {Array.isArray(feat.description || feat.desc)
+                                ? (feat.description || feat.desc).join(' ')
+                                : feat.description || feat.desc}
+                            </div>
+                          )}
+                          {isWeaponMastery && (
+                            <div className="weapon-mastery-card">
+                              <div className="mb-2 fw-semibold">
+                                Weapon Mastery selections available: {feat.mastery.picks}
+                              </div>
+                              <div className="d-flex flex-column gap-2">
+                                {masterySelections.map((selection, selectionIdx) => (
+                                  <Form.Select
+                                    key={`${featureKey}-${selectionIdx}`}
+                                    aria-label={`Select mastery option ${selectionIdx + 1}`}
+                                    value={selection}
+                                    onChange={(event) =>
+                                      handleMasterySelectionChange(
+                                        featureKey,
+                                        feat.mastery.picks,
+                                        selectionIdx,
+                                        event.target.value
+                                      )
+                                    }
+                                  >
+                                    <option value="">Choose a mastery option</option>
+                                    {masteryOptionElements}
+                                  </Form.Select>
+                                ))}
+                              </div>
+                              {masterySelections.filter(Boolean).length > 0 && (
+                                <div className="mt-3 text-start">
+                                  <div className="fw-semibold">Current selections</div>
+                                  <ul className="mb-0">
+                                    {masterySelections
+                                      .filter(Boolean)
+                                      .map((selection, selectionIdx) => {
+                                        const option =
+                                          WEAPON_MASTERY_OPTION_MAP[selection];
+                                        if (!option) return null;
+                                        return (
+                                          <li
+                                            key={`${featureKey}-${selection}-${selectionIdx}`}
+                                          >
+                                            <strong>{option.title}</strong>: {option.description}
+                                          </li>
+                                        );
+                                      })}
+                                  </ul>
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
                       </div>
                     );
                   })}

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -50,8 +50,10 @@ test('renders features and opens modal with description', async () => {
   });
   expect(useButtons).toHaveLength(2);
 
-  const actionSurgeRow = (await screen.findByText('Action Surge')).closest('tr');
-  const actionSurgeButton = within(actionSurgeRow).getByRole('button', {
+  const actionSurgeCard = (await screen.findByText('Action Surge')).closest(
+    '[data-testid="feature-card"]'
+  );
+  const actionSurgeButton = within(actionSurgeCard).getByRole('button', {
     name: /view feature/i
   });
 
@@ -59,8 +61,13 @@ test('renders features and opens modal with description', async () => {
     await userEvent.click(actionSurgeButton);
   });
 
+  const modals = await screen.findAllByRole('dialog');
+  const actionSurgeModal = modals.find((element) =>
+    within(element).queryByText('Action Surge')
+  );
+  expect(actionSurgeModal).toBeTruthy();
   expect(
-    await screen.findByText('You can take one additional action.')
+    within(actionSurgeModal).getByText('You can take one additional action.')
   ).toBeInTheDocument();
 });
 
@@ -100,18 +107,91 @@ test('features are sorted by class then level', async () => {
 
   expect(await screen.findByText('Arcane Recovery')).toBeInTheDocument();
 
-  const rows = screen.getAllByRole('row').slice(1); // skip header
-  const order = rows.map((row) => {
-    const cells = within(row).getAllByRole('cell');
+  const cards = screen.getAllByTestId('feature-card');
+  const order = cards.map((card) => {
+    const name = card.querySelector('.feature-card-name').textContent;
+    const [cls, lvl] = card.querySelectorAll('.feature-card-meta span');
     return {
-      cls: cells[0].textContent,
-      lvl: cells[1].textContent,
-      feat: cells[2].textContent,
+      cls: cls.textContent,
+      lvl: lvl.textContent,
+      feat: name,
     };
   });
   expect(order).toEqual([
-    { cls: 'Fighter', lvl: '1', feat: 'Second Wind' },
-    { cls: 'Fighter', lvl: '2', feat: 'Action Surge' },
-    { cls: 'Wizard', lvl: '1', feat: 'Arcane Recovery' },
+    { cls: 'Fighter', lvl: 'Level 1', feat: 'Second Wind' },
+    { cls: 'Fighter', lvl: 'Level 2', feat: 'Action Surge' },
+    { cls: 'Wizard', lvl: 'Level 1', feat: 'Arcane Recovery' },
   ]);
+});
+
+test('weapon mastery card supports selections and modal details', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      features: [
+        {
+          name: 'Weapon Mastery',
+          description: 'Choose your weapon mastery benefits.',
+          mastery: { picks: 2 },
+        },
+      ],
+    }),
+  });
+
+  const featureKey = 'fighter::1::weapon mastery';
+  const onFeatureStateChange = jest.fn();
+
+  render(
+    <Features
+      form={{
+        occupation: [{ Name: 'Fighter', Level: 1 }],
+        features: {
+          weaponMastery: {
+            [featureKey]: ['cleave', 'graze'],
+          },
+        },
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      onFeatureStateChange={onFeatureStateChange}
+    />
+  );
+
+  const masteryCard = await screen.findByTestId('feature-card');
+  expect(within(masteryCard).getByText('Weapon Mastery')).toBeInTheDocument();
+
+  const selects = within(masteryCard).getAllByRole('combobox');
+  expect(selects).toHaveLength(2);
+  expect(selects[0]).toHaveValue('cleave');
+  expect(selects[1]).toHaveValue('graze');
+
+  await act(async () => {
+    await userEvent.selectOptions(selects[1], 'vex');
+  });
+
+  expect(onFeatureStateChange).toHaveBeenCalled();
+  const updateFn = onFeatureStateChange.mock.calls.at(-1)[0];
+  const updatedState = updateFn({ weaponMastery: {} });
+  expect(updatedState.weaponMastery[featureKey]).toEqual(['cleave', 'vex']);
+
+  await act(async () => {
+    await userEvent.click(
+      within(masteryCard).getByRole('button', { name: /view feature/i })
+    );
+  });
+
+  const modals = await screen.findAllByRole('dialog');
+  const modal = modals.find((element) =>
+    within(element).queryByText('Weapon Mastery Selections')
+  );
+  expect(modal).toBeTruthy();
+  expect(
+    within(modal).getByText('Weapon Mastery Selections')
+  ).toBeInTheDocument();
+  expect(within(modal).getByText('Vex')).toBeInTheDocument();
+  expect(
+    within(modal).getByText(
+      /you have advantage on the next attack you make against that creature/i
+    )
+  ).toBeInTheDocument();
 });

--- a/client/src/components/Zombies/attributes/weaponMasteryOptions.js
+++ b/client/src/components/Zombies/attributes/weaponMasteryOptions.js
@@ -1,0 +1,64 @@
+export const WEAPON_MASTERY_OPTIONS = [
+  {
+    id: 'cleave',
+    title: 'Cleave',
+    description:
+      'When you hit a creature with this weapon, you can make another attack against a second creature within 5 feet of the original target and within your reach.'
+  },
+  {
+    id: 'flex',
+    title: 'Flex',
+    description:
+      'If this weapon has the Versatile property, you deal its Versatile damage even when wielding it with one hand.'
+  },
+  {
+    id: 'graze',
+    title: 'Graze',
+    description:
+      'If your attack roll misses, the target still takes damage equal to your Strength or Dexterity modifier.'
+  },
+  {
+    id: 'nick',
+    title: 'Nick',
+    description:
+      'You can make a bonus action attack with this weapon, but only once per turn.'
+  },
+  {
+    id: 'push',
+    title: 'Push',
+    description:
+      'On a hit, you can push the target up to 10 feet away from you if it is no more than one size larger than you.'
+  },
+  {
+    id: 'sap',
+    title: 'Sap',
+    description:
+      'When you hit, the target has disadvantage on its next attack roll before the start of your next turn.'
+  },
+  {
+    id: 'slow',
+    title: 'Slow',
+    description:
+      'A creature you hit has its speed reduced by 10 feet until the start of your next turn.'
+  },
+  {
+    id: 'topple',
+    title: 'Topple',
+    description:
+      'If the target is no more than one size larger than you, it must succeed on a Strength saving throw or fall prone.'
+  },
+  {
+    id: 'vex',
+    title: 'Vex',
+    description:
+      'If you hit a creature with this weapon, you have advantage on the next attack you make against that creature before the end of your next turn.'
+  }
+];
+
+export const WEAPON_MASTERY_OPTION_MAP = WEAPON_MASTERY_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  },
+  {}
+);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -778,6 +778,25 @@ export default function ZombiesCharacterSheet() {
     });
   }, []);
 
+  const handleFeatureStateChange = useCallback(
+    (updater) => {
+      setForm((prev) => {
+        if (!prev) return prev;
+        const prevFeatures = prev.features || {};
+        const nextFeatures =
+          typeof updater === 'function' ? updater(prevFeatures) : updater;
+        const updatedForm = { ...prev };
+        if (nextFeatures && Object.keys(nextFeatures).length > 0) {
+          updatedForm.features = nextFeatures;
+        } else {
+          delete updatedForm.features;
+        }
+        return updatedForm;
+      });
+    },
+    [setForm]
+  );
+
   const handlePassTurn = useCallback(async () => {
     if (isPassingTurn || !encodedCampaignId) {
       return;
@@ -1995,6 +2014,7 @@ const spellsGold =
       longRestCount={longRestCount}
       shortRestCount={shortRestCount}
       actionCount={actionCount}
+      onFeatureStateChange={handleFeatureStateChange}
     />
     <InventoryModal
       show={showInventory}


### PR DESCRIPTION
## Summary
- surface weapon mastery metadata with a new selection card and option catalog
- persist mastery choices in the character form state and display them in the feature detail modal
- extend feature tests to cover mastery rendering, selection, and modal details

## Testing
- CI=1 npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d94b173a748323b3b748c99a4f9346