### PR TITLE
Ensure campaign token grid respects minimum square size

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2476,7 +2476,11 @@ h1 {
   }
 
   &__tokens-layer {
-    --map-square-size: calc(100% / 24);
+    --tokens-layer-square-size: calc(100% / 24);
+    --map-square-size: max(
+      var(--campaign-map-square-size, clamp(36px, 8vw, 64px)),
+      var(--tokens-layer-square-size)
+    );
 
     position: absolute;
     inset: 0;


### PR DESCRIPTION
## Summary
- enforce a minimum map square size for the campaign token layer by combining the 24-column layout with the existing clamp fallback
- keep figurine sizing tied to the adjusted map square size so miniature scales remain consistent

## Testing
- `npm --prefix client run build` *(fails: missing socket.io-client module prior to dependency install)*


------
https://chatgpt.com/codex/tasks/task_e_68dc4eee48c8832ea262b7ebfbd5f9e1