### PR TITLE
Enable campaign map layer pointer interactions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2418,7 +2418,7 @@ h1 {
   &__tokens-layer {
     position: absolute;
     inset: 0;
-    pointer-events: none;
+    pointer-events: auto;
   }
 
   &__token {


### PR DESCRIPTION
## Summary
- allow the campaign map token layer to receive pointer events so background clicks register on the campaign map board

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae7166d8c832e8e60f9b9d96dabb4