### PR TITLE
Persist weapon mastery on feature use

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Modal, Card, Button, Spinner, Form } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
@@ -146,22 +146,12 @@ export default function Features({
     return Array.from({ length: picks }, (_, idx) => selections[idx] || '');
   };
 
-  const handleMasterySelectionChange = (featureKey, picks, index, value) => {
-    const normalizedValue = resolveWeaponMasteryEntry(value)?.key || '';
-    setWeaponMasterySelections((prev) => {
-      const nextSelections = {
-        ...prev,
-        [featureKey]: Array.from({ length: picks }, (_, idx) =>
-          idx === index
-            ? normalizedValue
-            : prev?.[featureKey]?.[idx] || ''
-        ),
-      };
-
-      const hasSelected = nextSelections[featureKey].some(Boolean);
-      if (!hasSelected) {
-        delete nextSelections[featureKey];
-      }
+  const persistWeaponMasterySelections = useCallback(
+    (featureKey, selections) => {
+      const normalizedSelections = Array.isArray(selections)
+        ? selections
+        : [];
+      const hasSelected = normalizedSelections.some(Boolean);
 
       handleFeatureStateChange((prevFeatureState = {}) => {
         const nextFeatureState = { ...prevFeatureState };
@@ -170,7 +160,7 @@ export default function Features({
         };
 
         if (hasSelected) {
-          existingWeaponMastery[featureKey] = nextSelections[featureKey];
+          existingWeaponMastery[featureKey] = [...normalizedSelections];
         } else {
           delete existingWeaponMastery[featureKey];
         }
@@ -183,6 +173,26 @@ export default function Features({
 
         return nextFeatureState;
       });
+    },
+    [handleFeatureStateChange]
+  );
+
+  const handleMasterySelectionChange = (featureKey, picks, index, value) => {
+    const normalizedValue = resolveWeaponMasteryEntry(value)?.key || '';
+    setWeaponMasterySelections((prev) => {
+      const nextFeatureSelections = Array.from({ length: picks }, (_, idx) =>
+        idx === index ? normalizedValue : prev?.[featureKey]?.[idx] || ''
+      );
+      const hasSelected = nextFeatureSelections.some(Boolean);
+      const nextSelections = { ...prev };
+
+      if (hasSelected) {
+        nextSelections[featureKey] = nextFeatureSelections;
+      } else {
+        delete nextSelections[featureKey];
+      }
+
+      persistWeaponMasterySelections(featureKey, nextFeatureSelections);
 
       return nextSelections;
     });
@@ -262,6 +272,7 @@ export default function Features({
                     const masterySelections = isWeaponMastery
                       ? getMasterySelections(featureKey, feat.mastery.picks)
                       : [];
+                    const hasMasterySelection = masterySelections.some(Boolean);
                     return (
                       <div
                         className="feature-card"
@@ -298,7 +309,26 @@ export default function Features({
                                 />
                               </Button>
                             ) : (
-                              <Button aria-label="use feature" variant="outline-light" size="sm">
+                              <Button
+                                aria-label="use feature"
+                                variant="outline-light"
+                                size="sm"
+                                onClick={() =>
+                                  persistWeaponMasterySelections(
+                                    featureKey,
+                                    weaponMasterySelections?.[featureKey] ||
+                                      masterySelections
+                                  )
+                                }
+                                disabled={
+                                  isWeaponMastery && !hasMasterySelection
+                                }
+                                title={
+                                  isWeaponMastery && !hasMasterySelection
+                                    ? 'Select a weapon to use this feature'
+                                    : undefined
+                                }
+                              >
                                 Use
                               </Button>
                             )}


### PR DESCRIPTION
## Summary
- persist weapon mastery selections whenever a feature is confirmed for use
- add UX feedback so weapon mastery features can only be used after choosing a weapon

## Testing
- npm --prefix client test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d96425c5c0832396d05743b7cc3331