### PR TITLE
Emit socket updates for enemy roster changes

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1608,15 +1608,27 @@ export default function ZombiesCharacterSheet() {
       applyMapPayload(workingPayload);
     };
 
+    const handleEnemiesUpdate = (roster) => {
+      if (!Array.isArray(roster)) {
+        setEnemies([]);
+        return;
+      }
+
+      const sanitized = roster.filter((entry) => entry && typeof entry === 'object');
+      setEnemies(sanitized);
+    };
+
     socket.on('combat:update', handleCombatUpdate);
     socket.on('character:health:update', handleCharacterHealthUpdate);
     socket.on('campaign:map:update', handleCampaignMapUpdate);
+    socket.on('campaign:enemies:update', handleEnemiesUpdate);
     socket.emit('campaign:join', campaignId);
 
     return () => {
       socket.off('combat:update', handleCombatUpdate);
       socket.off('character:health:update', handleCharacterHealthUpdate);
       socket.off('campaign:map:update', handleCampaignMapUpdate);
+      socket.off('campaign:enemies:update', handleEnemiesUpdate);
       socket.emit('campaign:leave', campaignId);
       socket.disconnect();
       socketRef.current = null;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1261,15 +1261,27 @@ export default function ZombiesDM() {
         setGeneratedMap(null);
       };
 
+      const handleEnemiesUpdate = (roster) => {
+        if (!Array.isArray(roster)) {
+          setEnemies([]);
+          return;
+        }
+
+        const sanitized = roster.filter((entry) => entry && typeof entry === 'object');
+        setEnemies(sanitized);
+      };
+
       socket.on('combat:update', handleCombatUpdate);
       socket.on('character:health:update', handleCharacterHealthUpdate);
       socket.on('campaign:map:update', handleMapUpdate);
+      socket.on('campaign:enemies:update', handleEnemiesUpdate);
       socket.emit('campaign:join', campaignId);
 
       return () => {
         socket.off('combat:update', handleCombatUpdate);
         socket.off('character:health:update', handleCharacterHealthUpdate);
         socket.off('campaign:map:update', handleMapUpdate);
+        socket.off('campaign:enemies:update', handleEnemiesUpdate);
         socket.emit('campaign:leave', campaignId);
         socket.disconnect();
         socketRef.current = null;

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -14,6 +14,7 @@ jest.mock('../middleware/auth', () => (req, res, next) => {
 });
 jest.mock('../utils/socket', () => ({
   emitCombatUpdate: jest.fn(),
+  emitEnemiesUpdate: jest.fn(),
   emitMapUpdate: jest.fn(),
 }));
 jest.mock('../utils/dnd5eApi', () => ({
@@ -22,7 +23,7 @@ jest.mock('../utils/dnd5eApi', () => ({
 jest.mock('../utils/monsters', () => ({
   buildEnemyRecord: jest.fn(),
 }));
-const { emitCombatUpdate, emitMapUpdate } = require('../utils/socket');
+const { emitCombatUpdate, emitEnemiesUpdate, emitMapUpdate } = require('../utils/socket');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
 const { buildEnemyRecord } = require('../utils/monsters');
 const registerCampaignRoutes = require('../routes/campaigns');
@@ -901,7 +902,12 @@ describe('Campaign routes', () => {
   test('add enemy success', async () => {
     getMonsterByIndex.mockResolvedValue({ index: 'goblin' });
     buildEnemyRecord.mockImplementation((monster, enemyId, providedName) => ({ enemyId, name: 'Goblin', providedName }));
-    const findOneAndUpdate = jest.fn().mockResolvedValue({ value: { campaignName: 'Test' } });
+    const findOneAndUpdate = jest.fn().mockImplementation(async (query, update) => ({
+      value: {
+        campaignName: 'Test',
+        enemies: [update.$push.enemies],
+      },
+    }));
     dbo.mockResolvedValue({
       collection: () => ({
         findOneAndUpdate,
@@ -917,6 +923,10 @@ describe('Campaign routes', () => {
     expect(typeof res.body.enemyId).toBe('string');
     expect(getMonsterByIndex).toHaveBeenCalledWith('goblin');
     expect(buildEnemyRecord).toHaveBeenCalledWith({ index: 'goblin' }, res.body.enemyId, undefined);
+    expect(emitEnemiesUpdate).toHaveBeenCalledWith(
+      'Test',
+      [expect.objectContaining({ enemyId: res.body.enemyId, name: 'Goblin' })]
+    );
   });
 
   test('delete enemy success', async () => {
@@ -950,6 +960,7 @@ describe('Campaign routes', () => {
         },
       }
     );
+    expect(emitEnemiesUpdate).toHaveBeenCalledWith('Test', []);
     expect(emitCombatUpdate).toHaveBeenCalledWith('Test', {
       participants: [{ characterId: 'char-1', initiative: 12 }],
       activeTurn: 0,
@@ -1005,6 +1016,10 @@ describe('Campaign routes', () => {
       }
     );
     expect(res.body.enemy.currentHp).toBe(12);
+    expect(emitEnemiesUpdate).toHaveBeenCalledWith(
+      'Test',
+      [expect.objectContaining({ enemyId: 'enemy-1', currentHp: 12 })]
+    );
     expect(emitCombatUpdate).toHaveBeenCalledWith('Test', {
       participants: [
         {

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -7,7 +7,7 @@ const { buildEnemyRecord } = require('../utils/monsters');
 const authenticateToken = require('../middleware/auth');
 const handleValidationErrors = require('../middleware/validation');
 const logger = require('../utils/logger');
-const { emitCombatUpdate, emitMapUpdate } = require('../utils/socket');
+const { emitCombatUpdate, emitEnemiesUpdate, emitMapUpdate } = require('../utils/socket');
 const {
   normalizeCampaignMapState,
   prepareStoredMap,
@@ -1076,6 +1076,8 @@ module.exports = (router) => {
             return res.status(404).json({ message: 'Campaign not found' });
           }
 
+          emitEnemiesUpdate(campaignName, result.value.enemies);
+
           res.json(enemyRecord);
         } catch (err) {
           if (err.statusCode === 404) {
@@ -1132,6 +1134,7 @@ module.exports = (router) => {
             { $set: { enemies: updatedEnemies, combat: combatState } }
           );
 
+          emitEnemiesUpdate(campaignName, updatedEnemies);
           emitCombatUpdate(campaignName, combatState);
 
           res.json({ success: true, enemies: updatedEnemies, combat: combatState });
@@ -1233,6 +1236,7 @@ module.exports = (router) => {
             { $set: { enemies: updatedEnemies, combat: combatState } }
           );
 
+          emitEnemiesUpdate(campaignName, updatedEnemies);
           emitCombatUpdate(campaignName, combatState);
 
           res.json({ success: true, enemy: updatedEnemy, combat: combatState });

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -167,6 +167,33 @@ const emitMapUpdate = (campaignId, payload) => {
   }
 };
 
+const sanitizeEnemies = (enemies) => {
+  if (!Array.isArray(enemies)) {
+    return [];
+  }
+
+  return enemies
+    .filter((enemy) => enemy && typeof enemy === 'object')
+    .map((enemy) => ({ ...enemy }));
+};
+
+const emitEnemiesUpdate = (campaignId, enemies) => {
+  if (!io) {
+    logger.warn('Socket.io server not initialized; cannot emit enemies update');
+    return;
+  }
+
+  if (typeof campaignId !== 'string' || campaignId.trim() === '') {
+    logger.warn('Invalid campaign id provided for enemies update', { campaignId });
+    return;
+  }
+
+  const normalizedId = campaignId.trim();
+  const payload = sanitizeEnemies(enemies);
+
+  io.to(getCampaignRoom(normalizedId)).emit('campaign:enemies:update', payload);
+};
+
 const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health }) => {
   if (!io) {
     logger.warn('Socket.io server not initialized; cannot emit character health update');
@@ -202,6 +229,7 @@ module.exports = {
   initializeSocket,
   emitCombatUpdate,
   emitMapUpdate,
+  emitEnemiesUpdate,
   emitCharacterHealthUpdate,
 };
 


### PR DESCRIPTION
## Summary
- add a reusable socket helper for broadcasting sanitized enemy rosters
- emit roster updates after campaign enemy mutations so connected clients stay in sync
- listen for the new socket event on both DM and player zombie pages to refresh local enemy state

## Testing
- npm --prefix server test -- campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db2ba4e598832e886ab4ed1fab8aae