### PR TITLE
Refine campaign token persistence

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -546,18 +546,29 @@ describe('Campaign routes', () => {
       expect(res.body.activeMapTokens).toEqual({
         'hero-1': expect.objectContaining({ x: 1, y: 0 }),
       });
-      expect(updateOne).toHaveBeenCalledWith(
-        { campaignName: 'Test' },
+      const lastUpdateCall =
+        updateOne.mock.calls[updateOne.mock.calls.length - 1];
+      expect(lastUpdateCall[0]).toEqual({ campaignName: 'Test' });
+      const updateDoc = lastUpdateCall[1];
+      expect(updateDoc).toEqual(
         expect.objectContaining({
-          $set: expect.objectContaining({
-            mapTokens: {
-              [storedMap.mapId]: expect.objectContaining({
-                'hero-1': expect.objectContaining({ x: 1, y: 0 }),
-              }),
-            },
+          $set: expect.any(Object),
+        })
+      );
+      expect(updateDoc.$set).toEqual(
+        expect.objectContaining({
+          mapTokens: {
+            [storedMap.mapId]: expect.objectContaining({
+              'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+            }),
+          },
+          'map.tokens': expect.objectContaining({
+            'hero-1': expect.objectContaining({ x: 1, y: 0 }),
           }),
         })
       );
+      expect(updateDoc.$set).not.toHaveProperty('map');
+      expect(updateDoc.$set).not.toHaveProperty('maps');
       expect(emitMapUpdate).toHaveBeenCalledWith('Test', expect.any(Object));
       const emittedPayload = emitMapUpdate.mock.calls[0][1];
       expect(Object.keys(emittedPayload).sort()).toEqual(
@@ -712,14 +723,23 @@ describe('Campaign routes', () => {
       });
       expect(res.body.tokensByMapId).toEqual({});
       expect(res.body.activeMapTokens).toEqual({});
-      expect(updateOne).toHaveBeenCalledWith(
-        { campaignName: 'Test' },
+      const lastUpdateCall =
+        updateOne.mock.calls[updateOne.mock.calls.length - 1];
+      expect(lastUpdateCall[0]).toEqual({ campaignName: 'Test' });
+      const updateDoc = lastUpdateCall[1];
+      expect(updateDoc).toEqual(
         expect.objectContaining({
-          $set: expect.objectContaining({
-            mapTokens: {},
-          }),
+          $set: expect.any(Object),
         })
       );
+      expect(updateDoc.$set).toEqual(
+        expect.objectContaining({
+          mapTokens: {},
+          'map.tokens': {},
+        })
+      );
+      expect(updateDoc.$set).not.toHaveProperty('map');
+      expect(updateDoc.$set).not.toHaveProperty('maps');
       expect(emitMapUpdate).toHaveBeenCalledWith(
         'Test',
         expect.objectContaining({

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -217,6 +217,34 @@ module.exports = (router) => {
     }, {});
   };
 
+  const resolveActiveMapState = ({
+    maps,
+    requestedActiveMapId,
+    tokensByMapId = {},
+  }) => {
+    const availableMaps = Array.isArray(maps) ? maps : [];
+    const trimmedActiveId =
+      typeof requestedActiveMapId === 'string' && requestedActiveMapId.trim() !== ''
+        ? requestedActiveMapId.trim()
+        : null;
+
+    let activeMapId =
+      trimmedActiveId && availableMaps.some((map) => map.mapId === trimmedActiveId)
+        ? trimmedActiveId
+        : null;
+
+    if (!activeMapId && availableMaps.length > 0) {
+      activeMapId = availableMaps[0].mapId;
+    }
+
+    const activeMapTokens =
+      activeMapId && tokensByMapId && typeof tokensByMapId === 'object'
+        ? tokensByMapId[activeMapId] || {}
+        : {};
+
+    return { activeMapId, activeMapTokens };
+  };
+
   // Apply authentication to all campaign routes
   campaignRouter.use(authenticateToken);
 
@@ -842,27 +870,35 @@ module.exports = (router) => {
             now,
           });
 
-          const payload = buildCampaignMapPayload(
-            normalizedCampaign.maps,
-            normalizedCampaign.activeMapId,
-            tokensByMapId
-          );
+          const { activeMapId: resolvedActiveMapId, activeMapTokens } =
+            resolveActiveMapState({
+              maps: normalizedCampaign.maps,
+              requestedActiveMapId: normalizedCampaign.activeMapId,
+              tokensByMapId,
+            });
 
           const tokenPayload = {
-            activeMapId: payload.activeMapId,
-            tokensByMapId: payload.tokensByMapId,
-            activeMapTokens: payload.activeMapTokens,
+            activeMapId: resolvedActiveMapId,
+            tokensByMapId,
+            activeMapTokens,
           };
+
+          const setDocument = {
+            mapTokens: tokensByMapId,
+          };
+
+          if (resolvedActiveMapId !== normalizedCampaign.activeMapId) {
+            setDocument.activeMapId = resolvedActiveMapId;
+          }
+
+          if (resolvedActiveMapId) {
+            setDocument['map.tokens'] = activeMapTokens;
+          }
 
           await campaignsCollection.updateOne(
             { campaignName },
             {
-              $set: {
-                mapTokens: payload.tokensByMapId,
-                maps: payload.maps,
-                activeMapId: payload.activeMapId,
-                map: payload.map || null,
-              },
+              $set: setDocument,
             }
           );
 
@@ -965,27 +1001,35 @@ module.exports = (router) => {
             now: new Date().toISOString(),
           });
 
-          const payload = buildCampaignMapPayload(
-            normalizedCampaign.maps,
-            normalizedCampaign.activeMapId,
-            tokensByMapId
-          );
+          const { activeMapId: resolvedActiveMapId, activeMapTokens } =
+            resolveActiveMapState({
+              maps: normalizedCampaign.maps,
+              requestedActiveMapId: normalizedCampaign.activeMapId,
+              tokensByMapId,
+            });
 
           const tokenPayload = {
-            activeMapId: payload.activeMapId,
-            tokensByMapId: payload.tokensByMapId,
-            activeMapTokens: payload.activeMapTokens,
+            activeMapId: resolvedActiveMapId,
+            tokensByMapId,
+            activeMapTokens,
           };
+
+          const setDocument = {
+            mapTokens: tokensByMapId,
+          };
+
+          if (resolvedActiveMapId !== normalizedCampaign.activeMapId) {
+            setDocument.activeMapId = resolvedActiveMapId;
+          }
+
+          if (resolvedActiveMapId) {
+            setDocument['map.tokens'] = activeMapTokens;
+          }
 
           await campaignsCollection.updateOne(
             { campaignName },
             {
-              $set: {
-                mapTokens: payload.tokensByMapId,
-                maps: payload.maps,
-                activeMapId: payload.activeMapId,
-                map: payload.map || null,
-              },
+              $set: setDocument,
             }
           );
 


### PR DESCRIPTION
## Summary
- derive token responses for campaign map token PUT/DELETE routes without rebuilding full map payloads
- restrict campaign persistence to updating mapTokens, map.tokens, and activeMapId when it changes
- update campaign route tests to cover the slimmer token persistence shape

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68dbff802874832e836c83250519fc1b