### PR TITLE
Remove map summaries from Zombies DM tools

### DIFF
--- a/client/src/components/Zombies/attributes/MapDisplay.js
+++ b/client/src/components/Zombies/attributes/MapDisplay.js
@@ -20,28 +20,12 @@ const buildImageSource = ({ imageUrl, imageBase64, imageType }) => {
 const normalizeText = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
 
-const renderParagraphs = (text) => {
-  if (!text) {
-    return null;
-  }
-
-  return text.split('\n').map((paragraph, index) => (
-    <p key={`summary-${index}`} className="mb-2">
-      {paragraph}
-    </p>
-  ));
-};
-
 const MapDisplay = ({ map }) => {
   const safeMap = map && typeof map === 'object' ? map : {};
   const title = normalizeText(safeMap.title);
-  const caption = normalizeText(safeMap.caption);
-  const summary = normalizeText(safeMap.summary);
   const altText =
     normalizeText(safeMap.altText) ||
     title ||
-    caption ||
-    summary ||
     normalizeText(safeMap.prompt) ||
     'Campaign map image';
   const imageSrc = buildImageSource(safeMap);
@@ -56,18 +40,9 @@ const MapDisplay = ({ map }) => {
             alt={altText}
             className="map-display__image img-fluid rounded"
           />
-          {caption && (
-            <p className="map-display__caption text-muted mt-2 mb-0">{caption}</p>
-          )}
         </div>
       ) : (
         <p className="text-muted mb-0">No map image available.</p>
-      )}
-      {summary && (
-        <div className="map-display__summary mt-3">
-          <h6>Summary</h6>
-          {renderParagraphs(summary)}
-        </div>
       )}
     </div>
   );

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -24,19 +24,6 @@ const resolveMapTitle = (map, index) => {
   return `Map ${index + 1}`;
 };
 
-const resolveMapSummary = (map) => {
-  if (!map || typeof map !== 'object') {
-    return '';
-  }
-
-  const { summary } = map;
-  if (typeof summary === 'string' && summary.trim() !== '') {
-    return summary.trim();
-  }
-
-  return '';
-};
-
 const findMapById = (maps, id) => {
   const normalizedId = normalizeMapId(id);
   if (!normalizedId) {
@@ -192,7 +179,6 @@ const MapModal = ({
           const isSelected = Boolean(resolvedSelectedId && mapId && resolvedSelectedId === mapId);
           const isProcessing = Boolean(mapId && normalizedActionId && normalizedActionId === mapId);
           const titleText = resolveMapTitle(mapItem, index);
-          const summaryText = resolveMapSummary(mapItem);
           const canSelect = typeof onSelectMap === 'function' && Boolean(mapId);
           const canActivate = typeof onActivateMap === 'function';
           const canDelete = typeof onDeleteMap === 'function';
@@ -212,10 +198,7 @@ const MapModal = ({
               data-testid={`map-modal-item-${key}`}
             >
               <div className="d-flex justify-content-between align-items-start">
-                <div>
-                  <div className="fw-semibold">{titleText}</div>
-                  {summaryText && <div className="text-muted small">{summaryText}</div>}
-                </div>
+                <div className="fw-semibold">{titleText}</div>
                 {isActive && (
                   <Badge bg="success" className="ms-2" data-testid={`map-modal-active-badge-${key}`}>
                     Active

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -314,7 +314,6 @@ test('map footer button toggles the campaign map modal', async () => {
             title: 'Wilds Overview',
             imageUrl: 'https://example.com/wilds-map.png',
             altText: 'Wilds overview map',
-            summary: 'Navigate from start to end.',
           },
         ],
         activeMapId: 'wilds-map',

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -265,8 +265,6 @@ export default function ZombiesDM() {
       mode: 'create',
       map: null,
       title: '',
-      summary: '',
-      caption: '',
       imageUrl: '',
       altText: '',
       activateOnSave: true,
@@ -1858,8 +1856,6 @@ export default function ZombiesDM() {
         mode: 'create',
         map: safeMap,
         title: typeof safeMap.title === 'string' ? safeMap.title : '',
-        summary: typeof safeMap.summary === 'string' ? safeMap.summary : '',
-        caption: typeof safeMap.caption === 'string' ? safeMap.caption : '',
         imageUrl: typeof safeMap.imageUrl === 'string' ? safeMap.imageUrl : '',
         altText: typeof safeMap.altText === 'string' ? safeMap.altText : '',
         activateOnSave: maps.length === 0,
@@ -1879,8 +1875,6 @@ export default function ZombiesDM() {
         mode: 'rename',
         map: safeMap,
         title: typeof safeMap.title === 'string' ? safeMap.title : '',
-        summary: typeof safeMap.summary === 'string' ? safeMap.summary : '',
-        caption: typeof safeMap.caption === 'string' ? safeMap.caption : '',
         imageUrl: typeof safeMap.imageUrl === 'string' ? safeMap.imageUrl : '',
         altText: typeof safeMap.altText === 'string' ? safeMap.altText : '',
         activateOnSave: false,
@@ -1916,8 +1910,6 @@ export default function ZombiesDM() {
           mode,
           map: editorMap,
           title,
-          summary,
-          caption,
           imageUrl,
           altText,
           activateOnSave,
@@ -1929,8 +1921,6 @@ export default function ZombiesDM() {
             : editorMap || generatedMap || previewMap || {};
 
         const trimmedTitle = typeof title === 'string' ? title.trim() : '';
-        const trimmedSummary = typeof summary === 'string' ? summary.trim() : '';
-        const trimmedCaption = typeof caption === 'string' ? caption.trim() : '';
         const trimmedImageUrl = typeof imageUrl === 'string' ? imageUrl.trim() : '';
         const trimmedAltText = typeof altText === 'string' ? altText.trim() : '';
 
@@ -1940,11 +1930,14 @@ export default function ZombiesDM() {
             ? baseMap.title.trim()
             : 'Untitled Map');
 
+        const sanitizedBaseMap =
+          baseMap && typeof baseMap === 'object' ? { ...baseMap } : {};
+        delete sanitizedBaseMap.summary;
+        delete sanitizedBaseMap.caption;
+
         const payloadMap = {
-          ...baseMap,
+          ...sanitizedBaseMap,
           title: normalizedTitle,
-          summary: trimmedSummary,
-          caption: trimmedCaption,
           imageUrl: trimmedImageUrl,
           altText: trimmedAltText,
         };
@@ -1997,7 +1990,37 @@ export default function ZombiesDM() {
                   if (payloadMap.imageBase64 && map.imageBase64 === payloadMap.imageBase64) {
                     return true;
                   }
-                  return map.title === payloadMap.title && map.summary === payloadMap.summary;
+                  const normalizedPayloadTitle =
+                    typeof payloadMap.title === 'string' ? payloadMap.title : '';
+                  const normalizedMapTitle =
+                    typeof map.title === 'string' ? map.title : '';
+                  if (!normalizedPayloadTitle || normalizedMapTitle !== normalizedPayloadTitle) {
+                    return false;
+                  }
+
+                  const normalizedPayloadPrompt =
+                    typeof payloadMap.prompt === 'string' ? payloadMap.prompt : '';
+                  const normalizedMapPrompt =
+                    typeof map.prompt === 'string' ? map.prompt : '';
+                  if (
+                    normalizedPayloadPrompt &&
+                    normalizedMapPrompt === normalizedPayloadPrompt
+                  ) {
+                    return true;
+                  }
+
+                  const normalizedPayloadAltText =
+                    typeof payloadMap.altText === 'string' ? payloadMap.altText : '';
+                  const normalizedMapAltText =
+                    typeof map.altText === 'string' ? map.altText : '';
+                  if (
+                    normalizedPayloadAltText &&
+                    normalizedMapAltText === normalizedPayloadAltText
+                  ) {
+                    return true;
+                  }
+
+                  return !normalizedPayloadPrompt && !normalizedPayloadAltText;
                 });
                 preferredId = matchingMap?.mapId || null;
               }
@@ -3716,10 +3739,6 @@ const resolveIcon = (category, iconMap, fallback) => {
                                 typeof mapItem?.title === 'string' && mapItem.title.trim() !== ''
                                   ? mapItem.title.trim()
                                   : 'Untitled Map';
-                              const summaryText =
-                                typeof mapItem?.summary === 'string'
-                                  ? mapItem.summary.trim()
-                                  : '';
                               return (
                                 <ListGroup.Item
                                   key={mapKey}
@@ -3730,12 +3749,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                                   data-testid={`map-list-item-${mapKey}`}
                                 >
                                   <div className="d-flex justify-content-between align-items-start">
-                                    <div>
-                                      <div className="fw-semibold">{title}</div>
-                                      {summaryText && (
-                                        <div className="text-muted small">{summaryText}</div>
-                                      )}
-                                    </div>
+                                    <div className="fw-semibold">{title}</div>
                                     {isActive && (
                                       <Badge
                                         bg="success"
@@ -5328,27 +5342,6 @@ const resolveIcon = (category, iconMap, fallback) => {
                 placeholder="Enter map title"
                 value={mapEditorState.title}
                 onChange={handleMapEditorInputChange('title')}
-                disabled={mapEditorSaving}
-              />
-            </Form.Group>
-            <Form.Group className="mb-3" controlId="map-editor-summary">
-              <Form.Label>Summary</Form.Label>
-              <Form.Control
-                as="textarea"
-                rows={3}
-                placeholder="Provide a short summary"
-                value={mapEditorState.summary}
-                onChange={handleMapEditorInputChange('summary')}
-                disabled={mapEditorSaving}
-              />
-            </Form.Group>
-            <Form.Group className="mb-3" controlId="map-editor-caption">
-              <Form.Label>Caption</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="Optional caption"
-                value={mapEditorState.caption}
-                onChange={handleMapEditorInputChange('caption')}
                 disabled={mapEditorSaving}
               />
             </Form.Group>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -476,10 +476,8 @@ describe('ZombiesDM AI generation', () => {
     const existingMap = {
       mapId: 'map-1',
       title: 'Existing Map',
-      summary: 'A well-traveled road.',
       imageUrl: 'https://example.com/existing-map.png',
       altText: 'Existing map illustration',
-      caption: 'A previously saved battlefield.',
     };
     const generatedMap = {
       title: 'Generated Map',
@@ -490,7 +488,6 @@ describe('ZombiesDM AI generation', () => {
     const createdMap = {
       ...generatedMap,
       mapId: 'map-2',
-      summary: 'Dense forest terrain.',
     };
     let savedPayload;
 
@@ -592,12 +589,10 @@ describe('ZombiesDM AI generation', () => {
     const primaryMap = {
       mapId: 'map-1',
       title: 'Primary Map',
-      summary: 'The original battlefield.',
     };
     const secondaryMap = {
       mapId: 'map-2',
       title: 'Secondary Map',
-      summary: 'A hidden cavern.',
     };
     let activationPayload;
 
@@ -668,7 +663,6 @@ describe('ZombiesDM AI generation', () => {
     const initialMap = {
       mapId: 'map-1',
       title: 'Initial Map',
-      summary: 'Original battleground.',
     };
     const socketMaps = [initialMap];
 
@@ -724,7 +718,6 @@ describe('ZombiesDM AI generation', () => {
     const updatedMap = {
       mapId: 'map-2',
       title: 'Updated Map',
-      summary: 'A mysterious valley.',
     };
 
     mapUpdateHandler({

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -354,7 +354,6 @@ module.exports = (router) => {
 
       const mapPayload = {
         title: 'Generated Battle Map',
-        summary: image.revised_prompt || undefined,
         prompt: prompt.trim(),
         provider: 'openai',
         model,

--- a/server/schemas/map.js
+++ b/server/schemas/map.js
@@ -65,7 +65,7 @@ const createMapSchema = (z) => {
       }
 
       if (!map.altText) {
-        const derivedAltText = map.title || map.summary || map.caption || map.prompt;
+        const derivedAltText = map.title || map.prompt;
         if (derivedAltText && typeof derivedAltText === 'string') {
           map.altText = derivedAltText;
         } else {

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -92,7 +92,7 @@ const prepareStoredMap = ({
     };
   }
 
-  const base = parsedInput.data;
+  const { summary: _summary, caption: _caption, ...base } = parsedInput.data;
   const now = new Date().toISOString();
   const existing = existingMap && typeof existingMap === 'object' ? existingMap : {};
 


### PR DESCRIPTION
## Summary
- stop populating the map summary field during AI generation and strip stored summaries/captions while keeping alt-text fallbacks to title/prompt
- remove summary/caption inputs and displays from the Zombies DM map manager and modal components
- update related Zombies tests to reflect the slimmer map payloads

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js client/src/components/Zombies/attributes/MapModal.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dabe087850832eaa86f1a05e53e412