### PR TITLE
Ensure map wrappers maintain square aspect ratio

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11,6 +11,15 @@
   position: relative;
   border-radius: var(--bs-border-radius);
   overflow: hidden;
+  aspect-ratio: 1 / 1;
+}
+
+.map-display__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
 }
 
 .map-display__grid-overlay,
@@ -2456,13 +2465,15 @@ h1 {
     border-radius: 0.75rem;
     overflow: hidden;
     background: rgba(0, 0, 0, 0.35);
+    aspect-ratio: 1 / 1;
   }
 
   &__image {
     display: block;
     width: 100%;
-    height: auto;
-    object-fit: cover;
+    height: 100%;
+    object-fit: contain;
+    object-position: center;
   }
 
   &__tokens-layer {


### PR DESCRIPTION
## Summary
- enforce a square aspect ratio for the DM preview and campaign map image wrappers
- adjust contained map imagery so artwork centers inside the square without distortion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db03e8f554832ea67c32c53d503a47