### PR TITLE
Refactor campaign map handling to support multiple maps

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -70,6 +70,8 @@ describe('Campaign routes', () => {
     expect(insertOne).toHaveBeenCalledWith(
       expect.objectContaining({
         players: [],
+        maps: [],
+        activeMapId: null,
         map: null,
         enemies: [],
         combat: { participants: [], activeTurn: null },
@@ -164,16 +166,36 @@ describe('Campaign routes', () => {
       altText: 'Dungeon entrance map',
     };
 
+    const storedMap = {
+      ...baseMap,
+      mapId: '11111111-1111-4111-8111-111111111111',
+      createdAt: '2023-01-01T00:00:00.000Z',
+      updatedAt: '2023-01-01T00:00:00.000Z',
+    };
+
+    const buildCampaignWithMap = (overrides = {}) => {
+      const mapRecord = { ...storedMap, ...overrides };
+      return {
+        campaignName: 'Test',
+        dm: 'DM',
+        maps: [mapRecord],
+        activeMapId: mapRecord.mapId,
+        map: mapRecord,
+      };
+    };
+
     test('get map success', async () => {
+      const updateOne = jest.fn();
       dbo.mockResolvedValue({
         collection: () => ({
-          findOne: async () => ({ campaignName: 'Test', map: baseMap }),
+          findOne: async () => buildCampaignWithMap(),
+          updateOne,
         }),
       });
 
       const res = await request(app).get('/campaigns/Test/map');
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(baseMap);
+      expect(res.body).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
     });
 
     test('get map missing campaign', async () => {
@@ -191,7 +213,14 @@ describe('Campaign routes', () => {
     test('get map missing map', async () => {
       dbo.mockResolvedValue({
         collection: () => ({
-          findOne: async () => ({ campaignName: 'Test', map: null }),
+          findOne: async () => ({
+            campaignName: 'Test',
+            dm: 'DM',
+            maps: [],
+            activeMapId: null,
+            map: null,
+          }),
+          updateOne: jest.fn(),
         }),
       });
 
@@ -200,11 +229,87 @@ describe('Campaign routes', () => {
       expect(res.body.message).toBe('Map not found');
     });
 
-    test('save map success', async () => {
+    test('list maps success', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => buildCampaignWithMap(),
+          updateOne: jest.fn(),
+        }),
+      });
+
+      const res = await request(app).get('/campaigns/Test/maps');
+      expect(res.status).toBe(200);
+      expect(res.body.activeMapId).toBe(storedMap.mapId);
+      expect(res.body.map).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
+      expect(res.body.maps).toEqual(
+        expect.arrayContaining([expect.objectContaining({ mapId: storedMap.mapId })])
+      );
+    });
+
+    test('create map success', async () => {
       const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
       dbo.mockResolvedValue({
         collection: () => ({
-          findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+          findOne: async () => ({
+            campaignName: 'Test',
+            dm: 'DM',
+            maps: [],
+            activeMapId: null,
+            map: null,
+          }),
+          updateOne,
+        }),
+      });
+
+      const res = await request(app)
+        .post('/campaigns/Test/maps')
+        .send({ map: baseMap, prompt: 'Create a dungeon map' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.activeMapId).toEqual(expect.any(String));
+      expect(res.body.map).toEqual(
+        expect.objectContaining({
+          title: baseMap.title,
+          originalPrompt: 'Create a dungeon map',
+          mapId: res.body.activeMapId,
+        })
+      );
+      expect(res.body.maps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+        ])
+      );
+      const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
+      expect(lastUpdate).toEqual(
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            activeMapId: res.body.activeMapId,
+            map: expect.objectContaining({ mapId: res.body.activeMapId }),
+            maps: expect.arrayContaining([
+              expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+            ]),
+          }),
+        })
+      );
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({
+          activeMapId: res.body.activeMapId,
+          map: expect.objectContaining({ mapId: res.body.activeMapId }),
+          maps: expect.arrayContaining([
+            expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+          ]),
+        })
+      );
+    });
+
+    test('legacy map update success', async () => {
+      const updatedAtBefore = '2023-01-02T00:00:00.000Z';
+      const campaignDoc = buildCampaignWithMap({ updatedAt: updatedAtBefore });
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => campaignDoc,
           updateOne,
         }),
       });
@@ -218,31 +323,39 @@ describe('Campaign routes', () => {
         expect.objectContaining({
           title: baseMap.title,
           originalPrompt: 'Create a dungeon map',
+          mapId: storedMap.mapId,
           updatedAt: expect.any(String),
         })
       );
-      expect(updateOne).toHaveBeenCalledWith(
-        { campaignName: 'Test' },
-        {
-          $set: {
+      const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
+      expect(lastUpdate).toEqual(
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            activeMapId: storedMap.mapId,
             map: expect.objectContaining({
-              title: baseMap.title,
+              mapId: storedMap.mapId,
               originalPrompt: 'Create a dungeon map',
-              updatedAt: expect.any(String),
             }),
-          },
-        }
+            maps: expect.arrayContaining([
+              expect.objectContaining({ mapId: storedMap.mapId, title: baseMap.title }),
+            ]),
+          }),
+        })
       );
       expect(emitMapUpdate).toHaveBeenCalledWith(
         'Test',
-        expect.objectContaining({ title: baseMap.title })
+        expect.objectContaining({
+          activeMapId: storedMap.mapId,
+          map: expect.objectContaining({ mapId: storedMap.mapId }),
+        })
       );
     });
 
-    test('save map validation failure', async () => {
+    test('legacy map validation failure', async () => {
       dbo.mockResolvedValue({
         collection: () => ({
-          findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+          findOne: async () => buildCampaignWithMap(),
+          updateOne: jest.fn(),
         }),
       });
 
@@ -257,11 +370,12 @@ describe('Campaign routes', () => {
       expect(emitMapUpdate).not.toHaveBeenCalled();
     });
 
-    test('save map forbidden for non-DM', async () => {
+    test('legacy map forbidden for non-DM', async () => {
       mockUser = { username: 'Player' };
       dbo.mockResolvedValue({
         collection: () => ({
-          findOne: async () => ({ campaignName: 'Test', dm: 'DM' }),
+          findOne: async () => buildCampaignWithMap(),
+          updateOne: jest.fn(),
         }),
       });
 
@@ -273,7 +387,7 @@ describe('Campaign routes', () => {
       expect(emitMapUpdate).not.toHaveBeenCalled();
     });
 
-    test('save map missing campaign', async () => {
+    test('legacy map missing campaign', async () => {
       dbo.mockResolvedValue({
         collection: () => ({
           findOne: async () => null,
@@ -286,6 +400,77 @@ describe('Campaign routes', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Campaign not found');
+    });
+
+    test('activate map via patch', async () => {
+      const secondaryMap = {
+        ...storedMap,
+        mapId: '22222222-2222-4222-8222-222222222222',
+        title: 'Forest',
+      };
+      const campaignDoc = {
+        campaignName: 'Test',
+        dm: 'DM',
+        maps: [storedMap, secondaryMap],
+        activeMapId: storedMap.mapId,
+        map: storedMap,
+      };
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => campaignDoc,
+          updateOne,
+        }),
+      });
+
+      const res = await request(app)
+        .patch(`/campaigns/Test/maps/${secondaryMap.mapId}`)
+        .send({ active: true });
+
+      expect(res.status).toBe(200);
+      expect(res.body.activeMapId).toBe(secondaryMap.mapId);
+      expect(res.body.map).toEqual(
+        expect.objectContaining({ mapId: secondaryMap.mapId, title: secondaryMap.title })
+      );
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({ activeMapId: secondaryMap.mapId })
+      );
+    });
+
+    test('delete map success', async () => {
+      const secondaryMap = {
+        ...storedMap,
+        mapId: '22222222-2222-4222-8222-222222222222',
+        title: 'Forest',
+      };
+      const campaignDoc = {
+        campaignName: 'Test',
+        dm: 'DM',
+        maps: [storedMap, secondaryMap],
+        activeMapId: secondaryMap.mapId,
+        map: secondaryMap,
+      };
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => campaignDoc,
+          updateOne,
+        }),
+      });
+
+      const res = await request(app).delete(`/campaigns/Test/maps/${secondaryMap.mapId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.activeMapId).toBe(storedMap.mapId);
+      expect(res.body.map).toEqual(
+        expect.objectContaining({ mapId: storedMap.mapId, title: storedMap.title })
+      );
+      expect(res.body.maps).toHaveLength(1);
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({ activeMapId: storedMap.mapId })
+      );
     });
   });
 

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node server.js",
     "watch": "nodemon server.js",
-    "test": "jest"
+    "test": "jest",
+    "backfill:campaign-maps": "node scripts/backfill-campaign-maps.js"
   },
   "keywords": [],
   "author": "",

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -72,12 +72,12 @@ module.exports = (router) => {
     }
   };
 
-  let mapSchema;
-  const getMapSchema = (Z) => {
-    if (!mapSchema) {
-      mapSchema = createMapSchema(Z);
+  let mapSchemas;
+  const getMapSchemas = (Z) => {
+    if (!mapSchemas) {
+      mapSchemas = createMapSchema(Z);
     }
-    return mapSchema;
+    return mapSchemas;
   };
 
   aiRouter.post('/weapon', async (req, res) => {
@@ -297,7 +297,7 @@ module.exports = (router) => {
     }
 
     const Z = resolveZod();
-    const MapSchema = Z ? getMapSchema(Z) : null;
+    const mapSchemas = Z ? getMapSchemas(Z) : null;
 
     try {
       const openai = new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY });
@@ -364,11 +364,11 @@ module.exports = (router) => {
           : {}),
       };
 
-      if (!MapSchema) {
+      if (!mapSchemas) {
         return res.json(mapPayload);
       }
 
-      const parsed = MapSchema.safeParse(mapPayload);
+      const parsed = mapSchemas.input.safeParse(mapPayload);
       if (!parsed.success) {
         logger.error('Image payload failed schema validation', {
           error: parsed.error?.message,

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -7,19 +7,14 @@ const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 const logger = require('../utils/logger');
 const { emitCombatUpdate, emitMapUpdate } = require('../utils/socket');
-const createMapSchema = require('../schemas/map');
+const {
+  normalizeCampaignMapState,
+  prepareStoredMap,
+  buildCampaignMapPayload,
+} = require('../utils/campaignMaps');
 
 module.exports = (router) => {
   const campaignRouter = express.Router();
-
-  let mapSchema;
-  const getMapSchema = () => {
-    if (!mapSchema) {
-      const { z } = require('zod');
-      mapSchema = createMapSchema(z);
-    }
-    return mapSchema;
-  };
 
   const createDefaultCombatState = () => ({
     participants: [],
@@ -288,12 +283,17 @@ module.exports = (router) => {
           if (!campaign) {
             return res.status(404).json({ message: 'Campaign not found' });
           }
+          const collection = db_connect.collection('Campaigns');
+          const { payload } = await normalizeCampaignMapState({
+            campaign,
+            collection,
+          });
 
-          if (!campaign.map) {
+          if (!payload.map) {
             return res.status(404).json({ message: 'Map not found' });
           }
 
-          return res.json(campaign.map);
+          return res.json(payload.map);
         } catch (err) {
           next(err);
         }
@@ -338,32 +338,366 @@ module.exports = (router) => {
             return res.status(403).json({ message: 'Forbidden' });
           }
 
-          const schema = getMapSchema();
-          const parsed = schema.safeParse(req.body.map);
-          if (!parsed.success) {
-            return res
-              .status(400)
-              .json({ message: parsed.error?.message || 'Invalid map data' });
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection,
+          });
+
+          const existingMap = normalizedCampaign?.activeMapId
+            ? normalizedCampaign.maps.find((map) => map.mapId === normalizedCampaign.activeMapId)
+            : null;
+
+          const prepared = prepareStoredMap({
+            mapInput: req.body.map,
+            existingMap,
+            prompt:
+              typeof req.body.prompt === 'string' && req.body.prompt.trim() !== ''
+                ? req.body.prompt
+                : undefined,
+          });
+
+          if (!prepared.success) {
+            return res.status(400).json({ message: prepared.error });
           }
 
-          const timestamp = new Date().toISOString();
-          const mapRecord = {
-            ...parsed.data,
-            updatedAt: timestamp,
-          };
+          const storedMap = prepared.data;
 
-          if (typeof req.body.prompt === 'string' && req.body.prompt.trim() !== '') {
-            mapRecord.originalPrompt = req.body.prompt;
-          }
+          const nextMaps = Array.isArray(normalizedCampaign.maps)
+            ? normalizedCampaign.maps.filter((map) => map.mapId !== storedMap.mapId)
+            : [];
+          nextMaps.push(storedMap);
+
+          const payload = buildCampaignMapPayload(nextMaps, storedMap.mapId);
 
           await collection.updateOne(
             { campaignName },
-            { $set: { map: mapRecord } }
+            {
+              $set: {
+                maps: payload.maps,
+                activeMapId: payload.activeMapId,
+                map: payload.map || null,
+              },
+            }
           );
 
-          emitMapUpdate(campaignName, mapRecord);
+          emitMapUpdate(campaignName, payload);
 
-          return res.json(mapRecord);
+          return res.json(payload.map);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/maps')
+    .get(
+      [param('campaign').trim().notEmpty().withMessage('campaign is required')],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const db_connect = req.db;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne({
+            campaignName: req.params.campaign,
+          });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const { payload } = await normalizeCampaignMapState({
+            campaign,
+            collection,
+          });
+
+          return res.json(payload);
+        } catch (err) {
+          next(err);
+        }
+      }
+    )
+    .post(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        body('map')
+          .custom((value) => {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+              throw new Error('map must be an object');
+            }
+            return true;
+          })
+          .withMessage('map must be provided'),
+        body('prompt')
+          .optional({ nullable: true })
+          .custom((value) => {
+            if (value === null || value === undefined) {
+              return true;
+            }
+            if (typeof value !== 'string') {
+              throw new Error('prompt must be a string');
+            }
+            return true;
+          }),
+        body('activate')
+          .optional()
+          .isBoolean()
+          .withMessage('activate must be a boolean')
+          .toBoolean(),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const db_connect = req.db;
+          const campaignName = req.params.campaign;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          if (!req.user || campaign.dm !== req.user.username) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection,
+          });
+
+          const prepared = prepareStoredMap({
+            mapInput: req.body.map,
+            existingMap: null,
+            prompt:
+              typeof req.body.prompt === 'string' && req.body.prompt.trim() !== ''
+                ? req.body.prompt
+                : undefined,
+          });
+
+          if (!prepared.success) {
+            return res.status(400).json({ message: prepared.error });
+          }
+
+          const storedMap = prepared.data;
+
+          const nextMaps = Array.isArray(normalizedCampaign.maps)
+            ? [...normalizedCampaign.maps, storedMap]
+            : [storedMap];
+
+          const requestedActivation =
+            req.body.activate === undefined
+              ? !normalizedCampaign.activeMapId
+              : Boolean(req.body.activate);
+
+          const desiredActiveId = requestedActivation
+            ? storedMap.mapId
+            : normalizedCampaign.activeMapId;
+
+          const payload = buildCampaignMapPayload(
+            nextMaps,
+            desiredActiveId || storedMap.mapId
+          );
+
+          await collection.updateOne(
+            { campaignName },
+            {
+              $set: {
+                maps: payload.maps,
+                activeMapId: payload.activeMapId,
+                map: payload.map || null,
+              },
+            }
+          );
+
+          emitMapUpdate(campaignName, payload);
+
+          return res.json(payload);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/maps/:mapId')
+    .patch(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        param('mapId').trim().notEmpty().withMessage('mapId is required'),
+        body('map')
+          .optional()
+          .custom((value) => {
+            if (value === undefined) {
+              return true;
+            }
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+              throw new Error('map must be an object');
+            }
+            return true;
+          }),
+        body('prompt')
+          .optional({ nullable: true })
+          .custom((value) => {
+            if (value === null || value === undefined) {
+              return true;
+            }
+            if (typeof value !== 'string') {
+              throw new Error('prompt must be a string');
+            }
+            return true;
+          }),
+        body('active')
+          .optional()
+          .isBoolean()
+          .withMessage('active must be a boolean')
+          .toBoolean(),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const mapId = req.params.mapId;
+          const db_connect = req.db;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          if (!req.user || campaign.dm !== req.user.username) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const wantsActivation = req.body.active === true;
+          const hasMapUpdate = req.body.map !== undefined;
+
+          if (!wantsActivation && !hasMapUpdate) {
+            return res.status(400).json({ message: 'No updates provided' });
+          }
+
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection,
+          });
+
+          const targetMap = Array.isArray(normalizedCampaign.maps)
+            ? normalizedCampaign.maps.find((map) => map.mapId === mapId)
+            : null;
+
+          if (!targetMap) {
+            return res.status(404).json({ message: 'Map not found' });
+          }
+
+          let storedMap = targetMap;
+
+          if (hasMapUpdate) {
+            const prepared = prepareStoredMap({
+              mapInput: req.body.map,
+              existingMap: targetMap,
+              prompt:
+                typeof req.body.prompt === 'string' && req.body.prompt.trim() !== ''
+                  ? req.body.prompt
+                  : undefined,
+            });
+
+            if (!prepared.success) {
+              return res.status(400).json({ message: prepared.error });
+            }
+
+            storedMap = prepared.data;
+          }
+
+          const nextMaps = normalizedCampaign.maps.map((map) =>
+            map.mapId === mapId ? storedMap : map
+          );
+
+          const desiredActiveId = wantsActivation
+            ? mapId
+            : normalizedCampaign.activeMapId;
+
+          const payload = buildCampaignMapPayload(nextMaps, desiredActiveId);
+
+          await collection.updateOne(
+            { campaignName },
+            {
+              $set: {
+                maps: payload.maps,
+                activeMapId: payload.activeMapId,
+                map: payload.map || null,
+              },
+            }
+          );
+
+          emitMapUpdate(campaignName, payload);
+
+          return res.json(payload);
+        } catch (err) {
+          next(err);
+        }
+      }
+    )
+    .delete(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        param('mapId').trim().notEmpty().withMessage('mapId is required'),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const mapId = req.params.mapId;
+          const db_connect = req.db;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          if (!req.user || campaign.dm !== req.user.username) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection,
+          });
+
+          const existingMap = Array.isArray(normalizedCampaign.maps)
+            ? normalizedCampaign.maps.find((map) => map.mapId === mapId)
+            : null;
+
+          if (!existingMap) {
+            return res.status(404).json({ message: 'Map not found' });
+          }
+
+          const remainingMaps = normalizedCampaign.maps.filter(
+            (map) => map.mapId !== mapId
+          );
+
+          const desiredActiveId =
+            normalizedCampaign.activeMapId === mapId
+              ? null
+              : normalizedCampaign.activeMapId;
+
+          const payload = buildCampaignMapPayload(remainingMaps, desiredActiveId);
+
+          await collection.updateOne(
+            { campaignName },
+            {
+              $set: {
+                maps: payload.maps,
+                activeMapId: payload.activeMapId,
+                map: payload.map || null,
+              },
+            }
+          );
+
+          emitMapUpdate(campaignName, payload);
+
+          return res.json(payload);
         } catch (err) {
           next(err);
         }
@@ -378,6 +712,8 @@ module.exports = (router) => {
       gameMode: req.body.gameMode,
       dm: req.body.dm,
       players: Array.isArray(req.body.players) ? req.body.players : [],
+      maps: [],
+      activeMapId: null,
       map: null,
       combat: createDefaultCombatState(),
       enemies: [],

--- a/server/schemas/map.js
+++ b/server/schemas/map.js
@@ -3,74 +3,112 @@ const createMapSchema = (z) => {
     throw new Error('A Zod instance is required to build the map schema');
   }
 
-  const MapSchema = z
-    .object({
-      title: z.string().trim().min(1).optional(),
-      summary: z.string().trim().min(1).optional(),
-      caption: z.string().trim().min(1).optional(),
-      altText: z.string().trim().min(1).optional(),
-      prompt: z.string().trim().min(1).optional(),
-      imageUrl: z.string().trim().url().optional(),
-      imageBase64: z
-        .string()
-        .trim()
-        .min(1)
-        .regex(/^[A-Za-z0-9+/=]+$/, 'imageBase64 must be a base64-encoded string')
-        .optional(),
-      imageType: z.string().trim().min(1).optional(),
-      width: z.number().int().positive().optional(),
-      height: z.number().int().positive().optional(),
-      provider: z.string().trim().min(1).optional(),
-      model: z.string().trim().min(1).optional(),
-    })
-    .passthrough();
-
-  const baseSafeParse = MapSchema.safeParse.bind(MapSchema);
-
-  MapSchema.safeParse = (value) => {
-    const parsed = baseSafeParse(value);
-    if (!parsed.success) {
-      return parsed;
+  const isIsoDateString = (value) => {
+    if (typeof value !== 'string') {
+      return false;
     }
-
-    const map = parsed.data;
-    const fail = (message) => ({ success: false, error: { message } });
-
-    const hasUrl = typeof map.imageUrl === 'string' && map.imageUrl.trim() !== '';
-    const hasBase64 =
-      typeof map.imageBase64 === 'string' && map.imageBase64.trim() !== '';
-
-    if (!hasUrl && !hasBase64) {
-      return fail('Either imageUrl or imageBase64 must be provided');
-    }
-
-    if (hasBase64) {
-      const base64Pattern = /^[A-Za-z0-9+/=]+$/;
-      if (!base64Pattern.test(map.imageBase64.trim())) {
-        return fail('imageBase64 must be a valid base64 string');
-      }
-    }
-
-    if (!map.altText) {
-      const derivedAltText = map.title || map.summary || map.caption || map.prompt;
-      if (derivedAltText && typeof derivedAltText === 'string') {
-        map.altText = derivedAltText;
-      } else {
-        map.altText = 'Dungeons & Dragons battle map';
-      }
-    }
-
-    if (map.imageType && typeof map.imageType === 'string') {
-      map.imageType = map.imageType.trim();
-      if (map.imageType.length === 0) {
-        delete map.imageType;
-      }
-    }
-
-    return { success: true, data: map };
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed);
   };
 
-  return MapSchema;
+  const buildBaseShape = () => ({
+    title: z.string().trim().min(1).optional(),
+    summary: z.string().trim().min(1).optional(),
+    caption: z.string().trim().min(1).optional(),
+    altText: z.string().trim().min(1).optional(),
+    prompt: z.string().trim().min(1).optional(),
+    imageUrl: z.string().trim().url().optional(),
+    imageBase64: z
+      .string()
+      .trim()
+      .min(1)
+      .regex(/^[A-Za-z0-9+/=]+$/, 'imageBase64 must be a base64-encoded string')
+      .optional(),
+    imageType: z.string().trim().min(1).optional(),
+    width: z.number().int().positive().optional(),
+    height: z.number().int().positive().optional(),
+    provider: z.string().trim().min(1).optional(),
+    model: z.string().trim().min(1).optional(),
+  });
+
+  const applyPostProcessing = (schema) => {
+    const baseSafeParse = schema.safeParse.bind(schema);
+
+    schema.safeParse = (value, ...rest) => {
+      const parsed = baseSafeParse(value, ...rest);
+      if (!parsed.success) {
+        return parsed;
+      }
+
+      const map = { ...parsed.data };
+      const fail = (message) => ({ success: false, error: { message } });
+
+      const hasUrl = typeof map.imageUrl === 'string' && map.imageUrl.trim() !== '';
+      const hasBase64 =
+        typeof map.imageBase64 === 'string' && map.imageBase64.trim() !== '';
+
+      if (!hasUrl && !hasBase64) {
+        return fail('Either imageUrl or imageBase64 must be provided');
+      }
+
+      if (hasUrl) {
+        map.imageUrl = map.imageUrl.trim();
+      }
+
+      if (hasBase64) {
+        const base64Value = map.imageBase64.trim();
+        const base64Pattern = /^[A-Za-z0-9+/=]+$/;
+        if (!base64Pattern.test(base64Value)) {
+          return fail('imageBase64 must be a valid base64 string');
+        }
+        map.imageBase64 = base64Value;
+      }
+
+      if (!map.altText) {
+        const derivedAltText = map.title || map.summary || map.caption || map.prompt;
+        if (derivedAltText && typeof derivedAltText === 'string') {
+          map.altText = derivedAltText;
+        } else {
+          map.altText = 'Dungeons & Dragons battle map';
+        }
+      }
+
+      if (map.altText && typeof map.altText === 'string') {
+        const trimmed = map.altText.trim();
+        map.altText = trimmed || 'Dungeons & Dragons battle map';
+      }
+
+      if (map.imageType && typeof map.imageType === 'string') {
+        const trimmedType = map.imageType.trim();
+        if (trimmedType.length === 0) {
+          delete map.imageType;
+        } else {
+          map.imageType = trimmedType;
+        }
+      }
+
+      return { success: true, data: map };
+    };
+
+    return schema;
+  };
+
+  const isoString = z.string().trim().min(1);
+
+  const inputSchema = applyPostProcessing(z.object(buildBaseShape()).passthrough());
+
+  const storedSchema = applyPostProcessing(
+    z
+      .object({
+        ...buildBaseShape(),
+        mapId: z.string().trim().min(1),
+        createdAt: isoString,
+        updatedAt: isoString,
+      })
+      .passthrough()
+  );
+
+  return { input: inputSchema, stored: storedSchema };
 };
 
 module.exports = createMapSchema;

--- a/server/scripts/backfill-campaign-maps.js
+++ b/server/scripts/backfill-campaign-maps.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+require('dotenv').config();
+
+const connectToDatabase = require('../db/conn');
+const logger = require('../utils/logger');
+const { normalizeCampaignMapState } = require('../utils/campaignMaps');
+
+(async () => {
+  try {
+    const db = await connectToDatabase();
+    const collection = db.collection('Campaigns');
+    const cursor = collection.find({});
+
+    let processed = 0;
+    let updated = 0;
+
+    while (await cursor.hasNext()) {
+      const campaign = await cursor.next();
+      processed += 1;
+
+      const { updated: didUpdate } = await normalizeCampaignMapState({
+        campaign,
+        collection,
+      });
+
+      if (didUpdate) {
+        updated += 1;
+      }
+    }
+
+    logger.info('Campaign map backfill complete', { processed, updated });
+    console.log(`Processed ${processed} campaigns; updated ${updated}.`);
+    process.exit(0);
+  } catch (error) {
+    logger.error('Failed to backfill campaign maps', { error: error.message });
+    console.error('Failed to backfill campaign maps:', error);
+    process.exit(1);
+  }
+})();

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -1,0 +1,261 @@
+const { randomUUID } = require('crypto');
+const createMapSchema = require('../schemas/map');
+
+let mapSchemas;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const getMapSchemas = () => {
+  if (!mapSchemas) {
+    const { z } = require('zod');
+    mapSchemas = createMapSchema(z);
+  }
+  return mapSchemas;
+};
+
+const generateStableId = () => {
+  if (typeof randomUUID === 'function') {
+    return randomUUID();
+  }
+
+  return `${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+};
+
+const isIsoDate = (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed);
+};
+
+const toIsoDate = (value, fallback) => {
+  if (isIsoDate(value)) {
+    return new Date(value).toISOString();
+  }
+  return fallback;
+};
+
+const sortMaps = (maps) => {
+  return [...maps].sort((a, b) => {
+    const aTime = Date.parse(a?.updatedAt ?? 0) || 0;
+    const bTime = Date.parse(b?.updatedAt ?? 0) || 0;
+    return bTime - aTime;
+  });
+};
+
+const buildCampaignMapPayload = (maps, activeMapId) => {
+  const sorted = sortMaps(Array.isArray(maps) ? maps : []);
+  let resolvedActiveId =
+    typeof activeMapId === 'string' && activeMapId.trim() !== ''
+      ? activeMapId.trim()
+      : null;
+
+  if (resolvedActiveId) {
+    const hasActive = sorted.some((map) => map.mapId === resolvedActiveId);
+    if (!hasActive) {
+      resolvedActiveId = null;
+    }
+  }
+
+  if (!resolvedActiveId && sorted.length > 0) {
+    resolvedActiveId = sorted[0].mapId;
+  }
+
+  const activeMap = resolvedActiveId
+    ? sorted.find((map) => map.mapId === resolvedActiveId) || null
+    : null;
+
+  return {
+    maps: sorted,
+    activeMapId: activeMap ? activeMap.mapId : null,
+    map: activeMap || null,
+  };
+};
+
+const prepareStoredMap = ({
+  mapInput,
+  existingMap,
+  prompt,
+  keepUpdatedAt = false,
+}) => {
+  const schemas = getMapSchemas();
+  const parsedInput = schemas.input.safeParse(mapInput);
+  if (!parsedInput.success) {
+    return {
+      success: false,
+      error: parsedInput.error?.message || 'Invalid map data',
+    };
+  }
+
+  const base = parsedInput.data;
+  const now = new Date().toISOString();
+  const existing = existingMap && typeof existingMap === 'object' ? existingMap : {};
+
+  let mapId =
+    typeof existing.mapId === 'string' && UUID_REGEX.test(existing.mapId)
+      ? existing.mapId
+      : null;
+  if (!mapId) {
+    mapId = generateStableId();
+  }
+
+  let createdAt = toIsoDate(existing.createdAt, null);
+  if (!createdAt) {
+    createdAt = toIsoDate(existing.updatedAt, now) || now;
+  }
+
+  let updatedAt = keepUpdatedAt
+    ? toIsoDate(existing.updatedAt, now) || now
+    : now;
+  if (Date.parse(updatedAt) < Date.parse(createdAt)) {
+    createdAt = updatedAt;
+  }
+
+  const storedMap = {
+    ...base,
+    mapId,
+    createdAt,
+    updatedAt,
+  };
+
+  if (typeof prompt === 'string' && prompt.trim() !== '') {
+    storedMap.originalPrompt = prompt.trim();
+  } else if (
+    typeof existing.originalPrompt === 'string' &&
+    existing.originalPrompt.trim() !== ''
+  ) {
+    storedMap.originalPrompt = existing.originalPrompt.trim();
+  }
+
+  const parsedStored = schemas.stored.safeParse(storedMap);
+  if (!parsedStored.success) {
+    return {
+      success: false,
+      error: parsedStored.error?.message || 'Invalid map data',
+    };
+  }
+
+  return { success: true, data: parsedStored.data };
+};
+
+const normalizeCampaignMapState = async ({ campaign, collection }) => {
+  if (!campaign || typeof campaign !== 'object') {
+    return {
+      campaign: null,
+      payload: { maps: [], activeMapId: null, map: null },
+      updated: false,
+    };
+  }
+
+  const schemas = getMapSchemas();
+  const now = new Date().toISOString();
+  const normalizedMaps = [];
+  let didMutate = false;
+
+  if (Array.isArray(campaign.maps)) {
+    campaign.maps.forEach((mapEntry) => {
+      if (!mapEntry || typeof mapEntry !== 'object') {
+        didMutate = true;
+        return;
+      }
+
+      const candidate = { ...mapEntry };
+      if (!UUID_REGEX.test(candidate.mapId || '')) {
+        candidate.mapId = generateStableId();
+        didMutate = true;
+      }
+
+      candidate.createdAt = toIsoDate(candidate.createdAt, null);
+      if (!candidate.createdAt) {
+        candidate.createdAt = toIsoDate(candidate.updatedAt, now) || now;
+        didMutate = true;
+      }
+
+      candidate.updatedAt = toIsoDate(candidate.updatedAt, candidate.createdAt);
+      if (!candidate.updatedAt) {
+        candidate.updatedAt = candidate.createdAt;
+        didMutate = true;
+      }
+
+      const parsed = schemas.stored.safeParse(candidate);
+      if (!parsed.success) {
+        didMutate = true;
+        return;
+      }
+
+      const sanitized = parsed.data;
+      if (!didMutate) {
+        const originalString = JSON.stringify(mapEntry);
+        const sanitizedString = JSON.stringify(sanitized);
+        if (originalString !== sanitizedString) {
+          didMutate = true;
+        }
+      }
+
+      normalizedMaps.push(sanitized);
+    });
+  }
+
+  if (normalizedMaps.length === 0) {
+    const legacyMap = campaign.map && typeof campaign.map === 'object' ? campaign.map : null;
+    if (legacyMap) {
+      const prepared = prepareStoredMap({
+        mapInput: legacyMap,
+        existingMap: legacyMap,
+        prompt: legacyMap.originalPrompt,
+        keepUpdatedAt: true,
+      });
+      if (prepared.success) {
+        normalizedMaps.push(prepared.data);
+        didMutate = true;
+      }
+    }
+  }
+
+  const payload = buildCampaignMapPayload(normalizedMaps, campaign.activeMapId);
+
+  const existingMapString = JSON.stringify(campaign.map ?? null);
+  const payloadMapString = JSON.stringify(payload.map ?? null);
+  const existingMapsString = JSON.stringify(campaign.maps ?? []);
+  const payloadMapsString = JSON.stringify(payload.maps);
+
+  const shouldUpdate =
+    didMutate ||
+    campaign.activeMapId !== payload.activeMapId ||
+    existingMapString !== payloadMapString ||
+    existingMapsString !== payloadMapsString;
+
+  if (shouldUpdate && collection) {
+    await collection.updateOne(
+      { campaignName: campaign.campaignName },
+      {
+        $set: {
+          maps: payload.maps,
+          activeMapId: payload.activeMapId,
+          map: payload.map || null,
+        },
+      }
+    );
+  }
+
+  const normalizedCampaign = {
+    ...campaign,
+    maps: payload.maps,
+    activeMapId: payload.activeMapId,
+    map: payload.map || null,
+  };
+
+  return { campaign: normalizedCampaign, payload, updated: shouldUpdate };
+};
+
+module.exports = {
+  buildCampaignMapPayload,
+  prepareStoredMap,
+  normalizeCampaignMapState,
+  getMapSchemas,
+};

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -136,7 +136,7 @@ const emitCombatUpdate = (campaignId, combatState) => {
   io.to(getCampaignRoom(normalizedId)).emit('combat:update', combatState);
 };
 
-const emitMapUpdate = (campaignId, map) => {
+const emitMapUpdate = (campaignId, payload) => {
   if (!io) {
     logger.warn('Socket.io server not initialized; cannot emit map update');
     return;
@@ -148,7 +148,11 @@ const emitMapUpdate = (campaignId, map) => {
   }
 
   const normalizedId = campaignId.trim();
-  io.to(getCampaignRoom(normalizedId)).emit('map:update', map);
+  io.to(getCampaignRoom(normalizedId)).emit('campaign:map:update', payload);
+
+  if (payload && typeof payload === 'object' && Object.prototype.hasOwnProperty.call(payload, 'map')) {
+    io.to(getCampaignRoom(normalizedId)).emit('map:update', payload.map);
+  }
 };
 
 const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health }) => {


### PR DESCRIPTION
## Summary
- refactor campaign routes to manage multi-map state and expose list/create/update/delete endpoints while preserving the legacy active-map handler
- add campaign map utility module, enhanced map schema validation, and websocket payload updates
- expand test coverage and provide a backfill script for existing campaign documents

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68da81e1edf8832e880846188d69a119