### PR TITLE
Increase Express body parser limits

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -38,7 +38,8 @@ app.use(cors({
   },
   credentials: true,
 }));
-app.use(express.json());
+app.use(express.json({ limit: '5mb' }));
+app.use(express.urlencoded({ extended: true, limit: '5mb' }));
 app.use(cookieParser());
 const apiHost = process.env.API_ORIGIN || 'https://realmtracker.org';
 const connectSrc = ["'self'", apiHost];


### PR DESCRIPTION
## Summary
- raise the JSON parser limit to 5mb to support larger payloads
- add urlencoded parser with matching limit for form submissions

## Testing
- npm run start (fails: Missing required environment variables: JWT_SECRET, ATLAS_URI, CLIENT_ORIGINS)

------
https://chatgpt.com/codex/tasks/task_e_68dbe7a1461c832eba32db533950faf4