### PR TITLE
Add campaign map modal to Zombies character sheet

### DIFF
--- a/client/src/components/Zombies/attributes/MapDisplay.js
+++ b/client/src/components/Zombies/attributes/MapDisplay.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const extractLegendEntries = (legend) => {
+  if (!legend || typeof legend !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(legend)) {
+    return legend
+      .map((entry) => {
+        if (!entry) {
+          return null;
+        }
+
+        if (Array.isArray(entry)) {
+          const [symbol, description] = entry;
+          return {
+            symbol: symbol === undefined || symbol === null ? '' : String(symbol),
+            description:
+              description === undefined || description === null
+                ? ''
+                : String(description),
+          };
+        }
+
+        if (typeof entry === 'object') {
+          return {
+            symbol:
+              entry.symbol === undefined || entry.symbol === null
+                ? ''
+                : String(entry.symbol),
+            description:
+              entry.description === undefined || entry.description === null
+                ? ''
+                : String(entry.description),
+          };
+        }
+
+        return {
+          symbol: '',
+          description: String(entry),
+        };
+      })
+      .filter(Boolean);
+  }
+
+  return Object.entries(legend).map(([symbol, description]) => ({
+    symbol: symbol === undefined || symbol === null ? '' : String(symbol),
+    description:
+      description === undefined || description === null ? '' : String(description),
+  }));
+};
+
+const normalizeGrid = (grid) => {
+  if (!Array.isArray(grid)) {
+    return [];
+  }
+
+  return grid
+    .map((row) => {
+      if (!Array.isArray(row)) {
+        return [];
+      }
+
+      return row.map((cell) => (cell === undefined || cell === null ? '' : String(cell)));
+    })
+    .filter((row) => row.length > 0);
+};
+
+const MapDisplay = ({ map }) => {
+  const safeMap = map && typeof map === 'object' ? map : {};
+  const title =
+    typeof safeMap.title === 'string' && safeMap.title.trim() !== ''
+      ? safeMap.title.trim()
+      : null;
+  const summary =
+    typeof safeMap.summary === 'string' && safeMap.summary.trim() !== ''
+      ? safeMap.summary.trim()
+      : null;
+  const grid = normalizeGrid(safeMap.grid);
+  const legendEntries = extractLegendEntries(safeMap.legend);
+
+  return (
+    <div className="map-display">
+      {title && <h5 className="map-display__title">{title}</h5>}
+      {grid.length > 0 ? (
+        <div className="map-display__grid-wrapper" role="table" aria-label="Campaign map grid">
+          <table className="map-display__grid">
+            <tbody>
+              {grid.map((row, rowIndex) => (
+                <tr key={`row-${rowIndex}`}>
+                  {row.map((cell, cellIndex) => (
+                    <td key={`cell-${rowIndex}-${cellIndex}`} className="map-display__cell">
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-muted mb-0">No map grid available.</p>
+      )}
+      {legendEntries.length > 0 && (
+        <div className="map-display__legend mt-3">
+          <h6>Legend</h6>
+          <ul className="map-display__legend-list">
+            {legendEntries.map(({ symbol, description }, index) => (
+              <li key={`legend-${index}`} className="map-display__legend-item">
+                <span className="map-display__legend-symbol">{symbol || '—'}</span>
+                <span className="map-display__legend-description">{description || 'No description'}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {summary && (
+        <div className="map-display__summary mt-3">
+          <h6>Summary</h6>
+          {summary.split('\n').map((paragraph, index) => (
+            <p key={`summary-${index}`} className="mb-2">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+MapDisplay.propTypes = {
+  map: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};
+
+MapDisplay.defaultProps = {
+  map: null,
+};
+
+export default MapDisplay;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button } from 'react-bootstrap';
+import MapDisplay from './MapDisplay';
+
+const MapModal = ({ show, onHide, map }) => (
+  <Modal show={show} onHide={onHide} size="lg" centered>
+    <Modal.Header closeButton>
+      <Modal.Title>Campaign Map</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <MapDisplay map={map} />
+    </Modal.Body>
+    <Modal.Footer>
+      <Button variant="secondary" onClick={onHide}>
+        Close
+      </Button>
+    </Modal.Footer>
+  </Modal>
+);
+
+MapModal.propTypes = {
+  show: PropTypes.bool,
+  onHide: PropTypes.func,
+  map: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};
+
+MapModal.defaultProps = {
+  show: false,
+  onHide: () => {},
+  map: null,
+};
+
+export default MapModal;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -39,6 +39,7 @@ import {
   normalizeAccessories as normalizeInventoryAccessories,
 } from "../attributes/inventoryNormalization";
 import { normalizeEquipmentMap } from "../attributes/equipmentNormalization";
+import MapModal from "../attributes/MapModal";
 
 const HEADER_PADDING = 16;
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
@@ -476,6 +477,8 @@ export default function ZombiesCharacterSheet() {
   const [campaignId, setCampaignId] = useState(null);
   const [combatState, setCombatState] = useState(createEmptyCombatState());
   const [campaignCharacters, setCampaignCharacters] = useState({});
+  const [campaignMap, setCampaignMap] = useState(null);
+  const [showMapModal, setShowMapModal] = useState(false);
   const [showCharacterInfo, setShowCharacterInfo] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const [showSkill, setShowSkill] = useState(false); // State for skills modal
@@ -970,14 +973,16 @@ export default function ZombiesCharacterSheet() {
         if (!normalizedCampaign) {
           setCombatState(createEmptyCombatState());
           setCampaignCharacters({});
+          setCampaignMap(null);
           return;
         }
 
         try {
           const encodedCampaign = encodeURIComponent(normalizedCampaign);
-          const [combatRes, charactersRes] = await Promise.all([
+          const [combatRes, charactersRes, mapRes] = await Promise.all([
             apiFetch(`/campaigns/${encodedCampaign}/combat`),
             apiFetch(`/campaigns/${encodedCampaign}/characters`),
+            apiFetch(`/campaigns/${encodedCampaign}/map`),
           ]);
 
           let combatData = createEmptyCombatState();
@@ -992,15 +997,31 @@ export default function ZombiesCharacterSheet() {
             characterMap = mapCharactersById(charactersJson);
           }
 
+          let mapData = null;
+          if (mapRes.ok) {
+            try {
+              const mapJson = await mapRes.json();
+              if (mapJson && typeof mapJson === "object") {
+                mapData = mapJson.map && typeof mapJson.map === "object" ? mapJson.map : mapJson;
+              }
+            } catch (mapError) {
+              console.error(mapError);
+            }
+          } else if (mapRes?.status === 404) {
+            mapData = null;
+          }
+
           if (!isCancelled) {
             setCombatState(combatData);
             setCampaignCharacters(characterMap);
+            setCampaignMap(mapData);
           }
         } catch (err) {
           console.error(err);
           if (!isCancelled) {
             setCombatState(createEmptyCombatState());
             setCampaignCharacters({});
+            setCampaignMap(null);
           }
         }
       } catch (error) {
@@ -1009,6 +1030,7 @@ export default function ZombiesCharacterSheet() {
           setCampaignId(null);
           setCombatState(createEmptyCombatState());
           setCampaignCharacters({});
+          setCampaignMap(null);
         }
       }
     }
@@ -1026,6 +1048,8 @@ export default function ZombiesCharacterSheet() {
         socketRef.current.disconnect();
         socketRef.current = null;
       }
+      setCampaignMap(null);
+      setShowMapModal(false);
       return undefined;
     }
 
@@ -1135,13 +1159,30 @@ export default function ZombiesCharacterSheet() {
       });
     };
 
+    const handleCampaignMapUpdate = (update) => {
+      if (update === null) {
+        setCampaignMap(null);
+        return;
+      }
+
+      if (!update || typeof update !== "object") {
+        return;
+      }
+
+      const normalizedMap =
+        update.map && typeof update.map === "object" ? update.map : update;
+      setCampaignMap(normalizedMap);
+    };
+
     socket.on('combat:update', handleCombatUpdate);
     socket.on('character:health:update', handleCharacterHealthUpdate);
+    socket.on('campaign:map:update', handleCampaignMapUpdate);
     socket.emit('campaign:join', campaignId);
 
     return () => {
       socket.off('combat:update', handleCombatUpdate);
       socket.off('character:health:update', handleCharacterHealthUpdate);
+      socket.off('campaign:map:update', handleCampaignMapUpdate);
       socket.emit('campaign:leave', campaignId);
       socket.disconnect();
       socketRef.current = null;
@@ -1176,6 +1217,8 @@ export default function ZombiesCharacterSheet() {
   const handleCloseHelpModal = () => setShowHelpModal(false);
   const handleShowBackground = () => setShowBackground(true);
   const handleCloseBackground = () => setShowBackground(false);
+  const handleShowMapModal = () => setShowMapModal(true);
+  const handleCloseMapModal = () => setShowMapModal(false);
 
   const handleRollResult = (result, breakdown, source) => {
     playerTurnActionsRef.current?.updateDamageValueWithAnimation(
@@ -1949,6 +1992,18 @@ const spellsGold =
               <i className="fas fa-store" aria-hidden="true"></i>
             </Button>
             <Button
+              onClick={handleShowMapModal}
+              style={{
+                color: "black",
+                backgroundColor: "#6C757D",
+              }}
+              className="footer-btn"
+              variant="secondary"
+              aria-label="Show campaign map"
+            >
+              <i className="fas fa-map" aria-hidden="true"></i>
+            </Button>
+            <Button
               onClick={handleShowHelpModal}
               style={{ color: "white" }}
               className="footer-btn"
@@ -2049,6 +2104,7 @@ const spellsGold =
       showHelpModal={showHelpModal}
       handleCloseHelpModal={handleCloseHelpModal}
     />
+    <MapModal show={showMapModal} onHide={handleCloseMapModal} map={campaignMap} />
   </div>
 );
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -5,7 +5,11 @@ import hasteIcon from '../../../images/spell-haste-icon.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
 
 jest.mock('../../../utils/apiFetch');
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(),
+}));
 import apiFetch from '../../../utils/apiFetch';
+import { io as mockSocketIo } from 'socket.io-client';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -54,6 +58,11 @@ jest.mock('../attributes/ShopModal', () => (props) => {
   mockShopModalProps.current = props;
   return null;
 });
+const mockMapModalProps = { current: null };
+jest.mock('../attributes/MapModal', () => (props) => {
+  mockMapModalProps.current = props;
+  return props.show ? <div data-testid="map-modal" /> : null;
+});
 const mockOnCastSpell = { current: null };
 const mockHandleClose = { current: null };
 jest.mock('../attributes/SpellSelector', () => (props) => {
@@ -67,6 +76,21 @@ import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
 beforeEach(() => {
   apiFetch.mockReset();
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/map')) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
+  });
+  mockSocketIo.mockReset();
+  const socketStub = {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+    disconnect: jest.fn(),
+  };
+  mockSocketIo.mockReturnValue(socketStub);
   mockUpdateDamage.mockClear();
   mockCalcDamage.mockClear();
   mockOnCastSpell.current = null;
@@ -74,6 +98,7 @@ beforeEach(() => {
   mockShopModalProps.current = null;
   mockInventoryModalProps.current = null;
   mockEquipmentModalProps.current = null;
+  mockMapModalProps.current = null;
 });
 
 test('spells button includes points-glow when spell points available', async () => {
@@ -243,6 +268,72 @@ test('footer renders equipment button before inventory for non-spellcasters', as
   expect(indexOf('fa-toolbox')).toBeGreaterThan(-1);
   expect(indexOf('fa-box-open')).toBeGreaterThan(-1);
   expect(indexOf('fa-toolbox')).toBeLessThan(indexOf('fa-box-open'));
+});
+
+test('map footer button toggles the campaign map modal', async () => {
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        occupation: [],
+        spells: [],
+        str: 10,
+        dex: 10,
+        con: 10,
+        int: 10,
+        wis: 10,
+        cha: 10,
+        startStatTotal: 60,
+        proficiencyPoints: 0,
+        skills: {},
+        item: [],
+        feat: [],
+        weapon: [],
+        armor: [],
+        campaign: 'The Wilds',
+      }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ participants: [], activeTurn: null }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        title: 'Wilds Overview',
+        grid: [
+          ['S', '.'],
+          ['.', 'E'],
+        ],
+        legend: {
+          S: 'Starting position',
+          E: 'Objective',
+        },
+        summary: 'Navigate from S to E.',
+      }),
+    });
+
+  render(<ZombiesCharacterSheet />);
+
+  const buttons = await screen.findAllByRole('button');
+  const mapButton = buttons.find((btn) => btn.querySelector('.fa-map'));
+  expect(mapButton).toBeInTheDocument();
+
+  await waitFor(() => expect(mockMapModalProps.current).not.toBeNull());
+  expect(mockMapModalProps.current.show).toBe(false);
+
+  await userEvent.click(mapButton);
+  await waitFor(() => expect(mockMapModalProps.current.show).toBe(true));
+
+  act(() => {
+    mockMapModalProps.current.onHide();
+  });
+
+  await waitFor(() => expect(mockMapModalProps.current.show).toBe(false));
 });
 
 test('renders SpellSlots for non-spellcasting characters', async () => {


### PR DESCRIPTION
## Summary
- add campaign map state management to the Zombies character sheet and subscribe to socket updates
- introduce reusable MapDisplay and MapModal components to render campaign map details safely
- update character sheet tests to cover campaign map fetching and modal toggling

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9c8dc8d14832eb4037e98383651aa