### PR TITLE
Adjust campaign map health color based on HP ratio

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -16,6 +16,16 @@ const clamp01 = (value) => {
   return parsed;
 };
 
+const getHealthColor = (ratio) => {
+  const clampedRatio = clamp01(ratio);
+  if (clampedRatio === null) {
+    return '#51cf66';
+  }
+
+  const hue = Math.round(120 * clampedRatio);
+  return `hsl(${hue}, 70%, 45%)`;
+};
+
 const toFiniteNumberOrNull = (value) => {
   if (value === null || value === undefined || value === '') {
     return null;
@@ -311,7 +321,7 @@ const CampaignMapBoard = ({
                     ? Math.min(1, Math.max(0, safeCurrentHp / safeMaxHp))
                     : 0;
                 const fillPercent = Math.round(ratio * 10000) / 100;
-                const healthColor = color || '#51cf66';
+                const healthColor = getHealthColor(ratio);
                 return (
                   <div
                     key={characterId}


### PR DESCRIPTION
## Summary
- add a helper to translate HP ratios into HSL hues for campaign map health bars
- use the helper so each token health bar color reflects its current HP percentage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf8842b54832eadc9d0d98bbc2754