### PR TITLE
Add HP overlays to Zombies campaign map tokens

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2443,12 +2443,53 @@ h1 {
     pointer-events: auto;
     cursor: default;
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
+    gap: clamp(2px, calc(var(--figurine-base-size) * 0.08), 0.25rem);
     outline: none;
     touch-action: none;
     width: var(--figurine-base-size);
     height: calc(var(--figurine-base-size) * 1.6);
+  }
+
+  &__health {
+    --campaign-map-board-health-color-resolved: var(
+      --campaign-map-board-health-color,
+      #51cf66
+    );
+    width: calc(var(--figurine-base-size) * 0.95);
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-end;
+    filter: drop-shadow(0 0.1rem 0.25rem rgba(0, 0, 0, 0.65));
+  }
+
+  &__health-track {
+    position: relative;
+    width: 100%;
+    height: clamp(4px, calc(var(--figurine-base-size) * 0.22), 8px);
+    background: rgba(0, 0, 0, 0.6);
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    overflow: hidden;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.75);
+  }
+
+  &__health-fill {
+    position: relative;
+    height: 100%;
+    width: 0;
+    background:
+      linear-gradient(90deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0)) 0 0 / 100% 100%,
+      linear-gradient(
+        90deg,
+        var(--campaign-map-board-health-color-resolved),
+        var(--campaign-map-board-health-color-resolved)
+      );
+    border-radius: inherit;
+    transition: width 0.25s ease;
   }
 
   &__token--draggable {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -16,6 +16,29 @@ const clamp01 = (value) => {
   return parsed;
 };
 
+const toFiniteNumberOrNull = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const formatHpValue = (value) => {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+
+  const clamped = value < 0 ? 0 : value;
+  if (Number.isInteger(clamped)) {
+    return `${clamped}`;
+  }
+
+  const precision = Math.abs(clamped) >= 100 ? 0 : 1;
+  return clamped.toFixed(precision);
+};
+
 const buildImageSource = ({ imageUrl, imageBase64, imageType }) => {
   if (typeof imageUrl === 'string' && imageUrl.trim() !== '') {
     return imageUrl.trim();
@@ -275,8 +298,20 @@ const CampaignMapBoard = ({
               onPointerDown={handleLayerPointerDown}
             >
               {tokenPositions.map((token) => {
-                const { characterId, position, color, label } = token;
+                const { characterId, position, color, label, currentHp, maxHp } = token;
                 const draggable = !interactionDisabled && token.isMovable !== false;
+                const numericCurrentHp = toFiniteNumberOrNull(currentHp);
+                const numericMaxHp = toFiniteNumberOrNull(maxHp);
+                const hasHealth =
+                  numericCurrentHp !== null && numericMaxHp !== null && numericMaxHp > 0;
+                const safeCurrentHp = hasHealth ? Math.max(0, numericCurrentHp) : null;
+                const safeMaxHp = hasHealth ? Math.max(0, numericMaxHp) : null;
+                const ratio =
+                  hasHealth && safeMaxHp && safeMaxHp > 0
+                    ? Math.min(1, Math.max(0, safeCurrentHp / safeMaxHp))
+                    : 0;
+                const fillPercent = Math.round(ratio * 10000) / 100;
+                const healthColor = color || '#51cf66';
                 return (
                   <div
                     key={characterId}
@@ -297,6 +332,22 @@ const CampaignMapBoard = ({
                     onPointerCancel={handlePointerCancel}
                     data-token-id={characterId}
                   >
+                    {hasHealth && safeCurrentHp !== null && safeMaxHp !== null && safeMaxHp > 0 && (
+                      <div
+                        className="campaign-map-board__health"
+                        style={{ '--campaign-map-board-health-color': healthColor }}
+                      >
+                        <span className="visually-hidden">{`HP: ${formatHpValue(
+                          safeCurrentHp
+                        )}/${formatHpValue(safeMaxHp)}`}</span>
+                        <div className="campaign-map-board__health-track">
+                          <div
+                            className="campaign-map-board__health-fill"
+                            style={{ width: `${Math.max(0, Math.min(100, fillPercent))}%` }}
+                          />
+                        </div>
+                      </div>
+                    )}
                     <div
                       className={classNames(
                         'campaign-map-board__figurine',
@@ -342,6 +393,8 @@ CampaignMapBoard.propTypes = {
       color: PropTypes.string,
       label: PropTypes.string,
       isMovable: PropTypes.bool,
+      currentHp: PropTypes.number,
+      maxHp: PropTypes.number,
     })
   ),
   onTokenDragStart: PropTypes.func,

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -18,6 +18,15 @@ const clamp01 = (value) => {
   return parsed;
 };
 
+const toFiniteNumberOrNull = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
 const sanitizeToken = (tokenValue, fallbackId) => {
   if (!tokenValue || typeof tokenValue !== 'object') {
     return null;
@@ -195,8 +204,15 @@ const MapModal = ({
         typeof value?.label === 'string' && value.label.trim() !== ''
           ? value.label.trim()
           : null;
+      const currentHp = toFiniteNumberOrNull(value?.currentHp);
+      const maxHp = toFiniteNumberOrNull(value?.maxHp);
 
-      acc[trimmedKey] = { color, label };
+      acc[trimmedKey] = {
+        color,
+        label,
+        ...(currentHp !== null ? { currentHp } : {}),
+        ...(maxHp !== null ? { maxHp } : {}),
+      };
       return acc;
     }, {});
   }, [characterLookup]);
@@ -257,6 +273,13 @@ const MapModal = ({
             ? token.color.trim()
             : null);
 
+        const currentHp = toFiniteNumberOrNull(
+          lookup.currentHp ?? token.currentHp ?? token.hpCurrent ?? token.health
+        );
+        const maxHp = toFiniteNumberOrNull(
+          lookup.maxHp ?? token.maxHp ?? token.hpMax ?? token.health
+        );
+
         const isMovable =
           isInteractive &&
           !placementPending &&
@@ -267,6 +290,8 @@ const MapModal = ({
           label: typeof rawLabel === 'string' ? rawLabel : token.characterId,
           color,
           isMovable,
+          ...(currentHp !== null ? { currentHp } : {}),
+          ...(maxHp !== null ? { maxHp } : {}),
         };
       })
       .sort((a, b) => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2110,7 +2110,14 @@ export default function ZombiesCharacterSheet() {
             ? value.diceColor.trim()
             : null;
 
-        lookup[trimmed] = { color, label };
+        const { currentHp, maxHp } = calculateCharacterHitPoints(value);
+
+        lookup[trimmed] = {
+          color,
+          label,
+          currentHp: Number.isFinite(currentHp) ? currentHp : null,
+          maxHp: Number.isFinite(maxHp) ? maxHp : null,
+        };
       });
     }
 
@@ -2127,7 +2134,14 @@ export default function ZombiesCharacterSheet() {
           ? form.name.trim()
           : null);
 
-      lookup[resolvedCharacterId] = { color, label };
+      const { currentHp, maxHp } = calculateCharacterHitPoints(form);
+
+      lookup[resolvedCharacterId] = {
+        color,
+        label,
+        currentHp: Number.isFinite(currentHp) ? currentHp : null,
+        maxHp: Number.isFinite(maxHp) ? maxHp : null,
+      };
     }
 
     return lookup;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -24,6 +24,7 @@ import useUser from '../../../hooks/useUser';
 import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative } from '../utils/derivedStats';
+import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import {
@@ -1834,6 +1835,23 @@ export default function ZombiesDM() {
             (typeof record.characterId === 'string' && record.characterId.trim()) ||
             null;
 
+          const { currentHp: derivedCurrentHp, maxHp: derivedMaxHp } =
+            calculateCharacterHitPoints(record);
+
+          const fallbackCurrentHp = toFiniteNumberOrNull(
+            record.currentHp ?? record.hpCurrent ?? record.tempHealth ?? record.health
+          );
+          const fallbackMaxHp = toFiniteNumberOrNull(
+            record.maxHp ?? record.hpMax ?? record.health
+          );
+
+          const normalizedCurrentHp = Number.isFinite(derivedCurrentHp)
+            ? derivedCurrentHp
+            : fallbackCurrentHp;
+          const normalizedMaxHp = Number.isFinite(derivedMaxHp)
+            ? derivedMaxHp
+            : fallbackMaxHp;
+
           const identifiers = [record.characterId, record._id, record.token].filter(
             (value) => typeof value === 'string' && value.trim() !== ''
           );
@@ -1842,6 +1860,8 @@ export default function ZombiesDM() {
             lookup[identifier.trim()] = {
               color,
               label,
+              ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
+              ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
             };
           });
         });
@@ -1866,12 +1886,19 @@ export default function ZombiesDM() {
             (typeof enemy.enemyType === 'string' && enemy.enemyType.trim()) ||
             enemyId;
 
+          const enemyCurrentHp = toFiniteNumberOrNull(
+            enemy.currentHp ?? enemy.maxHp ?? enemy.hitPoints
+          );
+          const enemyMaxHp = toFiniteNumberOrNull(enemy.maxHp ?? enemy.hitPoints);
+
           lookup[enemyId] = {
             color:
               typeof enemy.diceColor === 'string' && enemy.diceColor.trim() !== ''
                 ? enemy.diceColor.trim()
                 : null,
             label,
+            ...(enemyCurrentHp !== null ? { currentHp: enemyCurrentHp } : {}),
+            ...(enemyMaxHp !== null ? { maxHp: enemyMaxHp } : {}),
           };
         });
       }
@@ -1914,11 +1941,19 @@ export default function ZombiesDM() {
           const meta = tokenMetaById[token.characterId] || {};
           const rawLabel = meta.label || token.label || token.characterId;
           const label = typeof rawLabel === 'string' ? rawLabel.trim() : '';
+          const normalizedCurrentHp = toFiniteNumberOrNull(
+            meta.currentHp ?? token.currentHp ?? token.hpCurrent ?? token.health
+          );
+          const normalizedMaxHp = toFiniteNumberOrNull(
+            meta.maxHp ?? token.maxHp ?? token.hpMax ?? token.health
+          );
           return {
             ...token,
             label,
             color: meta.color || token.color || null,
             isMovable: true,
+            ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
+            ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
           };
         })
         .sort((a, b) => {


### PR DESCRIPTION
## Summary
- calculate and propagate hit point metadata for campaign tokens in both player and DM views
- surface HP data through the map modal and campaign board tokens, including derived fallbacks
- render an accessible health bar overlay with supporting styling on the campaign map

## Testing
- Not run (UI changes require manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68daf5803530832eb2ff929acbe0a842