### PR TITLE
Sync map modal highlighting with active combatants

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -122,6 +122,7 @@ const MapModal = ({
   title,
   tokensByMapId,
   currentCharacterId,
+  activeCharacterId,
   characterLookup,
   onTokenMove,
   readOnly,
@@ -179,6 +180,11 @@ const MapModal = ({
   const normalizedCurrentCharacterId = useMemo(
     () => normalizeMapId(currentCharacterId),
     [currentCharacterId]
+  );
+
+  const normalizedActiveCharacterId = useMemo(
+    () => normalizeMapId(activeCharacterId),
+    [activeCharacterId]
   );
 
   const normalizedCharacterLookup = useMemo(() => {
@@ -334,6 +340,9 @@ const MapModal = ({
           label: typeof rawLabel === 'string' ? rawLabel : token.characterId,
           color: normalizedColor,
           isMovable,
+          isActiveTurn:
+            Boolean(normalizedActiveCharacterId) &&
+            token.characterId === normalizedActiveCharacterId,
           ...(entityType ? { entityType } : {}),
           ...(variant ? { variant } : {}),
           ...(currentHp !== null ? { currentHp } : {}),
@@ -349,6 +358,7 @@ const MapModal = ({
     isInteractive,
     normalizedCharacterLookup,
     normalizedCurrentCharacterId,
+    normalizedActiveCharacterId,
     placementPending,
     readOnly,
     tokensDictionary,
@@ -693,6 +703,7 @@ MapModal.propTypes = {
   title: PropTypes.node,
   tokensByMapId: PropTypes.object,
   currentCharacterId: PropTypes.string,
+  activeCharacterId: PropTypes.string,
   characterLookup: PropTypes.objectOf(
     PropTypes.shape({
       color: PropTypes.string,
@@ -719,6 +730,7 @@ MapModal.defaultProps = {
   title: 'Campaign Map',
   tokensByMapId: null,
   currentCharacterId: null,
+  activeCharacterId: null,
   characterLookup: {},
   onTokenMove: null,
   readOnly: true,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2881,6 +2881,7 @@ const spellsGold =
         activeMapId={campaignActiveMapId}
         tokensByMapId={modalTokensByMapId}
         currentCharacterId={resolvedCharacterId}
+        activeCharacterId={activeTurnParticipantId}
         characterLookup={tokenMetaById}
         onTokenMove={handleTokenMove}
       />

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6318,6 +6318,7 @@ const resolveIcon = (category, iconMap, fallback) => {
         onDeleteMap={handleDeleteMap}
         isLoading={mapLoading}
         actionInProgressId={mapActionLoadingId}
+        activeCharacterId={activeParticipant?.characterId}
       />
 
       <MapModal
@@ -6335,6 +6336,7 @@ const resolveIcon = (category, iconMap, fallback) => {
         onSelectMap={handleSelectMap}
         tokensByMapId={modalTokensByMapId}
         currentCharacterId={mapPlacementState.enemyId}
+        activeCharacterId={activeParticipant?.characterId}
         characterLookup={tokenMetaById}
         onTokenMove={handleMapModalTokenMove}
         readOnly={false}


### PR DESCRIPTION
## Summary
- pass the active combatant ID from the character sheet and DM views into the map modal
- extend the map modal to mark the active token before rendering
- ensure both DM map dialogs receive the active participant ID for consistent highlighting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1a56324c832e988dd56f927c0c01