### PR TITLE
Ensure map preview respects rounded corners

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9,6 +9,8 @@
 
 .map-display__image-wrapper {
   position: relative;
+  border-radius: var(--bs-border-radius);
+  overflow: hidden;
 }
 
 .map-display__grid-overlay,


### PR DESCRIPTION
## Summary
- apply the Bootstrap border radius token to the map display image wrapper
- hide overflow so the overlay grid stays clipped to the rounded map preview

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68db0295d0b0832e9369c9b8f580bd32