### PR TITLE
Expand CSP directives for map assets

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -54,6 +54,9 @@ app.use(
       directives: {
         defaultSrc: ["'self'"],
         connectSrc,
+        imgSrc: ["'self'", 'https:', 'data:', 'blob:'],
+        mediaSrc: ["'self'", 'https:', 'data:', 'blob:'],
+        fontSrc: ["'self'", 'https:', 'data:', 'blob:'],
       },
     },
   })


### PR DESCRIPTION
## Summary
- extend helmet content security policy to explicitly allow map imagery and font/media sources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e2262514832e9f32003468721fb1