### PR TITLE
Enhance zombies map modal management

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1,34 +1,335 @@
-import React from 'react';
+import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Button } from 'react-bootstrap';
+import { Modal, Button, ListGroup, Badge, Spinner } from 'react-bootstrap';
 import MapDisplay from './MapDisplay';
 
-const MapModal = ({ show, onHide, map }) => (
-  <Modal show={show} onHide={onHide} size="lg" centered>
-    <Modal.Header closeButton>
-      <Modal.Title>Campaign Map</Modal.Title>
-    </Modal.Header>
-    <Modal.Body>
-      <MapDisplay map={map} />
-    </Modal.Body>
-    <Modal.Footer>
-      <Button variant="secondary" onClick={onHide}>
-        Close
-      </Button>
-    </Modal.Footer>
-  </Modal>
-);
+const normalizeMapId = (value) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+
+const normalizeMaps = (maps) =>
+  Array.isArray(maps)
+    ? maps.filter((map) => map && typeof map === 'object')
+    : [];
+
+const resolveMapTitle = (map, index) => {
+  if (!map || typeof map !== 'object') {
+    return `Map ${index + 1}`;
+  }
+
+  const { title } = map;
+  if (typeof title === 'string' && title.trim() !== '') {
+    return title.trim();
+  }
+
+  return `Map ${index + 1}`;
+};
+
+const resolveMapSummary = (map) => {
+  if (!map || typeof map !== 'object') {
+    return '';
+  }
+
+  const { summary } = map;
+  if (typeof summary === 'string' && summary.trim() !== '') {
+    return summary.trim();
+  }
+
+  return '';
+};
+
+const findMapById = (maps, id) => {
+  const normalizedId = normalizeMapId(id);
+  if (!normalizedId) {
+    return null;
+  }
+
+  return maps.find((map) => normalizeMapId(map?.mapId) === normalizedId) || null;
+};
+
+const MapModal = ({
+  show,
+  onHide,
+  map,
+  maps,
+  activeMapId,
+  selectedMapId,
+  onSelectMap,
+  onActivateMap,
+  onDeleteMap,
+  isLoading,
+  actionInProgressId,
+  emptyMessage,
+  title,
+}) => {
+  const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
+  const normalizedActiveId = useMemo(() => normalizeMapId(activeMapId), [activeMapId]);
+  const normalizedActionId = useMemo(
+    () => normalizeMapId(actionInProgressId),
+    [actionInProgressId]
+  );
+  const isSelectControlled = typeof onSelectMap === 'function';
+  const normalizedSelectedId = useMemo(
+    () => (isSelectControlled ? normalizeMapId(selectedMapId) : null),
+    [isSelectControlled, selectedMapId]
+  );
+
+  const resolvedSelectedId = useMemo(() => {
+    if (normalizedSelectedId && findMapById(normalizedMaps, normalizedSelectedId)) {
+      return normalizedSelectedId;
+    }
+
+    if (normalizedActiveId && findMapById(normalizedMaps, normalizedActiveId)) {
+      return normalizedActiveId;
+    }
+
+    const firstWithId = normalizedMaps.find((item) => normalizeMapId(item?.mapId));
+    return firstWithId ? normalizeMapId(firstWithId.mapId) : null;
+  }, [normalizedMaps, normalizedSelectedId, normalizedActiveId]);
+
+  const previewMap = useMemo(() => {
+    if (normalizedMaps.length > 0) {
+      const selectedFromList = findMapById(normalizedMaps, resolvedSelectedId);
+      if (selectedFromList) {
+        return selectedFromList;
+      }
+
+      if (normalizedActiveId) {
+        const activeMap = findMapById(normalizedMaps, normalizedActiveId);
+        if (activeMap) {
+          return activeMap;
+        }
+      }
+
+      return normalizedMaps[0];
+    }
+
+    return map || null;
+  }, [normalizedMaps, resolvedSelectedId, normalizedActiveId, map]);
+
+  const handleSelectMap = useCallback(
+    (mapId) => {
+      if (typeof onSelectMap !== 'function') {
+        return;
+      }
+
+      const normalizedId = normalizeMapId(mapId);
+      onSelectMap(normalizedId);
+    },
+    [onSelectMap]
+  );
+
+  const handleActivateMap = useCallback(
+    (event, mapId) => {
+      event.stopPropagation();
+      if (typeof onActivateMap !== 'function') {
+        return;
+      }
+
+      const normalizedId = normalizeMapId(mapId);
+      if (!normalizedId) {
+        return;
+      }
+
+      onActivateMap(normalizedId);
+    },
+    [onActivateMap]
+  );
+
+  const handleDeleteMap = useCallback(
+    (event, mapId) => {
+      event.stopPropagation();
+      if (typeof onDeleteMap !== 'function') {
+        return;
+      }
+
+      const normalizedId = normalizeMapId(mapId);
+      if (!normalizedId) {
+        return;
+      }
+
+      onDeleteMap(normalizedId);
+    },
+    [onDeleteMap]
+  );
+
+  const hasManagementFeatures = useMemo(
+    () =>
+      typeof onSelectMap === 'function' ||
+      typeof onActivateMap === 'function' ||
+      typeof onDeleteMap === 'function',
+    [onSelectMap, onActivateMap, onDeleteMap]
+  );
+
+  const renderMapList = () => {
+    if (isLoading) {
+      return (
+        <div className="d-flex justify-content-center py-4" data-testid="map-modal-loading">
+          <Spinner animation="border" role="status" size="sm">
+            <span className="visually-hidden">Loading maps…</span>
+          </Spinner>
+        </div>
+      );
+    }
+
+    if (normalizedMaps.length === 0) {
+      return (
+        <div className="text-muted" data-testid="map-modal-empty">
+          {emptyMessage}
+        </div>
+      );
+    }
+
+    return (
+      <ListGroup
+        variant="flush"
+        className="bg-transparent map-modal__list"
+        data-testid="map-modal-list"
+      >
+        {normalizedMaps.map((mapItem, index) => {
+          const mapId = normalizeMapId(mapItem?.mapId);
+          const key = mapId || `map-${index}`;
+          const isActive = Boolean(normalizedActiveId && mapId && normalizedActiveId === mapId);
+          const isSelected = Boolean(resolvedSelectedId && mapId && resolvedSelectedId === mapId);
+          const isProcessing = Boolean(mapId && normalizedActionId && normalizedActionId === mapId);
+          const titleText = resolveMapTitle(mapItem, index);
+          const summaryText = resolveMapSummary(mapItem);
+          const canSelect = typeof onSelectMap === 'function' && Boolean(mapId);
+          const canActivate = typeof onActivateMap === 'function';
+          const canDelete = typeof onDeleteMap === 'function';
+
+          return (
+            <ListGroup.Item
+              as="div"
+              key={key}
+              action={canSelect}
+              active={isSelected}
+              onClick={() => {
+                if (canSelect && mapId) {
+                  handleSelectMap(mapId);
+                }
+              }}
+              className="bg-dark text-light border-secondary"
+              data-testid={`map-modal-item-${key}`}
+            >
+              <div className="d-flex justify-content-between align-items-start">
+                <div>
+                  <div className="fw-semibold">{titleText}</div>
+                  {summaryText && <div className="text-muted small">{summaryText}</div>}
+                </div>
+                {isActive && (
+                  <Badge bg="success" className="ms-2" data-testid={`map-modal-active-badge-${key}`}>
+                    Active
+                  </Badge>
+                )}
+              </div>
+              {(canActivate || canDelete) && (
+                <div className="d-flex flex-wrap gap-2 mt-3">
+                  {canActivate && (
+                    <Button
+                      variant="outline-light"
+                      size="sm"
+                      disabled={!mapId || isProcessing || isActive}
+                      onClick={(event) => handleActivateMap(event, mapId)}
+                      data-testid={`map-modal-activate-${key}`}
+                    >
+                      {isActive ? 'Active' : 'Set Active'}
+                    </Button>
+                  )}
+                  {canDelete && (
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      disabled={!mapId || isProcessing}
+                      onClick={(event) => handleDeleteMap(event, mapId)}
+                      data-testid={`map-modal-delete-${key}`}
+                    >
+                      Delete
+                    </Button>
+                  )}
+                </div>
+              )}
+            </ListGroup.Item>
+          );
+        })}
+      </ListGroup>
+    );
+  };
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      size={hasManagementFeatures ? 'xl' : 'lg'}
+      centered
+      data-testid="map-modal-wrapper"
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {hasManagementFeatures ? (
+          <div className="d-flex flex-column flex-lg-row gap-4">
+            <div className="flex-grow-1" data-testid="map-modal-sidebar">
+              <h5 className="h6 mb-3">Saved Maps</h5>
+              {renderMapList()}
+            </div>
+            <div className="flex-grow-1" data-testid="map-modal-preview">
+              {previewMap ? (
+                <MapDisplay map={previewMap} />
+              ) : (
+                <p className="text-muted mb-0">No map selected.</p>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div data-testid="map-modal-preview">
+            {previewMap ? (
+              <MapDisplay map={previewMap} />
+            ) : (
+              <p className="text-muted mb-0">No map image available.</p>
+            )}
+          </div>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onHide} data-testid="map-modal-close">
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
 
 MapModal.propTypes = {
   show: PropTypes.bool,
   onHide: PropTypes.func,
   map: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  maps: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.array])),
+  activeMapId: PropTypes.string,
+  selectedMapId: PropTypes.string,
+  onSelectMap: PropTypes.func,
+  onActivateMap: PropTypes.func,
+  onDeleteMap: PropTypes.func,
+  isLoading: PropTypes.bool,
+  actionInProgressId: PropTypes.string,
+  emptyMessage: PropTypes.node,
+  title: PropTypes.node,
 };
 
 MapModal.defaultProps = {
   show: false,
   onHide: () => {},
   map: null,
+  maps: [],
+  activeMapId: null,
+  selectedMapId: null,
+  onSelectMap: null,
+  onActivateMap: null,
+  onDeleteMap: null,
+  isLoading: false,
+  actionInProgressId: null,
+  emptyMessage: 'No maps saved yet.',
+  title: 'Campaign Map',
 };
 
 export default MapModal;

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+jest.mock('./MapDisplay', () => ({
+  __esModule: true,
+  default: jest.fn(({ map }) => (
+    <div data-testid="map-display">{map?.title || 'no-map'}</div>
+  )),
+}));
+
+import MapModal from './MapModal';
+import MapDisplay from './MapDisplay';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders read-only map preview when no management callbacks provided', () => {
+  const map = {
+    title: 'Ancient Ruins',
+    imageUrl: 'https://example.com/ruins.png',
+  };
+
+  render(<MapModal show map={map} />);
+
+  expect(screen.queryByTestId('map-modal-sidebar')).not.toBeInTheDocument();
+  expect(MapDisplay).toHaveBeenCalledTimes(1);
+  expect(MapDisplay.mock.calls[0][0].map).toEqual(map);
+});
+
+test('renders map manager list with actions and handles callbacks', async () => {
+  const maps = [
+    { mapId: 'map-1', title: 'Old Map' },
+    { mapId: 'map-2', title: 'New Map' },
+  ];
+  const onSelectMap = jest.fn();
+  const onActivateMap = jest.fn();
+  const onDeleteMap = jest.fn();
+
+  render(
+    <MapModal
+      show
+      maps={maps}
+      map={maps[0]}
+      activeMapId="map-1"
+      onSelectMap={onSelectMap}
+      onActivateMap={onActivateMap}
+      onDeleteMap={onDeleteMap}
+    />
+  );
+
+  expect(screen.getByTestId('map-modal-sidebar')).toBeInTheDocument();
+  expect(screen.getByTestId('map-modal-item-map-1')).toBeInTheDocument();
+  expect(screen.getByTestId('map-modal-item-map-2')).toBeInTheDocument();
+  expect(screen.getByTestId('map-modal-active-badge-map-1')).toBeInTheDocument();
+
+  await userEvent.click(screen.getByTestId('map-modal-item-map-2'));
+  expect(onSelectMap).toHaveBeenCalledWith('map-2');
+
+  await userEvent.click(screen.getByTestId('map-modal-activate-map-2'));
+  expect(onActivateMap).toHaveBeenCalledWith('map-2');
+
+  await userEvent.click(screen.getByTestId('map-modal-delete-map-1'));
+  expect(onDeleteMap).toHaveBeenCalledWith('map-1');
+});
+
+test('shows loading indicator when map manager is loading', () => {
+  render(
+    <MapModal
+      show
+      maps={[]}
+      isLoading
+      onDeleteMap={jest.fn()}
+    />
+  );
+
+  expect(screen.getByTestId('map-modal-sidebar')).toBeInTheDocument();
+  expect(screen.getByTestId('map-modal-loading')).toBeInTheDocument();
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -477,6 +477,8 @@ export default function ZombiesCharacterSheet() {
   const [campaignId, setCampaignId] = useState(null);
   const [combatState, setCombatState] = useState(createEmptyCombatState());
   const [campaignCharacters, setCampaignCharacters] = useState({});
+  const [campaignMaps, setCampaignMaps] = useState([]);
+  const [campaignActiveMapId, setCampaignActiveMapId] = useState(null);
   const [campaignMap, setCampaignMap] = useState(null);
   const [showMapModal, setShowMapModal] = useState(false);
   const [showCharacterInfo, setShowCharacterInfo] = useState(false);
@@ -973,16 +975,18 @@ export default function ZombiesCharacterSheet() {
         if (!normalizedCampaign) {
           setCombatState(createEmptyCombatState());
           setCampaignCharacters({});
+          setCampaignMaps([]);
+          setCampaignActiveMapId(null);
           setCampaignMap(null);
           return;
         }
 
         try {
           const encodedCampaign = encodeURIComponent(normalizedCampaign);
-          const [combatRes, charactersRes, mapRes] = await Promise.all([
+          const [combatRes, charactersRes, mapsRes] = await Promise.all([
             apiFetch(`/campaigns/${encodedCampaign}/combat`),
             apiFetch(`/campaigns/${encodedCampaign}/characters`),
-            apiFetch(`/campaigns/${encodedCampaign}/map`),
+            apiFetch(`/campaigns/${encodedCampaign}/maps`),
           ]);
 
           let combatData = createEmptyCombatState();
@@ -997,23 +1001,91 @@ export default function ZombiesCharacterSheet() {
             characterMap = mapCharactersById(charactersJson);
           }
 
+          let mapsList = [];
+          let activeMapIdValue = null;
           let mapData = null;
-          if (mapRes.ok) {
+
+          if (mapsRes.ok) {
             try {
-              const mapJson = await mapRes.json();
-              if (mapJson && typeof mapJson === "object") {
-                mapData = mapJson.map && typeof mapJson.map === "object" ? mapJson.map : mapJson;
+              const mapsPayload = await mapsRes.json();
+              if (mapsPayload && typeof mapsPayload === 'object') {
+                const normalizedMaps = Array.isArray(mapsPayload.maps)
+                  ? mapsPayload.maps.filter((entry) => entry && typeof entry === 'object')
+                  : [];
+                mapsList = normalizedMaps;
+
+                const normalizedActiveId =
+                  typeof mapsPayload.activeMapId === 'string' &&
+                  mapsPayload.activeMapId.trim() !== ''
+                    ? mapsPayload.activeMapId.trim()
+                    : null;
+                activeMapIdValue = normalizedActiveId;
+
+                const payloadMap =
+                  mapsPayload.map &&
+                  typeof mapsPayload.map === 'object' &&
+                  !Array.isArray(mapsPayload.map)
+                    ? mapsPayload.map
+                    : null;
+
+                if (payloadMap) {
+                  mapData = payloadMap;
+                } else if (normalizedActiveId) {
+                  mapData =
+                    normalizedMaps.find((entry) => entry?.mapId === normalizedActiveId) || null;
+                } else if (normalizedMaps.length === 1) {
+                  mapData = normalizedMaps[0];
+                }
               }
             } catch (mapError) {
               console.error(mapError);
             }
-          } else if (mapRes?.status === 404) {
-            mapData = null;
+          }
+
+          let shouldLoadLegacyMap = false;
+          if (!mapsRes || mapsRes.status === 404) {
+            shouldLoadLegacyMap = true;
+          } else if (!mapsRes.ok) {
+            shouldLoadLegacyMap = true;
+          }
+
+          if (shouldLoadLegacyMap) {
+            try {
+              const legacyMapRes = await apiFetch(`/campaigns/${encodedCampaign}/map`);
+              if (legacyMapRes.ok) {
+                const mapJson = await legacyMapRes.json();
+                if (mapJson && typeof mapJson === 'object') {
+                  mapData =
+                    mapJson.map && typeof mapJson.map === 'object' ? mapJson.map : mapJson;
+                } else {
+                  mapData = null;
+                }
+              } else if (legacyMapRes.status === 404) {
+                mapData = null;
+              }
+            } catch (legacyMapError) {
+              console.error(legacyMapError);
+            }
+          }
+
+          if (!mapData && mapsList.length > 0) {
+            mapData = mapsList[0];
+          }
+
+          if (!activeMapIdValue && mapData && typeof mapData.mapId === 'string') {
+            const candidateId = mapData.mapId.trim();
+            activeMapIdValue = candidateId !== '' ? candidateId : null;
+          }
+
+          if (mapsList.length === 0 && mapData) {
+            mapsList = [mapData];
           }
 
           if (!isCancelled) {
             setCombatState(combatData);
             setCampaignCharacters(characterMap);
+            setCampaignMaps(mapsList);
+            setCampaignActiveMapId(activeMapIdValue);
             setCampaignMap(mapData);
           }
         } catch (err) {
@@ -1021,6 +1093,8 @@ export default function ZombiesCharacterSheet() {
           if (!isCancelled) {
             setCombatState(createEmptyCombatState());
             setCampaignCharacters({});
+            setCampaignMaps([]);
+            setCampaignActiveMapId(null);
             setCampaignMap(null);
           }
         }
@@ -1030,6 +1104,8 @@ export default function ZombiesCharacterSheet() {
           setCampaignId(null);
           setCombatState(createEmptyCombatState());
           setCampaignCharacters({});
+          setCampaignMaps([]);
+          setCampaignActiveMapId(null);
           setCampaignMap(null);
         }
       }
@@ -1048,6 +1124,8 @@ export default function ZombiesCharacterSheet() {
         socketRef.current.disconnect();
         socketRef.current = null;
       }
+      setCampaignMaps([]);
+      setCampaignActiveMapId(null);
       setCampaignMap(null);
       setShowMapModal(false);
       return undefined;
@@ -1161,16 +1239,65 @@ export default function ZombiesCharacterSheet() {
 
     const handleCampaignMapUpdate = (update) => {
       if (update === null) {
+        setCampaignMaps([]);
+        setCampaignActiveMapId(null);
         setCampaignMap(null);
         return;
       }
 
-      if (!update || typeof update !== "object") {
+      if (!update || typeof update !== 'object') {
+        return;
+      }
+
+      const hasMapCollection = Array.isArray(update.maps) || 'activeMapId' in update;
+
+      if (hasMapCollection) {
+        const normalizedMaps = Array.isArray(update.maps)
+          ? update.maps.filter((entry) => entry && typeof entry === 'object')
+          : [];
+        setCampaignMaps(normalizedMaps);
+
+        const normalizedActiveId =
+          typeof update.activeMapId === 'string' && update.activeMapId.trim() !== ''
+            ? update.activeMapId.trim()
+            : null;
+        setCampaignActiveMapId(normalizedActiveId);
+
+        const payloadMap =
+          update.map && typeof update.map === 'object' && !Array.isArray(update.map)
+            ? update.map
+            : null;
+
+        const resolvedMap =
+          payloadMap ||
+          (normalizedActiveId
+            ? normalizedMaps.find((entry) => entry?.mapId === normalizedActiveId)
+            : null) ||
+          (normalizedMaps.length === 1 ? normalizedMaps[0] : null) ||
+          null;
+
+        setCampaignMap(resolvedMap);
         return;
       }
 
       const normalizedMap =
-        update.map && typeof update.map === "object" ? update.map : update;
+        update.map && typeof update.map === 'object' && !Array.isArray(update.map)
+          ? update.map
+          : update;
+
+      if (normalizedMap === null) {
+        setCampaignMaps([]);
+        setCampaignActiveMapId(null);
+        setCampaignMap(null);
+        return;
+      }
+
+      setCampaignMaps(normalizedMap ? [normalizedMap] : []);
+      const normalizedActiveId =
+        typeof normalizedMap?.mapId === 'string' && normalizedMap.mapId.trim() !== ''
+          ? normalizedMap.mapId.trim()
+          : null;
+      setCampaignActiveMapId(normalizedActiveId);
       setCampaignMap(normalizedMap);
     };
 
@@ -2099,12 +2226,18 @@ const spellsGold =
         availableSlots={availableSlots}
       />
     )}
-    <Help
-      form={form}
-      showHelpModal={showHelpModal}
-      handleCloseHelpModal={handleCloseHelpModal}
-    />
-    <MapModal show={showMapModal} onHide={handleCloseMapModal} map={campaignMap} />
+      <Help
+        form={form}
+        showHelpModal={showHelpModal}
+        handleCloseHelpModal={handleCloseHelpModal}
+      />
+      <MapModal
+        show={showMapModal}
+        onHide={handleCloseMapModal}
+        map={campaignMap}
+        maps={campaignMaps}
+        activeMapId={campaignActiveMapId}
+      />
   </div>
 );
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -65,6 +65,7 @@ jest.mock('../attributes/MapModal', () => (props) => {
 });
 const mockOnCastSpell = { current: null };
 const mockHandleClose = { current: null };
+let socketStub;
 jest.mock('../attributes/SpellSelector', () => (props) => {
   mockOnCastSpell.current = props.onCastSpell;
   mockHandleClose.current = props.handleClose;
@@ -77,6 +78,9 @@ import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 beforeEach(() => {
   apiFetch.mockReset();
   apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/maps')) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
     if (typeof url === 'string' && url.includes('/map')) {
       return Promise.resolve({ ok: false, status: 404 });
     }
@@ -84,7 +88,7 @@ beforeEach(() => {
     return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
   });
   mockSocketIo.mockReset();
-  const socketStub = {
+  socketStub = {
     on: jest.fn(),
     off: jest.fn(),
     emit: jest.fn(),
@@ -304,10 +308,16 @@ test('map footer button toggles the campaign map modal', async () => {
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        title: 'Wilds Overview',
-        imageUrl: 'https://example.com/wilds-map.png',
-        altText: 'Wilds overview map',
-        summary: 'Navigate from start to end.',
+        maps: [
+          {
+            mapId: 'wilds-map',
+            title: 'Wilds Overview',
+            imageUrl: 'https://example.com/wilds-map.png',
+            altText: 'Wilds overview map',
+            summary: 'Navigate from start to end.',
+          },
+        ],
+        activeMapId: 'wilds-map',
       }),
     });
 
@@ -320,9 +330,12 @@ test('map footer button toggles the campaign map modal', async () => {
   await waitFor(() => expect(mockMapModalProps.current).not.toBeNull());
   expect(mockMapModalProps.current.show).toBe(false);
   expect(mockMapModalProps.current.map).toMatchObject({
+    mapId: 'wilds-map',
     title: 'Wilds Overview',
     imageUrl: 'https://example.com/wilds-map.png',
   });
+  expect(mockMapModalProps.current.maps).toHaveLength(1);
+  expect(mockMapModalProps.current.activeMapId).toBe('wilds-map');
 
   await userEvent.click(mapButton);
   await waitFor(() => expect(mockMapModalProps.current.show).toBe(true));
@@ -332,6 +345,96 @@ test('map footer button toggles the campaign map modal', async () => {
   });
 
   await waitFor(() => expect(mockMapModalProps.current.show).toBe(false));
+});
+
+test('campaign map update events synchronize active map and list', async () => {
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        occupation: [],
+        spells: [],
+        str: 10,
+        dex: 10,
+        con: 10,
+        int: 10,
+        wis: 10,
+        cha: 10,
+        startStatTotal: 60,
+        proficiencyPoints: 0,
+        skills: {},
+        item: [],
+        feat: [],
+        weapon: [],
+        armor: [],
+        campaign: 'The Wilds',
+      }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ participants: [], activeTurn: null }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        maps: [
+          {
+            mapId: 'old-map',
+            title: 'Old Map',
+            imageUrl: 'https://example.com/old-map.png',
+          },
+        ],
+        activeMapId: 'old-map',
+      }),
+    });
+
+  render(<ZombiesCharacterSheet />);
+
+  await waitFor(() => expect(mockMapModalProps.current?.map?.mapId).toBe('old-map'));
+  await waitFor(() =>
+    expect(socketStub.on).toHaveBeenCalledWith(
+      'campaign:map:update',
+      expect.any(Function)
+    )
+  );
+
+  const mapUpdateCall = socketStub.on.mock.calls.find(
+    ([eventName]) => eventName === 'campaign:map:update'
+  );
+  expect(mapUpdateCall).toBeTruthy();
+  const [, mapUpdateHandler] = mapUpdateCall;
+  expect(typeof mapUpdateHandler).toBe('function');
+
+  act(() => {
+    mapUpdateHandler({
+      maps: [
+        {
+          mapId: 'old-map',
+          title: 'Old Map',
+          imageUrl: 'https://example.com/old-map.png',
+        },
+        {
+          mapId: 'new-map',
+          title: 'New Map',
+          imageUrl: 'https://example.com/new-map.png',
+        },
+      ],
+      activeMapId: 'new-map',
+    });
+  });
+
+  await waitFor(() =>
+    expect(mockMapModalProps.current.map).toMatchObject({
+      mapId: 'new-map',
+      title: 'New Map',
+    })
+  );
+  expect(mockMapModalProps.current.activeMapId).toBe('new-map');
+  expect(mockMapModalProps.current.maps).toHaveLength(2);
 });
 
 test('renders SpellSlots for non-spellcasting characters', async () => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -24,6 +24,7 @@ import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative } from '../utils/derivedStats';
 import MapDisplay from '../attributes/MapDisplay';
+import MapModal from '../attributes/MapModal';
 import {
   GiCharacter,
   GiStoneAxe,
@@ -278,6 +279,7 @@ export default function ZombiesDM() {
     const [mapGenerating, setMapGenerating] = useState(false);
     const [mapSaving, setMapSaving] = useState(false);
     const [mapSaveMode, setMapSaveMode] = useState(null);
+    const [showMapManager, setShowMapManager] = useState(false);
     const socketRef = useRef(null);
 
     const campaignId = params.campaign ?? '';
@@ -1831,6 +1833,14 @@ export default function ZombiesDM() {
       },
       []
     );
+
+    const handleOpenMapManager = useCallback(() => {
+      setShowMapManager(true);
+    }, []);
+
+    const handleCloseMapManager = useCallback(() => {
+      setShowMapManager(false);
+    }, []);
 
     const openCreateMapModal = useCallback(() => {
       setMapEditorSaving(false);
@@ -3659,17 +3669,30 @@ const resolveIcon = (category, iconMap, fallback) => {
                       <Col md={4} className="text-start">
                         <div className="d-flex justify-content-between align-items-center mb-3">
                           <h4 className="h6 mb-0">Saved Maps</h4>
-                          <Button
-                            variant="outline-light"
-                            size="sm"
-                            className="rounded-pill d-flex align-items-center"
-                            onClick={openCreateMapModal}
-                            disabled={mapGenerating}
-                            data-testid="create-map-button"
-                          >
-                            <FiPlus className="me-1" aria-hidden="true" />
-                            New Map
-                          </Button>
+                          <div className="d-flex flex-wrap gap-2">
+                            <Button
+                              variant="outline-light"
+                              size="sm"
+                              className="rounded-pill d-flex align-items-center"
+                              onClick={handleOpenMapManager}
+                              disabled={mapLoading}
+                              data-testid="open-map-manager-button"
+                            >
+                              <FiList className="me-1" aria-hidden="true" />
+                              Manage
+                            </Button>
+                            <Button
+                              variant="outline-light"
+                              size="sm"
+                              className="rounded-pill d-flex align-items-center"
+                              onClick={openCreateMapModal}
+                              disabled={mapGenerating}
+                              data-testid="create-map-button"
+                            >
+                              <FiPlus className="me-1" aria-hidden="true" />
+                              New Map
+                            </Button>
+                          </div>
                         </div>
                         {Array.isArray(maps) && maps.length > 0 ? (
                           <ListGroup
@@ -5395,6 +5418,21 @@ const resolveIcon = (category, iconMap, fallback) => {
           </Modal.Footer>
         </Form>
       </Modal>
+
+      <MapModal
+        show={showMapManager}
+        onHide={handleCloseMapManager}
+        title="Campaign Map Manager"
+        maps={maps}
+        map={previewMap || campaignMap}
+        activeMapId={activeMapId}
+        selectedMapId={selectedMapId}
+        onSelectMap={handleSelectMap}
+        onActivateMap={handleActivateMap}
+        onDeleteMap={handleDeleteMap}
+        isLoading={mapLoading}
+        actionInProgressId={mapActionLoadingId}
+      />
 
       <Modal
       className="dnd-modal"


### PR DESCRIPTION
## Summary
- refactor the map modal to support selectable map lists, management actions, and loading states
- update the DM interface to launch the enhanced map manager and forward map callbacks to the backend
- sync the player character sheet with map list/active map payloads and cover the workflow with new tests

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/MapModal.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dab63725b0832ea564c118b1be1677