### PR TITLE
Add hover labels for campaign figurines

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2618,22 +2618,33 @@ h1 {
       inset 0 -0.2rem 0.35rem rgba(0, 0, 0, 0.35);
   }
 
-  &__figurine-emblem {
+  &__figurine-label {
+    position: absolute;
+    bottom: calc(100% + clamp(0.35rem, 1vw, 0.55rem));
+    left: 50%;
+    transform: translate(-50%, 0.35rem) scale(0.96);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: clamp(0.9rem, 1.4vw, 1.4rem);
-    min-height: clamp(0.9rem, 1.4vw, 1.4rem);
+    padding: clamp(0.18rem, 0.6vw, 0.35rem) clamp(0.4rem, 1.2vw, 0.75rem);
     border-radius: 999px;
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.1));
-    color: #1c1d23;
-    font-weight: 700;
-    font-size: clamp(0.6rem, 1.5vw, 0.95rem);
-    text-transform: uppercase;
-    text-shadow: 0 0.05rem 0.12rem rgba(255, 255, 255, 0.4);
-    padding: 0 0.15rem;
-    box-shadow: inset 0 0.1rem 0.15rem rgba(255, 255, 255, 0.6),
-      inset 0 -0.1rem 0.15rem rgba(0, 0, 0, 0.25);
+    background: linear-gradient(180deg, rgba(18, 21, 29, 0.95), rgba(18, 21, 29, 0.85));
+    color: #f8f9fa;
+    font-weight: 600;
+    font-size: clamp(0.65rem, 1.5vw, 0.95rem);
+    line-height: 1.2;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    letter-spacing: 0.01em;
+    filter: drop-shadow(0 0.35rem 0.65rem rgba(0, 0, 0, 0.65));
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    transform-origin: center bottom;
+    max-width: clamp(8rem, 24vw, 14rem);
+    text-overflow: ellipsis;
+    overflow: hidden;
+    z-index: 5;
   }
 
   &__figurine-base {
@@ -2685,6 +2696,13 @@ h1 {
     outline: 3px solid rgba(255, 255, 255, 0.85);
     outline-offset: 4px;
     box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.45);
+  }
+
+  &__token--label-active .campaign-map-board__figurine-label,
+  &__token:hover .campaign-map-board__figurine-label,
+  &__token:focus-visible .campaign-map-board__figurine-label {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
   }
 
   &__token:focus-visible .campaign-map-board__figurine {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -94,6 +94,7 @@ const CampaignMapBoard = ({
   const layerRef = useRef(null);
   const dragStateRef = useRef({ tokenId: null, pointerId: null });
   const [dragPositions, setDragPositions] = useState({});
+  const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
 
   const tokenPositions = useMemo(() => {
     if (!Array.isArray(tokens)) {
@@ -275,6 +276,7 @@ const CampaignMapBoard = ({
 
   const handleLayerPointerDown = useCallback(
     (event) => {
+      setActiveLabelTokenId(null);
       if (interactionDisabled || typeof onBackgroundClick !== 'function') {
         return;
       }
@@ -292,7 +294,12 @@ const CampaignMapBoard = ({
       event.stopPropagation();
       onBackgroundClick(coords);
     },
-    [getNormalizedCoordinates, interactionDisabled, onBackgroundClick]
+    [
+      getNormalizedCoordinates,
+      interactionDisabled,
+      onBackgroundClick,
+      setActiveLabelTokenId,
+    ]
   );
 
   return (
@@ -311,6 +318,9 @@ const CampaignMapBoard = ({
               {tokenPositions.map((token) => {
                 const { characterId, position, color, label, currentHp, maxHp } = token;
                 const draggable = !interactionDisabled && token.isMovable !== false;
+                const normalizedLabel = normalizeText(label);
+                const displayLabel = normalizedLabel || normalizeText(characterId) || characterId;
+                const isLabelActive = activeLabelTokenId === characterId;
                 const numericCurrentHp = toFiniteNumberOrNull(currentHp);
                 const numericMaxHp = toFiniteNumberOrNull(maxHp);
                 const hasHealth =
@@ -328,19 +338,36 @@ const CampaignMapBoard = ({
                     key={characterId}
                     role={draggable ? 'button' : undefined}
                     tabIndex={draggable ? 0 : -1}
-                    aria-label={label || characterId}
+                    aria-label={displayLabel}
                     className={classNames(
                       'campaign-map-board__token',
-                      draggable && 'campaign-map-board__token--draggable'
+                      draggable && 'campaign-map-board__token--draggable',
+                      isLabelActive && 'campaign-map-board__token--label-active'
                     )}
                     style={{
                       left: `${(position?.x ?? 0) * 100}%`,
                       top: `${(position?.y ?? 0) * 100}%`,
                     }}
-                    onPointerDown={(event) => handlePointerDown(event, token)}
+                    title={displayLabel || undefined}
+                    onPointerDown={(event) => {
+                      if (characterId) {
+                        setActiveLabelTokenId(characterId);
+                      }
+                      handlePointerDown(event, token);
+                    }}
                     onPointerMove={handlePointerMove}
-                    onPointerUp={handlePointerUp}
-                    onPointerCancel={handlePointerCancel}
+                    onPointerUp={(event) => {
+                      setActiveLabelTokenId((prev) =>
+                        prev === characterId ? null : prev
+                      );
+                      handlePointerUp(event);
+                    }}
+                    onPointerCancel={(event) => {
+                      setActiveLabelTokenId((prev) =>
+                        prev === characterId ? null : prev
+                      );
+                      handlePointerCancel(event);
+                    }}
                     data-token-id={characterId}
                   >
                     {hasHealth && safeCurrentHp !== null && safeMaxHp !== null && safeMaxHp > 0 && (
@@ -368,11 +395,7 @@ const CampaignMapBoard = ({
                     >
                       <span className="campaign-map-board__figurine-figure" aria-hidden="true">
                         <span className="campaign-map-board__figurine-head" />
-                        <span className="campaign-map-board__figurine-torso">
-                          <span className="campaign-map-board__figurine-emblem">
-                            {label ? label.charAt(0).toUpperCase() : ''}
-                          </span>
-                        </span>
+                        <span className="campaign-map-board__figurine-torso" />
                         <span className="campaign-map-board__figurine-cloak" />
                       </span>
                       <span className="campaign-map-board__figurine-base">
@@ -380,6 +403,14 @@ const CampaignMapBoard = ({
                         <span className="campaign-map-board__figurine-base-texture" />
                       </span>
                     </div>
+                    {displayLabel && (
+                      <span
+                        className="campaign-map-board__figurine-label"
+                        aria-hidden="true"
+                      >
+                        {displayLabel}
+                      </span>
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary
- replace the figurine emblem initial with a full name label that surfaces on hover, keyboard focus, or press while keeping screen reader support intact
- track the active pointer-hold token so touch interactions reveal the label without interfering with the existing drag behaviour
- restyle the campaign map figurine to remove the emblem badge and add a responsive tooltip-style label presentation

## Testing
- CI=1 npm test -- --watchAll=false *(fails: existing Zombies attribute tests emit act() warnings and map board expectations prior to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68db1261b3d4832e8fbc97d1f7f75e59