### PR TITLE
Scale campaign map figurines by creature size

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2436,8 +2436,7 @@ h1 {
 
 .campaign-map-board {
   --map-square-size: var(--campaign-map-square-size, clamp(36px, 8vw, 64px));
-  --figurine-base-size: clamp(20px, calc(var(--map-square-size) * 0.5), 32px);
-  --figurine-body-width: clamp(12px, calc(var(--figurine-base-size) * 0.6), 20px);
+  --figurine-size-scale: 1;
 
   position: relative;
   background: rgba(18, 16, 14, 0.85);
@@ -2484,6 +2483,8 @@ h1 {
   }
 
   &__token {
+    --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
+    --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
     position: absolute;
     transform: translate(-50%, -50%);
     pointer-events: auto;
@@ -2492,11 +2493,35 @@ h1 {
     flex-direction: column;
     align-items: center;
     justify-content: flex-end;
-    gap: clamp(2px, calc(var(--figurine-base-size) * 0.08), 0.25rem);
+    gap: clamp(2px, calc(var(--figurine-base-size) * 0.08), 0.4rem);
     outline: none;
     touch-action: none;
     width: var(--figurine-base-size);
     height: calc(var(--figurine-base-size) * 1.6);
+  }
+
+  &__token--size-tiny {
+    --figurine-size-scale: 0.25;
+  }
+
+  &__token--size-small {
+    --figurine-size-scale: 0.5;
+  }
+
+  &__token--size-medium {
+    --figurine-size-scale: 1;
+  }
+
+  &__token--size-large {
+    --figurine-size-scale: 2;
+  }
+
+  &__token--size-huge {
+    --figurine-size-scale: 3;
+  }
+
+  &__token--size-gargantuan {
+    --figurine-size-scale: 4;
   }
 
   &__health {
@@ -2620,18 +2645,19 @@ h1 {
 
   &__figurine-label {
     position: absolute;
-    bottom: calc(100% + clamp(0.35rem, 1vw, 0.55rem));
+    bottom: calc(100% + clamp(0.25rem, calc(var(--figurine-base-size) * 0.3), 1.1rem));
     left: 50%;
-    transform: translate(-50%, 0.35rem) scale(0.96);
+    transform: translate(-50%, calc(var(--figurine-base-size) * 0.12)) scale(0.96);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: clamp(0.18rem, 0.6vw, 0.35rem) clamp(0.4rem, 1.2vw, 0.75rem);
+    padding: clamp(0.18rem, calc(var(--figurine-base-size) * 0.18), 0.6rem)
+      clamp(0.4rem, calc(var(--figurine-base-size) * 0.35), 1.1rem);
     border-radius: 999px;
     background: linear-gradient(180deg, rgba(18, 21, 29, 0.95), rgba(18, 21, 29, 0.85));
     color: #f8f9fa;
     font-weight: 600;
-    font-size: clamp(0.65rem, 1.5vw, 0.95rem);
+    font-size: clamp(0.6rem, calc(var(--figurine-base-size) * 0.28), 1.05rem);
     line-height: 1.2;
     white-space: nowrap;
     pointer-events: none;
@@ -2641,7 +2667,7 @@ h1 {
     border: 1px solid rgba(255, 255, 255, 0.2);
     transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.25s ease;
     transform-origin: center bottom;
-    max-width: clamp(8rem, 24vw, 14rem);
+    max-width: clamp(8rem, calc(var(--figurine-base-size) * 3.5), 16rem);
     text-overflow: ellipsis;
     overflow: hidden;
     z-index: 5;

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -69,6 +69,45 @@ const buildImageSource = ({ imageUrl, imageBase64, imageType }) => {
 const normalizeText = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
 
+const FIGURINE_SIZE_MULTIPLIERS = {
+  tiny: 0.25,
+  small: 0.5,
+  medium: 1,
+  large: 2,
+  huge: 3,
+  gargantuan: 4,
+};
+
+const resolveFigurineSizeKey = (value) => {
+  if (typeof value !== 'string') {
+    return 'medium';
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return 'medium';
+  }
+
+  if (FIGURINE_SIZE_MULTIPLIERS[trimmed]) {
+    return trimmed;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  const tokenMatch = tokens.find((token) => FIGURINE_SIZE_MULTIPLIERS[token]);
+  if (tokenMatch) {
+    return tokenMatch;
+  }
+
+  const prefixMatch = Object.keys(FIGURINE_SIZE_MULTIPLIERS).find((key) =>
+    trimmed.startsWith(key)
+  );
+  if (prefixMatch) {
+    return prefixMatch;
+  }
+
+  return 'medium';
+};
+
 const CampaignMapBoard = ({
   map,
   tokens,
@@ -326,6 +365,7 @@ const CampaignMapBoard = ({
                   maxHp,
                   variant,
                   isActiveTurn,
+                  size,
                 } = token;
                 const draggable = !interactionDisabled && token.isMovable !== false;
                 const normalizedLabel = normalizeText(label);
@@ -348,6 +388,10 @@ const CampaignMapBoard = ({
                     ? variant.trim().toLowerCase()
                     : null;
 
+                const sizeKey = resolveFigurineSizeKey(size);
+                const figurineScale =
+                  FIGURINE_SIZE_MULTIPLIERS[sizeKey] || FIGURINE_SIZE_MULTIPLIERS.medium;
+
                 const figurineColor =
                   normalizedVariant === 'enemy'
                     ? ENEMY_FIGURINE_COLOR
@@ -368,11 +412,13 @@ const CampaignMapBoard = ({
                       'campaign-map-board__token',
                       draggable && 'campaign-map-board__token--draggable',
                       isLabelActive && 'campaign-map-board__token--label-active',
-                      isActiveTurn && 'campaign-map-board__token--active-turn'
+                      isActiveTurn && 'campaign-map-board__token--active-turn',
+                      `campaign-map-board__token--size-${sizeKey}`
                     )}
                     style={{
                       left: `${(position?.x ?? 0) * 100}%`,
                       top: `${(position?.y ?? 0) * 100}%`,
+                      '--figurine-size-scale': figurineScale,
                     }}
                     title={displayLabel || undefined}
                     onPointerDown={(event) => {
@@ -463,6 +509,7 @@ CampaignMapBoard.propTypes = {
       currentHp: PropTypes.number,
       maxHp: PropTypes.number,
       isActiveTurn: PropTypes.bool,
+      size: PropTypes.string,
     })
   ),
   onTokenDragStart: PropTypes.func,

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -220,6 +220,10 @@ const MapModal = ({
         typeof value?.variant === 'string' && value.variant.trim() !== ''
           ? value.variant.trim().toLowerCase()
           : null;
+      const size =
+        typeof value?.size === 'string' && value.size.trim() !== ''
+          ? value.size.trim().toLowerCase()
+          : null;
 
       acc[trimmedKey] = {
         color,
@@ -228,6 +232,7 @@ const MapModal = ({
         ...(variant ? { variant } : {}),
         ...(currentHp !== null ? { currentHp } : {}),
         ...(maxHp !== null ? { maxHp } : {}),
+        ...(size ? { size } : {}),
       };
       return acc;
     }, {});
@@ -314,6 +319,16 @@ const MapModal = ({
 
         const entityType = lookupEntityType || tokenEntityType || null;
 
+        const lookupSize =
+          typeof lookup.size === 'string' && lookup.size.trim() !== ''
+            ? lookup.size.trim().toLowerCase()
+            : null;
+        const tokenSize =
+          typeof token.size === 'string' && token.size.trim() !== ''
+            ? token.size.trim().toLowerCase()
+            : null;
+        const size = lookupSize || tokenSize || null;
+
         let variant = lookupVariant || tokenVariant || null;
         if (!variant && entityType) {
           if (entityType === 'enemy') {
@@ -347,6 +362,7 @@ const MapModal = ({
           ...(variant ? { variant } : {}),
           ...(currentHp !== null ? { currentHp } : {}),
           ...(maxHp !== null ? { maxHp } : {}),
+          ...(size ? { size } : {}),
         };
       })
       .sort((a, b) => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -98,6 +98,37 @@ const toFiniteNumberOrNull = (value) => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 
+const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
+
+const normalizeCreatureSize = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  const directMatch = CREATURE_SIZE_KEYS.find((size) => trimmed === size);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  const tokenMatch = CREATURE_SIZE_KEYS.find((size) => tokens.includes(size));
+  if (tokenMatch) {
+    return tokenMatch;
+  }
+
+  const prefixMatch = CREATURE_SIZE_KEYS.find((size) => trimmed.startsWith(size));
+  if (prefixMatch) {
+    return prefixMatch;
+  }
+
+  return null;
+};
+
 const sortParticipantsDescending = (participantsWithMeta) =>
   participantsWithMeta
     .slice()
@@ -2163,6 +2194,17 @@ export default function ZombiesDM() {
             (value) => typeof value === 'string' && value.trim() !== ''
           );
 
+          const recordSize = normalizeCreatureSize(
+            record.size ??
+              record.characterSize ??
+              record?.character?.size ??
+              record?.creature?.size ??
+              record?.profile?.size ??
+              record?.race?.size ??
+              record?.attributes?.size ??
+              record?.displayType
+          );
+
           identifiers.forEach((identifier) => {
             const trimmed = identifier.trim();
             if (!trimmed) {
@@ -2175,6 +2217,7 @@ export default function ZombiesDM() {
               entityType,
               ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
               ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
+              ...(recordSize ? { size: recordSize } : {}),
             };
           });
         });
@@ -2204,12 +2247,17 @@ export default function ZombiesDM() {
           );
           const enemyMaxHp = toFiniteNumberOrNull(enemy.maxHp ?? enemy.hitPoints);
 
+          const enemySize = normalizeCreatureSize(
+            enemy.size ?? enemy.displayType ?? enemy.type ?? enemy.enemyType
+          );
+
           lookup[enemyId] = {
             color: ENEMY_FIGURINE_COLOR,
             label,
             entityType: 'enemy',
             ...(enemyCurrentHp !== null ? { currentHp: enemyCurrentHp } : {}),
             ...(enemyMaxHp !== null ? { maxHp: enemyMaxHp } : {}),
+            ...(enemySize ? { size: enemySize } : {}),
           };
         });
       }
@@ -2365,6 +2413,16 @@ export default function ZombiesDM() {
               : null;
           const entityType = metaEntityType || tokenEntityType || null;
 
+          const metaSize =
+            typeof meta.size === 'string' && meta.size.trim() !== ''
+              ? meta.size.trim().toLowerCase()
+              : null;
+          const tokenSize =
+            typeof token.size === 'string' && token.size.trim() !== ''
+              ? token.size.trim().toLowerCase()
+              : null;
+          const size = metaSize || tokenSize || null;
+
           let variant = metaVariant || tokenVariant || null;
           if (!variant && entityType) {
             if (entityType === 'enemy') {
@@ -2388,6 +2446,7 @@ export default function ZombiesDM() {
             ...(isActiveTurn ? { isActiveTurn: true } : {}),
             ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
             ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
+            ...(size ? { size } : {}),
           };
         })
         .sort((a, b) => {


### PR DESCRIPTION
## Summary
- normalize creature sizes in token metadata and surface them to both board and modal tokens
- update CampaignMapBoard to apply size-aware classes and scale figurine footprints accordingly
- expand campaign map styling to provide per-size scaling for figurines, labels, and health elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc436988ac832ea379e90860ba1849