### PR TITLE
Highlight active combatant on campaign map

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2731,6 +2731,21 @@ h1 {
       drop-shadow(0 0.2rem 0.45rem rgba(255, 255, 255, 0.25));
   }
 
+  &__token--active-turn {
+    filter: drop-shadow(0 0.3rem 0.75rem rgba(209, 143, 0, 0.35));
+
+    .campaign-map-board__figurine {
+      filter: drop-shadow(0 0.45rem 1.2rem rgba(255, 214, 102, 0.55))
+        drop-shadow(0 0.1rem 0.4rem rgba(255, 248, 220, 0.6));
+    }
+
+    .campaign-map-board__figurine-base,
+    .campaign-map-board__figurine-base-top {
+      box-shadow: 0 0 0.55rem rgba(255, 214, 102, 0.65),
+        inset 0 0.08rem 0.22rem rgba(255, 255, 255, 0.55);
+    }
+  }
+
   &--disabled &__token--draggable {
     cursor: default;
   }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -317,7 +317,16 @@ const CampaignMapBoard = ({
               onPointerDown={handleLayerPointerDown}
             >
               {tokenPositions.map((token) => {
-                const { characterId, position, color, label, currentHp, maxHp, variant } = token;
+                const {
+                  characterId,
+                  position,
+                  color,
+                  label,
+                  currentHp,
+                  maxHp,
+                  variant,
+                  isActiveTurn,
+                } = token;
                 const draggable = !interactionDisabled && token.isMovable !== false;
                 const normalizedLabel = normalizeText(label);
                 const displayLabel = normalizedLabel || normalizeText(characterId) || characterId;
@@ -358,7 +367,8 @@ const CampaignMapBoard = ({
                     className={classNames(
                       'campaign-map-board__token',
                       draggable && 'campaign-map-board__token--draggable',
-                      isLabelActive && 'campaign-map-board__token--label-active'
+                      isLabelActive && 'campaign-map-board__token--label-active',
+                      isActiveTurn && 'campaign-map-board__token--active-turn'
                     )}
                     style={{
                       left: `${(position?.x ?? 0) * 100}%`,
@@ -405,7 +415,8 @@ const CampaignMapBoard = ({
                     <div
                       className={classNames(
                         'campaign-map-board__figurine',
-                        draggable && 'campaign-map-board__figurine--active'
+                        draggable && 'campaign-map-board__figurine--active',
+                        isActiveTurn && 'campaign-map-board__figurine--active-turn'
                       )}
                       style={{ '--figurine-color': figurineColor }}
                     >
@@ -451,6 +462,7 @@ CampaignMapBoard.propTypes = {
       isMovable: PropTypes.bool,
       currentHp: PropTypes.number,
       maxHp: PropTypes.number,
+      isActiveTurn: PropTypes.bool,
     })
   ),
   onTokenDragStart: PropTypes.func,

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -2222,6 +2222,11 @@ export default function ZombiesDM() {
     }, [activeMapId, activeMapTokens, campaignMap, mapTokens]);
 
     const boardTokens = useMemo(() => {
+      const activeCharacterId =
+        typeof activeParticipant?.characterId === 'string' &&
+        activeParticipant.characterId.trim() !== ''
+          ? activeParticipant.characterId.trim()
+          : null;
       const normalizedDisplayedMapId =
         typeof displayedMap?.mapId === 'string' && displayedMap.mapId.trim() !== ''
           ? displayedMap.mapId.trim()
@@ -2265,6 +2270,14 @@ export default function ZombiesDM() {
           const meta = tokenMetaById[token.characterId] || {};
           const rawLabel = meta.label || token.label || token.characterId;
           const label = typeof rawLabel === 'string' ? rawLabel.trim() : '';
+          const normalizedTokenCharacterId =
+            typeof token.characterId === 'string' && token.characterId.trim() !== ''
+              ? token.characterId.trim()
+              : null;
+          const isActiveTurn =
+            normalizedTokenCharacterId &&
+            activeCharacterId &&
+            normalizedTokenCharacterId === activeCharacterId;
           const normalizedCurrentHp = toFiniteNumberOrNull(
             meta.currentHp ?? token.currentHp ?? token.hpCurrent ?? token.health
           );
@@ -2309,6 +2322,7 @@ export default function ZombiesDM() {
             isMovable: true,
             ...(entityType ? { entityType } : {}),
             ...(variant ? { variant } : {}),
+            ...(isActiveTurn ? { isActiveTurn: true } : {}),
             ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
             ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
           };
@@ -2318,7 +2332,14 @@ export default function ZombiesDM() {
           const labelB = (b.label || b.characterId || '').toLowerCase();
           return labelA.localeCompare(labelB);
         });
-    }, [activeMapId, activeMapTokens, displayedMap, mapTokens, tokenMetaById]);
+    }, [
+      activeMapId,
+      activeMapTokens,
+      activeParticipant,
+      displayedMap,
+      mapTokens,
+      tokenMetaById,
+    ]);
 
     const handleTokenPositionChange = useCallback(
       ({ characterId, x, y }) => {


### PR DESCRIPTION
## Summary
- flag the active combatant when preparing map board tokens
- surface the active-turn state in the campaign map board rendering
- add styling that gives the active figurine a gold glow for clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc15eba1f4832e85c15c50af3f43ec