### PR TITLE
Fix campaign map token square sizing fallback

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2477,10 +2477,7 @@ h1 {
 
   &__tokens-layer {
     --tokens-layer-square-size: calc(100% / 24);
-    --map-square-size: max(
-      var(--campaign-map-square-size, clamp(36px, 8vw, 64px)),
-      var(--tokens-layer-square-size)
-    );
+    --map-square-size: var(--campaign-map-square-size, var(--tokens-layer-square-size));
 
     position: absolute;
     inset: 0;


### PR DESCRIPTION
## Summary
- update the campaign map token layer to fall back to the rendered grid cell size when a board square size is not explicitly provided

## Testing
- `npm run build -- --filter client` *(fails: Module not found: Can't resolve 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_68dc518c3d34832ea36b98b265a91613