### PR TITLE
Add map token variant styling for campaign boards

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2639,12 +2639,33 @@ h1 {
     letter-spacing: 0.01em;
     filter: drop-shadow(0 0.35rem 0.65rem rgba(0, 0, 0, 0.65));
     border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.25s ease;
     transform-origin: center bottom;
     max-width: clamp(8rem, 24vw, 14rem);
     text-overflow: ellipsis;
     overflow: hidden;
     z-index: 5;
+
+    &--enemy {
+      box-shadow:
+        0 0.35rem 0.75rem rgba(0, 0, 0, 0.45),
+        0 0 0.85rem rgba(255, 77, 79, 0.55),
+        0 0 1.75rem rgba(255, 77, 79, 0.75);
+    }
+
+    &--ally {
+      box-shadow:
+        0 0.35rem 0.75rem rgba(0, 0, 0, 0.45),
+        0 0 0.85rem rgba(81, 207, 102, 0.5),
+        0 0 1.75rem rgba(81, 207, 102, 0.7);
+    }
+
+    &--self {
+      box-shadow:
+        0 0.35rem 0.75rem rgba(0, 0, 0, 0.45),
+        0 0 0.85rem rgba(51, 154, 240, 0.5),
+        0 0 1.75rem rgba(51, 154, 240, 0.75);
+    }
   }
 
   &__figurine-base {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from '../../../utils/classNames';
+import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -316,7 +317,7 @@ const CampaignMapBoard = ({
               onPointerDown={handleLayerPointerDown}
             >
               {tokenPositions.map((token) => {
-                const { characterId, position, color, label, currentHp, maxHp } = token;
+                const { characterId, position, color, label, currentHp, maxHp, variant } = token;
                 const draggable = !interactionDisabled && token.isMovable !== false;
                 const normalizedLabel = normalizeText(label);
                 const displayLabel = normalizedLabel || normalizeText(characterId) || characterId;
@@ -333,6 +334,21 @@ const CampaignMapBoard = ({
                     : 0;
                 const fillPercent = Math.round(ratio * 10000) / 100;
                 const healthColor = getHealthColor(ratio);
+                const normalizedVariant =
+                  typeof variant === 'string' && variant.trim() !== ''
+                    ? variant.trim().toLowerCase()
+                    : null;
+
+                const figurineColor =
+                  normalizedVariant === 'enemy'
+                    ? ENEMY_FIGURINE_COLOR
+                    : normalizeText(color) || undefined;
+
+                const labelClassName = classNames(
+                  'campaign-map-board__figurine-label',
+                  normalizedVariant ? `campaign-map-board__figurine-label--${normalizedVariant}` : null
+                );
+
                 return (
                   <div
                     key={characterId}
@@ -391,7 +407,7 @@ const CampaignMapBoard = ({
                         'campaign-map-board__figurine',
                         draggable && 'campaign-map-board__figurine--active'
                       )}
-                      style={{ '--figurine-color': color || undefined }}
+                      style={{ '--figurine-color': figurineColor }}
                     >
                       <span className="campaign-map-board__figurine-figure" aria-hidden="true">
                         <span className="campaign-map-board__figurine-head" />
@@ -404,10 +420,7 @@ const CampaignMapBoard = ({
                       </span>
                     </div>
                     {displayLabel && (
-                      <span
-                        className="campaign-map-board__figurine-label"
-                        aria-hidden="true"
-                      >
+                      <span className={labelClassName} aria-hidden="true">
                         {displayLabel}
                       </span>
                     )}
@@ -434,6 +447,7 @@ CampaignMapBoard.propTypes = {
       y: PropTypes.number,
       color: PropTypes.string,
       label: PropTypes.string,
+      variant: PropTypes.oneOf(['enemy', 'ally', 'self']),
       isMovable: PropTypes.bool,
       currentHp: PropTypes.number,
       maxHp: PropTypes.number,

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -206,10 +206,20 @@ const MapModal = ({
           : null;
       const currentHp = toFiniteNumberOrNull(value?.currentHp);
       const maxHp = toFiniteNumberOrNull(value?.maxHp);
+      const entityType =
+        typeof value?.entityType === 'string' && value.entityType.trim() !== ''
+          ? value.entityType.trim().toLowerCase()
+          : null;
+      const variant =
+        typeof value?.variant === 'string' && value.variant.trim() !== ''
+          ? value.variant.trim().toLowerCase()
+          : null;
 
       acc[trimmedKey] = {
         color,
         label,
+        ...(entityType ? { entityType } : {}),
+        ...(variant ? { variant } : {}),
         ...(currentHp !== null ? { currentHp } : {}),
         ...(maxHp !== null ? { maxHp } : {}),
       };
@@ -267,12 +277,6 @@ const MapModal = ({
           (typeof token.label === 'string' && token.label.trim() !== '' ? token.label.trim() : null) ||
           token.characterId;
 
-        const color =
-          lookup.color ||
-          (typeof token.color === 'string' && token.color.trim() !== ''
-            ? token.color.trim()
-            : null);
-
         const currentHp = toFiniteNumberOrNull(
           lookup.currentHp ?? token.currentHp ?? token.hpCurrent ?? token.health
         );
@@ -285,11 +289,53 @@ const MapModal = ({
           !placementPending &&
           (!readOnly || token.characterId === normalizedCurrentCharacterId);
 
+        const lookupVariant =
+          typeof lookup.variant === 'string' && lookup.variant.trim() !== ''
+            ? lookup.variant.trim().toLowerCase()
+            : null;
+        const tokenVariant =
+          typeof token.variant === 'string' && token.variant.trim() !== ''
+            ? token.variant.trim().toLowerCase()
+            : null;
+        const lookupEntityType =
+          typeof lookup.entityType === 'string' && lookup.entityType.trim() !== ''
+            ? lookup.entityType.trim().toLowerCase()
+            : null;
+        const tokenEntityType =
+          typeof token.entityType === 'string' && token.entityType.trim() !== ''
+            ? token.entityType.trim().toLowerCase()
+            : null;
+
+        const entityType = lookupEntityType || tokenEntityType || null;
+
+        let variant = lookupVariant || tokenVariant || null;
+        if (!variant && entityType) {
+          if (entityType === 'enemy') {
+            variant = 'enemy';
+          } else if (
+            entityType === 'character' &&
+            normalizedCurrentCharacterId &&
+            token.characterId === normalizedCurrentCharacterId
+          ) {
+            variant = 'self';
+          } else if (entityType === 'character') {
+            variant = 'ally';
+          } else if (entityType !== 'enemy') {
+            variant = 'ally';
+          }
+        }
+
+        const baseColor = lookup.color || token.color || null;
+        const normalizedColor =
+          typeof baseColor === 'string' && baseColor.trim() !== '' ? baseColor.trim() : null;
+
         return {
           ...token,
           label: typeof rawLabel === 'string' ? rawLabel : token.characterId,
-          color,
+          color: normalizedColor,
           isMovable,
+          ...(entityType ? { entityType } : {}),
+          ...(variant ? { variant } : {}),
           ...(currentHp !== null ? { currentHp } : {}),
           ...(maxHp !== null ? { maxHp } : {}),
         };
@@ -300,9 +346,9 @@ const MapModal = ({
         return labelA.localeCompare(labelB);
       });
   }, [
-    currentCharacterId,
     isInteractive,
     normalizedCharacterLookup,
+    normalizedCurrentCharacterId,
     placementPending,
     readOnly,
     tokensDictionary,

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -73,8 +73,8 @@ describe('MapModal', () => {
         }}
         currentCharacterId="hero"
         characterLookup={{
-          hero: { color: '#123456', label: 'Hero' },
-          ally: { color: '#654321', label: 'Ally' },
+          hero: { color: '#123456', label: 'Hero', entityType: 'character' },
+          ally: { color: '#654321', label: 'Ally', entityType: 'character' },
         }}
         onTokenMove={jest.fn().mockResolvedValue(true)}
       />
@@ -88,11 +88,13 @@ describe('MapModal', () => {
           characterId: 'hero',
           isMovable: true,
           color: '#123456',
+          variant: 'self',
         }),
         expect.objectContaining({
           characterId: 'ally',
           isMovable: false,
           color: '#654321',
+          variant: 'ally',
         }),
       ])
     );
@@ -111,7 +113,7 @@ describe('MapModal', () => {
         activeMapId="map-1"
         tokensByMapId={{ 'map-1': {} }}
         currentCharacterId="hero"
-        characterLookup={{ hero: { color: '#111111', label: 'Hero' } }}
+        characterLookup={{ hero: { color: '#111111', label: 'Hero', entityType: 'character' } }}
         onTokenMove={onTokenMove}
       />
     );

--- a/client/src/components/Zombies/constants/tokenAppearance.js
+++ b/client/src/components/Zombies/constants/tokenAppearance.js
@@ -1,0 +1,1 @@
+export const ENEMY_FIGURINE_COLOR = '#ff4d4f';

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2110,38 +2110,56 @@ export default function ZombiesCharacterSheet() {
             ? value.diceColor.trim()
             : null;
 
+        const entityTypeRaw =
+          typeof value?.entityType === 'string' && value.entityType.trim() !== ''
+            ? value.entityType.trim()
+            : 'character';
+        const entityType = entityTypeRaw.toLowerCase();
+
         const { currentHp, maxHp } = calculateCharacterHitPoints(value);
 
         lookup[trimmed] = {
           color,
           label,
+          entityType,
           currentHp: Number.isFinite(currentHp) ? currentHp : null,
           maxHp: Number.isFinite(maxHp) ? maxHp : null,
         };
       });
     }
 
-    if (resolvedCharacterId && !lookup[resolvedCharacterId]) {
-      const color =
-        typeof form?.diceColor === 'string' && form.diceColor.trim() !== ''
-          ? form.diceColor.trim()
-          : null;
-      const label =
-        (typeof form?.characterName === 'string' && form.characterName.trim() !== ''
-          ? form.characterName.trim()
-          : null) ||
-        (typeof form?.name === 'string' && form.name.trim() !== ''
-          ? form.name.trim()
-          : null);
+    if (resolvedCharacterId) {
+      if (!lookup[resolvedCharacterId]) {
+        const color =
+          typeof form?.diceColor === 'string' && form.diceColor.trim() !== ''
+            ? form.diceColor.trim()
+            : null;
+        const label =
+          (typeof form?.characterName === 'string' && form.characterName.trim() !== ''
+            ? form.characterName.trim()
+            : null) ||
+          (typeof form?.name === 'string' && form.name.trim() !== ''
+            ? form.name.trim()
+            : null);
 
-      const { currentHp, maxHp } = calculateCharacterHitPoints(form);
+        const { currentHp, maxHp } = calculateCharacterHitPoints(form);
 
-      lookup[resolvedCharacterId] = {
-        color,
-        label,
-        currentHp: Number.isFinite(currentHp) ? currentHp : null,
-        maxHp: Number.isFinite(maxHp) ? maxHp : null,
-      };
+        lookup[resolvedCharacterId] = {
+          color,
+          label,
+          entityType: 'character',
+          currentHp: Number.isFinite(currentHp) ? currentHp : null,
+          maxHp: Number.isFinite(maxHp) ? maxHp : null,
+        };
+      } else if (
+        typeof lookup[resolvedCharacterId].entityType !== 'string' ||
+        lookup[resolvedCharacterId].entityType.trim() === ''
+      ) {
+        lookup[resolvedCharacterId] = {
+          ...lookup[resolvedCharacterId],
+          entityType: 'character',
+        };
+      }
     }
 
     return lookup;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -27,6 +27,7 @@ import { calculateCharacterInitiative } from '../utils/derivedStats';
 import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
+import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import {
   GiCharacter,
   GiStoneAxe,
@@ -2008,6 +2009,12 @@ export default function ZombiesDM() {
             (typeof record.characterId === 'string' && record.characterId.trim()) ||
             null;
 
+          const entityTypeRaw =
+            typeof record.entityType === 'string' && record.entityType.trim() !== ''
+              ? record.entityType.trim()
+              : 'character';
+          const entityType = entityTypeRaw.toLowerCase();
+
           const { currentHp: derivedCurrentHp, maxHp: derivedMaxHp } =
             calculateCharacterHitPoints(record);
 
@@ -2030,9 +2037,15 @@ export default function ZombiesDM() {
           );
 
           identifiers.forEach((identifier) => {
-            lookup[identifier.trim()] = {
+            const trimmed = identifier.trim();
+            if (!trimmed) {
+              return;
+            }
+
+            lookup[trimmed] = {
               color,
               label,
+              entityType,
               ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
               ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
             };
@@ -2065,11 +2078,9 @@ export default function ZombiesDM() {
           const enemyMaxHp = toFiniteNumberOrNull(enemy.maxHp ?? enemy.hitPoints);
 
           lookup[enemyId] = {
-            color:
-              typeof enemy.diceColor === 'string' && enemy.diceColor.trim() !== ''
-                ? enemy.diceColor.trim()
-                : null,
+            color: ENEMY_FIGURINE_COLOR,
             label,
+            entityType: 'enemy',
             ...(enemyCurrentHp !== null ? { currentHp: enemyCurrentHp } : {}),
             ...(enemyMaxHp !== null ? { maxHp: enemyMaxHp } : {}),
           };
@@ -2165,11 +2176,44 @@ export default function ZombiesDM() {
           const normalizedMaxHp = toFiniteNumberOrNull(
             meta.maxHp ?? token.maxHp ?? token.hpMax ?? token.health
           );
+          const metaVariant =
+            typeof meta.variant === 'string' && meta.variant.trim() !== ''
+              ? meta.variant.trim().toLowerCase()
+              : null;
+          const tokenVariant =
+            typeof token.variant === 'string' && token.variant.trim() !== ''
+              ? token.variant.trim().toLowerCase()
+              : null;
+          const metaEntityType =
+            typeof meta.entityType === 'string' && meta.entityType.trim() !== ''
+              ? meta.entityType.trim().toLowerCase()
+              : null;
+          const tokenEntityType =
+            typeof token.entityType === 'string' && token.entityType.trim() !== ''
+              ? token.entityType.trim().toLowerCase()
+              : null;
+          const entityType = metaEntityType || tokenEntityType || null;
+
+          let variant = metaVariant || tokenVariant || null;
+          if (!variant && entityType) {
+            if (entityType === 'enemy') {
+              variant = 'enemy';
+            } else if (entityType === 'character') {
+              variant = 'ally';
+            }
+          }
+
+          const baseColor = meta.color || token.color || null;
+          const normalizedColor =
+            typeof baseColor === 'string' && baseColor.trim() !== '' ? baseColor.trim() : null;
+
           return {
             ...token,
             label,
-            color: meta.color || token.color || null,
+            color: normalizedColor,
             isMovable: true,
+            ...(entityType ? { entityType } : {}),
+            ...(variant ? { variant } : {}),
             ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
             ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
           };


### PR DESCRIPTION
## Summary
- add a shared enemy figurine color constant and apply it in the campaign map board
- propagate entity type metadata so map tokens can expose enemy, ally, and self variants
- style figurine labels with glow modifiers and cover the new behavior in MapModal tests

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/attributes/MapModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db24c420b4832e8afad47dcb2110fa