### PR TITLE
Overlay map placement saving indicator

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3,6 +3,18 @@
 @import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
 
+.map-modal__board-wrapper {
+  position: relative;
+}
+
+.map-modal__saving-indicator {
+  position: absolute;
+  inset: auto 0 0 0;
+  display: flex;
+  justify-content: center;
+  padding-block: 0.75rem;
+}
+
 .zombies-dm-container {
   padding-left: 1rem;
   padding-right: 1rem;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -531,27 +531,29 @@ const MapModal = ({
 
     return (
       <>
-        <CampaignMapBoard
-          map={previewMap}
-          tokens={boardTokens}
-          disabled={placementPending}
-          onTokenPositionChange={handleTokenPositionChange}
-          onBackgroundClick={handleBackgroundPlacement}
-        />
+        <div className="map-modal__board-wrapper">
+          <CampaignMapBoard
+            map={previewMap}
+            tokens={boardTokens}
+            disabled={placementPending}
+            onTokenPositionChange={handleTokenPositionChange}
+            onBackgroundClick={handleBackgroundPlacement}
+          />
+          {placementPending && (
+            <div
+              className="map-modal__saving-indicator d-flex align-items-center gap-2 text-muted small"
+              data-testid="map-modal-placement-pending"
+            >
+              <Spinner animation="border" role="status" size="sm">
+                <span className="visually-hidden">Saving figurine position…</span>
+              </Spinner>
+              <span>Saving figurine position…</span>
+            </div>
+          )}
+        </div>
         {canClickToPlace && (
           <div className="text-info small mt-3" data-testid="map-modal-placement-hint">
             Click the map to place your figurine.
-          </div>
-        )}
-        {placementPending && (
-          <div
-            className="d-flex align-items-center gap-2 mt-3 text-muted small"
-            data-testid="map-modal-placement-pending"
-          >
-            <Spinner animation="border" role="status" size="sm">
-              <span className="visually-hidden">Saving figurine position…</span>
-            </Spinner>
-            <span>Saving figurine position…</span>
           </div>
         )}
         {placementError && (


### PR DESCRIPTION
## Summary
- wrap the campaign map board in a positioned container to host placement status overlays
- overlay the figurine placement pending indicator at the bottom of the map without shifting layout
- add styling hooks to keep the saving message accessible while positioned over the board

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf368ce24832e92deb5832ed695ed