### PR TITLE
Normalize weapon property lookups

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -300,14 +300,43 @@ const [isFumble, setIsFumble] = useState(false);
     return formatWeaponLabel(raw || 'Unknown');
   };
 
+  const getWeaponPropertyDefinitionKeys = (prop) => {
+    if (typeof prop !== 'string') return [];
+
+    const base = prop
+      .replace(/\s*[\(\[\{][^\)\]\}]*[\)\]\}]\s*/g, ' ')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    if (!base) return [];
+
+    const titleCase = toTitleCase(base);
+    const candidates = new Set([titleCase]);
+
+    if (titleCase.includes(' ')) {
+      candidates.add(titleCase.replace(/\s+/g, '-'));
+    }
+
+    if (!titleCase.endsWith(':')) {
+      candidates.add(`${titleCase}:`);
+    }
+
+    return Array.from(candidates);
+  };
+
   const getWeaponPropertyDetails = (weapon) => {
     if (!Array.isArray(weapon?.properties)) return [];
     return weapon.properties
       .filter((prop) => typeof prop === 'string' && prop.trim())
       .map((prop) => {
         const label = formatWeaponLabel(prop);
-        const description =
-          weaponPropertyDefinitions[label] || 'Definition not available.';
+        const definitionKey = getWeaponPropertyDefinitionKeys(prop).find(
+          (key) => weaponPropertyDefinitions[key]
+        );
+        const description = definitionKey
+          ? weaponPropertyDefinitions[definitionKey]
+          : 'Definition not available.';
         return { label, description };
       });
   };

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -84,7 +84,7 @@ describe('PlayerTurnActions weapon damage display', () => {
       category: 'melee',
       source: 'weapon',
       type: 'martial melee weapon',
-      properties: ['Finesse', 'Light'],
+      properties: ['Finesse', 'Versatile (1d10)'],
     };
     render(
       <PlayerTurnActions
@@ -115,7 +115,9 @@ describe('PlayerTurnActions weapon damage display', () => {
       .getByText('Properties')
       .closest('.attack-card__row');
     expect(propertiesRow).not.toBeNull();
-    expect(within(propertiesRow).getByText('Finesse, Light')).toBeInTheDocument();
+    expect(
+      within(propertiesRow).getByText('Finesse, Versatile (1d10)')
+    ).toBeInTheDocument();
     const propertiesButton = within(propertiesRow).getByRole('button', {
       name: /view weapon property descriptions/i,
     });
@@ -129,6 +131,15 @@ describe('PlayerTurnActions weapon damage display', () => {
           /When making an attack with a finesse weapon, you use your choice/
         )
       ).toBeInTheDocument();
+      expect(screen.getByText('Versatile (1d10)')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /This weapon can be used with one or two hands\. A damage value in parentheses/
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Definition not available.')
+      ).not.toBeInTheDocument();
     });
     await act(async () => {
       fireEvent.click(document.body);


### PR DESCRIPTION
## Summary
- normalize weapon property lookups by stripping annotations and checking multiple key variants
- extend PlayerTurnActions tests to cover Versatile property descriptions

## Testing
- CI=1 npm test -- PlayerTurnActions

------
https://chatgpt.com/codex/tasks/task_e_68d9961eaec08323b4eb3749dc53a609