### PR TITLE
Gate OpenAI image style by model support

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -271,9 +271,26 @@ describe('AI accessory route', () => {
 });
 
 describe('AI map route', () => {
+  const originalImageModel = process.env.OPENAI_IMAGE_MODEL;
+  const originalImageStyle = process.env.OPENAI_IMAGE_STYLE;
+  const originalImageStyleModels = process.env.OPENAI_IMAGE_STYLE_MODELS;
+
   beforeEach(() => {
     mockParse.mockReset();
     mockGenerate.mockReset();
+    process.env.OPENAI_IMAGE_MODEL = 'gpt-image-1';
+    process.env.OPENAI_IMAGE_STYLE = 'vivid';
+    delete process.env.OPENAI_IMAGE_STYLE_MODELS;
+  });
+
+  afterAll(() => {
+    process.env.OPENAI_IMAGE_MODEL = originalImageModel;
+    process.env.OPENAI_IMAGE_STYLE = originalImageStyle;
+    if (originalImageStyleModels === undefined) {
+      delete process.env.OPENAI_IMAGE_STYLE_MODELS;
+    } else {
+      process.env.OPENAI_IMAGE_STYLE_MODELS = originalImageStyleModels;
+    }
   });
 
   test('returns generated image metadata', async () => {
@@ -328,6 +345,45 @@ describe('AI map route', () => {
 
     expect(res.status).toBe(500);
     expect(res.body.message).toBe('Generated map was invalid');
+  });
+
+  test('omits style for models without style support', async () => {
+    process.env.OPENAI_IMAGE_MODEL = 'gpt-image-1';
+    delete process.env.OPENAI_IMAGE_STYLE_MODELS;
+
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          url: 'https://example.com/map.png',
+        },
+      ],
+    });
+
+    await request(app).post('/ai/map').send({ prompt: 'no-style map' });
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    const payload = mockGenerate.mock.calls[0][0];
+    expect(payload.style).toBeUndefined();
+  });
+
+  test('includes style when explicitly enabled for model', async () => {
+    process.env.OPENAI_IMAGE_MODEL = 'dall-e-3';
+    process.env.OPENAI_IMAGE_STYLE_MODELS = 'dall-e-3, gpt-image-1';
+    process.env.OPENAI_IMAGE_STYLE = 'natural';
+
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          url: 'https://example.com/map.png',
+        },
+      ],
+    });
+
+    await request(app).post('/ai/map').send({ prompt: 'styled map' });
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    const payload = mockGenerate.mock.calls[0][0];
+    expect(payload.style).toBe('natural');
   });
 });
 

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -313,9 +313,27 @@ module.exports = (router) => {
         prompt: generationPrompt,
         size,
         n: 1,
-        style: process.env.OPENAI_IMAGE_STYLE || 'vivid',
         response_format: responseFormat,
       };
+
+      const configuredStyle = process.env.OPENAI_IMAGE_STYLE || 'vivid';
+      const styleModelList = (process.env.OPENAI_IMAGE_STYLE_MODELS || '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+
+      let includeStyle = Boolean(configuredStyle);
+      if (includeStyle) {
+        if (styleModelList.length > 0) {
+          includeStyle = styleModelList.includes(model);
+        } else {
+          includeStyle = model !== 'gpt-image-1';
+        }
+      }
+
+      if (includeStyle) {
+        requestPayload.style = configuredStyle;
+      }
 
       if (quality) {
         requestPayload.quality = quality;


### PR DESCRIPTION
## Summary
- gate the OpenAI image generation style field behind model support, defaulting to omit it for gpt-image-1 unless explicitly configured
- add server-side tests covering the new style inclusion and omission behavior for the map image endpoint

## Testing
- npm --prefix server test -- ai.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d5171cd8832eb8ba4bb09f401ba2