### PR TITLE
Adjust map placement button styling

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -4967,7 +4967,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           {inCombat ? 'Remove from Combat' : 'Add to Combat'}
                         </Button>
                         <Button
-                          variant="outline-light"
+                          variant="outline-primary"
                           size="sm"
                           onClick={() =>
                             handleOpenMapPlacement(


### PR DESCRIPTION
## Summary
- switch the enemy "Place on Map" button to use the outline-primary variant for better visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db202d7660832eba6f6a52502b1838