### PR TITLE
Clarify gridless AI map prompt dimensions

### DIFF
--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -307,7 +307,8 @@ module.exports = (router) => {
       const quality = process.env.OPENAI_IMAGE_QUALITY;
       const responseFormat = process.env.OPENAI_IMAGE_RESPONSE_FORMAT || 'b64_json';
 
-      const generationPrompt = `Top-down tactical battle map for Dungeons & Dragons 5th Edition. Include clear terrain features, obstacles, and space for miniatures on a grid, but do not draw grid labels. ${prompt.trim()}`;
+      const generationPrompt =
+        `Top-down tactical battle map for Dungeons & Dragons 5th Edition. Create a square, gridless map measuring 120 feet by 120 feet (24 by 24 five-foot squares). Include clear terrain features and obstacles sized for miniatures, ensuring all placements align to five-foot increments so the scene matches a 24-by-24 overlay. Do not draw any grid lines. ${prompt.trim()}`;
 
       const requestPayload = {
         model,


### PR DESCRIPTION
## Summary
- refine the AI map generation prompt to request a 120 ft by 120 ft square battle map aligned to 5-foot increments
- emphasize that the map must remain gridless while still matching the 24-by-24 overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db065b29a0832e89cc38a4ea87a504