### PR TITLE
Add helper to remove enemy tokens when removing enemies

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -739,6 +739,171 @@ export default function ZombiesDM() {
       [selectedMonsterIndex, encodedCampaign, customEnemyName, fetchRecords]
     );
 
+    const removeCharacterTokensFromMaps = useCallback(
+      async (characterId) => {
+        const normalizedCharacterId =
+          typeof characterId === 'string' && characterId.trim() !== ''
+            ? characterId.trim()
+            : null;
+
+        if (!normalizedCharacterId || !encodedCampaign) {
+          return true;
+        }
+
+        const mapsWithToken = new Set();
+        const currentTokensByMap = mapTokensRef.current || {};
+        Object.entries(currentTokensByMap).forEach(([mapId, tokens]) => {
+          if (
+            typeof mapId === 'string' &&
+            mapId.trim() !== '' &&
+            tokens &&
+            typeof tokens === 'object' &&
+            Object.prototype.hasOwnProperty.call(tokens, normalizedCharacterId)
+          ) {
+            mapsWithToken.add(mapId);
+          }
+        });
+
+        if (
+          campaignMap &&
+          typeof campaignMap === 'object' &&
+          typeof campaignMap.mapId === 'string' &&
+          campaignMap.mapId.trim() !== '' &&
+          campaignMap.tokens &&
+          Object.prototype.hasOwnProperty.call(
+            campaignMap.tokens,
+            normalizedCharacterId
+          )
+        ) {
+          mapsWithToken.add(campaignMap.mapId);
+        }
+
+        if (
+          typeof activeMapId === 'string' &&
+          activeMapId.trim() !== '' &&
+          activeMapTokensRef.current &&
+          Object.prototype.hasOwnProperty.call(
+            activeMapTokensRef.current,
+            normalizedCharacterId
+          )
+        ) {
+          mapsWithToken.add(activeMapId);
+        }
+
+        const shouldClosePlacement =
+          mapPlacementState?.enemyId === normalizedCharacterId;
+
+        if (mapsWithToken.size === 0 && !shouldClosePlacement) {
+          return true;
+        }
+
+        const previousMapTokens = mapTokensRef.current || {};
+        const previousActiveTokens = activeMapTokensRef.current || {};
+        const previousCampaignMap = campaignMap;
+        const previousMapPlacementState = mapPlacementState;
+
+        if (mapsWithToken.size > 0) {
+          setMapTokens((prev) => {
+            const next = { ...(prev || {}) };
+            mapsWithToken.forEach((mapId) => {
+              if (typeof mapId !== 'string' || mapId.trim() === '') {
+                return;
+              }
+              if (!next[mapId]) {
+                return;
+              }
+              const updated = { ...next[mapId] };
+              delete updated[normalizedCharacterId];
+              if (Object.keys(updated).length === 0) {
+                delete next[mapId];
+              } else {
+                next[mapId] = updated;
+              }
+            });
+            return next;
+          });
+
+          setActiveMapTokens((prev) => {
+            if (!prev || !prev[normalizedCharacterId]) {
+              return prev;
+            }
+            const next = { ...prev };
+            delete next[normalizedCharacterId];
+            return next;
+          });
+
+          setCampaignMap((prev) => {
+            if (!prev || !mapsWithToken.has(prev.mapId)) {
+              return prev;
+            }
+            const nextTokens = { ...(prev.tokens || {}) };
+            delete nextTokens[normalizedCharacterId];
+            return { ...prev, tokens: nextTokens };
+          });
+        }
+
+        if (shouldClosePlacement) {
+          setMapPlacementState({ show: false, enemyId: null, enemyName: null });
+        }
+
+        const mapIds = Array.from(mapsWithToken).filter(
+          (mapId) => typeof mapId === 'string' && mapId.trim() !== ''
+        );
+
+        if (mapIds.length === 0) {
+          return true;
+        }
+
+        try {
+          const encodedCharacterId = encodeURIComponent(normalizedCharacterId);
+          for (const mapId of mapIds) {
+            const encodedMapId = encodeURIComponent(mapId);
+            const response = await apiFetch(
+              `/campaigns/${encodedCampaign}/maps/${encodedMapId}/tokens/${encodedCharacterId}`,
+              {
+                method: 'DELETE',
+              }
+            );
+
+            if (response && response.status === 404) {
+              continue;
+            }
+
+            if (!response || !response.ok) {
+              const message = await parseErrorMessage(
+                response,
+                'Failed to remove token from map.'
+              );
+              throw new Error(message);
+            }
+          }
+        } catch (error) {
+          console.error(error);
+          setStatus({
+            type: 'danger',
+            message: error?.message || 'Failed to remove token from map.',
+          });
+          setMapTokens(previousMapTokens || {});
+          setActiveMapTokens(previousActiveTokens || {});
+          setCampaignMap(previousCampaignMap || null);
+          setMapPlacementState(
+            previousMapPlacementState || { show: false, enemyId: null, enemyName: null }
+          );
+          return false;
+        }
+
+        return true;
+      },
+      [
+        activeMapId,
+        campaignMap,
+        encodedCampaign,
+        mapPlacementState,
+        parseErrorMessage,
+        setStatus,
+      ]
+    );
+
     const handleRemoveEnemy = useCallback(
       async (enemyId) => {
         if (!enemyId || !encodedCampaign) {
@@ -762,8 +927,11 @@ export default function ZombiesDM() {
             throw new Error(message);
           }
 
+          const tokensRemoved = await removeCharacterTokensFromMaps(enemyId);
           await fetchRecords();
-          setStatus({ type: 'success', message: 'Enemy removed.' });
+          if (tokensRemoved) {
+            setStatus({ type: 'success', message: 'Enemy removed.' });
+          }
         } catch (error) {
           console.error(error);
           setStatus({ type: 'danger', message: error.message || 'Failed to remove enemy.' });
@@ -771,7 +939,7 @@ export default function ZombiesDM() {
           setRemovingEnemyId(null);
         }
       },
-      [encodedCampaign, fetchRecords]
+      [encodedCampaign, fetchRecords, removeCharacterTokensFromMaps]
     );
 
     const handleEnemyAdjustmentInputChange = useCallback((enemyId, value) => {

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import apiFetch from '../../../utils/apiFetch';
 import useUser from '../../../hooks/useUser';
@@ -258,6 +258,130 @@ describe('ZombiesDM AI generation', () => {
       'Select slot',
       ...armorSlotOptions.map((slot) => slot.label),
     ]);
+  });
+
+  test('removes enemy tokens from maps before success status', async () => {
+    const enemies = [{ enemyId: 'enemy-1', name: 'Goblin', type: 'humanoid' }];
+    let enemiesFetchCount = 0;
+    const mapDeleteResolvers = {};
+
+    apiFetch.mockImplementation((url, options = {}) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ participants: [], activeTurn: null }),
+          });
+        case '/campaigns/Camp1/enemies':
+          enemiesFetchCount += 1;
+          if (enemiesFetchCount === 1) {
+            return Promise.resolve({ ok: true, json: async () => enemies });
+          }
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/enemies/enemy-1':
+          if (options.method === 'DELETE') {
+            return Promise.resolve({ ok: true, status: 204 });
+          }
+          break;
+        case '/campaigns/Camp1/maps/Map%20Alpha/tokens/enemy-1':
+          if (options.method === 'DELETE') {
+            return new Promise((resolve) => {
+              mapDeleteResolvers.alpha = () => resolve({ ok: true, status: 204 });
+            });
+          }
+          break;
+        case '/campaigns/Camp1/maps/Map%20Beta/tokens/enemy-1':
+          if (options.method === 'DELETE') {
+            return new Promise((resolve) => {
+              mapDeleteResolvers.beta = () => resolve({ ok: true, status: 204 });
+            });
+          }
+          break;
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(<ZombiesDM />);
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/characters')
+    );
+
+    const sockets = socketModule.__getMockSockets();
+    const componentSocket = sockets[sockets.length - 1];
+    expect(componentSocket).toBeDefined();
+    const mapUpdateHandlerEntry = componentSocket.on.mock.calls.find(
+      ([eventName]) => eventName === 'campaign:map:update'
+    );
+    expect(mapUpdateHandlerEntry).toBeDefined();
+    const mapUpdateHandler = mapUpdateHandlerEntry[1];
+
+    const primaryToken = { characterId: 'enemy-1', x: 0.25, y: 0.5 };
+    const secondaryToken = { characterId: 'enemy-1', x: 0.6, y: 0.7 };
+
+    await act(async () => {
+      mapUpdateHandler({
+        maps: [
+          { mapId: 'Map Alpha', tokens: { 'enemy-1': primaryToken } },
+          { mapId: 'Map Beta', tokens: { 'enemy-1': secondaryToken } },
+        ],
+        activeMapId: 'Map Alpha',
+        tokensByMapId: {
+          'Map Alpha': { 'enemy-1': primaryToken },
+          'Map Beta': { 'enemy-1': secondaryToken },
+        },
+        activeMapTokens: { 'enemy-1': primaryToken },
+        map: { mapId: 'Map Alpha', tokens: { 'enemy-1': primaryToken } },
+      });
+    });
+
+    const removeButton = await screen.findByRole('button', { name: 'Remove' });
+    await userEvent.click(removeButton);
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/campaigns/Camp1/enemies/enemy-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    );
+
+    await waitFor(() => {
+      expect(mapDeleteResolvers.alpha).toBeInstanceOf(Function);
+      expect(mapDeleteResolvers.beta).toBeInstanceOf(Function);
+    });
+
+    expect(screen.queryByText('Enemy removed.')).not.toBeInTheDocument();
+
+    await act(async () => {
+      mapDeleteResolvers.alpha();
+      mapDeleteResolvers.beta();
+    });
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/campaigns/Camp1/maps/Map%20Alpha/tokens/enemy-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    );
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/campaigns/Camp1/maps/Map%20Beta/tokens/enemy-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Enemy removed.')).toBeInTheDocument()
+    );
   });
 
   test('generates item via AI and populates bonus fields', async () => {


### PR DESCRIPTION
## Summary
- add a removeCharacterTokensFromMaps helper to clear local map state and send DELETE requests when an enemy is removed
- call the helper from handleRemoveEnemy so map tokens stay in sync with campaign data
- expand the ZombiesDM tests to cover removing enemy tokens from multiple maps and verifying the DELETE calls

## Testing
- CI=1 npx jest src/components/Zombies/pages/ZombiesDM.test.js --runInBand *(fails: Jest cannot parse JSX without additional config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db1d5d6b18832e97e45aacdc5123c4