### PR TITLE
Add weapon mastery modal to player turn actions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -288,11 +288,25 @@
   margin-top: auto;
   display: flex;
   justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .attack-card__roll {
   font-size: 1.25rem;
   color: rgba(255, 255, 255, 0.85);
+}
+
+.attack-card__mastery {
+  font-size: 1.25rem;
+  color: #f1c40f;
+  text-shadow: 0 0 6px rgba(241, 196, 15, 0.7);
+}
+
+.attack-card__mastery:hover,
+.attack-card__mastery:focus {
+  color: #ffeaa7;
+  text-shadow: 0 0 10px rgba(255, 234, 167, 0.85);
+  text-decoration: none;
 }
 
 .attack-card__roll:hover,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -6,10 +6,12 @@ import React, {
 } from 'react';
 import { Button, Modal, Card } from "react-bootstrap";
 import UpcastModal from './UpcastModal';
+import WeaponMasteryModal from './WeaponMasteryModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
+import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -244,9 +246,9 @@ const PlayerTurnActions = React.forwardRef(
     };
   }, []);
 
-//--------------------------------------------Critical status------------------------------------------------
-const [isCritical, setIsCritical] = useState(false);
-const [isFumble, setIsFumble] = useState(false);
+  //--------------------------------------------Critical status------------------------------------------------
+  const [isCritical, setIsCritical] = useState(false);
+  const [isFumble, setIsFumble] = useState(false);
   const equipmentProvided = useMemo(
     () => typeof form?.equipment === 'object' && form.equipment !== null,
     [form.equipment]
@@ -255,6 +257,27 @@ const [isFumble, setIsFumble] = useState(false);
     () => normalizeEquipmentMap(form.equipment),
     [form.equipment]
   );
+  const getWeaponMasteryId = (weapon) => {
+    if (!weapon || typeof weapon !== 'object') return '';
+    const { mastery } = weapon;
+    if (!mastery) return '';
+    if (typeof mastery === 'string') {
+      const trimmed = mastery.trim();
+      return trimmed ? trimmed.toLowerCase() : '';
+    }
+    if (typeof mastery === 'object') {
+      const { id, key, name } = mastery;
+      const candidate =
+        (typeof id === 'string' && id) ||
+        (typeof key === 'string' && key) ||
+        (typeof name === 'string' && name) ||
+        '';
+      const trimmed = candidate.trim();
+      return trimmed ? trimmed.toLowerCase() : '';
+    }
+    return '';
+  };
+
   const equippedWeapons = useMemo(() => {
     if (equipmentProvided) {
       return WEAPON_SLOT_KEYS.map((slot) => {
@@ -264,17 +287,28 @@ const [isFumble, setIsFumble] = useState(false);
         const damage =
           typeof weapon.damage === 'string' ? weapon.damage.trim() : '';
         if (!damage) return null;
-        return { slot, weapon };
+        const masteryId = getWeaponMasteryId(weapon);
+        const masteryDetails = masteryId
+          ? WEAPON_MASTERY_OPTION_MAP[masteryId]
+          : undefined;
+        return { slot, weapon, masteryId, masteryDetails };
       }).filter(Boolean);
     }
 
     const legacyWeapons = normalizeWeapons(form.weapon || [], {
       includeUnowned: true,
     });
-    return legacyWeapons.map((weapon, index) => ({
-      slot: `legacy-${index}`,
-      weapon,
-    }));
+    return legacyWeapons.map((weapon, index) => {
+      const masteryId = getWeaponMasteryId(weapon);
+      return {
+        slot: `legacy-${index}`,
+        weapon,
+        masteryId,
+        masteryDetails: masteryId
+          ? WEAPON_MASTERY_OPTION_MAP[masteryId]
+          : undefined,
+      };
+    });
   }, [equipmentProvided, normalizedEquipment, form.weapon]);
   // --------------------------------Breaks down weapon damage into useable numbers--------------------------------
   const abilityForWeapon = (weapon) => {
@@ -335,8 +369,9 @@ const [isFumble, setIsFumble] = useState(false);
     );
   };
 
-const [showUpcast, setShowUpcast] = useState(false);
-const [pendingSpell, setPendingSpell] = useState(null);
+  const [showUpcast, setShowUpcast] = useState(false);
+  const [pendingSpell, setPendingSpell] = useState(null);
+  const [activeMastery, setActiveMastery] = useState(null);
 
   const applyUpcast = (spell, level, crit, slotType) => {
     const diff = level - (spell.level || 0);
@@ -744,7 +779,7 @@ const showSparklesEffect = () => {
                   <p className="text-muted mb-0">No weapons equipped.</p>
                 </div>
               ) : (
-                equippedWeapons.map(({ slot, weapon }) => (
+                equippedWeapons.map(({ slot, weapon, masteryId, masteryDetails }) => (
                   <div
                     className="attack-card"
                     key={`${slot}-${weapon.name || slot}`}
@@ -767,6 +802,21 @@ const showSparklesEffect = () => {
                       </div>
                     </div>
                     <div className="attack-card__actions">
+                      {masteryDetails && (
+                        <Button
+                          onClick={() =>
+                            setActiveMastery({
+                              id: masteryId,
+                              weaponName: weapon.name || 'Unknown weapon',
+                            })
+                          }
+                          variant="link"
+                          aria-label={`View mastery: ${masteryDetails.title}`}
+                          className="attack-card__mastery"
+                        >
+                          <i className="fa-solid fa-crown" aria-hidden="true"></i>
+                        </Button>
+                      )}
                       <Button
                         onClick={() => {
                           handleWeaponAttack(weapon);
@@ -854,6 +904,12 @@ const showSparklesEffect = () => {
           }
           setShowUpcast(false);
         }}
+      />
+      <WeaponMasteryModal
+        show={Boolean(activeMastery)}
+        masteryId={activeMastery?.id || ''}
+        weaponName={activeMastery?.weaponName}
+        onHide={() => setActiveMastery(null)}
       />
     </div>
   );

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, act, fireEvent, screen, within, waitFor } from '@testing-library/react';
 import PlayerTurnActions, * as PlayerTurnActionsModule from './PlayerTurnActions';
+import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
 import damageTypeColors from '../../../utils/damageTypeColors';
 
 const { calculateDamage } = PlayerTurnActionsModule;
@@ -99,9 +100,10 @@ describe('PlayerTurnActions weapon damage display', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const row = screen.getByText('Frost Brand').closest('tr');
-    const cold = within(row).getByText(/1d4\+2 cold/);
-    const slashing = within(row).getByText(/1d6\+2 slashing/);
+    const card = screen.getByText('Frost Brand').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const cold = within(card).getByText(/1d4\+2 cold/);
+    const slashing = within(card).getByText(/1d6\+2 slashing/);
     expect(cold).toHaveClass('damage-cold');
     expect(slashing).toHaveClass('damage-slashing');
   });
@@ -126,9 +128,87 @@ describe('PlayerTurnActions weapon damage display', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const row = screen.getByText('Fire Bolt').closest('tr');
-    const fire = within(row).getByText(/1d10 fire/);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const fire = within(card).getByText(/1d10 fire/);
     expect(fire).toHaveClass('damage-fire');
+  });
+});
+
+describe('PlayerTurnActions weapon mastery modal', () => {
+  test('renders crown button and shows mastery details', async () => {
+    const weapon = {
+      name: 'Longsword',
+      damage: '1d8 slashing',
+      category: 'martial melee',
+      source: 'weapon',
+      mastery: 'flex',
+    };
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          weapon: [],
+          spells: [],
+        }}
+        strMod={2}
+        dexMod={0}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const attackModal = await screen.findByRole('dialog');
+    expect(within(attackModal).getByText('Attacks')).toBeInTheDocument();
+    const masteryDetails = WEAPON_MASTERY_OPTION_MAP.flex;
+    const crownButton = within(attackModal).getByRole('button', {
+      name: `View mastery: ${masteryDetails.title}`,
+    });
+    act(() => {
+      fireEvent.click(crownButton);
+    });
+    const masteryModal = await screen.findByRole('dialog', {
+      name: masteryDetails.title,
+    });
+    expect(
+      within(masteryModal).getByRole('heading', { name: /flex/i })
+    ).toBeInTheDocument();
+    expect(
+      within(masteryModal).getByText(masteryDetails.description)
+    ).toBeInTheDocument();
+    expect(
+      within(masteryModal).getByText(/for Longsword/i)
+    ).toBeInTheDocument();
+  });
+
+  test('omits crown button when no mastery is present', async () => {
+    const weapon = {
+      name: 'Battleaxe',
+      damage: '1d8 slashing',
+      category: 'martial melee',
+      source: 'weapon',
+    };
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          weapon: [],
+          spells: [],
+        }}
+        strMod={3}
+        dexMod={1}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+    const attackModal = await screen.findByRole('dialog');
+    expect(within(attackModal).getByText('Attacks')).toBeInTheDocument();
+    expect(
+      within(attackModal).queryByRole('button', { name: /view mastery/i })
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -359,9 +439,10 @@ describe('PlayerTurnActions weapon damage display', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const row = screen.getByText('Frost Brand').closest('tr');
-    const cold = within(row).getByText(/1d4\+2 cold/);
-    const slashing = within(row).getByText(/1d6\+2 slashing/);
+    const card = screen.getByText('Frost Brand').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const cold = within(card).getByText(/1d4\+2 cold/);
+    const slashing = within(card).getByText(/1d6\+2 slashing/);
     expect(cold).toHaveClass('damage-cold');
     expect(slashing).toHaveClass('damage-slashing');
   });
@@ -386,8 +467,9 @@ describe('PlayerTurnActions weapon damage display', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const row = screen.getByText('Fire Bolt').closest('tr');
-    const fire = within(row).getByText(/1d10 fire/);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const fire = within(card).getByText(/1d10 fire/);
     expect(fire).toHaveClass('damage-fire');
   });
 });
@@ -680,12 +762,12 @@ describe('PlayerTurnActions spell casting', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
 
-    const header = await screen.findByText('Spell Name');
-    const table = header.closest('table');
-    const rows = within(table).getAllByRole('row').slice(1);
-    const names = rows.map(
-      (row) => within(row).getAllByRole('cell')[0].textContent
-    );
+    const spellsHeading = await screen.findByText('Spells');
+    const spellsGrid = spellsHeading.nextElementSibling;
+    expect(spellsGrid).not.toBeNull();
+    const names = Array.from(
+      spellsGrid.querySelectorAll('.attack-card__title')
+    ).map((el) => el.textContent);
     expect(names).toEqual(['Cure Wounds', 'Magic Missile', 'Fireball']);
   });
 });

--- a/client/src/components/Zombies/attributes/WeaponMasteryModal.js
+++ b/client/src/components/Zombies/attributes/WeaponMasteryModal.js
@@ -1,0 +1,36 @@
+import React, { useMemo } from 'react';
+import { Modal } from 'react-bootstrap';
+import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
+
+const getMasteryDetails = (masteryId) => {
+  if (!masteryId) return null;
+  const normalized = masteryId.trim().toLowerCase();
+  return WEAPON_MASTERY_OPTION_MAP[normalized] || null;
+};
+
+const WeaponMasteryModal = ({ show, onHide, masteryId, weaponName }) => {
+  const mastery = useMemo(() => getMasteryDetails(masteryId), [masteryId]);
+  const title = mastery?.title || 'Weapon Mastery';
+
+  return (
+    <Modal centered show={show} onHide={onHide} aria-label={title}>
+      <Modal.Header closeButton>
+        <Modal.Title as="h3" className="h5 mb-0">
+          {title}
+          {weaponName ? (
+            <span className="d-block mt-1 text-muted">for {weaponName}</span>
+          ) : null}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {mastery ? (
+          <p className="mb-0">{mastery.description}</p>
+        ) : (
+          <p className="mb-0 text-muted">Mastery details are unavailable.</p>
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default WeaponMasteryModal;

--- a/client/src/components/Zombies/attributes/inventoryNormalization.js
+++ b/client/src/components/Zombies/attributes/inventoryNormalization.js
@@ -34,6 +34,23 @@ const normalizeAccessoryOverrides = (overrides) =>
     ? overrides
     : {};
 
+const normalizeMastery = (value) => {
+  if (!value) return undefined;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed.toLowerCase() : undefined;
+  }
+  if (typeof value === 'object') {
+    const { id, key, name } = value;
+    const candidate = id || key || name;
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      return trimmed ? trimmed.toLowerCase() : undefined;
+    }
+  }
+  return undefined;
+};
+
 export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
   if (!Array.isArray(weapons)) return [];
   return weapons
@@ -52,8 +69,10 @@ export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
           cost,
           type,
           attackBonus,
+          mastery,
         ] = weapon;
         if (!name) return null;
+        const masteryId = normalizeMastery(mastery);
         const normalized = {
           name,
           category: category ?? '',
@@ -65,6 +84,7 @@ export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
         if (type !== undefined) normalized.type = type;
         if (attackBonus !== undefined) normalized.attackBonus = attackBonus;
         if (owned !== undefined) normalized.owned = owned;
+        if (masteryId) normalized.mastery = masteryId;
         return normalized;
       }
       if (typeof weapon === 'string') {
@@ -87,11 +107,13 @@ export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
           cost = '',
           type,
           attackBonus,
+          mastery: rawMastery,
           owned: ownedProp,
           ...rest
         } = weapon;
         if (!name) return null;
         if (!includeUnowned && ownedProp === false) return null;
+        const mastery = normalizeMastery(rawMastery);
         const normalized = {
           name,
           category,
@@ -104,6 +126,7 @@ export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
           ...rest,
         };
         if (ownedProp !== undefined) normalized.owned = ownedProp;
+        if (mastery) normalized.mastery = mastery;
         return normalized;
       }
       return null;

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -295,7 +295,7 @@ describe('Character routes', () => {
         duration: 'Instantaneous',
       }],
       equipment: {
-        mainHand: { name: 'Longsword', source: 'weapon' },
+        mainHand: { name: 'Longsword', source: 'weapon', mastery: 'cleave' },
         ranged: { name: 'Shortbow', source: 'weapon' },
         ringLeft: 'Ring of Protection',
         tail: { name: 'Tail Blade' },
@@ -322,6 +322,7 @@ describe('Character routes', () => {
     expect(res.body.equipment.mainHand).toMatchObject({
       name: 'Longsword',
       source: 'weapon',
+      mastery: 'cleave',
     });
     expect(res.body.equipment.ranged).toMatchObject({
       name: 'Shortbow',

--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -32,6 +32,10 @@ export interface Weapon {
    */
   attackBonus?: number;
   /**
+   * Assigned weapon mastery identifier such as "cleave" or "vex".
+   */
+  mastery?: string;
+  /**
    * Whether the creature currently owns the weapon.
    */
   owned: boolean;


### PR DESCRIPTION
## Summary
- extend weapon typings and normalization so equipped weapons carry their mastery identifiers from the backend
- surface a mastery crown control in the attacks modal that opens a detailed weapon mastery dialog
- add styling and unit tests covering mastery visibility and descriptions

## Testing
- CI=true npm test -- PlayerTurnActions

------
https://chatgpt.com/codex/tasks/task_e_68d94e62168083238118d1d54f52d89d