### PR TITLE
Implement weapon mastery catalog and update feature selection

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, Card, Button } from 'react-bootstrap';
-import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
+import { resolveWeaponMasteryEntry } from './weaponMasteryCatalog';
 
 export default function FeatureModal({ show, onHide, feature }) {
   if (!show || !feature) return null;
@@ -11,7 +11,7 @@ export default function FeatureModal({ show, onHide, feature }) {
     ? feature.masterySelections
     : [];
   const masteryDetails = masterySelections
-    .map((selection) => WEAPON_MASTERY_OPTION_MAP[selection])
+    .map((selection) => resolveWeaponMasteryEntry(selection))
     .filter(Boolean);
   return (
     <Modal
@@ -32,9 +32,12 @@ export default function FeatureModal({ show, onHide, feature }) {
                 <h5 className="fw-semibold">Weapon Mastery Selections</h5>
                 <ul className="mb-0">
                   {masteryDetails.map((option) => (
-                    <li key={option.id} className="mb-2">
-                      <strong>{option.title}</strong>
-                      <div>{option.description}</div>
+                    <li key={option.key} className="mb-2">
+                      <strong>{option.label}</strong> —{' '}
+                      <span className="fw-semibold">
+                        {option.masteryTitle}
+                      </span>
+                      <div>{option.masteryDescription}</div>
                     </li>
                   ))}
                 </ul>

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -4,9 +4,28 @@ import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import actionSurgeIcon from '../../../images/action-surge-icon.png';
 import {
-  WEAPON_MASTERY_OPTIONS,
-  WEAPON_MASTERY_OPTION_MAP,
-} from './weaponMasteryOptions';
+  WEAPON_MASTERY_LIST,
+  getWeaponsForProficiency,
+  resolveWeaponMasteryEntry,
+  resolveWeaponMasteryEntryFromWeapon,
+} from './weaponMasteryCatalog';
+import { normalizeEquipmentMap } from './equipmentNormalization';
+import { normalizeWeapons } from './inventoryNormalization';
+
+const EQUIPPED_WEAPON_SLOTS = ['mainHand', 'offHand', 'ranged'];
+
+const normalizeWeaponMasteryRecord = (record) => {
+  if (!record || typeof record !== 'object') return {};
+  const normalized = {};
+  Object.entries(record).forEach(([featureKey, selections]) => {
+    if (!Array.isArray(selections)) return;
+    normalized[featureKey] = selections.map((value) => {
+      const entry = resolveWeaponMasteryEntry(value);
+      return entry?.key || '';
+    });
+  });
+  return normalized;
+};
 
 export default function Features({
   form,
@@ -23,8 +42,8 @@ export default function Features({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [surgeUsed, setSurgeUsed] = useState(false);
-  const [weaponMasterySelections, setWeaponMasterySelections] = useState(
-    () => form?.features?.weaponMastery || {}
+  const [weaponMasterySelections, setWeaponMasterySelections] = useState(() =>
+    normalizeWeaponMasteryRecord(form?.features?.weaponMastery)
   );
 
   const handleFeatureStateChange =
@@ -33,17 +52,88 @@ export default function Features({
       : () => {};
 
   useEffect(() => {
-    setWeaponMasterySelections(form?.features?.weaponMastery || {});
+    setWeaponMasterySelections(
+      normalizeWeaponMasteryRecord(form?.features?.weaponMastery)
+    );
   }, [form?.features?.weaponMastery]);
 
-  const masteryOptionElements = useMemo(
+  const normalizedEquipment = useMemo(
+    () => normalizeEquipmentMap(form?.equipment),
+    [form?.equipment]
+  );
+
+  const normalizedWeapons = useMemo(
+    () => normalizeWeapons(form?.weapon || [], { includeUnowned: true }),
+    [form?.weapon]
+  );
+
+  const availableWeaponOptions = useMemo(() => {
+    const optionMap = new Map();
+    const addEntry = (entry) => {
+      if (entry && !optionMap.has(entry.key)) {
+        optionMap.set(entry.key, entry);
+      }
+    };
+
+    EQUIPPED_WEAPON_SLOTS.forEach((slot) => {
+      const equipped = normalizedEquipment?.[slot];
+      const entry = resolveWeaponMasteryEntryFromWeapon(equipped);
+      if (entry) addEntry(entry);
+    });
+
+    normalizedWeapons.forEach((weapon) => {
+      const entry = resolveWeaponMasteryEntryFromWeapon(weapon);
+      if (entry) addEntry(entry);
+    });
+
+    const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
+    occupations.forEach((occ) => {
+      const proficiencyList = Array.isArray(occ?.weapons)
+        ? occ.weapons
+        : Array.isArray(occ?.proficiencies?.weapons)
+        ? occ.proficiencies.weapons
+        : [];
+      proficiencyList.forEach((value) => {
+        if (!value) return;
+        const entries = getWeaponsForProficiency(value);
+        if (entries.length) {
+          entries.forEach(addEntry);
+          return;
+        }
+        const entry = resolveWeaponMasteryEntry(value);
+        if (entry) addEntry(entry);
+      });
+    });
+
+    Object.values(weaponMasterySelections || {}).forEach((selections) => {
+      (selections || []).forEach((value) => {
+        const entry = resolveWeaponMasteryEntry(value);
+        if (entry) addEntry(entry);
+      });
+    });
+
+    if (!optionMap.size) {
+      WEAPON_MASTERY_LIST.forEach(addEntry);
+    }
+
+    return Array.from(optionMap.values()).sort((a, b) =>
+      a.label.localeCompare(b.label)
+    );
+  }, [
+    form?.occupation,
+    normalizedEquipment,
+    normalizedWeapons,
+    weaponMasterySelections,
+  ]);
+
+  const weaponOptionElements = useMemo(
     () =>
-      WEAPON_MASTERY_OPTIONS.map((option) => (
-        <option value={option.id} key={option.id}>
-          {option.title}
+      availableWeaponOptions.map((option) => (
+        <option value={option.key} key={option.key}>
+          {option.label}
         </option>
       )),
-    []
+    [availableWeaponOptions]
   );
 
   const buildFeatureKey = (feat) =>
@@ -57,11 +147,14 @@ export default function Features({
   };
 
   const handleMasterySelectionChange = (featureKey, picks, index, value) => {
+    const normalizedValue = resolveWeaponMasteryEntry(value)?.key || '';
     setWeaponMasterySelections((prev) => {
       const nextSelections = {
         ...prev,
         [featureKey]: Array.from({ length: picks }, (_, idx) =>
-          idx === index ? value : prev?.[featureKey]?.[idx] || ''
+          idx === index
+            ? normalizedValue
+            : prev?.[featureKey]?.[idx] || ''
         ),
       };
 
@@ -218,9 +311,14 @@ export default function Features({
                                 const selectedMasteries = masterySelections.filter(
                                   Boolean
                                 );
+                                const selectedEntries = selectedMasteries
+                                  .map((selection) =>
+                                    resolveWeaponMasteryEntry(selection)
+                                  )
+                                  .filter(Boolean);
                                 setModalFeature({
                                   ...feat,
-                                  masterySelections: selectedMasteries,
+                                  masterySelections: selectedEntries,
                                 });
                                 setShowModal(true);
                               }}
@@ -257,8 +355,8 @@ export default function Features({
                                       )
                                     }
                                   >
-                                    <option value="">Choose a mastery option</option>
-                                    {masteryOptionElements}
+                                    <option value="">Choose a weapon</option>
+                                    {weaponOptionElements}
                                   </Form.Select>
                                 ))}
                               </div>
@@ -270,13 +368,17 @@ export default function Features({
                                       .filter(Boolean)
                                       .map((selection, selectionIdx) => {
                                         const option =
-                                          WEAPON_MASTERY_OPTION_MAP[selection];
+                                          resolveWeaponMasteryEntry(selection);
                                         if (!option) return null;
                                         return (
                                           <li
                                             key={`${featureKey}-${selection}-${selectionIdx}`}
                                           >
-                                            <strong>{option.title}</strong>: {option.description}
+                                            <strong>{option.label}</strong> —{' '}
+                                            <span className="fw-semibold">
+                                              {option.masteryTitle}
+                                            </span>
+                                            <div>{option.masteryDescription}</div>
                                           </li>
                                         );
                                       })}

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Features from './Features';
+import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
 
 jest.mock('../../../utils/apiFetch');
 import apiFetch from '../../../utils/apiFetch';
@@ -144,10 +145,23 @@ test('weapon mastery card supports selections and modal details', async () => {
   render(
     <Features
       form={{
-        occupation: [{ Name: 'Fighter', Level: 1 }],
+        occupation: [
+          {
+            Name: 'Fighter',
+            Level: 1,
+            weapons: ['simple', 'martial'],
+          },
+        ],
+        weapon: [
+          ['Longsword', 'martial melee', '1d8 slashing', [], '', '', 'longsword'],
+          ['Shortsword', 'martial melee', '1d6 piercing', [], '', '', 'shortsword'],
+        ],
+        equipment: {
+          mainHand: { name: 'Longsword', type: 'longsword', source: 'weapon' },
+        },
         features: {
           weaponMastery: {
-            [featureKey]: ['cleave', 'graze'],
+            [featureKey]: ['longsword', 'shortsword'],
           },
         },
       }}
@@ -162,17 +176,39 @@ test('weapon mastery card supports selections and modal details', async () => {
 
   const selects = within(masteryCard).getAllByRole('combobox');
   expect(selects).toHaveLength(2);
-  expect(selects[0]).toHaveValue('cleave');
-  expect(selects[1]).toHaveValue('graze');
+  expect(selects[0]).toHaveDisplayValue('Longsword');
+  expect(selects[1]).toHaveDisplayValue('Shortsword');
+
+  const handaxeOption = within(selects[1]).getByRole('option', {
+    name: 'Handaxe',
+  });
 
   await act(async () => {
-    await userEvent.selectOptions(selects[1], 'vex');
+    await userEvent.selectOptions(selects[1], handaxeOption);
   });
 
   expect(onFeatureStateChange).toHaveBeenCalled();
   const updateFn = onFeatureStateChange.mock.calls.at(-1)[0];
   const updatedState = updateFn({ weaponMastery: {} });
-  expect(updatedState.weaponMastery[featureKey]).toEqual(['cleave', 'vex']);
+  expect(updatedState.weaponMastery[featureKey]).toEqual([
+    'longsword',
+    'handaxe',
+  ]);
+  expect(updatedState.weaponMastery[featureKey]).not.toContain('vex');
+
+  const selectionsHeader = within(masteryCard).getByText('Current selections');
+  const selectionsSection = selectionsHeader.parentElement;
+  expect(selectionsSection).toBeTruthy();
+  const selectionsList = within(selectionsSection).getByRole('list');
+  const currentListItems = within(selectionsList).getAllByRole('listitem');
+  expect(currentListItems[0]).toHaveTextContent('Longsword — Flex');
+  expect(currentListItems[0]).toHaveTextContent(
+    WEAPON_MASTERY_OPTION_MAP.flex.description
+  );
+  expect(currentListItems[1]).toHaveTextContent('Handaxe — Vex');
+  expect(currentListItems[1]).toHaveTextContent(
+    WEAPON_MASTERY_OPTION_MAP.vex.description
+  );
 
   await act(async () => {
     await userEvent.click(
@@ -188,10 +224,15 @@ test('weapon mastery card supports selections and modal details', async () => {
   expect(
     within(modal).getByText('Weapon Mastery Selections')
   ).toBeInTheDocument();
-  expect(within(modal).getByText('Vex')).toBeInTheDocument();
-  expect(
-    within(modal).getByText(
-      /you have advantage on the next attack you make against that creature/i
-    )
-  ).toBeInTheDocument();
+  const modalListItems = within(modal).getAllByRole('listitem');
+  expect(modalListItems[0]).toHaveTextContent('Longsword');
+  expect(modalListItems[0]).toHaveTextContent('Flex');
+  expect(modalListItems[0]).toHaveTextContent(
+    WEAPON_MASTERY_OPTION_MAP.flex.description
+  );
+  expect(modalListItems[1]).toHaveTextContent('Handaxe');
+  expect(modalListItems[1]).toHaveTextContent('Vex');
+  expect(modalListItems[1]).toHaveTextContent(
+    WEAPON_MASTERY_OPTION_MAP.vex.description
+  );
 });

--- a/client/src/components/Zombies/attributes/weaponMasteryCatalog.js
+++ b/client/src/components/Zombies/attributes/weaponMasteryCatalog.js
@@ -1,0 +1,233 @@
+import { WEAPON_MASTERY_OPTION_MAP } from './weaponMasteryOptions';
+
+const normalizeKey = (value) =>
+  typeof value === 'string'
+    ? value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+    : '';
+
+const RAW_ENTRIES = [
+  { key: 'club', name: 'Club', category: 'simple melee', masteryId: 'sap' },
+  { key: 'dagger', name: 'Dagger', category: 'simple melee', masteryId: 'nick' },
+  {
+    key: 'greatclub',
+    name: 'Greatclub',
+    category: 'simple melee',
+    masteryId: 'push',
+  },
+  { key: 'handaxe', name: 'Handaxe', category: 'simple melee', masteryId: 'vex' },
+  { key: 'javelin', name: 'Javelin', category: 'simple melee', masteryId: 'slow' },
+  {
+    key: 'light-hammer',
+    name: 'Light Hammer',
+    category: 'simple melee',
+    masteryId: 'nick',
+  },
+  { key: 'mace', name: 'Mace', category: 'simple melee', masteryId: 'sap' },
+  {
+    key: 'quarterstaff',
+    name: 'Quarterstaff',
+    category: 'simple melee',
+    masteryId: 'flex',
+  },
+  { key: 'sickle', name: 'Sickle', category: 'simple melee', masteryId: 'nick' },
+  { key: 'spear', name: 'Spear', category: 'simple melee', masteryId: 'flex' },
+  {
+    key: 'light-crossbow',
+    name: 'Light Crossbow',
+    category: 'simple ranged',
+    masteryId: 'slow',
+  },
+  { key: 'dart', name: 'Dart', category: 'simple ranged', masteryId: 'nick' },
+  { key: 'shortbow', name: 'Shortbow', category: 'simple ranged', masteryId: 'vex' },
+  { key: 'sling', name: 'Sling', category: 'simple ranged', masteryId: 'slow' },
+  {
+    key: 'battleaxe',
+    name: 'Battleaxe',
+    category: 'martial melee',
+    masteryId: 'flex',
+  },
+  { key: 'flail', name: 'Flail', category: 'martial melee', masteryId: 'topple' },
+  { key: 'glaive', name: 'Glaive', category: 'martial melee', masteryId: 'cleave' },
+  { key: 'greataxe', name: 'Greataxe', category: 'martial melee', masteryId: 'cleave' },
+  {
+    key: 'greatsword',
+    name: 'Greatsword',
+    category: 'martial melee',
+    masteryId: 'graze',
+  },
+  { key: 'halberd', name: 'Halberd', category: 'martial melee', masteryId: 'cleave' },
+  { key: 'lance', name: 'Lance', category: 'martial melee', masteryId: 'topple' },
+  {
+    key: 'longsword',
+    name: 'Longsword',
+    category: 'martial melee',
+    masteryId: 'flex',
+  },
+  { key: 'maul', name: 'Maul', category: 'martial melee', masteryId: 'topple' },
+  {
+    key: 'morningstar',
+    name: 'Morningstar',
+    category: 'martial melee',
+    masteryId: 'topple',
+  },
+  { key: 'pike', name: 'Pike', category: 'martial melee', masteryId: 'push' },
+  { key: 'rapier', name: 'Rapier', category: 'martial melee', masteryId: 'vex' },
+  { key: 'scimitar', name: 'Scimitar', category: 'martial melee', masteryId: 'vex' },
+  {
+    key: 'shortsword',
+    name: 'Shortsword',
+    category: 'martial melee',
+    masteryId: 'vex',
+  },
+  { key: 'trident', name: 'Trident', category: 'martial melee', masteryId: 'flex' },
+  { key: 'war-pick', name: 'War Pick', category: 'martial melee', masteryId: 'topple' },
+  {
+    key: 'warhammer',
+    name: 'Warhammer',
+    category: 'martial melee',
+    masteryId: 'push',
+  },
+  { key: 'whip', name: 'Whip', category: 'martial melee', masteryId: 'vex' },
+  { key: 'blowgun', name: 'Blowgun', category: 'martial ranged', masteryId: 'sap' },
+  {
+    key: 'hand-crossbow',
+    name: 'Hand Crossbow',
+    category: 'martial ranged',
+    masteryId: 'vex',
+  },
+  {
+    key: 'heavy-crossbow',
+    name: 'Heavy Crossbow',
+    category: 'martial ranged',
+    masteryId: 'slow',
+  },
+  { key: 'longbow', name: 'Longbow', category: 'martial ranged', masteryId: 'slow' },
+  { key: 'net', name: 'Net', category: 'martial ranged', masteryId: 'slow' },
+];
+
+const catalog = {};
+const nameLookup = new Map();
+const categoryIndex = new Map();
+
+RAW_ENTRIES.forEach(({ key, name, category, masteryId, aliases = [] }) => {
+  const normalizedKey = normalizeKey(key || name);
+  if (!normalizedKey) {
+    return;
+  }
+
+  const mastery = WEAPON_MASTERY_OPTION_MAP[masteryId] || {
+    title: masteryId,
+    description: '',
+  };
+
+  const entry = {
+    key: normalizedKey,
+    label: name,
+    category,
+    masteryId,
+    masteryTitle: mastery.title,
+    masteryDescription: mastery.description,
+  };
+
+  catalog[normalizedKey] = entry;
+
+  const registerName = (value) => {
+    const normalized = normalizeKey(value);
+    if (normalized && !nameLookup.has(normalized)) {
+      nameLookup.set(normalized, normalizedKey);
+    }
+  };
+
+  registerName(name);
+  registerName(normalizedKey);
+  aliases.forEach(registerName);
+
+  const categoryKey = normalizeKey(category);
+  if (categoryKey) {
+    if (!categoryIndex.has(categoryKey)) {
+      categoryIndex.set(categoryKey, []);
+    }
+    categoryIndex.get(categoryKey).push(entry);
+  }
+});
+
+const sortByLabel = (a, b) => a.label.localeCompare(b.label);
+
+export const WEAPON_MASTERY_CATALOG = catalog;
+
+export const WEAPON_MASTERY_LIST = Object.values(catalog).sort(sortByLabel);
+
+const proficiencyCategoryMap = {
+  simple: ['simple-melee', 'simple-ranged'],
+  martial: ['martial-melee', 'martial-ranged'],
+};
+
+const getCategoryEntries = (categoryKey) => {
+  const normalized = normalizeKey(categoryKey);
+  if (!normalized) return [];
+  const direct = categoryIndex.get(normalized);
+  if (direct) return [...direct];
+  return [];
+};
+
+export const resolveWeaponMasteryKey = (value) => {
+  if (!value) return '';
+  const keyCandidate = normalizeKey(value);
+  if (catalog[keyCandidate]) return keyCandidate;
+  return nameLookup.get(keyCandidate) || '';
+};
+
+export const resolveWeaponMasteryEntry = (value) => {
+  if (!value) return undefined;
+  if (typeof value === 'string') {
+    const key = resolveWeaponMasteryKey(value);
+    return key ? catalog[key] : undefined;
+  }
+  if (typeof value === 'object') {
+    const candidates = [
+      value.type,
+      value.weaponType,
+      value.key,
+      value.id,
+      value.name,
+      value.displayName,
+      value.title,
+    ];
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== 'string') continue;
+      const key = resolveWeaponMasteryKey(candidate);
+      if (key) return catalog[key];
+    }
+  }
+  return undefined;
+};
+
+export const resolveWeaponMasteryEntryFromWeapon = (weapon) =>
+  resolveWeaponMasteryEntry(weapon);
+
+export const getWeaponsForProficiency = (value) => {
+  if (!value) return [];
+  const normalized = normalizeKey(value).replace(/-?weapons?$/, '');
+  const categories =
+    proficiencyCategoryMap[normalized] || proficiencyCategoryMap[value];
+  const entries = [];
+  if (categories) {
+    categories.forEach((categoryKey) => {
+      getCategoryEntries(categoryKey).forEach((entry) => entries.push(entry));
+    });
+    return entries.sort(sortByLabel);
+  }
+
+  const direct = getCategoryEntries(normalized);
+  if (direct.length) {
+    return direct.sort(sortByLabel);
+  }
+
+  const fallbackKey = resolveWeaponMasteryKey(normalized);
+  return fallbackKey ? [catalog[fallbackKey]] : [];
+};
+


### PR DESCRIPTION
## Summary
- add a shared weapon mastery catalog that maps weapon types to mastery metadata and supports proficiency lookups
- update the features panel to drive weapon mastery choices from weapon types and surface the derived mastery details in the UI
- adjust the feature modal and tests to cover weapon-driven selections and mastery descriptions

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d957c5f2a88323973a96840146a5d2