### PR TITLE
Wrap ZombiesDM map save payload in map object

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1451,10 +1451,14 @@ export default function ZombiesDM() {
 
       setMapSaving(true);
       try {
+        const trimmedPrompt = mapPrompt.trim();
         const response = await apiFetch(`/campaigns/${encodedCampaign}/map`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(mapToSave),
+          body: JSON.stringify({
+            map: mapToSave,
+            prompt: trimmedPrompt || undefined,
+          }),
         });
 
         if (!response.ok) {
@@ -1472,10 +1476,19 @@ export default function ZombiesDM() {
         try {
           savedMap = await response.json();
         } catch (error) {
-          savedMap = mapToSave;
+          savedMap = null;
         }
 
-        setCampaignMap(savedMap && Object.keys(savedMap).length > 0 ? savedMap : mapToSave);
+        const normalizedMap =
+          savedMap && typeof savedMap === 'object' && !Array.isArray(savedMap)
+            ? savedMap
+            : mapToSave;
+
+        setCampaignMap(
+          normalizedMap && Object.keys(normalizedMap || {}).length > 0
+            ? normalizedMap
+            : mapToSave
+        );
         setGeneratedMap(null);
         setStatus({ type: 'success', message: 'Map saved.' });
       } catch (error) {
@@ -1487,7 +1500,7 @@ export default function ZombiesDM() {
       } finally {
         setMapSaving(false);
       }
-    }, [campaignId, encodedCampaign, campaignMap, generatedMap]);
+    }, [campaignId, encodedCampaign, campaignMap, generatedMap, mapPrompt]);
     //--------------------------------------------Currency Adjustments------------------------------
     const [currencyModalState, setCurrencyModalState] = useState({ show: false, character: null });
     const [currencyInputs, setCurrencyInputs] = useState({ cp: '0', sp: '0', gp: '0', pp: '0' });

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -500,7 +500,16 @@ describe('ZombiesDM AI generation', () => {
         case '/campaigns/Camp1/map':
           if (options.method === 'PUT') {
             savedPayload = JSON.parse(options.body);
-            return Promise.resolve({ ok: true, json: async () => savedPayload });
+            const responseMap = {
+              ...savedPayload.map,
+              updatedAt: '2024-01-01T00:00:00.000Z',
+            };
+
+            if (savedPayload.prompt) {
+              responseMap.originalPrompt = savedPayload.prompt;
+            }
+
+            return Promise.resolve({ ok: true, json: async () => responseMap });
           }
           return Promise.resolve({ ok: true, json: async () => existingMap });
         case '/ai/map':
@@ -548,7 +557,10 @@ describe('ZombiesDM AI generation', () => {
     await screen.findByText('Map saved.');
 
     await waitFor(() => {
-      expect(savedPayload).toEqual(generatedMap);
+      expect(savedPayload).toEqual({
+        map: generatedMap,
+        prompt: 'dark forest',
+      });
     });
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- wrap the ZombiesDM map save request body in an object with the map and trimmed prompt
- normalize the save response to use the validated map record returned by the API
- update the ZombiesDM map save test to expect the wrapped payload and mocked record metadata

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9cf95a534832ebb5af6b81404d4c5