### PR TITLE
Add weapon mastery controls to attack cards

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -335,11 +335,49 @@
   margin-top: auto;
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.attack-card__mastery {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.25rem;
+  border-radius: 50%;
+  color: #2e1b00;
+  background: linear-gradient(135deg, #f8e16c, #d29c0f);
+  box-shadow: 0 0 0 2px rgba(250, 217, 97, 0.6), 0 0 8px rgba(248, 225, 108, 0.85);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.attack-card__mastery:hover,
+.attack-card__mastery:focus {
+  color: #1d1300;
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 2px rgba(255, 223, 128, 0.85), 0 0 12px rgba(255, 223, 128, 0.95);
+}
+
+.attack-card__mastery:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.attack-card__mastery-description {
+  margin-bottom: 0;
 }
 
 .attack-card__roll {
   font-size: 1.25rem;
   color: rgba(255, 255, 255, 0.85);
+  margin-left: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .attack-card__roll:hover,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -11,6 +11,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
+import weaponMasteryProperties from '../../../data/weaponMasteryProperties';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -255,6 +256,10 @@ const [isFumble, setIsFumble] = useState(false);
     () => typeof form?.equipment === 'object' && form.equipment !== null,
     [form.equipment]
   );
+  const weaponMasteryCapability =
+    form?.capabilities?.weaponMastery === true ||
+    form?.weaponMastery === true ||
+    form?.features?.weaponMastery === true;
   const normalizedEquipment = useMemo(
     () => normalizeEquipmentMap(form.equipment),
     [form.equipment]
@@ -873,6 +878,16 @@ const showSparklesEffect = () => {
                       ? propertyLabels.join(', ')
                       : 'None';
                   const popoverId = `weapon-properties-${slot}`;
+                  const rawMastery =
+                    typeof weapon?.mastery === 'string' ? weapon.mastery.trim() : '';
+                  const masteryName = rawMastery ? toTitleCase(rawMastery) : '';
+                  const masteryDescription = masteryName
+                    ? weaponMasteryProperties[masteryName] || 'Description not available.'
+                    : '';
+                  const masteryPopoverId = `weapon-mastery-${slot}`;
+                  const hasWeaponMastery = Boolean(
+                    masteryName && weaponMasteryCapability
+                  );
 
                   const propertiesPopover = (
                     <Popover id={popoverId}>
@@ -940,6 +955,32 @@ const showSparklesEffect = () => {
                         </div>
                       </div>
                       <div className="attack-card__actions">
+                        {hasWeaponMastery && (
+                          <OverlayTrigger
+                            trigger="click"
+                            placement="auto"
+                            overlay={
+                              <Popover id={masteryPopoverId}>
+                                <Popover.Header as="h3">{masteryName}</Popover.Header>
+                                <Popover.Body>
+                                  <p className="attack-card__mastery-description">
+                                    {masteryDescription}
+                                  </p>
+                                </Popover.Body>
+                              </Popover>
+                            }
+                            rootClose
+                          >
+                            <Button
+                              type="button"
+                              variant="link"
+                              className="attack-card__mastery"
+                              aria-label={`View ${masteryName} weapon mastery details`}
+                            >
+                              <i className="fa-solid fa-crown" aria-hidden="true"></i>
+                            </Button>
+                          </OverlayTrigger>
+                        )}
                         <Button
                           onClick={() => {
                             handleWeaponAttack(weapon);

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -182,6 +182,89 @@ describe('PlayerTurnActions weapon damage display', () => {
     ).toEqual({ total: 6, breakdown: '5 slashing + 1 lightning' });
   });
 
+  test('weapon mastery button appears only when capability enabled', async () => {
+    const weapon = {
+      name: 'Royal Halberd',
+      damage: '1d10 slashing',
+      category: 'melee',
+      source: 'weapon',
+      mastery: 'Slow',
+    };
+    const baseForm = {
+      diceColor: '#000000',
+      equipment: { mainHand: weapon },
+      weapon: [],
+      spells: [],
+    };
+
+    const { rerender } = render(
+      <PlayerTurnActions
+        form={{ ...baseForm, capabilities: { weaponMastery: true } }}
+        strMod={2}
+        dexMod={0}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const card = screen.getByText('Royal Halberd').closest('.attack-card');
+    expect(card).not.toBeNull();
+
+    const masteryButton = within(card).getByRole('button', {
+      name: /view slow weapon mastery details/i,
+    });
+    expect(masteryButton).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(masteryButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Slow' })).toBeInTheDocument();
+      expect(
+        screen.getByText(/reduce its Speed by 10 feet until the start of your next turn/i)
+      ).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(document.body);
+    });
+
+    rerender(
+      <PlayerTurnActions
+        form={{ ...baseForm, capabilities: { weaponMastery: false } }}
+        strMod={2}
+        dexMod={0}
+      />
+    );
+
+    const cardWithoutCapability = screen
+      .getByText('Royal Halberd')
+      .closest('.attack-card');
+    expect(cardWithoutCapability).not.toBeNull();
+    expect(
+      within(cardWithoutCapability).queryByRole('button', {
+        name: /view slow weapon mastery details/i,
+      })
+    ).toBeNull();
+
+    rerender(
+      <PlayerTurnActions form={baseForm} strMod={2} dexMod={0} />
+    );
+
+    const cardWithoutField = screen
+      .getByText('Royal Halberd')
+      .closest('.attack-card');
+    expect(cardWithoutField).not.toBeNull();
+    expect(
+      within(cardWithoutField).queryByRole('button', {
+        name: /view slow weapon mastery details/i,
+      })
+    ).toBeNull();
+  });
+
   test('spell damage segments include type classes', () => {
     const spell = {
       name: 'Fire Bolt',


### PR DESCRIPTION
## Summary
- surface weapon mastery metadata on attack cards and gate it behind the character capability flag
- add a mastery popover control alongside the roll action and style it with the requested gold treatment
- cover the mastery button visibility and popover content with unit tests

## Testing
- CI=true npm --prefix client test -- PlayerTurnActions

------
https://chatgpt.com/codex/tasks/task_e_68d9a9cef9a48323a276713e0a4f3c88