### PR TITLE
Default OpenAI map responses to base64 payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The server uses a `config.env` file for configuration. Ensure the following vari
 |----------|-------------|
 | `CLIENT_ORIGINS` | Comma-separated list of client application URLs allowed to make cross-origin requests, e.g., `http://localhost,http://example.com`. |
 | `OPENAI_API_KEY` | API key used by the server to access OpenAI for item generation. |
+| `OPENAI_IMAGE_RESPONSE_FORMAT` | Optional override for the battle map response format. Defaults to `b64_json`, which stores generated maps as base64 strings in the `imageBase64` field. Set to `url` only if you plan to manage persistent image hosting yourself. |
 
 ### Client Environment Variables
 

--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -300,11 +300,12 @@ describe('AI map route', () => {
     }
   });
 
-  test('returns generated image metadata', async () => {
+  test('returns generated image metadata with base64 output', async () => {
     mockGenerate.mockResolvedValue({
       data: [
         {
-          url: 'https://example.com/map.png',
+          b64_json: 'ZGF0YQ==',
+          mime_type: 'image/webp',
           revised_prompt: 'Reimagined cavern layout',
         },
       ],
@@ -317,7 +318,8 @@ describe('AI map route', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
       title: 'Reimagined Cavern Layout',
-      imageUrl: 'https://example.com/map.png',
+      imageBase64: 'ZGF0YQ==',
+      imageType: 'image/webp',
       prompt: 'create a cavern map',
       provider: 'openai',
     });
@@ -326,6 +328,7 @@ describe('AI map route', () => {
       expect.objectContaining({
         model: expect.any(String),
         prompt: expect.stringContaining('create a cavern map'),
+        response_format: 'b64_json',
       })
     );
   });
@@ -334,7 +337,7 @@ describe('AI map route', () => {
     mockGenerate.mockResolvedValue({
       data: [
         {
-          url: 'https://example.com/prompt-only-map.png',
+          b64_json: 'YmFzZTY0',
         },
       ],
     });
@@ -345,9 +348,13 @@ describe('AI map route', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.title).toBe('Haunted Crypt With Flickering Torches');
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    expect(mockGenerate.mock.calls[0][0].response_format).toBe('b64_json');
   });
 
-  test('omits response_format for models that do not require it', async () => {
+  test('allows url responses when configured', async () => {
+    process.env.OPENAI_IMAGE_RESPONSE_FORMAT = 'url';
+
     mockGenerate.mockResolvedValue({
       data: [
         {
@@ -356,29 +363,17 @@ describe('AI map route', () => {
       ],
     });
 
-    await request(app).post('/ai/map').send({ prompt: 'standard map' });
+    const res = await request(app)
+      .post('/ai/map')
+      .send({ prompt: 'standard map' });
 
     expect(mockGenerate).toHaveBeenCalledTimes(1);
     const payload = mockGenerate.mock.calls[0][0];
     expect(payload.response_format).toBeUndefined();
-  });
 
-  test('includes response_format when requesting base64 output', async () => {
-    process.env.OPENAI_IMAGE_RESPONSE_FORMAT = 'b64_json';
-
-    mockGenerate.mockResolvedValue({
-      data: [
-        {
-          b64_json: 'ZGF0YQ==',
-        },
-      ],
-    });
-
-    await request(app).post('/ai/map').send({ prompt: 'base64 map' });
-
-    expect(mockGenerate).toHaveBeenCalledTimes(1);
-    const payload = mockGenerate.mock.calls[0][0];
-    expect(payload.response_format).toBe('b64_json');
+    expect(res.status).toBe(200);
+    expect(res.body.imageUrl).toBe('https://example.com/map.png');
+    expect(res.body.imageBase64).toBeUndefined();
   });
 
   test('returns error when the provider returns no image', async () => {

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -305,7 +305,7 @@ module.exports = (router) => {
       const model = process.env.OPENAI_IMAGE_MODEL || 'gpt-image-1';
       const size = process.env.OPENAI_IMAGE_SIZE || '1024x1024';
       const quality = process.env.OPENAI_IMAGE_QUALITY;
-      const responseFormat = process.env.OPENAI_IMAGE_RESPONSE_FORMAT || 'url';
+      const responseFormat = process.env.OPENAI_IMAGE_RESPONSE_FORMAT || 'b64_json';
 
       const generationPrompt = `Top-down tactical battle map for Dungeons & Dragons 5th Edition. Include clear terrain features, obstacles, and space for miniatures on a grid, but do not draw grid labels. ${prompt.trim()}`;
 
@@ -316,8 +316,7 @@ module.exports = (router) => {
         n: 1,
       };
 
-      const shouldIncludeResponseFormat = responseFormat === 'b64_json';
-      if (shouldIncludeResponseFormat) {
+      if (responseFormat === 'b64_json') {
         requestPayload.response_format = responseFormat;
       }
 
@@ -363,7 +362,13 @@ module.exports = (router) => {
         model,
         ...(image.url ? { imageUrl: image.url } : {}),
         ...(image.b64_json
-          ? { imageBase64: image.b64_json, imageType: 'image/png' }
+          ? {
+              imageBase64: image.b64_json,
+              imageType:
+                typeof image.mime_type === 'string' && image.mime_type.trim() !== ''
+                  ? image.mime_type.trim()
+                  : 'image/png',
+            }
           : {}),
       };
 


### PR DESCRIPTION
## Summary
- request base64-encoded map images from OpenAI by default and persist the mime type alongside the payload
- update AI route tests to cover the new default response format and optional URL fallback
- document the new default configuration so deployments expect stored base64 images

## Testing
- npm --prefix server test -- ai.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dafa6dad34832e8d60512a262e7266