### PR TITLE
Emit dice color metadata updates

### DIFF
--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,11 +1,28 @@
-import React, { useState, useEffect, useRef } from 'react'; // Import useState and React
+import React, { useState, useEffect, useCallback } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Alert } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import CampaignModals from "../components/CampaignModals";
 import useCampaignActions from "../hooks/useCampaignActions";
 
-export default function Help({ form, showHelpModal, handleCloseHelpModal }) {
+const HEX_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
+const DEFAULT_DICE_COLOR = '#000000';
+
+const normalizeDiceColor = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return HEX_COLOR_PATTERN.test(trimmed) ? trimmed : null;
+};
+
+export default function Help({
+  form,
+  showHelpModal,
+  handleCloseHelpModal,
+  onDiceColorChange,
+}) {
   const params = useParams();
   const navigate = useNavigate();
   const {
@@ -28,65 +45,94 @@ export default function Help({ form, showHelpModal, handleCloseHelpModal }) {
   } = useCampaignActions();
   const [showDeleteCharacter, setShowDeleteCharacter] = useState(false);
   const handleCloseDeleteCharacter = () => setShowDeleteCharacter(false);
- const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
- // This method will delete a record
- async function deleteRecord() {
- await apiFetch(`/characters/delete-character/${params.id}`, {
-   method: "DELETE",
-  });
-  navigate(`/zombies-character-select/${form.campaign}`);
-}
+  const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
 
- async function handleLogout() {
-  await apiFetch("/logout", { method: "POST" });
-  window.location.assign("/");
- }
-  //-------------------------------------------Help Module--------------------------------------------------------------------
-// Color Picker
-document.documentElement.style.setProperty('--dice-face-color', form.diceColor);
-const colorPickerRef = useRef(null);
-const [newColor, setNewColor] = useState(form.diceColor);
-
-useEffect(() => {
-  const colorPicker = colorPickerRef.current;
-
-  if (colorPicker) {
-    colorPicker.addEventListener('input', (e) => {
-      const selectedColor = e.target.value;
-      setNewColor(selectedColor); // Update the state with the new color
-      document.documentElement.style.setProperty('--dice-face-color', selectedColor);
+  // This method will delete a record
+  async function deleteRecord() {
+    await apiFetch(`/characters/delete-character/${params.id}`, {
+      method: 'DELETE',
     });
+    navigate(`/zombies-character-select/${form.campaign}`);
   }
-}, []); // Empty dependency array ensures this runs after component mounts
 
-const handleColorChange = (e) => {
-  const selectedColor = e.target.value;
-  setNewColor(selectedColor); // Update the state with the new color
-  document.documentElement.style.setProperty('--dice-face-color', selectedColor);
-};
+  async function handleLogout() {
+    await apiFetch('/logout', { method: 'POST' });
+    window.location.assign('/');
+  }
+  //-------------------------------------------Help Module--------------------------------------------------------------------
+  const initialColor = normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR;
+  const [newColor, setNewColor] = useState(initialColor);
 
-const opacity = 0.85;
-// Calculate RGBA color with opacity
-const rgbaColor = `rgba(${parseInt(form.diceColor.slice(1, 3), 16)}, ${parseInt(form.diceColor.slice(3, 5), 16)}, ${parseInt(form.diceColor.slice(5, 7), 16)}, ${opacity})`;
+  const applyDiceFaceColor = useCallback((color) => {
+    if (typeof document === 'undefined') {
+      return;
+    }
 
-// Apply the calculated RGBA color to the element
-document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
+    const normalized = normalizeDiceColor(color) || DEFAULT_DICE_COLOR;
+    const r = parseInt(normalized.slice(1, 3), 16);
+    const g = parseInt(normalized.slice(3, 5), 16);
+    const b = parseInt(normalized.slice(5, 7), 16);
+    const opacity = 0.85;
+    const rgbaColor = `rgba(${r}, ${g}, ${b}, ${opacity})`;
+    document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
+  }, []);
 
- // Sends dice color update to database
- async function diceColorUpdate(){
-   await apiFetch(`/characters/update-dice-color/${params.id}`, {
-     method: "PUT",
-     headers: {
-       "Content-Type": "application/json",
-     },
-     body: JSON.stringify({diceColor: newColor}),
-   })
-   .catch(error => {
-    //  window.alert(error);
-     return;
-   });
-   navigate(0);
- } 
+  useEffect(() => {
+    applyDiceFaceColor(newColor);
+  }, [applyDiceFaceColor, newColor]);
+
+  useEffect(() => {
+    const normalized = normalizeDiceColor(form?.diceColor);
+    if (normalized) {
+      setNewColor((prev) => (prev === normalized ? prev : normalized));
+    } else if (form?.diceColor === undefined || form?.diceColor === null) {
+      setNewColor((prev) => (prev === DEFAULT_DICE_COLOR ? prev : DEFAULT_DICE_COLOR));
+    }
+  }, [form?.diceColor]);
+
+  const handleColorChange = (event) => {
+    const selectedColor = event?.target?.value;
+    if (typeof selectedColor === 'string') {
+      setNewColor(selectedColor);
+    }
+  };
+
+  async function diceColorUpdate() {
+    const normalizedColor = normalizeDiceColor(newColor);
+    if (!normalizedColor) {
+      return;
+    }
+
+    try {
+      const response = await apiFetch(`/characters/update-dice-color/${params.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ diceColor: normalizedColor }),
+      });
+
+      if (!response.ok) {
+        return;
+      }
+
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (error) {
+        payload = null;
+      }
+
+      const nextColor = normalizeDiceColor(payload?.diceColor) || normalizedColor;
+      setNewColor(nextColor);
+
+      if (typeof onDiceColorChange === 'function') {
+        onDiceColorChange(nextColor);
+      }
+    } catch (error) {
+      // Swallow fetch errors silently for now.
+    }
+  }
   return (
     <div>
       <Modal
@@ -124,7 +170,6 @@ document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
                       <input
                         type="color"
                         id="colorPicker"
-                        ref={colorPickerRef}
                         value={newColor}
                         onChange={handleColorChange}
                       />

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1416,255 +1416,6 @@ export default function ZombiesCharacterSheet() {
     };
   }, [characterId, applyMapPayload]);
 
-  useEffect(() => {
-    if (!campaignId) {
-      if (socketRef.current) {
-        socketRef.current.disconnect();
-        socketRef.current = null;
-      }
-      applyMapPayload({ maps: [], activeMapId: null, map: null });
-      setShowMapModal(false);
-      return undefined;
-    }
-
-    const socketUrl = process.env.REACT_APP_API_URL || undefined;
-    const socket = io(socketUrl, { withCredentials: true });
-    socketRef.current = socket;
-
-    const handleCombatUpdate = (state) => {
-      setCombatState(normalizeCombatState(state));
-    };
-
-    const handleCharacterHealthUpdate = (update) => {
-      if (!update || typeof update !== 'object') {
-        return;
-      }
-
-      const rawCharacterId = update.characterId;
-      const normalizedCharacterId =
-        typeof rawCharacterId === 'string' && rawCharacterId.trim() !== ''
-          ? rawCharacterId.trim()
-          : null;
-
-      if (!normalizedCharacterId) {
-        return;
-      }
-
-      const nextTempHealthValue =
-        update.tempHealth !== undefined && update.tempHealth !== null
-          ? (() => {
-              const numeric = Number(update.tempHealth);
-              return Number.isFinite(numeric) ? numeric : update.tempHealth;
-            })()
-          : undefined;
-
-      const nextHealthValue =
-        update.health !== undefined && update.health !== null
-          ? (() => {
-              const numeric = Number(update.health);
-              return Number.isFinite(numeric) ? numeric : update.health;
-            })()
-          : undefined;
-
-      setCampaignCharacters((prev) => {
-        if (!prev || typeof prev !== 'object') {
-          return prev;
-        }
-
-        const existing = prev[normalizedCharacterId];
-        if (!existing) {
-          return prev;
-        }
-
-        let didUpdate = false;
-        const updatedCharacter = { ...existing };
-
-        if (nextTempHealthValue !== undefined && existing.tempHealth !== nextTempHealthValue) {
-          updatedCharacter.tempHealth = nextTempHealthValue;
-          didUpdate = true;
-        }
-
-        if (nextHealthValue !== undefined && existing.health !== nextHealthValue) {
-          updatedCharacter.health = nextHealthValue;
-          didUpdate = true;
-        }
-
-        if (!didUpdate) {
-          return prev;
-        }
-
-        return {
-          ...prev,
-          [normalizedCharacterId]: updatedCharacter,
-        };
-      });
-
-      setForm((prev) => {
-        if (!prev || typeof prev !== 'object') {
-          return prev;
-        }
-
-        const candidateIds = [];
-        if (typeof prev._id === 'string' && prev._id.trim() !== '') {
-          candidateIds.push(prev._id.trim());
-        }
-        if (typeof prev.characterId === 'string' && prev.characterId.trim() !== '') {
-          candidateIds.push(prev.characterId.trim());
-        }
-
-        if (!candidateIds.includes(normalizedCharacterId)) {
-          return prev;
-        }
-
-        let didUpdate = false;
-        const updatedForm = { ...prev };
-
-        if (nextTempHealthValue !== undefined && prev.tempHealth !== nextTempHealthValue) {
-          updatedForm.tempHealth = nextTempHealthValue;
-          didUpdate = true;
-        }
-
-        if (nextHealthValue !== undefined && prev.health !== nextHealthValue) {
-          updatedForm.health = nextHealthValue;
-          didUpdate = true;
-        }
-
-        return didUpdate ? updatedForm : prev;
-      });
-    };
-
-    const handleCampaignMapUpdate = (update) => {
-      if (update === null) {
-        applyMapPayload({ maps: [], activeMapId: null, map: null });
-        return;
-      }
-
-      if (!update || typeof update !== 'object') {
-        return;
-      }
-
-      const hasTokensByMapIdProp = Object.prototype.hasOwnProperty.call(update, 'tokensByMapId');
-      const hasActiveTokensProp = Object.prototype.hasOwnProperty.call(update, 'activeMapTokens');
-      const hasMapsProp = Array.isArray(update.maps);
-      const hasMapProp =
-        update.map && typeof update.map === 'object' && !Array.isArray(update.map);
-      const hasMapExplicitNull = Object.prototype.hasOwnProperty.call(update, 'map') && update.map === null;
-      const hasActiveIdProp = Object.prototype.hasOwnProperty.call(update, 'activeMapId');
-
-      const sanitizedTokens = hasTokensByMapIdProp
-        ? sanitizeTokensByMapId(update.tokensByMapId)
-        : {};
-      const sanitizedActiveTokens = hasActiveTokensProp
-        ? sanitizeTokenDictionary(update.activeMapTokens)
-        : {};
-
-      const normalizedIncomingActiveId =
-        hasActiveIdProp && typeof update.activeMapId === 'string' && update.activeMapId.trim() !== ''
-          ? update.activeMapId.trim()
-          : null;
-
-      const tokenKeys = ['tokensByMapId', 'activeMapTokens', 'activeMapId'];
-      const payloadKeys = Object.keys(update);
-      const tokenOnlyUpdate =
-        payloadKeys.length > 0 &&
-        payloadKeys.every((key) => tokenKeys.includes(key)) &&
-        (hasTokensByMapIdProp || hasActiveTokensProp || hasActiveIdProp);
-
-      if (tokenOnlyUpdate) {
-        const merged = mergeTokenPayload({
-          incomingTokensByMapId: sanitizedTokens,
-          incomingActiveMapTokens: sanitizedActiveTokens,
-          incomingActiveMapId: normalizedIncomingActiveId,
-          previousActiveMapId: campaignActiveMapIdRef.current,
-          previousCampaignMap: campaignMapRef.current,
-          previousMapTokens: campaignMapTokensRef.current || {},
-        });
-
-        setCampaignActiveMapId(merged.activeMapId);
-        setCampaignMapTokens(merged.mapTokens);
-        setActiveMapTokens(merged.activeMapTokens);
-        setCampaignMap(merged.campaignMap);
-        return;
-      }
-
-      if (
-        !hasMapsProp &&
-        !hasMapProp &&
-        !hasMapExplicitNull &&
-        !hasActiveIdProp &&
-        !hasTokensByMapIdProp &&
-        !hasActiveTokensProp
-      ) {
-        const normalizedMap = hasMapProp ? update.map : update;
-        const normalizedMapId =
-          typeof normalizedMap?.mapId === 'string' && normalizedMap.mapId.trim() !== ''
-            ? normalizedMap.mapId.trim()
-            : null;
-        applyMapPayload({
-          maps: normalizedMap ? [normalizedMap] : campaignMapsRef.current,
-          activeMapId: normalizedMapId || campaignActiveMapIdRef.current,
-          map: normalizedMap,
-        });
-        return;
-      }
-
-      let mapFromList = null;
-      if (hasMapsProp && normalizedIncomingActiveId) {
-        mapFromList = (update.maps || []).find((entry) => {
-          if (!entry || typeof entry !== 'object') {
-            return false;
-          }
-
-          const entryId =
-            typeof entry.mapId === 'string' && entry.mapId.trim() !== ''
-              ? entry.mapId.trim()
-              : null;
-          return entryId === normalizedIncomingActiveId;
-        }) || null;
-      }
-
-      const workingPayload = {
-        maps: hasMapsProp ? update.maps : campaignMapsRef.current,
-        activeMapId: normalizedIncomingActiveId || campaignActiveMapIdRef.current,
-        map: hasMapProp
-          ? update.map
-          : hasMapExplicitNull
-            ? null
-            : mapFromList || campaignMapRef.current,
-        ...(hasTokensByMapIdProp ? { tokensByMapId: sanitizedTokens } : {}),
-        ...(hasActiveTokensProp ? { activeMapTokens: sanitizedActiveTokens } : {}),
-      };
-
-      applyMapPayload(workingPayload);
-    };
-
-    const handleEnemiesUpdate = (roster) => {
-      if (!Array.isArray(roster)) {
-        setEnemies([]);
-        return;
-      }
-
-      const sanitized = roster.filter((entry) => entry && typeof entry === 'object');
-      setEnemies(sanitized);
-    };
-
-    socket.on('combat:update', handleCombatUpdate);
-    socket.on('character:health:update', handleCharacterHealthUpdate);
-    socket.on('campaign:map:update', handleCampaignMapUpdate);
-    socket.on('campaign:enemies:update', handleEnemiesUpdate);
-    socket.emit('campaign:join', campaignId);
-
-    return () => {
-      socket.off('combat:update', handleCombatUpdate);
-      socket.off('character:health:update', handleCharacterHealthUpdate);
-      socket.off('campaign:map:update', handleCampaignMapUpdate);
-      socket.off('campaign:enemies:update', handleEnemiesUpdate);
-      socket.emit('campaign:leave', campaignId);
-      socket.disconnect();
-      socketRef.current = null;
-    };
-  }, [campaignId, applyMapPayload]);
-
   const handleShowCharacterInfo = () => setShowCharacterInfo(true);
   const handleCloseCharacterInfo = () => setShowCharacterInfo(false);
   const handleShowStats = () => setShowStats(true);
@@ -2142,6 +1893,388 @@ export default function ZombiesCharacterSheet() {
     }
     return candidates.find(Boolean) || null;
   }, [characterId, form]);
+
+  const resolvedCharacterIdRef = useRef(resolvedCharacterId);
+
+  useEffect(() => {
+    resolvedCharacterIdRef.current = resolvedCharacterId;
+  }, [resolvedCharacterId]);
+
+  const updateLocalDiceColor = useCallback(
+    (incomingCharacterId, nextColor) => {
+      const normalizedCharacterId =
+        typeof incomingCharacterId === 'string' && incomingCharacterId.trim() !== ''
+          ? incomingCharacterId.trim()
+          : null;
+      const normalizedColor =
+        typeof nextColor === 'string' && nextColor.trim() !== '' ? nextColor.trim() : null;
+
+      if (!normalizedCharacterId || !normalizedColor) {
+        return;
+      }
+
+      setCampaignCharacters((prev) => {
+        if (!prev || typeof prev !== 'object' || Object.keys(prev).length === 0) {
+          return prev;
+        }
+
+        let didUpdate = false;
+        const next = { ...prev };
+
+        Object.entries(prev).forEach(([key, value]) => {
+          if (!value || typeof value !== 'object') {
+            return;
+          }
+
+          const identifiers = new Set();
+          if (typeof key === 'string' && key.trim() !== '') {
+            identifiers.add(key.trim());
+          }
+          if (typeof value._id === 'string' && value._id.trim() !== '') {
+            identifiers.add(value._id.trim());
+          }
+          if (typeof value.characterId === 'string' && value.characterId.trim() !== '') {
+            identifiers.add(value.characterId.trim());
+          }
+
+          if (!identifiers.has(normalizedCharacterId)) {
+            return;
+          }
+
+          const existingColor =
+            typeof value.diceColor === 'string' && value.diceColor.trim() !== ''
+              ? value.diceColor.trim()
+              : null;
+
+          if (existingColor === normalizedColor) {
+            return;
+          }
+
+          next[key] = { ...value, diceColor: normalizedColor };
+          didUpdate = true;
+        });
+
+        return didUpdate ? next : prev;
+      });
+
+      setForm((prev) => {
+        if (!prev) {
+          return prev;
+        }
+
+        const identifiers = [];
+        if (typeof prev._id === 'string' && prev._id.trim() !== '') {
+          identifiers.push(prev._id.trim());
+        }
+        if (typeof prev.characterId === 'string' && prev.characterId.trim() !== '') {
+          identifiers.push(prev.characterId.trim());
+        }
+        const resolvedId = resolvedCharacterIdRef.current;
+        if (typeof resolvedId === 'string' && resolvedId.trim() !== '') {
+          identifiers.push(resolvedId.trim());
+        }
+
+        if (!identifiers.includes(normalizedCharacterId)) {
+          return prev;
+        }
+
+        if (typeof prev.diceColor === 'string' && prev.diceColor.trim() === normalizedColor) {
+          return prev;
+        }
+
+        return { ...prev, diceColor: normalizedColor };
+      });
+    },
+    [setCampaignCharacters, setForm]
+  );
+
+  useEffect(() => {
+    if (!campaignId) {
+      if (socketRef.current) {
+        socketRef.current.disconnect();
+        socketRef.current = null;
+      }
+      applyMapPayload({ maps: [], activeMapId: null, map: null });
+      setShowMapModal(false);
+      return undefined;
+    }
+
+    const socketUrl = process.env.REACT_APP_API_URL || undefined;
+    const socket = io(socketUrl, { withCredentials: true });
+    socketRef.current = socket;
+
+    const handleCombatUpdate = (state) => {
+      setCombatState(normalizeCombatState(state));
+    };
+
+    const handleCharacterHealthUpdate = (update) => {
+      if (!update || typeof update !== 'object') {
+        return;
+      }
+
+      const rawCharacterId = update.characterId;
+      const normalizedCharacterId =
+        typeof rawCharacterId === 'string' && rawCharacterId.trim() !== ''
+          ? rawCharacterId.trim()
+          : null;
+
+      if (!normalizedCharacterId) {
+        return;
+      }
+
+      const nextTempHealthValue =
+        update.tempHealth !== undefined && update.tempHealth !== null
+          ? (() => {
+              const numeric = Number(update.tempHealth);
+              return Number.isFinite(numeric) ? numeric : update.tempHealth;
+            })()
+          : undefined;
+
+      const nextHealthValue =
+        update.health !== undefined && update.health !== null
+          ? (() => {
+              const numeric = Number(update.health);
+              return Number.isFinite(numeric) ? numeric : update.health;
+            })()
+          : undefined;
+
+      setCampaignCharacters((prev) => {
+        if (!prev || typeof prev !== 'object') {
+          return prev;
+        }
+
+        const existing = prev[normalizedCharacterId];
+        if (!existing) {
+          return prev;
+        }
+
+        let didUpdate = false;
+        const updatedCharacter = { ...existing };
+
+        if (nextTempHealthValue !== undefined && existing.tempHealth !== nextTempHealthValue) {
+          updatedCharacter.tempHealth = nextTempHealthValue;
+          didUpdate = true;
+        }
+
+        if (nextHealthValue !== undefined && existing.health !== nextHealthValue) {
+          updatedCharacter.health = nextHealthValue;
+          didUpdate = true;
+        }
+
+        if (!didUpdate) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [normalizedCharacterId]: updatedCharacter,
+        };
+      });
+
+      setForm((prev) => {
+        if (!prev || typeof prev !== 'object') {
+          return prev;
+        }
+
+        const candidateIds = [];
+        if (typeof prev._id === 'string' && prev._id.trim() !== '') {
+          candidateIds.push(prev._id.trim());
+        }
+        if (typeof prev.characterId === 'string' && prev.characterId.trim() !== '') {
+          candidateIds.push(prev.characterId.trim());
+        }
+
+        if (!candidateIds.includes(normalizedCharacterId)) {
+          return prev;
+        }
+
+        let didUpdate = false;
+        const updatedForm = { ...prev };
+
+        if (nextTempHealthValue !== undefined && prev.tempHealth !== nextTempHealthValue) {
+          updatedForm.tempHealth = nextTempHealthValue;
+          didUpdate = true;
+        }
+
+        if (nextHealthValue !== undefined && prev.health !== nextHealthValue) {
+          updatedForm.health = nextHealthValue;
+          didUpdate = true;
+        }
+
+        return didUpdate ? updatedForm : prev;
+      });
+    };
+
+    const handleCampaignMapUpdate = (update) => {
+      if (update === null) {
+        applyMapPayload({ maps: [], activeMapId: null, map: null });
+        return;
+      }
+
+      if (!update || typeof update !== 'object') {
+        return;
+      }
+
+      const hasTokensByMapIdProp = Object.prototype.hasOwnProperty.call(update, 'tokensByMapId');
+      const hasActiveTokensProp = Object.prototype.hasOwnProperty.call(update, 'activeMapTokens');
+      const hasMapsProp = Array.isArray(update.maps);
+      const hasMapProp =
+        update.map && typeof update.map === 'object' && !Array.isArray(update.map);
+      const hasMapExplicitNull = Object.prototype.hasOwnProperty.call(update, 'map') && update.map === null;
+      const hasActiveIdProp = Object.prototype.hasOwnProperty.call(update, 'activeMapId');
+
+      const sanitizedTokens = hasTokensByMapIdProp
+        ? sanitizeTokensByMapId(update.tokensByMapId)
+        : {};
+      const sanitizedActiveTokens = hasActiveTokensProp
+        ? sanitizeTokenDictionary(update.activeMapTokens)
+        : {};
+
+      const normalizedIncomingActiveId =
+        hasActiveIdProp && typeof update.activeMapId === 'string' && update.activeMapId.trim() !== ''
+          ? update.activeMapId.trim()
+          : null;
+
+      const tokenKeys = ['tokensByMapId', 'activeMapTokens', 'activeMapId'];
+      const payloadKeys = Object.keys(update);
+      const tokenOnlyUpdate =
+        payloadKeys.length > 0 &&
+        payloadKeys.every((key) => tokenKeys.includes(key)) &&
+        (hasTokensByMapIdProp || hasActiveTokensProp || hasActiveIdProp);
+
+      if (tokenOnlyUpdate) {
+        const merged = mergeTokenPayload({
+          incomingTokensByMapId: sanitizedTokens,
+          incomingActiveMapTokens: sanitizedActiveTokens,
+          incomingActiveMapId: normalizedIncomingActiveId,
+          previousActiveMapId: campaignActiveMapIdRef.current,
+          previousCampaignMap: campaignMapRef.current,
+          previousMapTokens: campaignMapTokensRef.current || {},
+        });
+
+        setCampaignActiveMapId(merged.activeMapId);
+        setCampaignMapTokens(merged.mapTokens);
+        setActiveMapTokens(merged.activeMapTokens);
+        setCampaignMap(merged.campaignMap);
+        return;
+      }
+
+      if (
+        !hasMapsProp &&
+        !hasMapProp &&
+        !hasMapExplicitNull &&
+        !hasActiveIdProp &&
+        !hasTokensByMapIdProp &&
+        !hasActiveTokensProp
+      ) {
+        const normalizedMap = hasMapProp ? update.map : update;
+        const normalizedMapId =
+          typeof normalizedMap?.mapId === 'string' && normalizedMap.mapId.trim() !== ''
+            ? normalizedMap.mapId.trim()
+            : null;
+        applyMapPayload({
+          maps: normalizedMap ? [normalizedMap] : campaignMapsRef.current,
+          activeMapId: normalizedMapId || campaignActiveMapIdRef.current,
+          map: normalizedMap,
+        });
+        return;
+      }
+
+      let mapFromList = null;
+      if (hasMapsProp && normalizedIncomingActiveId) {
+        mapFromList = (update.maps || []).find((entry) => {
+          if (!entry || typeof entry !== 'object') {
+            return false;
+          }
+
+          const entryId =
+            typeof entry.mapId === 'string' && entry.mapId.trim() !== ''
+              ? entry.mapId.trim()
+              : null;
+          return entryId === normalizedIncomingActiveId;
+        }) || null;
+      }
+
+      const workingPayload = {
+        maps: hasMapsProp ? update.maps : campaignMapsRef.current,
+        activeMapId: normalizedIncomingActiveId || campaignActiveMapIdRef.current,
+        map: hasMapProp
+          ? update.map
+          : hasMapExplicitNull
+            ? null
+            : mapFromList || campaignMapRef.current,
+        ...(hasTokensByMapIdProp ? { tokensByMapId: sanitizedTokens } : {}),
+        ...(hasActiveTokensProp ? { activeMapTokens: sanitizedActiveTokens } : {}),
+      };
+
+      applyMapPayload(workingPayload);
+    };
+
+    const handleEnemiesUpdate = (roster) => {
+      if (!Array.isArray(roster)) {
+        setEnemies([]);
+        return;
+      }
+
+      const sanitized = roster.filter((entry) => entry && typeof entry === 'object');
+      setEnemies(sanitized);
+    };
+
+    const handleCharacterMetadataUpdate = (update) => {
+      if (!update || typeof update !== 'object') {
+        return;
+      }
+
+      const normalizedCharacterId =
+        typeof update.characterId === 'string' && update.characterId.trim() !== ''
+          ? update.characterId.trim()
+          : null;
+
+      if (!normalizedCharacterId) {
+        return;
+      }
+
+      const normalizedDiceColor =
+        typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
+          ? update.diceColor.trim()
+          : null;
+
+      if (!normalizedDiceColor) {
+        return;
+      }
+
+      updateLocalDiceColor(normalizedCharacterId, normalizedDiceColor);
+    };
+
+    socket.on('combat:update', handleCombatUpdate);
+    socket.on('character:health:update', handleCharacterHealthUpdate);
+    socket.on('campaign:map:update', handleCampaignMapUpdate);
+    socket.on('campaign:enemies:update', handleEnemiesUpdate);
+    socket.on('campaign:characters:update', handleCharacterMetadataUpdate);
+    socket.emit('campaign:join', campaignId);
+
+    return () => {
+      socket.off('combat:update', handleCombatUpdate);
+      socket.off('character:health:update', handleCharacterHealthUpdate);
+      socket.off('campaign:map:update', handleCampaignMapUpdate);
+      socket.off('campaign:enemies:update', handleEnemiesUpdate);
+      socket.off('campaign:characters:update', handleCharacterMetadataUpdate);
+      socket.emit('campaign:leave', campaignId);
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [campaignId, applyMapPayload, updateLocalDiceColor]);
+
+  const handleDiceColorChange = useCallback(
+    (nextColor) => {
+      const currentId = resolvedCharacterIdRef.current;
+      if (!currentId) {
+        return;
+      }
+      updateLocalDiceColor(currentId, nextColor);
+    },
+    [updateLocalDiceColor]
+  );
 
   const tokenMetaById = useMemo(() => {
     const lookup = {};
@@ -2872,6 +3005,7 @@ const spellsGold =
         form={form}
         showHelpModal={showHelpModal}
         handleCloseHelpModal={handleCloseHelpModal}
+        onDiceColorChange={handleDiceColorChange}
       />
       <MapModal
         show={showMapModal}

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1323,10 +1323,72 @@ export default function ZombiesDM() {
         setEnemies(sanitized);
       };
 
+      const handleCharacterMetadataUpdate = (update) => {
+        if (!update || typeof update !== 'object') {
+          return;
+        }
+
+        const normalizedCharacterId =
+          typeof update.characterId === 'string' && update.characterId.trim() !== ''
+            ? update.characterId.trim()
+            : null;
+
+        if (!normalizedCharacterId) {
+          return;
+        }
+
+        const normalizedDiceColor =
+          typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
+            ? update.diceColor.trim()
+            : null;
+
+        if (!normalizedDiceColor) {
+          return;
+        }
+
+        setRecords((prev) => {
+          if (!Array.isArray(prev) || prev.length === 0) {
+            return prev;
+          }
+
+          let didUpdate = false;
+          const next = prev.map((record) => {
+            if (!record || typeof record !== 'object') {
+              return record;
+            }
+
+            const identifiers = [];
+            if (typeof record._id === 'string' && record._id.trim() !== '') {
+              identifiers.push(record._id.trim());
+            }
+            if (typeof record.characterId === 'string' && record.characterId.trim() !== '') {
+              identifiers.push(record.characterId.trim());
+            }
+
+            if (!identifiers.includes(normalizedCharacterId)) {
+              return record;
+            }
+
+            if (
+              typeof record.diceColor === 'string' &&
+              record.diceColor.trim() === normalizedDiceColor
+            ) {
+              return record;
+            }
+
+            didUpdate = true;
+            return { ...record, diceColor: normalizedDiceColor };
+          });
+
+          return didUpdate ? next : prev;
+        });
+      };
+
       socket.on('combat:update', handleCombatUpdate);
       socket.on('character:health:update', handleCharacterHealthUpdate);
       socket.on('campaign:map:update', handleMapUpdate);
       socket.on('campaign:enemies:update', handleEnemiesUpdate);
+      socket.on('campaign:characters:update', handleCharacterMetadataUpdate);
       socket.emit('campaign:join', campaignId);
 
       return () => {
@@ -1334,6 +1396,7 @@ export default function ZombiesDM() {
         socket.off('character:health:update', handleCharacterHealthUpdate);
         socket.off('campaign:map:update', handleMapUpdate);
         socket.off('campaign:enemies:update', handleEnemiesUpdate);
+        socket.off('campaign:characters:update', handleCharacterMetadataUpdate);
         socket.emit('campaign:leave', campaignId);
         socket.disconnect();
         socketRef.current = null;

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -9,6 +9,7 @@ const proficiencyBonus = require('../../utils/proficiency');
 const collectAllowedSkills = require('../../utils/collectAllowedSkills');
 const collectAllowedExpertise = require('../../utils/collectAllowedExpertise');
 const { normalizeEquipmentMap } = require('../../constants/equipmentSlots');
+const { emitCharacterMetadataUpdate } = require('../../utils/socket');
 
 const countFeatProficiencies = (feat = []) => {
   const profs = new Set();
@@ -418,11 +419,45 @@ module.exports = (router) => {
       const db_connect = req.db;
       const { diceColor } = matchedData(req, { locations: ['body'] });
       try {
-        await db_connect.collection('Characters').updateOne(id, {
-          $set: { diceColor },
-        });
+        const updateResult = await db_connect.collection('Characters').findOneAndUpdate(
+          id,
+          {
+            $set: { diceColor },
+          },
+          { returnDocument: 'after' }
+        );
+
+        const updatedCharacter = updateResult && updateResult.value ? updateResult.value : null;
+        if (!updatedCharacter) {
+          return res.status(404).json({ message: 'Character not found' });
+        }
+
+        const rawCampaignId =
+          typeof updatedCharacter.campaign === 'string'
+            ? updatedCharacter.campaign
+            : typeof updatedCharacter.campaignId === 'string'
+              ? updatedCharacter.campaignId
+              : null;
+        const campaignId = rawCampaignId && rawCampaignId.trim() !== '' ? rawCampaignId.trim() : null;
+        const characterId =
+          updatedCharacter._id && typeof updatedCharacter._id.toString === 'function'
+            ? updatedCharacter._id.toString()
+            : typeof updatedCharacter.characterId === 'string'
+              ? updatedCharacter.characterId
+              : null;
+
+        const payload = {
+          campaignId,
+          characterId,
+          diceColor,
+        };
+
+        if (campaignId && characterId) {
+          emitCharacterMetadataUpdate(campaignId, payload);
+        }
+
         logger.info('Dice Color updated');
-        res.json({ message: 'User updated successfully' });
+        res.json(payload);
       } catch (err) {
         next(err);
       }

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -245,11 +245,50 @@ const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health
   io.to(getCampaignRoom(normalizedCampaignId)).emit('character:health:update', payload);
 };
 
+const emitCharacterMetadataUpdate = (campaignId, payload) => {
+  if (!io) {
+    logger.warn('Socket.io server not initialized; cannot emit character metadata update');
+    return;
+  }
+
+  if (typeof campaignId !== 'string' || campaignId.trim() === '') {
+    logger.warn('Invalid campaign id provided for character metadata update', {
+      campaignId,
+    });
+    return;
+  }
+
+  const normalizedId = campaignId.trim();
+  const outgoingPayload =
+    payload && typeof payload === 'object'
+      ? { ...payload, campaignId: payload.campaignId || normalizedId }
+      : { campaignId: normalizedId };
+
+  if (
+    typeof outgoingPayload.characterId === 'string' &&
+    outgoingPayload.characterId.trim() !== ''
+  ) {
+    outgoingPayload.characterId = outgoingPayload.characterId.trim();
+  }
+
+  if (
+    typeof outgoingPayload.diceColor === 'string' &&
+    outgoingPayload.diceColor.trim() !== ''
+  ) {
+    outgoingPayload.diceColor = outgoingPayload.diceColor.trim();
+  }
+
+  outgoingPayload.campaignId = normalizedId;
+
+  io.to(getCampaignRoom(normalizedId)).emit('campaign:characters:update', outgoingPayload);
+};
+
 module.exports = {
   initializeSocket,
   emitCombatUpdate,
   emitMapUpdate,
   emitEnemiesUpdate,
   emitCharacterHealthUpdate,
+  emitCharacterMetadataUpdate,
 };
 


### PR DESCRIPTION
## Summary
- broadcast dice color updates from the characters route and return the updated metadata payload
- add a socket utility for campaign character metadata events and subscribe on the DM board and character sheet
- refresh local state instantly after dice color changes by wiring the Help modal through a callback instead of reloading

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js *(fails: existing act() warnings and waitFor expectations in the large campaign test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1f1c0d2c832e93d217d1f164de9a