### PR TITLE
Add interactive campaign map board with token management

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2378,3 +2378,127 @@ h1 {
   border-top: 1px solid #ccc;
   margin: 0.25rem 0;
 }
+
+.campaign-map-board {
+  position: relative;
+  background: rgba(18, 16, 14, 0.85);
+  border-radius: 0.75rem;
+  padding: clamp(0.5rem, 1vw, 0.75rem);
+  color: #f8f9fa;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 0.5rem 1.5rem rgba(0, 0, 0, 0.45);
+
+  &__title {
+    font-family: 'Raleway', sans-serif;
+    font-weight: 600;
+    font-size: clamp(1rem, 2vw, 1.25rem);
+    text-align: center;
+    margin-bottom: 0.75rem;
+    text-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.6);
+  }
+
+  &__stage {
+    position: relative;
+  }
+
+  &__image-wrapper {
+    position: relative;
+    width: 100%;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.35);
+  }
+
+  &__image {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+  }
+
+  &__tokens-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  &__token {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    pointer-events: auto;
+    cursor: default;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    outline: none;
+    touch-action: none;
+  }
+
+  &__token--draggable {
+    cursor: grab;
+  }
+
+  &__token--draggable:active {
+    cursor: grabbing;
+  }
+
+  &__figurine {
+    --figurine-color: #adb5bd;
+    width: clamp(36px, 7vw, 72px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(0.2rem, 0.6vw, 0.35rem);
+    pointer-events: none;
+    filter: drop-shadow(0 0.25rem 0.75rem rgba(0, 0, 0, 0.65));
+    transition: transform 0.2s ease, filter 0.2s ease;
+  }
+
+  &__figurine--active {
+    transform: translateY(-2px) scale(1.02);
+    filter: drop-shadow(0 0.4rem 1rem rgba(0, 0, 0, 0.75));
+  }
+
+  &__figurine-body {
+    width: clamp(18px, 3.5vw, 32px);
+    aspect-ratio: 0.75 / 1;
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.35),
+      rgba(0, 0, 0, 0.3)
+    ),
+      var(--figurine-color);
+    border-radius: 45% 45% 38% 38%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #f1f3f5;
+    font-weight: 700;
+    font-size: clamp(0.6rem, 1.5vw, 0.95rem);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+    box-shadow: inset 0 0.1rem 0.2rem rgba(255, 255, 255, 0.2),
+      inset 0 -0.2rem 0.3rem rgba(0, 0, 0, 0.35);
+  }
+
+  &__figurine-base {
+    width: clamp(32px, 6vw, 64px);
+    aspect-ratio: 1 / 0.28;
+    border-radius: 999px 999px 500px 500px / 70% 70% 100% 100%;
+    background: linear-gradient(180deg, rgba(40, 40, 42, 0.95), rgba(8, 8, 8, 0.95));
+    box-shadow: inset 0 0.3rem 0.5rem rgba(255, 255, 255, 0.08),
+      inset 0 -0.25rem 0.4rem rgba(0, 0, 0, 0.45);
+  }
+
+  &--disabled &__token--draggable {
+    cursor: default;
+  }
+}
+
+@media (max-width: 576px) {
+  .campaign-map-board {
+    padding: 0.5rem;
+
+    &__title {
+      margin-bottom: 0.5rem;
+    }
+  }
+}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1,0 +1,332 @@
+import React, { useRef, useState, useMemo, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import classNames from '../../../utils/classNames';
+
+const clamp01 = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  if (parsed < 0) {
+    return 0;
+  }
+  if (parsed > 1) {
+    return 1;
+  }
+  return parsed;
+};
+
+const buildImageSource = ({ imageUrl, imageBase64, imageType }) => {
+  if (typeof imageUrl === 'string' && imageUrl.trim() !== '') {
+    return imageUrl.trim();
+  }
+
+  if (typeof imageBase64 === 'string' && imageBase64.trim() !== '') {
+    const mimeType =
+      typeof imageType === 'string' && imageType.trim() !== ''
+        ? imageType.trim()
+        : 'image/png';
+    return `data:${mimeType};base64,${imageBase64.trim()}`;
+  }
+
+  return null;
+};
+
+const normalizeText = (value) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+
+const CampaignMapBoard = ({
+  map,
+  tokens,
+  onTokenDragStart,
+  onTokenDrag,
+  onTokenDragEnd,
+  onTokenPositionChange,
+  disabled,
+  className,
+  children,
+}) => {
+  const safeMap = map && typeof map === 'object' ? map : {};
+  const title = normalizeText(safeMap.title);
+  const altText =
+    normalizeText(safeMap.altText) ||
+    title ||
+    normalizeText(safeMap.prompt) ||
+    'Campaign map image';
+  const imageSrc = buildImageSource(safeMap);
+
+  const interactionDisabled = disabled || !imageSrc;
+
+  const layerRef = useRef(null);
+  const dragStateRef = useRef({ tokenId: null, pointerId: null });
+  const [dragPositions, setDragPositions] = useState({});
+
+  const tokenPositions = useMemo(() => {
+    if (!Array.isArray(tokens)) {
+      return [];
+    }
+
+    return tokens
+      .filter((token) => token && typeof token === 'object' && token.characterId)
+      .map((token) => {
+        const { characterId } = token;
+        const activePosition =
+          dragPositions[characterId] || {
+            x: clamp01(token.x) ?? 0,
+            y: clamp01(token.y) ?? 0,
+          };
+        return {
+          ...token,
+          position: activePosition,
+        };
+      });
+  }, [tokens, dragPositions]);
+
+  const resetDragState = useCallback(() => {
+    dragStateRef.current = { tokenId: null, pointerId: null };
+    setDragPositions((prev) => {
+      if (Object.keys(prev).length === 0) {
+        return prev;
+      }
+      return {};
+    });
+  }, []);
+
+  const getNormalizedCoordinates = useCallback((clientX, clientY) => {
+    const layer = layerRef.current;
+    if (!layer) {
+      return null;
+    }
+
+    const rect = layer.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) {
+      return null;
+    }
+
+    const rawX = (clientX - rect.left) / rect.width;
+    const rawY = (clientY - rect.top) / rect.height;
+
+    const x = clamp01(rawX);
+    const y = clamp01(rawY);
+
+    if (x === null || y === null) {
+      return null;
+    }
+
+    return { x, y };
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event, token) => {
+      if (interactionDisabled || !token || token.isMovable === false) {
+        return;
+      }
+
+      const { characterId } = token;
+      if (typeof characterId !== 'string' || characterId.trim() === '') {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      dragStateRef.current = { tokenId: characterId, pointerId: event.pointerId };
+      setDragPositions((prev) => ({
+        ...prev,
+        [characterId]: {
+          x: clamp01(token.x) ?? 0,
+          y: clamp01(token.y) ?? 0,
+        },
+      }));
+
+      if (typeof onTokenDragStart === 'function') {
+        onTokenDragStart({ token, characterId });
+      }
+
+      if (event.currentTarget.setPointerCapture) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch (error) {
+          // Ignore pointer capture errors (e.g., when unsupported)
+        }
+      }
+    },
+    [interactionDisabled, onTokenDragStart]
+  );
+
+  const updateDragPosition = useCallback((tokenId, nextPosition) => {
+    if (!tokenId || !nextPosition) {
+      return;
+    }
+    setDragPositions((prev) => ({
+      ...prev,
+      [tokenId]: nextPosition,
+    }));
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (event) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || !dragState.tokenId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const coords = getNormalizedCoordinates(event.clientX, event.clientY);
+      if (!coords) {
+        return;
+      }
+
+      updateDragPosition(dragState.tokenId, coords);
+
+      if (typeof onTokenDrag === 'function') {
+        onTokenDrag({ characterId: dragState.tokenId, ...coords });
+      }
+    },
+    [getNormalizedCoordinates, onTokenDrag, updateDragPosition]
+  );
+
+  const finalizeDrag = useCallback(
+    (event, cancelled = false) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || !dragState.tokenId) {
+        return;
+      }
+
+      const { tokenId, pointerId } = dragState;
+      if (pointerId !== undefined && event.pointerId !== pointerId) {
+        return;
+      }
+
+      const coords = getNormalizedCoordinates(event.clientX, event.clientY);
+      if (!coords) {
+        resetDragState();
+        return;
+      }
+
+      updateDragPosition(tokenId, coords);
+
+      if (typeof onTokenPositionChange === 'function' && !cancelled) {
+        onTokenPositionChange({ characterId: tokenId, ...coords });
+      }
+
+      if (typeof onTokenDragEnd === 'function') {
+        onTokenDragEnd({ characterId: tokenId, ...coords, cancelled });
+      }
+
+      resetDragState();
+    },
+    [getNormalizedCoordinates, onTokenDragEnd, onTokenPositionChange, resetDragState, updateDragPosition]
+  );
+
+  const handlePointerUp = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      finalizeDrag(event, false);
+    },
+    [finalizeDrag]
+  );
+
+  const handlePointerCancel = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      finalizeDrag(event, true);
+    },
+    [finalizeDrag]
+  );
+
+  return (
+    <div className={classNames('campaign-map-board', className, interactionDisabled && 'campaign-map-board--disabled')}>
+      {title && <h5 className="campaign-map-board__title">{title}</h5>}
+      {imageSrc ? (
+        <div className="campaign-map-board__stage">
+          <div className="campaign-map-board__image-wrapper">
+            <img src={imageSrc} alt={altText} className="campaign-map-board__image" />
+            <div className="campaign-map-board__tokens-layer" ref={layerRef}>
+              {tokenPositions.map((token) => {
+                const { characterId, position, color, label } = token;
+                const draggable = !interactionDisabled && token.isMovable !== false;
+                return (
+                  <div
+                    key={characterId}
+                    role={draggable ? 'button' : undefined}
+                    tabIndex={draggable ? 0 : -1}
+                    aria-label={label || characterId}
+                    className={classNames(
+                      'campaign-map-board__token',
+                      draggable && 'campaign-map-board__token--draggable'
+                    )}
+                    style={{
+                      left: `${(position?.x ?? 0) * 100}%`,
+                      top: `${(position?.y ?? 0) * 100}%`,
+                    }}
+                    onPointerDown={(event) => handlePointerDown(event, token)}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerCancel}
+                    data-token-id={characterId}
+                  >
+                    <div
+                      className={classNames(
+                        'campaign-map-board__figurine',
+                        draggable && 'campaign-map-board__figurine--active'
+                      )}
+                      style={{ '--figurine-color': color || undefined }}
+                    >
+                      <span className="campaign-map-board__figurine-body">
+                        {label ? label.charAt(0).toUpperCase() : ''}
+                      </span>
+                      <span className="campaign-map-board__figurine-base" />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          {children}
+        </div>
+      ) : (
+        <p className="text-muted mb-0">No map image available.</p>
+      )}
+    </div>
+  );
+};
+
+CampaignMapBoard.propTypes = {
+  map: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  tokens: PropTypes.arrayOf(
+    PropTypes.shape({
+      characterId: PropTypes.string.isRequired,
+      x: PropTypes.number,
+      y: PropTypes.number,
+      color: PropTypes.string,
+      label: PropTypes.string,
+      isMovable: PropTypes.bool,
+    })
+  ),
+  onTokenDragStart: PropTypes.func,
+  onTokenDrag: PropTypes.func,
+  onTokenDragEnd: PropTypes.func,
+  onTokenPositionChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+CampaignMapBoard.defaultProps = {
+  map: null,
+  tokens: [],
+  onTokenDragStart: null,
+  onTokenDrag: null,
+  onTokenDragEnd: null,
+  onTokenPositionChange: null,
+  disabled: false,
+  className: '',
+  children: null,
+};
+
+export default CampaignMapBoard;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -24,7 +24,7 @@ import useUser from '../../../hooks/useUser';
 import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative } from '../utils/derivedStats';
-import MapDisplay from '../attributes/MapDisplay';
+import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import {
   GiCharacter,
@@ -180,6 +180,79 @@ const normalizeCombatState = (state) => {
   return { participants: sortedParticipants, activeTurn };
 };
 
+const clamp01 = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  if (parsed < 0) {
+    return 0;
+  }
+  if (parsed > 1) {
+    return 1;
+  }
+  return parsed;
+};
+
+const sanitizeToken = (tokenValue, fallbackId) => {
+  if (!tokenValue || typeof tokenValue !== 'object') {
+    return null;
+  }
+
+  const candidate = { ...tokenValue };
+  const candidateId =
+    (typeof candidate.characterId === 'string' && candidate.characterId.trim()) ||
+    (typeof fallbackId === 'string' && fallbackId.trim()) ||
+    null;
+
+  if (!candidateId) {
+    return null;
+  }
+
+  const x = clamp01(candidate.x);
+  const y = clamp01(candidate.y);
+
+  if (x === null || y === null) {
+    return null;
+  }
+
+  return { ...candidate, characterId: candidateId, x, y };
+};
+
+const sanitizeTokenDictionary = (tokens) => {
+  if (!tokens || typeof tokens !== 'object') {
+    return {};
+  }
+
+  return Object.entries(tokens).reduce((acc, [key, value]) => {
+    const token = sanitizeToken(value, key);
+    if (token) {
+      acc[token.characterId] = token;
+    }
+    return acc;
+  }, {});
+};
+
+const sanitizeTokensByMapId = (tokensByMapId) => {
+  if (!tokensByMapId || typeof tokensByMapId !== 'object') {
+    return {};
+  }
+
+  return Object.entries(tokensByMapId).reduce((acc, [mapId, tokens]) => {
+    if (typeof mapId !== 'string') {
+      return acc;
+    }
+
+    const trimmed = mapId.trim();
+    if (!trimmed) {
+      return acc;
+    }
+
+    acc[trimmed] = sanitizeTokenDictionary(tokens);
+    return acc;
+  }, {});
+};
+
 const CLASS_ICON_MAP = {
   barbarian: { icon: GiBattleAxe, label: 'Barbarian' },
   bard: { icon: GiLyre, label: 'Bard' },
@@ -279,13 +352,25 @@ export default function ZombiesDM() {
     const [mapSaving, setMapSaving] = useState(false);
     const [mapSaveMode, setMapSaveMode] = useState(null);
     const [showMapManager, setShowMapManager] = useState(false);
+    const [mapTokens, setMapTokens] = useState({});
+    const [activeMapTokens, setActiveMapTokens] = useState({});
     const socketRef = useRef(null);
+    const mapTokensRef = useRef(mapTokens);
+    const activeMapTokensRef = useRef(activeMapTokens);
 
     const campaignId = params.campaign ?? '';
     const encodedCampaign = useMemo(
       () => (campaignId ? encodeURIComponent(campaignId) : ''),
       [campaignId]
     );
+
+    useEffect(() => {
+      mapTokensRef.current = mapTokens;
+    }, [mapTokens]);
+
+    useEffect(() => {
+      activeMapTokensRef.current = activeMapTokens;
+    }, [activeMapTokens]);
 
     const applyMapPayload = useCallback(
       (payload, options = {}) => {
@@ -312,7 +397,41 @@ export default function ZombiesDM() {
             : null) ||
           null;
 
-        setCampaignMap(resolvedActiveMap);
+        const hasTokensByMapIdProp =
+          payload && Object.prototype.hasOwnProperty.call(payload, 'tokensByMapId');
+        const hasActiveTokensProp =
+          payload && Object.prototype.hasOwnProperty.call(payload, 'activeMapTokens');
+
+        const activeTokensFromPayload = hasActiveTokensProp
+          ? sanitizeTokenDictionary(payload.activeMapTokens)
+          : null;
+        const mapTokensFromPayload = hasTokensByMapIdProp
+          ? sanitizeTokensByMapId(payload.tokensByMapId)
+          : null;
+
+        const resolvedActiveTokens =
+          activeTokensFromPayload ||
+          (resolvedActiveMap && resolvedActiveMap.tokens
+            ? sanitizeTokenDictionary(resolvedActiveMap.tokens)
+            : {});
+
+        if (hasTokensByMapIdProp) {
+          setMapTokens(mapTokensFromPayload || {});
+        } else if (resolvedActiveMap && resolvedActiveMap.mapId) {
+          setMapTokens((prev) => ({
+            ...(prev || {}),
+            [resolvedActiveMap.mapId]: resolvedActiveTokens,
+          }));
+        } else {
+          setMapTokens({});
+        }
+
+        setActiveMapTokens(resolvedActiveTokens);
+
+        const nextCampaignMap = resolvedActiveMap
+          ? { ...resolvedActiveMap, tokens: resolvedActiveTokens }
+          : null;
+        setCampaignMap(nextCampaignMap);
 
         setSelectedMapId((prevSelected) => {
           const preferredId =
@@ -376,6 +495,8 @@ export default function ZombiesDM() {
         setActiveMapId(null);
         setSelectedMapId(null);
         setGeneratedMap(null);
+        setMapTokens({});
+        setActiveMapTokens({});
         setMapLoading(false);
         return;
       }
@@ -492,6 +613,8 @@ export default function ZombiesDM() {
         setActiveMapId(null);
         setSelectedMapId(null);
         setGeneratedMap(null);
+        setMapTokens({});
+        setActiveMapTokens({});
       } finally {
         setMapLoading(false);
       }
@@ -791,6 +914,7 @@ export default function ZombiesDM() {
       return monsterCatalog.filter((monster) => monster?.name?.toLowerCase().includes(query));
     }, [monsterCatalog, monsterSearch]);
 
+
     useEffect(() => {
       fetchRecords();
       return;
@@ -886,14 +1010,66 @@ export default function ZombiesDM() {
 
       const handleMapUpdate = (mapData) => {
         if (mapData && typeof mapData === 'object') {
+          let workingPayload = mapData;
+          const hasTokensByMapIdProp = Object.prototype.hasOwnProperty.call(
+            mapData,
+            'tokensByMapId'
+          );
+          const hasActiveTokensProp = Object.prototype.hasOwnProperty.call(
+            mapData,
+            'activeMapTokens'
+          );
+
+          if (hasTokensByMapIdProp) {
+            const sanitizedTokens = sanitizeTokensByMapId(mapData.tokensByMapId);
+            const incomingKeys = Object.keys(mapData.tokensByMapId || {}).reduce(
+              (acc, key) => {
+                if (typeof key !== 'string') {
+                  return acc;
+                }
+                const trimmed = key.trim();
+                if (trimmed) {
+                  acc.push(trimmed);
+                }
+                return acc;
+              },
+              []
+            );
+
+            if (incomingKeys.length === 0) {
+              workingPayload = { ...workingPayload, tokensByMapId: sanitizedTokens };
+            } else {
+              const mergedTokens = { ...(mapTokensRef.current || {}) };
+              incomingKeys.forEach((mapId) => {
+                if (Object.prototype.hasOwnProperty.call(sanitizedTokens, mapId)) {
+                  mergedTokens[mapId] = sanitizedTokens[mapId];
+                } else {
+                  delete mergedTokens[mapId];
+                }
+              });
+              workingPayload = { ...workingPayload, tokensByMapId: mergedTokens };
+            }
+          }
+
+          if (hasActiveTokensProp) {
+            const sanitizedActive = sanitizeTokenDictionary(mapData.activeMapTokens);
+            workingPayload = { ...workingPayload, activeMapTokens: sanitizedActive };
+            if (workingPayload.map && typeof workingPayload.map === 'object') {
+              workingPayload = {
+                ...workingPayload,
+                map: { ...workingPayload.map, tokens: sanitizedActive },
+              };
+            }
+          }
+
           if (
-            Array.isArray(mapData.maps) ||
-            mapData.activeMapId !== undefined ||
-            (mapData.map && typeof mapData.map === 'object')
+            Array.isArray(workingPayload.maps) ||
+            workingPayload.activeMapId !== undefined ||
+            (workingPayload.map && typeof workingPayload.map === 'object')
           ) {
-            applyMapPayload(mapData);
+            applyMapPayload(workingPayload);
           } else {
-            const normalizedMap = mapData;
+            const normalizedMap = workingPayload;
             const normalizedMapId =
               typeof normalizedMap?.mapId === 'string' && normalizedMap.mapId.trim() !== ''
                 ? normalizedMap.mapId.trim()
@@ -924,6 +1100,99 @@ export default function ZombiesDM() {
         socketRef.current = null;
       };
     }, [campaignId, applyMapPayload]);
+
+    const persistTokenPosition = useCallback(
+      async ({ mapId, characterId, x, y }) => {
+        const normalizedMapId =
+          typeof mapId === 'string' && mapId.trim() !== '' ? mapId.trim() : null;
+        const normalizedCharacterId =
+          typeof characterId === 'string' && characterId.trim() !== ''
+            ? characterId.trim()
+            : null;
+
+        const clampedX = clamp01(x);
+        const clampedY = clamp01(y);
+
+        if (!normalizedMapId || !normalizedCharacterId || clampedX === null || clampedY === null) {
+          return;
+        }
+
+        if (!encodedCampaign) {
+          return;
+        }
+
+        const previousTokens = mapTokensRef.current || {};
+        const previousActiveTokens = activeMapTokensRef.current || {};
+        const previousCampaignMap = campaignMap;
+
+        const optimisticToken = {
+          ...(previousTokens?.[normalizedMapId]?.[normalizedCharacterId] || {}),
+          characterId: normalizedCharacterId,
+          x: clampedX,
+          y: clampedY,
+          updatedAt: new Date().toISOString(),
+        };
+
+        setMapTokens((prev) => {
+          const next = { ...(prev || {}) };
+          const existing = { ...(next[normalizedMapId] || {}) };
+          existing[normalizedCharacterId] = optimisticToken;
+          next[normalizedMapId] = existing;
+          return next;
+        });
+
+        if (normalizedMapId === activeMapId) {
+          setActiveMapTokens((prev) => ({
+            ...(prev || {}),
+            [normalizedCharacterId]: optimisticToken,
+          }));
+        }
+
+        setCampaignMap((prev) => {
+          if (!prev || prev.mapId !== normalizedMapId) {
+            return prev;
+          }
+          return {
+            ...prev,
+            tokens: {
+              ...(prev.tokens || {}),
+              [normalizedCharacterId]: optimisticToken,
+            },
+          };
+        });
+
+        try {
+          const encodedMapId = encodeURIComponent(normalizedMapId);
+          const encodedCharacterId = encodeURIComponent(normalizedCharacterId);
+          const response = await apiFetch(
+            `/campaigns/${encodedCampaign}/maps/${encodedMapId}/tokens/${encodedCharacterId}`,
+            {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ x: clampedX, y: clampedY }),
+            }
+          );
+
+          if (!response.ok) {
+            const message = await parseErrorMessage(
+              response,
+              'Failed to update token position.'
+            );
+            throw new Error(message);
+          }
+        } catch (error) {
+          console.error(error);
+          setStatus({
+            type: 'danger',
+            message: error.message || 'Failed to update token position.',
+          });
+          setMapTokens(previousTokens || {});
+          setActiveMapTokens(previousActiveTokens || {});
+          setCampaignMap(previousCampaignMap || null);
+        }
+      },
+      [activeMapId, campaignMap, encodedCampaign, parseErrorMessage, setStatus]
+    );
 
     const persistCombatState = useCallback(
       async (nextState) => {
@@ -1543,6 +1812,146 @@ export default function ZombiesDM() {
 
       return campaignMap;
     }, [generatedMap, selectedMapId, maps, campaignMap]);
+
+    const tokenMetaById = useMemo(() => {
+      const lookup = {};
+
+      if (Array.isArray(records)) {
+        records.forEach((record) => {
+          if (!record || typeof record !== 'object') {
+            return;
+          }
+
+          const color =
+            typeof record.diceColor === 'string' && record.diceColor.trim() !== ''
+              ? record.diceColor.trim()
+              : null;
+          const label =
+            (typeof record.characterName === 'string' && record.characterName.trim()) ||
+            (typeof record.name === 'string' && record.name.trim()) ||
+            (typeof record.token === 'string' && record.token.trim()) ||
+            (typeof record._id === 'string' && record._id.trim()) ||
+            (typeof record.characterId === 'string' && record.characterId.trim()) ||
+            null;
+
+          const identifiers = [record.characterId, record._id, record.token].filter(
+            (value) => typeof value === 'string' && value.trim() !== ''
+          );
+
+          identifiers.forEach((identifier) => {
+            lookup[identifier.trim()] = {
+              color,
+              label,
+            };
+          });
+        });
+      }
+
+      if (Array.isArray(enemies)) {
+        enemies.forEach((enemy) => {
+          if (!enemy || typeof enemy !== 'object') {
+            return;
+          }
+
+          const enemyId =
+            typeof enemy.enemyId === 'string' && enemy.enemyId.trim() !== ''
+              ? enemy.enemyId.trim()
+              : null;
+          if (!enemyId) {
+            return;
+          }
+
+          const label =
+            (typeof enemy.name === 'string' && enemy.name.trim()) ||
+            (typeof enemy.enemyType === 'string' && enemy.enemyType.trim()) ||
+            enemyId;
+
+          lookup[enemyId] = {
+            color:
+              typeof enemy.diceColor === 'string' && enemy.diceColor.trim() !== ''
+                ? enemy.diceColor.trim()
+                : null,
+            label,
+          };
+        });
+      }
+
+      return lookup;
+    }, [records, enemies]);
+
+    const shouldShowCampaignTokens = useMemo(() => {
+      return Boolean(!generatedMap && !previewMap && campaignMap && campaignMap.mapId);
+    }, [campaignMap, generatedMap, previewMap]);
+
+    const boardTokens = useMemo(() => {
+      if (!shouldShowCampaignTokens || !campaignMap?.mapId) {
+        return [];
+      }
+
+      const mapId = campaignMap.mapId;
+      const combinedTokens = {
+        ...(mapTokens?.[mapId] || {}),
+      };
+
+      if (activeMapTokens && typeof activeMapTokens === 'object') {
+        Object.entries(activeMapTokens).forEach(([key, value]) => {
+          if (!value || typeof value !== 'object') {
+            return;
+          }
+          const identifier = typeof key === 'string' && key.trim() !== '' ? key.trim() : value.characterId;
+          if (identifier) {
+            combinedTokens[identifier] = { ...combinedTokens[identifier], ...value };
+          }
+        });
+      }
+
+      const tokensList = Object.values(combinedTokens).filter(
+        (token) => token && typeof token === 'object' && token.characterId
+      );
+
+      return tokensList
+        .map((token) => {
+          const meta = tokenMetaById[token.characterId] || {};
+          const rawLabel = meta.label || token.label || token.characterId;
+          const label = typeof rawLabel === 'string' ? rawLabel.trim() : '';
+          return {
+            ...token,
+            label,
+            color: meta.color || token.color || null,
+            isMovable: true,
+          };
+        })
+        .sort((a, b) => {
+          const labelA = (a.label || a.characterId || '').toLowerCase();
+          const labelB = (b.label || b.characterId || '').toLowerCase();
+          return labelA.localeCompare(labelB);
+        });
+    }, [
+      activeMapTokens,
+      campaignMap,
+      mapTokens,
+      shouldShowCampaignTokens,
+      tokenMetaById,
+    ]);
+
+    const displayedMap = generatedMap || previewMap || campaignMap;
+
+    const handleTokenPositionChange = useCallback(
+      ({ characterId, x, y }) => {
+        if (!shouldShowCampaignTokens || !campaignMap?.mapId) {
+          return;
+        }
+
+        persistTokenPosition({
+          mapId: campaignMap.mapId,
+          characterId,
+          x,
+          y,
+        });
+      },
+      [campaignMap, persistTokenPosition, shouldShowCampaignTokens]
+    );
+
 
     const RESOURCE_TABS = useMemo(
       () => [
@@ -3813,8 +4222,15 @@ const resolveIcon = (category, iconMap, fallback) => {
                       </Col>
                       <Col md={8} className="text-start">
                         <div className="mb-4 p-3 bg-dark rounded" data-testid="map-preview-card">
-                          {generatedMap || previewMap || campaignMap ? (
-                            <MapDisplay map={generatedMap || previewMap || campaignMap} />
+                          {displayedMap ? (
+                            <CampaignMapBoard
+                              map={displayedMap}
+                              tokens={boardTokens}
+                              disabled={!shouldShowCampaignTokens}
+                              onTokenPositionChange={
+                                shouldShowCampaignTokens ? handleTokenPositionChange : undefined
+                              }
+                            />
                           ) : (
                             <p className="text-muted mb-0">No map selected.</p>
                           )}

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -5,6 +5,13 @@ import apiFetch from '../../../utils/apiFetch';
 import useUser from '../../../hooks/useUser';
 jest.mock('../../../utils/apiFetch');
 jest.mock('../../../hooks/useUser');
+jest.mock('../attributes/CampaignMapBoard', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: jest.fn(() => React.createElement('div', { 'data-testid': 'campaign-map-board' })),
+  };
+});
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({ campaign: 'Camp1' }),
@@ -18,6 +25,7 @@ jest.mock(
 );
 
 const socketModule = require('socket.io-client');
+const CampaignMapBoard = require('../attributes/CampaignMapBoard').default;
 
 const ZombiesDM = require('./ZombiesDM').default;
 
@@ -57,6 +65,7 @@ describe('ZombiesDM AI generation', () => {
   beforeEach(() => {
     apiFetch.mockReset();
     useUser.mockReturnValue({ username: 'dm' });
+    CampaignMapBoard.mockClear();
     const sockets = socketModule.__getMockSockets();
     sockets.length = 0;
     const ioMock = socketModule.__getIoMock();
@@ -729,6 +738,121 @@ describe('ZombiesDM AI generation', () => {
     await waitFor(() => {
       const list = within(mapCard).getByTestId('map-list');
       expect(within(list).getByText('Updated Map')).toBeInTheDocument();
+    });
+  });
+
+  test('passes campaign tokens to the board component and updates on socket events', async () => {
+    const characters = [
+      { _id: 'hero-1', characterName: 'Hero One', diceColor: '#3366ff' },
+      { _id: 'hero-2', characterName: 'Hero Two', diceColor: '#cc0000' },
+    ];
+
+    const mapTokens = {
+      'map-1': {
+        'hero-1': { characterId: 'hero-1', x: 0.1, y: 0.2 },
+      },
+    };
+
+    const activeMap = {
+      mapId: 'map-1',
+      title: 'Active Map',
+      tokens: mapTokens['map-1'],
+    };
+
+    apiFetch.mockImplementation((url) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => characters });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ participants: [], activeTurn: null }),
+          });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/maps':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              maps: [activeMap],
+              activeMapId: activeMap.mapId,
+              map: activeMap,
+              tokensByMapId: mapTokens,
+              activeMapTokens: mapTokens['map-1'],
+            }),
+          });
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    render(<ZombiesDM />);
+
+    const mapTab = await screen.findByRole('tab', { name: 'Map' });
+    await userEvent.click(mapTab);
+
+    await waitFor(() => {
+      expect(CampaignMapBoard).toHaveBeenCalled();
+    });
+
+    const initialBoardCall = CampaignMapBoard.mock.calls
+      .map(([props]) => props)
+      .find((props) => props && props.map && props.map.mapId === 'map-1');
+
+    expect(initialBoardCall).toBeDefined();
+    expect(initialBoardCall.disabled).toBe(false);
+    expect(initialBoardCall.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          characterId: 'hero-1',
+          x: 0.1,
+          y: 0.2,
+          color: '#3366ff',
+        }),
+      ])
+    );
+
+    const sockets = socketModule.__getMockSockets();
+    const socketInstance = sockets[sockets.length - 1];
+    const mapUpdateHandler = socketInstance.on.mock.calls.find(
+      ([eventName]) => eventName === 'campaign:map:update'
+    )[1];
+
+    mapUpdateHandler({
+      tokensByMapId: {
+        'map-1': {
+          'hero-1': { characterId: 'hero-1', x: 0.25, y: 0.5 },
+          'hero-2': { characterId: 'hero-2', x: 0.75, y: 0.8 },
+        },
+      },
+      activeMapTokens: {
+        'hero-1': { characterId: 'hero-1', x: 0.25, y: 0.5 },
+        'hero-2': { characterId: 'hero-2', x: 0.75, y: 0.8 },
+      },
+    });
+
+    await waitFor(() => {
+      const latestCall = CampaignMapBoard.mock.calls[CampaignMapBoard.mock.calls.length - 1][0];
+      expect(latestCall.tokens).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            characterId: 'hero-1',
+            x: 0.25,
+            y: 0.5,
+            color: '#3366ff',
+          }),
+          expect.objectContaining({
+            characterId: 'hero-2',
+            x: 0.75,
+            y: 0.8,
+            color: '#cc0000',
+          }),
+        ])
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- add a reusable CampaignMapBoard component for interactive map previews with draggable tokens
- extend ZombiesDM state management to load, track, and persist campaign map tokens
- restyle the board tokens to resemble miniatures and cover the new board in tests

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js

------
https://chatgpt.com/codex/tasks/task_e_68daceade750832ea8145e02fe90279c