### PR TITLE
Align campaign map tokens with grid squares

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2476,6 +2476,8 @@ h1 {
   }
 
   &__tokens-layer {
+    --map-square-size: calc(100% / 24);
+
     position: absolute;
     inset: 0;
     pointer-events: auto;


### PR DESCRIPTION
## Summary
- scope the map square sizing to the token layer so figurine bases use the live board width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4bd21f88832e8409ae1ef4d2e847