### PR TITLE
Add shared grid overlays to zombies map displays

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -7,6 +7,38 @@
   position: relative;
 }
 
+.map-display__image-wrapper {
+  position: relative;
+}
+
+.map-display__grid-overlay,
+.campaign-map-board__grid-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: inherit;
+  background-image:
+    linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.35) 0,
+      rgba(255, 255, 255, 0.35) 1px,
+      transparent 1px,
+      transparent 100%
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.35) 0,
+      rgba(255, 255, 255, 0.35) 1px,
+      transparent 1px,
+      transparent 100%
+    );
+  background-size: calc(100% / 24) calc(100% / 24);
+  background-repeat: repeat;
+  mix-blend-mode: screen;
+  z-index: 1;
+}
+
 .map-modal__saving-indicator {
   position: absolute;
   inset: auto 0 0 0;
@@ -2435,6 +2467,7 @@ h1 {
     position: absolute;
     inset: 0;
     pointer-events: auto;
+    z-index: 2;
   }
 
   &__token {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -302,6 +302,7 @@ const CampaignMapBoard = ({
         <div className="campaign-map-board__stage">
           <div className="campaign-map-board__image-wrapper">
             <img src={imageSrc} alt={altText} className="campaign-map-board__image" />
+            <div className="campaign-map-board__grid-overlay" aria-hidden="true" />
             <div
               className="campaign-map-board__tokens-layer"
               ref={layerRef}

--- a/client/src/components/Zombies/attributes/MapDisplay.js
+++ b/client/src/components/Zombies/attributes/MapDisplay.js
@@ -40,6 +40,7 @@ const MapDisplay = ({ map }) => {
             alt={altText}
             className="map-display__image img-fluid rounded"
           />
+          <div className="map-display__grid-overlay" aria-hidden="true" />
         </div>
       ) : (
         <p className="text-muted mb-0">No map image available.</p>


### PR DESCRIPTION
## Summary
- add aria-hidden grid overlay elements to the map display and campaign board so static previews show the grid
- style the shared overlays with a 24×24 repeated gradient grid and keep the campaign token layer above it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafe9a33b0832ea5b7b9eb07ebe100