### PR TITLE
Add indexes for Campaigns collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Example gif is listed below:
 
 Run `npm run build` to generate the production build of the client. The `npm start` script runs this build step before launching the server so deployments always serve the latest assets from `client/build`.
 
+## Database Indexes
+
+The server ensures critical MongoDB indexes at startup so common lookups stay performant:
+
+- `users.username` (unique)
+- `Campaigns.dm`
+- `Campaigns.players` (multikey)
+- `Campaigns.campaignName`
+
+If you run manual migrations or restore data, re-running the server will recreate any missing indexes automatically.
+
 ## Environment Variables
 
 The server uses a `config.env` file for configuration. Ensure the following variable is set:

--- a/server/db/conn.js
+++ b/server/db/conn.js
@@ -19,6 +19,16 @@ async function connectToDatabase() {
   await db.collection('users').createIndex({ username: 1 }, { unique: true });
   logger.info('Ensured unique index on users.username.');
 
+  // Ensure indexes used by common Campaign lookups
+  await db.collection('Campaigns').createIndex({ dm: 1 });
+  logger.info('Ensured index on Campaigns.dm.');
+
+  await db.collection('Campaigns').createIndex({ players: 1 });
+  logger.info('Ensured index on Campaigns.players.');
+
+  await db.collection('Campaigns').createIndex({ campaignName: 1 });
+  logger.info('Ensured index on Campaigns.campaignName.');
+
   return db;
 }
 


### PR DESCRIPTION
## Summary
- ensure the database connection seeds the Campaigns collection indexes for dm, players, and campaignName
- log the index creation alongside the existing users index message for visibility
- document the key MongoDB indexes in the README for future operations context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc627c2544832eb6420c85d064dbcf