### PR TITLE
Add campaign map schema and AI endpoint

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -248,3 +248,62 @@ describe('AI accessory route', () => {
   });
 });
 
+describe('AI map route', () => {
+  beforeEach(() => {
+    mockParse.mockReset();
+  });
+
+  const baseMap = {
+    title: 'Cavern',
+    summary: 'A twisting cavern system.',
+    environment: 'Underground',
+    cellSizeFeet: 5,
+    grid: [
+      ['S', 'E'],
+      ['S', 'S'],
+    ],
+    legend: [
+      { symbol: 'S', description: 'Stone' },
+      { symbol: 'E', description: 'Entrance' },
+    ],
+  };
+
+  test('returns validated map', async () => {
+    mockParse.mockResolvedValue({
+      output: [
+        {
+          content: [
+            {
+              parsed: baseMap,
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await request(app).post('/ai/map').send({ prompt: 'create a cavern map' });
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe(baseMap.title);
+    expect(mockParse.mock.calls[0][0].text.format.name).toBe('map');
+  });
+
+  test('rejects invalid map data from AI', async () => {
+    mockParse.mockResolvedValue({
+      output: [
+        {
+          content: [
+            {
+              parsed: { ...baseMap, grid: [] },
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await request(app).post('/ai/map').send({ prompt: 'bad map' });
+    expect(res.status).toBe(500);
+    expect(res.body.message).toBeDefined();
+    expect(mockParse.mock.calls[0][0].text.format.name).toBe('map');
+  });
+});
+

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -14,6 +14,7 @@ jest.mock('../middleware/auth', () => (req, res, next) => {
 });
 jest.mock('../utils/socket', () => ({
   emitCombatUpdate: jest.fn(),
+  emitMapUpdate: jest.fn(),
 }));
 jest.mock('../utils/dnd5eApi', () => ({
   getMonsterByIndex: jest.fn(),
@@ -21,7 +22,7 @@ jest.mock('../utils/dnd5eApi', () => ({
 jest.mock('../utils/monsters', () => ({
   buildEnemyRecord: jest.fn(),
 }));
-const { emitCombatUpdate } = require('../utils/socket');
+const { emitCombatUpdate, emitMapUpdate } = require('../utils/socket');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
 const { buildEnemyRecord } = require('../utils/monsters');
 const registerCampaignRoutes = require('../routes/campaigns');
@@ -69,6 +70,7 @@ describe('Campaign routes', () => {
     expect(insertOne).toHaveBeenCalledWith(
       expect.objectContaining({
         players: [],
+        map: null,
         enemies: [],
         combat: { participants: [], activeTurn: null },
       })
@@ -152,6 +154,147 @@ describe('Campaign routes', () => {
     });
     const res = await request(app).get('/campaigns/dm/DM/Test');
     expect(res.status).toBe(500);
+  });
+
+  describe('map routes', () => {
+    const baseMap = {
+      title: 'Dungeon',
+      summary: 'An underground lair',
+      environment: 'Underground',
+      cellSizeFeet: 5,
+      grid: [
+        ['S', 'E'],
+        ['S', 'S'],
+      ],
+      legend: [
+        { symbol: 'S', description: 'Stone floor' },
+        { symbol: 'E', description: 'Entrance' },
+      ],
+    };
+
+    test('get map success', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => ({ campaignName: 'Test', map: baseMap }),
+        }),
+      });
+
+      const res = await request(app).get('/campaigns/Test/map');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(baseMap);
+    });
+
+    test('get map missing campaign', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => null,
+        }),
+      });
+
+      const res = await request(app).get('/campaigns/Test/map');
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Campaign not found');
+    });
+
+    test('get map missing map', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => ({ campaignName: 'Test', map: null }),
+        }),
+      });
+
+      const res = await request(app).get('/campaigns/Test/map');
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Map not found');
+    });
+
+    test('save map success', async () => {
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+          updateOne,
+        }),
+      });
+
+      const res = await request(app)
+        .put('/campaigns/Test/map')
+        .send({ map: baseMap, prompt: 'Create a dungeon map' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          title: baseMap.title,
+          originalPrompt: 'Create a dungeon map',
+          updatedAt: expect.any(String),
+        })
+      );
+      expect(updateOne).toHaveBeenCalledWith(
+        { campaignName: 'Test' },
+        {
+          $set: {
+            map: expect.objectContaining({
+              title: baseMap.title,
+              originalPrompt: 'Create a dungeon map',
+              updatedAt: expect.any(String),
+            }),
+          },
+        }
+      );
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({ title: baseMap.title })
+      );
+    });
+
+    test('save map validation failure', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+        }),
+      });
+
+      const res = await request(app)
+        .put('/campaigns/Test/map')
+        .send({
+          map: { ...baseMap, grid: [] },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBeDefined();
+      expect(emitMapUpdate).not.toHaveBeenCalled();
+    });
+
+    test('save map forbidden for non-DM', async () => {
+      mockUser = { username: 'Player' };
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+        }),
+      });
+
+      const res = await request(app)
+        .put('/campaigns/Test/map')
+        .send({ map: baseMap });
+
+      expect(res.status).toBe(403);
+      expect(emitMapUpdate).not.toHaveBeenCalled();
+    });
+
+    test('save map missing campaign', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => null,
+        }),
+      });
+
+      const res = await request(app)
+        .put('/campaigns/Test/map')
+        .send({ map: baseMap });
+
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Campaign not found');
+    });
   });
 
   test('get combat state success', async () => {

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -15,6 +15,7 @@ const {
   slotKeys: accessorySlotKeys,
 } = require('../data/accessories');
 const { skillNames } = require('./fieldConstants');
+const createMapSchema = require('../schemas/map');
 
 const resolveOpenAI = () => {
   if (!OpenAI) {
@@ -69,6 +70,14 @@ module.exports = (router) => {
       });
       return { name, schema: {} };
     }
+  };
+
+  let mapSchema;
+  const getMapSchema = (Z) => {
+    if (!mapSchema) {
+      mapSchema = createMapSchema(Z);
+    }
+    return mapSchema;
   };
 
   aiRouter.post('/weapon', async (req, res) => {
@@ -270,6 +279,48 @@ module.exports = (router) => {
       if (!Array.isArray(parsed.data.targetSlots) || parsed.data.targetSlots.length === 0) {
         return res.status(500).json({ message: 'targetSlots must be a non-empty array' });
       }
+      return res.json(parsed.data);
+    } catch (err) {
+      return res.status(500).json({ message: err.message });
+    }
+  });
+
+  aiRouter.post('/map', async (req, res) => {
+    const { prompt } = req.body || {};
+    if (!prompt) {
+      return res.status(400).json({ message: 'Prompt is required' });
+    }
+
+    const OpenAIClient = resolveOpenAI();
+    const Z = resolveZod();
+    if (!OpenAIClient || !Z || !resolveZodResponseFormat()) {
+      return res.status(500).json({ message: 'OpenAI not configured' });
+    }
+
+    const MapSchema = getMapSchema(Z);
+
+    try {
+      const openai = new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY });
+      const format = buildFormat(MapSchema, 'map');
+      const response = await openai.responses.parse({
+        model: 'gpt-4o-2024-08-06',
+        input: [
+          {
+            role: 'system',
+            content:
+              'Create a Dungeons and Dragons 5e battle map. Use a rectangular grid of 5-foot squares, always set "cellSizeFeet" to 5, and ensure every symbol used in the grid is documented in the legend with a description.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        text: { format },
+      });
+
+      const data = response.output?.[0]?.content?.[0]?.parsed;
+      const parsed = MapSchema.safeParse(data);
+      if (!parsed.success) {
+        return res.status(500).json({ message: parsed.error.message });
+      }
+
       return res.json(parsed.data);
     } catch (err) {
       return res.status(500).json({ message: err.message });

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -6,10 +6,20 @@ const { buildEnemyRecord } = require('../utils/monsters');
 const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 const logger = require('../utils/logger');
-const { emitCombatUpdate } = require('../utils/socket');
+const { emitCombatUpdate, emitMapUpdate } = require('../utils/socket');
+const createMapSchema = require('../schemas/map');
 
 module.exports = (router) => {
   const campaignRouter = express.Router();
+
+  let mapSchema;
+  const getMapSchema = () => {
+    if (!mapSchema) {
+      const { z } = require('zod');
+      mapSchema = createMapSchema(z);
+    }
+    return mapSchema;
+  };
 
   const createDefaultCombatState = () => ({
     participants: [],
@@ -263,6 +273,103 @@ module.exports = (router) => {
     }
   });
 
+  campaignRouter
+    .route('/:campaign/map')
+    .get(
+      [param('campaign').trim().notEmpty().withMessage('campaign is required')],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const db_connect = req.db;
+          const campaign = await db_connect
+            .collection('Campaigns')
+            .findOne({ campaignName: req.params.campaign });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          if (!campaign.map) {
+            return res.status(404).json({ message: 'Map not found' });
+          }
+
+          return res.json(campaign.map);
+        } catch (err) {
+          next(err);
+        }
+      }
+    )
+    .put(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        body('map')
+          .custom((value) => {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+              throw new Error('map must be an object');
+            }
+            return true;
+          })
+          .withMessage('map must be provided'),
+        body('prompt')
+          .optional({ nullable: true })
+          .custom((value) => {
+            if (value === null || value === undefined) {
+              return true;
+            }
+            if (typeof value !== 'string') {
+              throw new Error('prompt must be a string');
+            }
+            return true;
+          }),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const db_connect = req.db;
+          const campaignName = req.params.campaign;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          if (!req.user || campaign.dm !== req.user.username) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const schema = getMapSchema();
+          const parsed = schema.safeParse(req.body.map);
+          if (!parsed.success) {
+            return res
+              .status(400)
+              .json({ message: parsed.error?.message || 'Invalid map data' });
+          }
+
+          const timestamp = new Date().toISOString();
+          const mapRecord = {
+            ...parsed.data,
+            updatedAt: timestamp,
+          };
+
+          if (typeof req.body.prompt === 'string' && req.body.prompt.trim() !== '') {
+            mapRecord.originalPrompt = req.body.prompt;
+          }
+
+          await collection.updateOne(
+            { campaignName },
+            { $set: { map: mapRecord } }
+          );
+
+          emitMapUpdate(campaignName, mapRecord);
+
+          return res.json(mapRecord);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
   // This section will create a new campaign.
   campaignRouter.route('/add').post(async (req, response, next) => {
     const db_connect = req.db;
@@ -271,6 +378,7 @@ module.exports = (router) => {
       gameMode: req.body.gameMode,
       dm: req.body.dm,
       players: Array.isArray(req.body.players) ? req.body.players : [],
+      map: null,
       combat: createDefaultCombatState(),
       enemies: [],
     };

--- a/server/schemas/map.js
+++ b/server/schemas/map.js
@@ -1,0 +1,110 @@
+const createMapSchema = (z) => {
+  if (!z || typeof z.object !== 'function') {
+    throw new Error('A Zod instance is required to build the map schema');
+  }
+
+  const MapSchema = z.object({
+    title: z.string(),
+    summary: z.string(),
+    environment: z.string(),
+    cellSizeFeet: z.number(),
+    grid: z.array(z.array(z.string())),
+    legend: z.array(
+      z.object({
+        symbol: z.string(),
+        description: z.string(),
+      })
+    ),
+  });
+
+  const baseSafeParse = MapSchema.safeParse.bind(MapSchema);
+
+  MapSchema.safeParse = (value) => {
+    const parsed = baseSafeParse(value);
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    const map = parsed.data;
+    const fail = (message) => ({ success: false, error: { message } });
+    const isNonEmptyString = (input) =>
+      typeof input === 'string' && input.trim().length > 0;
+
+    if (!isNonEmptyString(map.title)) {
+      return fail('title must be a non-empty string');
+    }
+
+    if (!isNonEmptyString(map.summary)) {
+      return fail('summary must be a non-empty string');
+    }
+
+    if (!isNonEmptyString(map.environment)) {
+      return fail('environment must be a non-empty string');
+    }
+
+    if (map.cellSizeFeet !== 5) {
+      return fail('cellSizeFeet must be 5');
+    }
+
+    if (!Array.isArray(map.grid) || map.grid.length === 0) {
+      return fail('grid must contain at least one row');
+    }
+
+    const firstRowLength = Array.isArray(map.grid[0]) ? map.grid[0].length : 0;
+    if (firstRowLength === 0) {
+      return fail('grid rows must contain at least one cell');
+    }
+
+    for (const row of map.grid) {
+      if (!Array.isArray(row) || row.length !== firstRowLength) {
+        return fail('grid rows must all be the same length');
+      }
+
+      for (const cell of row) {
+        if (!isNonEmptyString(cell)) {
+          return fail('grid cells must be non-empty strings');
+        }
+      }
+    }
+
+    if (!Array.isArray(map.legend) || map.legend.length === 0) {
+      return fail('legend must contain at least one entry');
+    }
+
+    const seenSymbols = new Set();
+    for (const entry of map.legend) {
+      if (!entry || typeof entry !== 'object') {
+        return fail('legend entries must be objects');
+      }
+
+      if (!isNonEmptyString(entry.symbol)) {
+        return fail('legend symbols must be non-empty strings');
+      }
+
+      if (!isNonEmptyString(entry.description)) {
+        return fail('legend descriptions must be non-empty strings');
+      }
+
+      if (seenSymbols.has(entry.symbol)) {
+        return fail('legend symbols must be unique');
+      }
+
+      seenSymbols.add(entry.symbol);
+    }
+
+    const allowedSymbols = seenSymbols;
+    for (const row of map.grid) {
+      for (const cell of row) {
+        if (!allowedSymbols.has(cell)) {
+          return fail('grid contains symbols not present in the legend');
+        }
+      }
+    }
+
+    return { success: true, data: map };
+  };
+
+  return MapSchema;
+};
+
+module.exports = createMapSchema;

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -136,6 +136,21 @@ const emitCombatUpdate = (campaignId, combatState) => {
   io.to(getCampaignRoom(normalizedId)).emit('combat:update', combatState);
 };
 
+const emitMapUpdate = (campaignId, map) => {
+  if (!io) {
+    logger.warn('Socket.io server not initialized; cannot emit map update');
+    return;
+  }
+
+  if (typeof campaignId !== 'string' || campaignId.trim() === '') {
+    logger.warn('Invalid campaign id provided for map update', { campaignId });
+    return;
+  }
+
+  const normalizedId = campaignId.trim();
+  io.to(getCampaignRoom(normalizedId)).emit('map:update', map);
+};
+
 const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health }) => {
   if (!io) {
     logger.warn('Socket.io server not initialized; cannot emit character health update');
@@ -170,6 +185,7 @@ const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health
 module.exports = {
   initializeSocket,
   emitCombatUpdate,
+  emitMapUpdate,
   emitCharacterHealthUpdate,
 };
 


### PR DESCRIPTION
## Summary
- add a reusable D&D 5e battle map schema with structural validation
- expose a new AI map generation endpoint and campaign map CRUD routes using the shared schema
- broadcast map updates over sockets and extend tests to cover new functionality

## Testing
- npm test --prefix server

------
https://chatgpt.com/codex/tasks/task_e_68d9cc3ecaa0832ea8c95183f3bb53f6