### PR TITLE
Refine map token updates to avoid resending imagery

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -41,6 +41,7 @@ import {
 import { normalizeEquipmentMap } from "../attributes/equipmentNormalization";
 import MapModal from "../attributes/MapModal";
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
+import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 
 const HEADER_PADDING = 16;
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
@@ -1550,6 +1551,42 @@ export default function ZombiesCharacterSheet() {
       const hasMapExplicitNull = Object.prototype.hasOwnProperty.call(update, 'map') && update.map === null;
       const hasActiveIdProp = Object.prototype.hasOwnProperty.call(update, 'activeMapId');
 
+      const sanitizedTokens = hasTokensByMapIdProp
+        ? sanitizeTokensByMapId(update.tokensByMapId)
+        : {};
+      const sanitizedActiveTokens = hasActiveTokensProp
+        ? sanitizeTokenDictionary(update.activeMapTokens)
+        : {};
+
+      const normalizedIncomingActiveId =
+        hasActiveIdProp && typeof update.activeMapId === 'string' && update.activeMapId.trim() !== ''
+          ? update.activeMapId.trim()
+          : null;
+
+      const tokenKeys = ['tokensByMapId', 'activeMapTokens', 'activeMapId'];
+      const payloadKeys = Object.keys(update);
+      const tokenOnlyUpdate =
+        payloadKeys.length > 0 &&
+        payloadKeys.every((key) => tokenKeys.includes(key)) &&
+        (hasTokensByMapIdProp || hasActiveTokensProp || hasActiveIdProp);
+
+      if (tokenOnlyUpdate) {
+        const merged = mergeTokenPayload({
+          incomingTokensByMapId: sanitizedTokens,
+          incomingActiveMapTokens: sanitizedActiveTokens,
+          incomingActiveMapId: normalizedIncomingActiveId,
+          previousActiveMapId: campaignActiveMapIdRef.current,
+          previousCampaignMap: campaignMapRef.current,
+          previousMapTokens: campaignMapTokensRef.current || {},
+        });
+
+        setCampaignActiveMapId(merged.activeMapId);
+        setCampaignMapTokens(merged.mapTokens);
+        setActiveMapTokens(merged.activeMapTokens);
+        setCampaignMap(merged.campaignMap);
+        return;
+      }
+
       if (
         !hasMapsProp &&
         !hasMapProp &&
@@ -1570,13 +1607,6 @@ export default function ZombiesCharacterSheet() {
         });
         return;
       }
-
-      const normalizedIncomingActiveId =
-        hasActiveIdProp &&
-        typeof update.activeMapId === 'string' &&
-        update.activeMapId.trim() !== ''
-          ? update.activeMapId.trim()
-          : null;
 
       let mapFromList = null;
       if (hasMapsProp && normalizedIncomingActiveId) {
@@ -1601,8 +1631,8 @@ export default function ZombiesCharacterSheet() {
           : hasMapExplicitNull
             ? null
             : mapFromList || campaignMapRef.current,
-        ...(hasTokensByMapIdProp ? { tokensByMapId: update.tokensByMapId } : {}),
-        ...(hasActiveTokensProp ? { activeMapTokens: update.activeMapTokens } : {}),
+        ...(hasTokensByMapIdProp ? { tokensByMapId: sanitizedTokens } : {}),
+        ...(hasActiveTokensProp ? { activeMapTokens: sanitizedActiveTokens } : {}),
       };
 
       applyMapPayload(workingPayload);

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import apiFetch from '../../../utils/apiFetch';
 import { DEFAULT_MAP_TITLE, getMapDisplayTitle } from '../../../utils/mapTitle';
 import { io } from "socket.io-client";
+import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import {
   Button,
   Col,
@@ -364,6 +365,8 @@ export default function ZombiesDM() {
     const socketRef = useRef(null);
     const mapTokensRef = useRef(mapTokens);
     const activeMapTokensRef = useRef(activeMapTokens);
+    const campaignMapRef = useRef(campaignMap);
+    const activeMapIdRef = useRef(activeMapId);
 
     const campaignId = params.campaign ?? '';
     const encodedCampaign = useMemo(
@@ -378,6 +381,14 @@ export default function ZombiesDM() {
     useEffect(() => {
       activeMapTokensRef.current = activeMapTokens;
     }, [activeMapTokens]);
+
+    useEffect(() => {
+      campaignMapRef.current = campaignMap;
+    }, [campaignMap]);
+
+    useEffect(() => {
+      activeMapIdRef.current = activeMapId;
+    }, [activeMapId]);
 
     const applyMapPayload = useCallback(
       (payload, options = {}) => {
@@ -1185,7 +1196,6 @@ export default function ZombiesDM() {
 
       const handleMapUpdate = (mapData) => {
         if (mapData && typeof mapData === 'object') {
-          let workingPayload = mapData;
           const hasTokensByMapIdProp = Object.prototype.hasOwnProperty.call(
             mapData,
             'tokensByMapId'
@@ -1194,9 +1204,52 @@ export default function ZombiesDM() {
             mapData,
             'activeMapTokens'
           );
+          const hasActiveIdProp = Object.prototype.hasOwnProperty.call(
+            mapData,
+            'activeMapId'
+          );
+
+          const sanitizedTokens = hasTokensByMapIdProp
+            ? sanitizeTokensByMapId(mapData.tokensByMapId)
+            : {};
+          const sanitizedActiveTokens = hasActiveTokensProp
+            ? sanitizeTokenDictionary(mapData.activeMapTokens)
+            : {};
+          const normalizedIncomingActiveId =
+            hasActiveIdProp &&
+            typeof mapData.activeMapId === 'string' &&
+            mapData.activeMapId.trim() !== ''
+              ? mapData.activeMapId.trim()
+              : null;
+
+          const tokenKeys = ['tokensByMapId', 'activeMapTokens', 'activeMapId'];
+          const payloadKeys = Object.keys(mapData);
+          const tokenOnlyUpdate =
+            payloadKeys.length > 0 &&
+            payloadKeys.every((key) => tokenKeys.includes(key)) &&
+            (hasTokensByMapIdProp || hasActiveTokensProp || hasActiveIdProp);
+
+          if (tokenOnlyUpdate) {
+            const merged = mergeTokenPayload({
+              incomingTokensByMapId: sanitizedTokens,
+              incomingActiveMapTokens: sanitizedActiveTokens,
+              incomingActiveMapId: normalizedIncomingActiveId,
+              previousActiveMapId: activeMapIdRef.current,
+              previousCampaignMap: campaignMapRef.current,
+              previousMapTokens: mapTokensRef.current || {},
+            });
+
+            setActiveMapId(merged.activeMapId);
+            setMapTokens(merged.mapTokens);
+            setActiveMapTokens(merged.activeMapTokens);
+            setCampaignMap(merged.campaignMap);
+            setGeneratedMap(null);
+            return;
+          }
+
+          let workingPayload = mapData;
 
           if (hasTokensByMapIdProp) {
-            const sanitizedTokens = sanitizeTokensByMapId(mapData.tokensByMapId);
             const incomingKeys = Object.keys(mapData.tokensByMapId || {}).reduce(
               (acc, key) => {
                 if (typeof key !== 'string') {
@@ -1227,12 +1280,11 @@ export default function ZombiesDM() {
           }
 
           if (hasActiveTokensProp) {
-            const sanitizedActive = sanitizeTokenDictionary(mapData.activeMapTokens);
-            workingPayload = { ...workingPayload, activeMapTokens: sanitizedActive };
+            workingPayload = { ...workingPayload, activeMapTokens: sanitizedActiveTokens };
             if (workingPayload.map && typeof workingPayload.map === 'object') {
               workingPayload = {
                 ...workingPayload,
-                map: { ...workingPayload.map, tokens: sanitizedActive },
+                map: { ...workingPayload.map, tokens: sanitizedActiveTokens },
               };
             }
           }

--- a/client/src/components/Zombies/pages/utils/__tests__/mergeTokenPayload.test.js
+++ b/client/src/components/Zombies/pages/utils/__tests__/mergeTokenPayload.test.js
@@ -1,0 +1,59 @@
+import { mergeTokenPayload } from "../mergeTokenPayload";
+
+describe('mergeTokenPayload', () => {
+  it('preserves existing map imagery while updating tokens', () => {
+    const previousCampaignMap = {
+      mapId: 'map-1',
+      imageBase64: 'abc123',
+      title: 'Test Map',
+      tokens: {
+        hero: { characterId: 'hero', x: 0.1, y: 0.2 },
+      },
+    };
+
+    const result = mergeTokenPayload({
+      incomingTokensByMapId: {
+        'map-1': {
+          hero: { characterId: 'hero', x: 0.3, y: 0.4 },
+          rogue: { characterId: 'rogue', x: 0.5, y: 0.6 },
+        },
+      },
+      incomingActiveMapTokens: {
+        hero: { characterId: 'hero', x: 0.3, y: 0.4 },
+        rogue: { characterId: 'rogue', x: 0.5, y: 0.6 },
+      },
+      incomingActiveMapId: 'map-1',
+      previousActiveMapId: 'map-1',
+      previousCampaignMap,
+      previousMapTokens: {
+        'map-1': previousCampaignMap.tokens,
+      },
+    });
+
+    expect(result.campaignMap).not.toBeNull();
+    expect(result.campaignMap).not.toBe(previousCampaignMap);
+    expect(result.campaignMap.imageBase64).toBe('abc123');
+    expect(result.campaignMap.tokens).toEqual({
+      hero: { characterId: 'hero', x: 0.3, y: 0.4 },
+      rogue: { characterId: 'rogue', x: 0.5, y: 0.6 },
+    });
+  });
+
+  it('falls back to previous active map id when update omits it', () => {
+    const result = mergeTokenPayload({
+      incomingTokensByMapId: {
+        'map-2': {
+          cleric: { characterId: 'cleric', x: 0.7, y: 0.8 },
+        },
+      },
+      previousActiveMapId: 'map-2',
+      previousCampaignMap: { mapId: 'map-2', imageBase64: 'img', tokens: {} },
+      previousMapTokens: {},
+    });
+
+    expect(result.activeMapId).toBe('map-2');
+    expect(result.activeMapTokens).toEqual({
+      cleric: { characterId: 'cleric', x: 0.7, y: 0.8 },
+    });
+  });
+});

--- a/client/src/components/Zombies/pages/utils/mergeTokenPayload.js
+++ b/client/src/components/Zombies/pages/utils/mergeTokenPayload.js
@@ -1,0 +1,111 @@
+export const mergeTokenPayload = ({
+  incomingTokensByMapId = {},
+  incomingActiveMapTokens = {},
+  incomingActiveMapId = null,
+  previousActiveMapId = null,
+  previousCampaignMap = null,
+  previousMapTokens = {},
+} = {}) => {
+  const normalizedIncomingActiveId =
+    typeof incomingActiveMapId === 'string' && incomingActiveMapId.trim() !== ''
+      ? incomingActiveMapId.trim()
+      : null;
+
+  const normalizedPreviousActiveId =
+    typeof previousActiveMapId === 'string' && previousActiveMapId.trim() !== ''
+      ? previousActiveMapId.trim()
+      : null;
+
+  const nextActiveMapId = normalizedIncomingActiveId || normalizedPreviousActiveId || null;
+
+  const nextTokensByMapId = Object.entries(incomingTokensByMapId || {}).reduce(
+    (acc, [mapId, tokens]) => {
+      if (typeof mapId !== 'string' || mapId.trim() === '') {
+        return acc;
+      }
+
+      const trimmedId = mapId.trim();
+      if (!tokens || typeof tokens !== 'object') {
+        acc[trimmedId] = {};
+        return acc;
+      }
+
+      acc[trimmedId] = Object.entries(tokens).reduce((tokenAcc, [tokenId, tokenValue]) => {
+        if (!tokenValue || typeof tokenValue !== 'object') {
+          return tokenAcc;
+        }
+
+        const normalizedTokenId =
+          typeof tokenValue.characterId === 'string' && tokenValue.characterId.trim() !== ''
+            ? tokenValue.characterId.trim()
+            : typeof tokenId === 'string' && tokenId.trim() !== ''
+              ? tokenId.trim()
+              : null;
+
+        if (!normalizedTokenId) {
+          return tokenAcc;
+        }
+
+        tokenAcc[normalizedTokenId] = { ...tokenValue, characterId: normalizedTokenId };
+        return tokenAcc;
+      }, {});
+
+      return acc;
+    },
+    {}
+  );
+
+  const resolvedPreviousTokens =
+    previousMapTokens && typeof previousMapTokens === 'object' ? previousMapTokens : {};
+
+  const mergedTokensByMapId =
+    Object.keys(nextTokensByMapId).length > 0 ? nextTokensByMapId : { ...resolvedPreviousTokens };
+
+  const hasActiveTokensCandidate =
+    incomingActiveMapTokens &&
+    typeof incomingActiveMapTokens === 'object' &&
+    !Array.isArray(incomingActiveMapTokens) &&
+    Object.keys(incomingActiveMapTokens).length > 0;
+
+  const activeTokensCandidate = hasActiveTokensCandidate ? incomingActiveMapTokens : null;
+
+  const resolvedActiveTokens = activeTokensCandidate
+    ? Object.entries(activeTokensCandidate).reduce((acc, [tokenId, tokenValue]) => {
+        if (!tokenValue || typeof tokenValue !== 'object') {
+          return acc;
+        }
+
+        const normalizedTokenId =
+          typeof tokenValue.characterId === 'string' && tokenValue.characterId.trim() !== ''
+            ? tokenValue.characterId.trim()
+            : typeof tokenId === 'string' && tokenId.trim() !== ''
+              ? tokenId.trim()
+              : null;
+
+        if (!normalizedTokenId) {
+          return acc;
+        }
+
+        acc[normalizedTokenId] = { ...tokenValue, characterId: normalizedTokenId };
+        return acc;
+      }, {})
+    : nextActiveMapId && mergedTokensByMapId[nextActiveMapId]
+      ? { ...mergedTokensByMapId[nextActiveMapId] }
+      : {};
+
+  const nextCampaignMap =
+    previousCampaignMap && typeof previousCampaignMap === 'object'
+      ? previousCampaignMap.mapId && previousCampaignMap.mapId === nextActiveMapId
+        ? { ...previousCampaignMap, tokens: resolvedActiveTokens }
+        : previousCampaignMap
+      : null;
+
+  return {
+    activeMapId: nextActiveMapId,
+    mapTokens: mergedTokensByMapId,
+    activeMapTokens: resolvedActiveTokens,
+    campaignMap: nextCampaignMap,
+  };
+};
+
+export default mergeTokenPayload;

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -530,6 +530,9 @@ describe('Campaign routes', () => {
         .send({ x: 1.5, y: -0.25 });
 
       expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('map');
+      expect(res.body).not.toHaveProperty('maps');
+      expect(res.body).toHaveProperty('activeMapId', storedMap.mapId);
       expect(res.body.tokensByMapId).toEqual({
         [storedMap.mapId]: {
           'hero-1': expect.objectContaining({
@@ -555,17 +558,21 @@ describe('Campaign routes', () => {
           }),
         })
       );
-      expect(emitMapUpdate).toHaveBeenCalledWith(
-        'Test',
+      expect(emitMapUpdate).toHaveBeenCalledWith('Test', expect.any(Object));
+      const emittedPayload = emitMapUpdate.mock.calls[0][1];
+      expect(Object.keys(emittedPayload).sort()).toEqual(
+        ['activeMapId', 'activeMapTokens', 'tokensByMapId'].sort()
+      );
+      expect(emittedPayload.tokensByMapId).toEqual(
         expect.objectContaining({
-          tokensByMapId: expect.objectContaining({
-            [storedMap.mapId]: expect.objectContaining({
-              'hero-1': expect.objectContaining({ x: 1, y: 0 }),
-            }),
-          }),
-          activeMapTokens: expect.objectContaining({
+          [storedMap.mapId]: expect.objectContaining({
             'hero-1': expect.objectContaining({ x: 1, y: 0 }),
           }),
+        })
+      );
+      expect(emittedPayload.activeMapTokens).toEqual(
+        expect.objectContaining({
+          'hero-1': expect.objectContaining({ x: 1, y: 0 }),
         })
       );
     });
@@ -621,6 +628,8 @@ describe('Campaign routes', () => {
         .send({ x: 0.3, y: 0.7 });
 
       expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('activeMapId', storedMap.mapId);
+      expect(res.body).not.toHaveProperty('map');
       expect(charactersFindOne).toHaveBeenCalled();
       expect(res.body.tokensByMapId[storedMap.mapId]['hero-1']).toEqual(
         expect.objectContaining({
@@ -696,6 +705,11 @@ describe('Campaign routes', () => {
       );
 
       expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        activeMapId: storedMap.mapId,
+        tokensByMapId: {},
+        activeMapTokens: {},
+      });
       expect(res.body.tokensByMapId).toEqual({});
       expect(res.body.activeMapTokens).toEqual({});
       expect(updateOne).toHaveBeenCalledWith(

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -848,6 +848,12 @@ module.exports = (router) => {
             tokensByMapId
           );
 
+          const tokenPayload = {
+            activeMapId: payload.activeMapId,
+            tokensByMapId: payload.tokensByMapId,
+            activeMapTokens: payload.activeMapTokens,
+          };
+
           await campaignsCollection.updateOne(
             { campaignName },
             {
@@ -860,9 +866,9 @@ module.exports = (router) => {
             }
           );
 
-          emitMapUpdate(campaignName, payload);
+          emitMapUpdate(campaignName, tokenPayload);
 
-          return res.json(payload);
+          return res.json(tokenPayload);
         } catch (err) {
           next(err);
         }
@@ -965,6 +971,12 @@ module.exports = (router) => {
             tokensByMapId
           );
 
+          const tokenPayload = {
+            activeMapId: payload.activeMapId,
+            tokensByMapId: payload.tokensByMapId,
+            activeMapTokens: payload.activeMapTokens,
+          };
+
           await campaignsCollection.updateOne(
             { campaignName },
             {
@@ -977,9 +989,9 @@ module.exports = (router) => {
             }
           );
 
-          emitMapUpdate(campaignName, payload);
+          emitMapUpdate(campaignName, tokenPayload);
 
-          return res.json(payload);
+          return res.json(tokenPayload);
         } catch (err) {
           next(err);
         }

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -136,6 +136,25 @@ const emitCombatUpdate = (campaignId, combatState) => {
   io.to(getCampaignRoom(normalizedId)).emit('combat:update', combatState);
 };
 
+const TOKEN_PAYLOAD_KEYS = new Set([
+  'activeMapId',
+  'tokensByMapId',
+  'activeMapTokens',
+]);
+
+const isTokenOnlyPayload = (payload) => {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  const keys = Object.keys(payload);
+  if (keys.length === 0) {
+    return false;
+  }
+
+  return keys.every((key) => TOKEN_PAYLOAD_KEYS.has(key));
+};
+
 const emitMapUpdate = (campaignId, payload) => {
   if (!io) {
     logger.warn('Socket.io server not initialized; cannot emit map update');
@@ -148,10 +167,11 @@ const emitMapUpdate = (campaignId, payload) => {
   }
 
   const normalizedId = campaignId.trim();
+  const tokenOnly = isTokenOnlyPayload(payload);
   io.to(getCampaignRoom(normalizedId)).emit('campaign:map:update', payload);
 
   if (payload && typeof payload === 'object') {
-    if (Object.prototype.hasOwnProperty.call(payload, 'map') && payload.map) {
+    if (!tokenOnly && Object.prototype.hasOwnProperty.call(payload, 'map') && payload.map) {
       const mapPayload =
         typeof payload.map === 'object'
           ? { ...payload.map, tokens: payload.map.tokens || payload.activeMapTokens || {} }


### PR DESCRIPTION
## Summary
- return lightweight token payloads from campaign token update and delete routes
- let the socket map broadcaster detect token-only updates to avoid emitting map imagery unnecessarily
- merge token-only updates on the Zombies DM and character sheet views while preserving cached imagery and add focused regression coverage

## Testing
- npm --prefix server test
- npm --prefix server test -- --runTestsByPath __tests__/campaigns.test.js --runInBand --testNamePattern "delete map token success"
- CI=true npm --prefix client test -- mergeTokenPayload.test --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dbf5d70f70832e99dc2310d19523cf