### PR TITLE
Derive descriptive map titles from prompts

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import apiFetch from '../../../utils/apiFetch';
+import { DEFAULT_MAP_TITLE, getMapDisplayTitle } from '../../../utils/mapTitle';
 import { io } from "socket.io-client";
 import {
   Button,
@@ -1924,11 +1925,7 @@ export default function ZombiesDM() {
         const trimmedImageUrl = typeof imageUrl === 'string' ? imageUrl.trim() : '';
         const trimmedAltText = typeof altText === 'string' ? altText.trim() : '';
 
-        const normalizedTitle =
-          trimmedTitle ||
-          (typeof baseMap.title === 'string' && baseMap.title.trim() !== ''
-            ? baseMap.title.trim()
-            : 'Untitled Map');
+        const normalizedTitle = trimmedTitle || getMapDisplayTitle(baseMap, DEFAULT_MAP_TITLE);
 
         const sanitizedBaseMap =
           baseMap && typeof baseMap === 'object' ? { ...baseMap } : {};
@@ -3735,10 +3732,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                               );
                               const isProcessing =
                                 Boolean(mapIdValue && mapActionLoadingId === mapIdValue);
-                              const title =
-                                typeof mapItem?.title === 'string' && mapItem.title.trim() !== ''
-                                  ? mapItem.title.trim()
-                                  : 'Untitled Map';
+                              const title = getMapDisplayTitle(
+                                mapItem,
+                                DEFAULT_MAP_TITLE
+                              );
                               return (
                                 <ListGroup.Item
                                   key={mapKey}

--- a/client/src/utils/mapTitle.js
+++ b/client/src/utils/mapTitle.js
@@ -1,0 +1,101 @@
+const DEFAULT_MAP_TITLE = 'Generated Battle Map';
+const MAX_TITLE_LENGTH = 60;
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, ' ').trim();
+
+const toTitleCase = (value) =>
+  value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => {
+      if (word.length === 0) {
+        return '';
+      }
+      const [firstChar, ...rest] = word;
+      return `${firstChar.toUpperCase()}${rest.join('').toLowerCase()}`;
+    })
+    .join(' ');
+
+const truncate = (value, maxLength) => {
+  if (!value || value.length <= maxLength) {
+    return value;
+  }
+
+  const truncated = value.slice(0, maxLength);
+  const withoutPartialWord = truncated.replace(/\s+\S*$/, '').trim();
+
+  if (withoutPartialWord.length >= Math.floor(maxLength * 0.6)) {
+    return withoutPartialWord;
+  }
+
+  return truncated.trim();
+};
+
+const deriveClause = (value) => {
+  const clauseMatch = value.match(/^[^.!?;:\n]+/);
+  if (clauseMatch && clauseMatch[0]) {
+    return clauseMatch[0].trim();
+  }
+  const firstLine = value.split(/\n/)[0];
+  if (firstLine && firstLine.trim()) {
+    return firstLine.trim();
+  }
+  return value;
+};
+
+export const deriveMapTitle = ({ revisedPrompt, prompt, fallback = DEFAULT_MAP_TITLE } = {}) => {
+  const sources = [revisedPrompt, prompt];
+  const sourceText = sources.find(
+    (value) => typeof value === 'string' && value.trim().length > 0
+  );
+
+  if (!sourceText) {
+    return fallback;
+  }
+
+  const normalized = normalizeWhitespace(sourceText);
+  if (!normalized) {
+    return fallback;
+  }
+
+  let clause = deriveClause(normalized);
+  if (!clause) {
+    clause = normalized;
+  }
+
+  clause = clause.replace(/[\s\-–—]+$/, '').trim();
+  if (!clause) {
+    clause = normalized;
+  }
+
+  clause = truncate(clause, MAX_TITLE_LENGTH);
+  if (!clause) {
+    return fallback;
+  }
+
+  const title = toTitleCase(clause);
+  return title || fallback;
+};
+
+export const getMapDisplayTitle = (
+  map,
+  fallback = DEFAULT_MAP_TITLE
+) => {
+  if (!map || typeof map !== 'object') {
+    return fallback;
+  }
+
+  if (typeof map.title === 'string' && map.title.trim() !== '') {
+    return map.title.trim();
+  }
+
+  const promptSource =
+    (typeof map.revised_prompt === 'string' && map.revised_prompt.trim()) ||
+    (typeof map.prompt === 'string' && map.prompt.trim()) ||
+    (typeof map.originalPrompt === 'string' && map.originalPrompt.trim()) ||
+    null;
+
+  return deriveMapTitle({ prompt: promptSource, fallback });
+};
+
+export { DEFAULT_MAP_TITLE };

--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -316,7 +316,7 @@ describe('AI map route', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      title: 'Generated Battle Map',
+      title: 'Reimagined Cavern Layout',
       imageUrl: 'https://example.com/map.png',
       prompt: 'create a cavern map',
       provider: 'openai',
@@ -328,6 +328,23 @@ describe('AI map route', () => {
         prompt: expect.stringContaining('create a cavern map'),
       })
     );
+  });
+
+  test('derives a title from the user prompt when no revision is provided', async () => {
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          url: 'https://example.com/prompt-only-map.png',
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/ai/map')
+      .send({ prompt: 'haunted crypt with flickering torches. include secret doors' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Haunted Crypt With Flickering Torches');
   });
 
   test('omits response_format for models that do not require it', async () => {

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -16,6 +16,7 @@ const {
 } = require('../data/accessories');
 const { skillNames } = require('./fieldConstants');
 const createMapSchema = require('../schemas/map');
+const { deriveMapTitle } = require('../utils/mapTitle');
 
 const resolveOpenAI = () => {
   if (!OpenAI) {
@@ -353,7 +354,10 @@ module.exports = (router) => {
       }
 
       const mapPayload = {
-        title: 'Generated Battle Map',
+        title: deriveMapTitle({
+          revisedPrompt: image.revised_prompt,
+          prompt: prompt.trim(),
+        }),
         prompt: prompt.trim(),
         provider: 'openai',
         model,

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -123,6 +123,23 @@ const prepareStoredMap = ({
     updatedAt,
   };
 
+  if (typeof storedMap.title === 'string') {
+    const trimmedTitle = storedMap.title.trim();
+    if (trimmedTitle) {
+      storedMap.title = trimmedTitle;
+    } else {
+      delete storedMap.title;
+    }
+  }
+
+  if (
+    !storedMap.title &&
+    typeof existing.title === 'string' &&
+    existing.title.trim() !== ''
+  ) {
+    storedMap.title = existing.title.trim();
+  }
+
   if (typeof prompt === 'string' && prompt.trim() !== '') {
     storedMap.originalPrompt = prompt.trim();
   } else if (

--- a/server/utils/mapTitle.js
+++ b/server/utils/mapTitle.js
@@ -1,0 +1,83 @@
+const DEFAULT_MAP_TITLE = 'Generated Battle Map';
+const MAX_TITLE_LENGTH = 60;
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, ' ').trim();
+
+const toTitleCase = (value) =>
+  value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => {
+      if (word.length === 0) {
+        return '';
+      }
+      const [firstChar, ...rest] = word;
+      return `${firstChar.toUpperCase()}${rest.join('').toLowerCase()}`;
+    })
+    .join(' ');
+
+const truncate = (value, maxLength) => {
+  if (!value || value.length <= maxLength) {
+    return value;
+  }
+
+  const truncated = value.slice(0, maxLength);
+  const withoutPartialWord = truncated.replace(/\s+\S*$/, '').trim();
+
+  if (withoutPartialWord.length >= Math.floor(maxLength * 0.6)) {
+    return withoutPartialWord;
+  }
+
+  return truncated.trim();
+};
+
+const deriveClause = (value) => {
+  const clauseMatch = value.match(/^[^.!?;:\n]+/);
+  if (clauseMatch && clauseMatch[0]) {
+    return clauseMatch[0].trim();
+  }
+  const firstLine = value.split(/\n/)[0];
+  if (firstLine && firstLine.trim()) {
+    return firstLine.trim();
+  }
+  return value;
+};
+
+const deriveMapTitle = ({ revisedPrompt, prompt, fallback = DEFAULT_MAP_TITLE } = {}) => {
+  const sources = [revisedPrompt, prompt];
+  const sourceText = sources.find(
+    (value) => typeof value === 'string' && value.trim().length > 0
+  );
+
+  if (!sourceText) {
+    return fallback;
+  }
+
+  const normalized = normalizeWhitespace(sourceText);
+  if (!normalized) {
+    return fallback;
+  }
+
+  let clause = deriveClause(normalized);
+  if (!clause) {
+    clause = normalized;
+  }
+
+  clause = clause.replace(/[\s\-–—]+$/, '').trim();
+  if (!clause) {
+    clause = normalized;
+  }
+
+  clause = truncate(clause, MAX_TITLE_LENGTH);
+  if (!clause) {
+    return fallback;
+  }
+
+  const title = toTitleCase(clause);
+  return title || fallback;
+};
+
+module.exports = {
+  DEFAULT_MAP_TITLE,
+  deriveMapTitle,
+};


### PR DESCRIPTION
## Summary
- add helpers to derive descriptive battle map titles from AI prompts and use them across the API and UI
- preserve generated titles when storing campaign maps and surface the derived labels in the Zombies DM interface
- update AI route tests to cover the new naming behavior

## Testing
- npm --prefix server test -- ai.test.js
- CI=1 npm --prefix client test -- ZombiesDM.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dac0c27564832eb7888a36705c781e