### PR TITLE
Add campaign map token management

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -73,6 +73,7 @@ describe('Campaign routes', () => {
         maps: [],
         activeMapId: null,
         map: null,
+        mapTokens: {},
         enemies: [],
         combat: { participants: [], activeTurn: null },
       })
@@ -173,14 +174,18 @@ describe('Campaign routes', () => {
       updatedAt: '2023-01-01T00:00:00.000Z',
     };
 
-    const buildCampaignWithMap = (overrides = {}) => {
-      const mapRecord = { ...storedMap, ...overrides };
+    const buildCampaignWithMap = (mapOverrides = {}, campaignOverrides = {}) => {
+      const mapRecord = { ...storedMap, ...mapOverrides };
+      const { mapTokens: overrideTokens, ...restCampaignOverrides } =
+        campaignOverrides || {};
       return {
         campaignName: 'Test',
         dm: 'DM',
         maps: [mapRecord],
         activeMapId: mapRecord.mapId,
         map: mapRecord,
+        mapTokens: overrideTokens !== undefined ? overrideTokens : {},
+        ...restCampaignOverrides,
       };
     };
 
@@ -193,10 +198,11 @@ describe('Campaign routes', () => {
         }),
       });
 
-      const res = await request(app).get('/campaigns/Test/map');
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
-    });
+    const res = await request(app).get('/campaigns/Test/map');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
+    expect(res.body.tokens).toEqual({});
+  });
 
     test('get map missing campaign', async () => {
       dbo.mockResolvedValue({
@@ -237,14 +243,17 @@ describe('Campaign routes', () => {
         }),
       });
 
-      const res = await request(app).get('/campaigns/Test/maps');
-      expect(res.status).toBe(200);
-      expect(res.body.activeMapId).toBe(storedMap.mapId);
-      expect(res.body.map).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
-      expect(res.body.maps).toEqual(
-        expect.arrayContaining([expect.objectContaining({ mapId: storedMap.mapId })])
-      );
-    });
+    const res = await request(app).get('/campaigns/Test/maps');
+    expect(res.status).toBe(200);
+    expect(res.body.activeMapId).toBe(storedMap.mapId);
+    expect(res.body.map).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
+    expect(res.body.map.tokens).toEqual({});
+    expect(res.body.activeMapTokens).toEqual({});
+    expect(res.body.tokensByMapId).toEqual({});
+    expect(res.body.maps).toEqual(
+      expect.arrayContaining([expect.objectContaining({ mapId: storedMap.mapId })])
+    );
+  });
 
     test('create map success', async () => {
       const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
@@ -265,43 +274,49 @@ describe('Campaign routes', () => {
         .post('/campaigns/Test/maps')
         .send({ map: baseMap, prompt: 'Create a dungeon map' });
 
-      expect(res.status).toBe(200);
-      expect(res.body.activeMapId).toEqual(expect.any(String));
-      expect(res.body.map).toEqual(
-        expect.objectContaining({
-          title: baseMap.title,
-          originalPrompt: 'Create a dungeon map',
-          mapId: res.body.activeMapId,
-        })
-      );
-      expect(res.body.maps).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
-        ])
-      );
-      const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
-      expect(lastUpdate).toEqual(
-        expect.objectContaining({
-          $set: expect.objectContaining({
-            activeMapId: res.body.activeMapId,
-            map: expect.objectContaining({ mapId: res.body.activeMapId }),
-            maps: expect.arrayContaining([
-              expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
-            ]),
-          }),
-        })
-      );
-      expect(emitMapUpdate).toHaveBeenCalledWith(
-        'Test',
-        expect.objectContaining({
+    expect(res.status).toBe(200);
+    expect(res.body.activeMapId).toEqual(expect.any(String));
+    expect(res.body.map).toEqual(
+      expect.objectContaining({
+        title: baseMap.title,
+        originalPrompt: 'Create a dungeon map',
+        mapId: res.body.activeMapId,
+      })
+    );
+    expect(res.body.map.tokens).toEqual({});
+    expect(res.body.activeMapTokens).toEqual({});
+    expect(res.body.tokensByMapId).toEqual({});
+    expect(res.body.maps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+      ])
+    );
+    const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
+    expect(lastUpdate).toEqual(
+      expect.objectContaining({
+        $set: expect.objectContaining({
           activeMapId: res.body.activeMapId,
           map: expect.objectContaining({ mapId: res.body.activeMapId }),
           maps: expect.arrayContaining([
             expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
           ]),
-        })
-      );
-    });
+          mapTokens: {},
+        }),
+      })
+    );
+    expect(emitMapUpdate).toHaveBeenCalledWith(
+      'Test',
+      expect.objectContaining({
+        activeMapId: res.body.activeMapId,
+        map: expect.objectContaining({ mapId: res.body.activeMapId }),
+        maps: expect.arrayContaining([
+          expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+        ]),
+        tokensByMapId: {},
+        activeMapTokens: {},
+      })
+    );
+  });
 
     test('legacy map update success', async () => {
       const updatedAtBefore = '2023-01-02T00:00:00.000Z';
@@ -325,6 +340,7 @@ describe('Campaign routes', () => {
           originalPrompt: 'Create a dungeon map',
           mapId: storedMap.mapId,
           updatedAt: expect.any(String),
+          tokens: {},
         })
       );
       const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
@@ -339,6 +355,7 @@ describe('Campaign routes', () => {
             maps: expect.arrayContaining([
               expect.objectContaining({ mapId: storedMap.mapId, title: baseMap.title }),
             ]),
+            mapTokens: {},
           }),
         })
       );
@@ -347,6 +364,8 @@ describe('Campaign routes', () => {
         expect.objectContaining({
           activeMapId: storedMap.mapId,
           map: expect.objectContaining({ mapId: storedMap.mapId }),
+          tokensByMapId: {},
+          activeMapTokens: {},
         })
       );
     });
@@ -432,9 +451,16 @@ describe('Campaign routes', () => {
       expect(res.body.map).toEqual(
         expect.objectContaining({ mapId: secondaryMap.mapId, title: secondaryMap.title })
       );
+      expect(res.body.map.tokens).toEqual({});
+      expect(res.body.activeMapTokens).toEqual({});
+      expect(res.body.tokensByMapId).toEqual({});
       expect(emitMapUpdate).toHaveBeenCalledWith(
         'Test',
-        expect.objectContaining({ activeMapId: secondaryMap.mapId })
+        expect.objectContaining({
+          activeMapId: secondaryMap.mapId,
+          activeMapTokens: {},
+          tokensByMapId: {},
+        })
       );
     });
 
@@ -466,11 +492,250 @@ describe('Campaign routes', () => {
       expect(res.body.map).toEqual(
         expect.objectContaining({ mapId: storedMap.mapId, title: storedMap.title })
       );
+      expect(res.body.map.tokens).toEqual({});
+      expect(res.body.activeMapTokens).toEqual({});
+      expect(res.body.tokensByMapId).toEqual({});
       expect(res.body.maps).toHaveLength(1);
       expect(emitMapUpdate).toHaveBeenCalledWith(
         'Test',
-        expect.objectContaining({ activeMapId: storedMap.mapId })
+        expect.objectContaining({
+          activeMapId: storedMap.mapId,
+          activeMapTokens: {},
+          tokensByMapId: {},
+        })
       );
+    });
+
+    test('update map token success as DM', async () => {
+      const campaignDoc = buildCampaignWithMap();
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne,
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: jest.fn() };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app)
+        .put(`/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`)
+        .send({ x: 1.5, y: -0.25 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.tokensByMapId).toEqual({
+        [storedMap.mapId]: {
+          'hero-1': expect.objectContaining({
+            characterId: 'hero-1',
+            x: 1,
+            y: 0,
+            updatedAt: expect.any(String),
+          }),
+        },
+      });
+      expect(res.body.activeMapTokens).toEqual({
+        'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+      });
+      expect(updateOne).toHaveBeenCalledWith(
+        { campaignName: 'Test' },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            mapTokens: {
+              [storedMap.mapId]: expect.objectContaining({
+                'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+              }),
+            },
+          }),
+        })
+      );
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({
+          tokensByMapId: expect.objectContaining({
+            [storedMap.mapId]: expect.objectContaining({
+              'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+            }),
+          }),
+          activeMapTokens: expect.objectContaining({
+            'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+          }),
+        })
+      );
+    });
+
+    test('update map token requires numeric coordinates', async () => {
+      const campaignDoc = buildCampaignWithMap();
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne: jest.fn(),
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: jest.fn() };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app)
+        .put(`/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`)
+        .send({ x: 'invalid', y: 0.2 });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('update map token success for character owner', async () => {
+      mockUser = { username: 'PlayerOwner' };
+      const campaignDoc = buildCampaignWithMap({}, { dm: 'DM' });
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      const charactersFindOne = jest
+        .fn()
+        .mockResolvedValue({ token: 'PlayerOwner' });
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne,
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: charactersFindOne };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app)
+        .put(`/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`)
+        .send({ x: 0.3, y: 0.7 });
+
+      expect(res.status).toBe(200);
+      expect(charactersFindOne).toHaveBeenCalled();
+      expect(res.body.tokensByMapId[storedMap.mapId]['hero-1']).toEqual(
+        expect.objectContaining({
+          characterId: 'hero-1',
+          x: 0.3,
+          y: 0.7,
+        })
+      );
+      expect(updateOne).toHaveBeenCalled();
+    });
+
+    test('update map token forbidden for non-owner', async () => {
+      mockUser = { username: 'OtherPlayer' };
+      const campaignDoc = buildCampaignWithMap({}, { dm: 'DM' });
+      const campaignsUpdate = jest.fn();
+      const charactersFindOne = jest.fn().mockResolvedValue({ token: 'PlayerOwner' });
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne: campaignsUpdate,
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: charactersFindOne };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app)
+        .put(`/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`)
+        .send({ x: 0.4, y: 0.4 });
+
+      expect(res.status).toBe(403);
+      expect(charactersFindOne).toHaveBeenCalled();
+      expect(campaignsUpdate).not.toHaveBeenCalled();
+    });
+
+    test('delete map token success', async () => {
+      const tokenRecord = {
+        characterId: 'hero-1',
+        x: 0.25,
+        y: 0.75,
+        updatedAt: '2023-01-01T00:00:00.000Z',
+      };
+      const campaignDoc = buildCampaignWithMap({}, {
+        mapTokens: {
+          [storedMap.mapId]: {
+            'hero-1': tokenRecord,
+          },
+        },
+      });
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne,
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: jest.fn() };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app).delete(
+        `/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.tokensByMapId).toEqual({});
+      expect(res.body.activeMapTokens).toEqual({});
+      expect(updateOne).toHaveBeenCalledWith(
+        { campaignName: 'Test' },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            mapTokens: {},
+          }),
+        })
+      );
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({
+          tokensByMapId: {},
+          activeMapTokens: {},
+        })
+      );
+    });
+
+    test('delete map token missing entry returns 404', async () => {
+      const campaignDoc = buildCampaignWithMap();
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne: jest.fn(),
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: jest.fn() };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app).delete(
+        `/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`
+      );
+
+      expect(res.status).toBe(404);
     });
   });
 

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1,6 +1,7 @@
 const { param, body } = require('express-validator');
 const express = require('express');
 const { randomUUID } = require('crypto');
+const { ObjectId } = require('mongodb');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
 const { buildEnemyRecord } = require('../utils/monsters');
 const authenticateToken = require('../middleware/auth');
@@ -11,6 +12,7 @@ const {
   normalizeCampaignMapState,
   prepareStoredMap,
   buildCampaignMapPayload,
+  normalizeMapTokens,
 } = require('../utils/campaignMaps');
 
 module.exports = (router) => {
@@ -192,6 +194,29 @@ module.exports = (router) => {
     return withDefaultCombat(campaigns);
   };
 
+  const cloneMapTokens = (tokensByMapId = {}) => {
+    if (!tokensByMapId || typeof tokensByMapId !== 'object') {
+      return {};
+    }
+
+    return Object.keys(tokensByMapId).reduce((acc, mapId) => {
+      const mapTokens = tokensByMapId[mapId];
+      if (!mapTokens || typeof mapTokens !== 'object' || Array.isArray(mapTokens)) {
+        return acc;
+      }
+
+      acc[mapId] = Object.keys(mapTokens).reduce((tokenAcc, characterId) => {
+        const entry = mapTokens[characterId];
+        if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+          tokenAcc[characterId] = { ...entry };
+        }
+        return tokenAcc;
+      }, {});
+
+      return acc;
+    }, {});
+  };
+
   // Apply authentication to all campaign routes
   campaignRouter.use(authenticateToken);
 
@@ -367,7 +392,13 @@ module.exports = (router) => {
             : [];
           nextMaps.push(storedMap);
 
-          const payload = buildCampaignMapPayload(nextMaps, storedMap.mapId);
+          const nextTokens = cloneMapTokens(normalizedCampaign.mapTokens);
+
+          const payload = buildCampaignMapPayload(
+            nextMaps,
+            storedMap.mapId,
+            nextTokens
+          );
 
           await collection.updateOne(
             { campaignName },
@@ -376,6 +407,7 @@ module.exports = (router) => {
                 maps: payload.maps,
                 activeMapId: payload.activeMapId,
                 map: payload.map || null,
+                mapTokens: payload.tokensByMapId,
               },
             }
           );
@@ -494,9 +526,12 @@ module.exports = (router) => {
             ? storedMap.mapId
             : normalizedCampaign.activeMapId;
 
+          const nextTokens = cloneMapTokens(normalizedCampaign.mapTokens);
+
           const payload = buildCampaignMapPayload(
             nextMaps,
-            desiredActiveId || storedMap.mapId
+            desiredActiveId || storedMap.mapId,
+            nextTokens
           );
 
           await collection.updateOne(
@@ -506,6 +541,7 @@ module.exports = (router) => {
                 maps: payload.maps,
                 activeMapId: payload.activeMapId,
                 map: payload.map || null,
+                mapTokens: payload.tokensByMapId,
               },
             }
           );
@@ -617,7 +653,13 @@ module.exports = (router) => {
             ? mapId
             : normalizedCampaign.activeMapId;
 
-          const payload = buildCampaignMapPayload(nextMaps, desiredActiveId);
+          const nextTokens = cloneMapTokens(normalizedCampaign.mapTokens);
+
+          const payload = buildCampaignMapPayload(
+            nextMaps,
+            desiredActiveId,
+            nextTokens
+          );
 
           await collection.updateOne(
             { campaignName },
@@ -626,6 +668,7 @@ module.exports = (router) => {
                 maps: payload.maps,
                 activeMapId: payload.activeMapId,
                 map: payload.map || null,
+                mapTokens: payload.tokensByMapId,
               },
             }
           );
@@ -682,12 +725,251 @@ module.exports = (router) => {
               ? null
               : normalizedCampaign.activeMapId;
 
-          const payload = buildCampaignMapPayload(remainingMaps, desiredActiveId);
+          const nextTokens = cloneMapTokens(normalizedCampaign.mapTokens);
+          delete nextTokens[mapId];
+
+          const payload = buildCampaignMapPayload(
+            remainingMaps,
+            desiredActiveId,
+            nextTokens
+          );
 
           await collection.updateOne(
             { campaignName },
             {
               $set: {
+                maps: payload.maps,
+                activeMapId: payload.activeMapId,
+                map: payload.map || null,
+                mapTokens: payload.tokensByMapId,
+              },
+            }
+          );
+
+          emitMapUpdate(campaignName, payload);
+
+          return res.json(payload);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/maps/:mapId/tokens/:characterId')
+    .put(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        param('mapId').trim().notEmpty().withMessage('mapId is required'),
+        param('characterId')
+          .trim()
+          .notEmpty()
+          .withMessage('characterId is required'),
+        body('x').isFloat().withMessage('x must be a number').toFloat(),
+        body('y').isFloat().withMessage('y must be a number').toFloat(),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const mapId = req.params.mapId;
+          const characterId = req.params.characterId;
+          const db_connect = req.db;
+          const campaignsCollection = db_connect.collection('Campaigns');
+          const campaign = await campaignsCollection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const trimmedCharacterId = characterId.trim();
+
+          const isDm = req.user && campaign.dm === req.user.username;
+          if (!isDm) {
+            const charactersCollection = db_connect.collection('Characters');
+            const orConditions = [{ characterId: trimmedCharacterId }];
+            if (ObjectId.isValid(trimmedCharacterId)) {
+              orConditions.push({ _id: new ObjectId(trimmedCharacterId) });
+            }
+
+            const character = await charactersCollection.findOne(
+              {
+                campaign: campaignName,
+                $or: orConditions,
+              },
+              { projection: { token: 1 } }
+            );
+
+            if (!character || character.token !== req.user?.username) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+          }
+
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection: campaignsCollection,
+          });
+
+          const targetMap = Array.isArray(normalizedCampaign.maps)
+            ? normalizedCampaign.maps.find((map) => map.mapId === mapId)
+            : null;
+
+          if (!targetMap) {
+            return res.status(404).json({ message: 'Map not found' });
+          }
+
+          const nextTokens = cloneMapTokens(normalizedCampaign.mapTokens);
+          const now = new Date().toISOString();
+
+          if (!nextTokens[mapId] || typeof nextTokens[mapId] !== 'object') {
+            nextTokens[mapId] = {};
+          }
+
+          nextTokens[mapId][trimmedCharacterId] = {
+            characterId: trimmedCharacterId,
+            x: req.body.x,
+            y: req.body.y,
+            updatedAt: now,
+          };
+
+          const { tokensByMapId } = normalizeMapTokens({
+            mapTokens: nextTokens,
+            validMapIds: new Set(
+              Array.isArray(normalizedCampaign.maps)
+                ? normalizedCampaign.maps.map((map) => map.mapId)
+                : []
+            ),
+            now,
+          });
+
+          const payload = buildCampaignMapPayload(
+            normalizedCampaign.maps,
+            normalizedCampaign.activeMapId,
+            tokensByMapId
+          );
+
+          await campaignsCollection.updateOne(
+            { campaignName },
+            {
+              $set: {
+                mapTokens: payload.tokensByMapId,
+                maps: payload.maps,
+                activeMapId: payload.activeMapId,
+                map: payload.map || null,
+              },
+            }
+          );
+
+          emitMapUpdate(campaignName, payload);
+
+          return res.json(payload);
+        } catch (err) {
+          next(err);
+        }
+      }
+    )
+    .delete(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        param('mapId').trim().notEmpty().withMessage('mapId is required'),
+        param('characterId')
+          .trim()
+          .notEmpty()
+          .withMessage('characterId is required'),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const mapId = req.params.mapId;
+          const characterId = req.params.characterId;
+          const db_connect = req.db;
+          const campaignsCollection = db_connect.collection('Campaigns');
+          const campaign = await campaignsCollection.findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const trimmedCharacterId = characterId.trim();
+
+          const isDm = req.user && campaign.dm === req.user.username;
+          if (!isDm) {
+            const charactersCollection = db_connect.collection('Characters');
+            const orConditions = [{ characterId: trimmedCharacterId }];
+            if (ObjectId.isValid(trimmedCharacterId)) {
+              orConditions.push({ _id: new ObjectId(trimmedCharacterId) });
+            }
+
+            const character = await charactersCollection.findOne(
+              {
+                campaign: campaignName,
+                $or: orConditions,
+              },
+              { projection: { token: 1 } }
+            );
+
+            if (!character || character.token !== req.user?.username) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+          }
+
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection: campaignsCollection,
+          });
+
+          const targetMap = Array.isArray(normalizedCampaign.maps)
+            ? normalizedCampaign.maps.find((map) => map.mapId === mapId)
+            : null;
+
+          if (!targetMap) {
+            return res.status(404).json({ message: 'Map not found' });
+          }
+
+          const existingTokens =
+            normalizedCampaign.mapTokens &&
+            typeof normalizedCampaign.mapTokens === 'object'
+              ? normalizedCampaign.mapTokens[mapId]
+              : null;
+
+          if (
+            !existingTokens ||
+            typeof existingTokens !== 'object' ||
+            !existingTokens[trimmedCharacterId]
+          ) {
+            return res.status(404).json({ message: 'Token not found' });
+          }
+
+          const nextTokens = cloneMapTokens(normalizedCampaign.mapTokens);
+          if (nextTokens[mapId]) {
+            delete nextTokens[mapId][trimmedCharacterId];
+            if (Object.keys(nextTokens[mapId]).length === 0) {
+              delete nextTokens[mapId];
+            }
+          }
+
+          const { tokensByMapId } = normalizeMapTokens({
+            mapTokens: nextTokens,
+            validMapIds: new Set(
+              Array.isArray(normalizedCampaign.maps)
+                ? normalizedCampaign.maps.map((map) => map.mapId)
+                : []
+            ),
+            now: new Date().toISOString(),
+          });
+
+          const payload = buildCampaignMapPayload(
+            normalizedCampaign.maps,
+            normalizedCampaign.activeMapId,
+            tokensByMapId
+          );
+
+          await campaignsCollection.updateOne(
+            { campaignName },
+            {
+              $set: {
+                mapTokens: payload.tokensByMapId,
                 maps: payload.maps,
                 activeMapId: payload.activeMapId,
                 map: payload.map || null,
@@ -715,6 +997,7 @@ module.exports = (router) => {
       maps: [],
       activeMapId: null,
       map: null,
+      mapTokens: {},
       combat: createDefaultCombatState(),
       enemies: [],
     };

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -48,7 +48,139 @@ const sortMaps = (maps) => {
   });
 };
 
-const buildCampaignMapPayload = (maps, activeMapId) => {
+const clampPercentage = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  if (parsed < 0) {
+    return 0;
+  }
+  if (parsed > 1) {
+    return 1;
+  }
+  return parsed;
+};
+
+const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
+  const normalizedTokens = {};
+  let didMutate = false;
+
+  if (!mapTokens || typeof mapTokens !== 'object' || Array.isArray(mapTokens)) {
+    if (mapTokens && typeof mapTokens === 'object') {
+      didMutate = true;
+    }
+    return { tokensByMapId: normalizedTokens, didMutate };
+  }
+
+  const timestamp = toIsoDate(now, new Date().toISOString()) || new Date().toISOString();
+
+  Object.keys(mapTokens).forEach((rawMapId) => {
+    const value = mapTokens[rawMapId];
+    if (typeof rawMapId !== 'string') {
+      didMutate = true;
+      return;
+    }
+
+    const mapId = rawMapId.trim();
+    if (!mapId) {
+      didMutate = true;
+      return;
+    }
+
+    if (validMapIds.size > 0 && !validMapIds.has(mapId)) {
+      didMutate = true;
+      return;
+    }
+
+    if (!value || typeof value !== 'object') {
+      if (value !== undefined && value !== null) {
+        didMutate = true;
+      }
+      return;
+    }
+
+    const tokenEntries = Array.isArray(value)
+      ? value.map((entry) => [null, entry])
+      : Object.entries(value);
+
+    const sanitizedForMap = {};
+
+    tokenEntries.forEach(([rawKey, rawValue]) => {
+      if (!rawValue || typeof rawValue !== 'object') {
+        didMutate = true;
+        return;
+      }
+
+      const candidate = { ...rawValue };
+      let characterId =
+        typeof candidate.characterId === 'string' && candidate.characterId.trim() !== ''
+          ? candidate.characterId.trim()
+          : null;
+
+      if (!characterId && typeof rawKey === 'string' && rawKey.trim() !== '') {
+        characterId = rawKey.trim();
+        didMutate = true;
+      }
+
+      if (!characterId) {
+        didMutate = true;
+        return;
+      }
+
+      const clampedX = clampPercentage(candidate.x);
+      const clampedY = clampPercentage(candidate.y);
+
+      if (clampedX === null || clampedY === null) {
+        didMutate = true;
+        return;
+      }
+
+      if (clampedX !== candidate.x || clampedY !== candidate.y) {
+        didMutate = true;
+      }
+
+      const updatedAt = toIsoDate(candidate.updatedAt, null);
+      const resolvedUpdatedAt = updatedAt || timestamp;
+      if (!updatedAt || updatedAt !== candidate.updatedAt) {
+        didMutate = true;
+      }
+
+      const sanitizedToken = {
+        characterId,
+        x: clampedX,
+        y: clampedY,
+        updatedAt: resolvedUpdatedAt,
+      };
+
+      const originalComparable = JSON.stringify({
+        characterId: rawValue.characterId,
+        x: rawValue.x,
+        y: rawValue.y,
+        updatedAt: rawValue.updatedAt,
+      });
+      const sanitizedComparable = JSON.stringify(sanitizedToken);
+      if (originalComparable !== sanitizedComparable) {
+        didMutate = true;
+      }
+
+      sanitizedForMap[characterId] = sanitizedToken;
+    });
+
+    if (Object.keys(sanitizedForMap).length > 0) {
+      normalizedTokens[mapId] = sanitizedForMap;
+    } else if (
+      (Array.isArray(value) && value.length > 0) ||
+      (!Array.isArray(value) && Object.keys(value).length > 0)
+    ) {
+      didMutate = true;
+    }
+  });
+
+  return { tokensByMapId: normalizedTokens, didMutate };
+};
+
+const buildCampaignMapPayload = (maps, activeMapId, mapTokens = {}) => {
   const sorted = sortMaps(Array.isArray(maps) ? maps : []);
   let resolvedActiveId =
     typeof activeMapId === 'string' && activeMapId.trim() !== ''
@@ -66,14 +198,30 @@ const buildCampaignMapPayload = (maps, activeMapId) => {
     resolvedActiveId = sorted[0].mapId;
   }
 
-  const activeMap = resolvedActiveId
+  const validMapIds = new Set(sorted.map((map) => map.mapId));
+  const { tokensByMapId } = normalizeMapTokens({
+    mapTokens,
+    validMapIds,
+    now: new Date().toISOString(),
+  });
+
+  const activeMapTokens = resolvedActiveId
+    ? tokensByMapId[resolvedActiveId] || {}
+    : {};
+
+  const activeMapBase = resolvedActiveId
     ? sorted.find((map) => map.mapId === resolvedActiveId) || null
+    : null;
+  const activeMap = activeMapBase
+    ? { ...activeMapBase, tokens: activeMapTokens }
     : null;
 
   return {
     maps: sorted,
     activeMapId: activeMap ? activeMap.mapId : null,
-    map: activeMap || null,
+    map: activeMap,
+    tokensByMapId,
+    activeMapTokens,
   };
 };
 
@@ -164,7 +312,13 @@ const normalizeCampaignMapState = async ({ campaign, collection }) => {
   if (!campaign || typeof campaign !== 'object') {
     return {
       campaign: null,
-      payload: { maps: [], activeMapId: null, map: null },
+      payload: {
+        maps: [],
+        activeMapId: null,
+        map: null,
+        tokensByMapId: {},
+        activeMapTokens: {},
+      },
       updated: false,
     };
   }
@@ -234,18 +388,37 @@ const normalizeCampaignMapState = async ({ campaign, collection }) => {
     }
   }
 
-  const payload = buildCampaignMapPayload(normalizedMaps, campaign.activeMapId);
+  const validMapIds = new Set(normalizedMaps.map((map) => map.mapId));
+  const { tokensByMapId: normalizedTokens, didMutate: tokensMutated } =
+    normalizeMapTokens({
+      mapTokens: campaign.mapTokens,
+      validMapIds,
+      now,
+    });
+
+  if (tokensMutated) {
+    didMutate = true;
+  }
+
+  const payload = buildCampaignMapPayload(
+    normalizedMaps,
+    campaign.activeMapId,
+    normalizedTokens
+  );
 
   const existingMapString = JSON.stringify(campaign.map ?? null);
   const payloadMapString = JSON.stringify(payload.map ?? null);
   const existingMapsString = JSON.stringify(campaign.maps ?? []);
   const payloadMapsString = JSON.stringify(payload.maps);
+  const existingTokensString = JSON.stringify(campaign.mapTokens ?? {});
+  const payloadTokensString = JSON.stringify(payload.tokensByMapId);
 
   const shouldUpdate =
     didMutate ||
     campaign.activeMapId !== payload.activeMapId ||
     existingMapString !== payloadMapString ||
-    existingMapsString !== payloadMapsString;
+    existingMapsString !== payloadMapsString ||
+    existingTokensString !== payloadTokensString;
 
   if (shouldUpdate && collection) {
     await collection.updateOne(
@@ -255,6 +428,7 @@ const normalizeCampaignMapState = async ({ campaign, collection }) => {
           maps: payload.maps,
           activeMapId: payload.activeMapId,
           map: payload.map || null,
+          mapTokens: payload.tokensByMapId,
         },
       }
     );
@@ -265,6 +439,7 @@ const normalizeCampaignMapState = async ({ campaign, collection }) => {
     maps: payload.maps,
     activeMapId: payload.activeMapId,
     map: payload.map || null,
+    mapTokens: payload.tokensByMapId,
   };
 
   return { campaign: normalizedCampaign, payload, updated: shouldUpdate };
@@ -275,4 +450,5 @@ module.exports = {
   prepareStoredMap,
   normalizeCampaignMapState,
   getMapSchemas,
+  normalizeMapTokens,
 };

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -150,8 +150,20 @@ const emitMapUpdate = (campaignId, payload) => {
   const normalizedId = campaignId.trim();
   io.to(getCampaignRoom(normalizedId)).emit('campaign:map:update', payload);
 
-  if (payload && typeof payload === 'object' && Object.prototype.hasOwnProperty.call(payload, 'map')) {
-    io.to(getCampaignRoom(normalizedId)).emit('map:update', payload.map);
+  if (payload && typeof payload === 'object') {
+    if (Object.prototype.hasOwnProperty.call(payload, 'map') && payload.map) {
+      const mapPayload =
+        typeof payload.map === 'object'
+          ? { ...payload.map, tokens: payload.map.tokens || payload.activeMapTokens || {} }
+          : payload.map;
+      io.to(getCampaignRoom(normalizedId)).emit('map:update', mapPayload);
+    }
+
+    io.to(getCampaignRoom(normalizedId)).emit('map:tokens:update', {
+      tokensByMapId: payload.tokensByMapId || {},
+      activeMapId: payload.activeMapId || null,
+      activeMapTokens: payload.activeMapTokens || {},
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- sanitize and normalize map tokens along with campaign map payloads
- update campaign routes and websocket updates to persist and broadcast map tokens
- add REST endpoints and tests for managing map token updates and removals

## Testing
- npm test -- --runTestsByPath __tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dacaff497c832ea2b91c749035b02c