### PR TITLE
Handle campaign map tokens layer attachment

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -136,9 +136,15 @@ const CampaignMapBoard = ({
   const [dragPositions, setDragPositions] = useState({});
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
   const [squareSize, setSquareSize] = useState(null);
+  const [layerElement, setLayerElement] = useState(null);
+
+  const handleLayerRef = useCallback((node) => {
+    layerRef.current = node;
+    setLayerElement((prev) => (prev === node ? prev : node));
+  }, []);
 
   useEffect(() => {
-    const element = layerRef.current;
+    const element = layerElement;
     const ResizeObserverCtor =
       typeof window !== 'undefined' && window.ResizeObserver
         ? window.ResizeObserver
@@ -172,7 +178,7 @@ const CampaignMapBoard = ({
     return () => {
       observer.disconnect();
     };
-  }, [imageSrc]);
+  }, [layerElement]);
 
   const tokenPositions = useMemo(() => {
     if (!Array.isArray(tokens)) {
@@ -390,7 +396,7 @@ const CampaignMapBoard = ({
             <div className="campaign-map-board__grid-overlay" aria-hidden="true" />
             <div
               className="campaign-map-board__tokens-layer"
-              ref={layerRef}
+              ref={handleLayerRef}
               onPointerDown={handleLayerPointerDown}
               style={
                 Number.isFinite(squareSize) && squareSize > 0


### PR DESCRIPTION
## Summary
- track the campaign map tokens layer element with a callback ref to know when it mounts or unmounts
- retry ResizeObserver setup whenever the layer element changes while keeping the existing measurement behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc594f93b8832e8571eb7f843db676