### PR TITLE
Adjust figurine base overlap

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2383,7 +2383,6 @@ h1 {
   --map-square-size: var(--campaign-map-square-size, clamp(36px, 8vw, 64px));
   --figurine-base-size: clamp(20px, calc(var(--map-square-size) * 0.5), 32px);
   --figurine-body-width: clamp(12px, calc(var(--figurine-base-size) * 0.6), 20px);
-  --figurine-gap: clamp(0.08rem, calc(var(--figurine-base-size) * 0.16), 0.18rem);
 
   position: relative;
   background: rgba(18, 16, 14, 0.85);
@@ -2454,7 +2453,6 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--figurine-gap);
     pointer-events: none;
     filter: drop-shadow(0 0.35rem 0.85rem rgba(6, 7, 10, 0.65))
       drop-shadow(0 0.05rem 0.25rem rgba(255, 255, 255, 0.12));
@@ -2543,6 +2541,7 @@ h1 {
     position: relative;
     width: var(--figurine-base-size);
     aspect-ratio: 1 / 0.3;
+    margin-top: calc(var(--figurine-base-size) * -0.18);
     border-radius: 70% 70% 85% 85% / 65% 65% 100% 100%;
     background:
       linear-gradient(180deg, rgba(78, 82, 94, 0.95), rgba(21, 22, 26, 0.98) 75%),


### PR DESCRIPTION
## Summary
- remove the figurine stack gap so the body and base sit flush
- overlap the base slightly with a negative margin to hide the grey seam

## Testing
- npm run develop *(fails: server requires JWT_SECRET, ATLAS_URI, CLIENT_ORIGINS env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68daf13bdebc832e80b05455a0eeaf5b