### PR TITLE
Slim campaign listing responses

### DIFF
--- a/client/src/components/Zombies/hooks/useCampaignActions.js
+++ b/client/src/components/Zombies/hooks/useCampaignActions.js
@@ -3,6 +3,56 @@ import { useNavigate } from "react-router-dom";
 import apiFetch from "../../../utils/apiFetch";
 import useUser from "../../../hooks/useUser";
 
+const normalizeCampaignSummaries = (campaigns) => {
+  if (!Array.isArray(campaigns)) {
+    return [];
+  }
+
+  return campaigns
+    .map((campaign) => {
+      if (!campaign || typeof campaign !== "object") {
+        return null;
+      }
+
+      const campaignName =
+        typeof campaign.campaignName === "string"
+          ? campaign.campaignName.trim()
+          : "";
+
+      if (!campaignName) {
+        return null;
+      }
+
+      const dm =
+        typeof campaign.dm === "string" && campaign.dm.trim() !== ""
+          ? campaign.dm.trim()
+          : null;
+
+      const players = Array.isArray(campaign.players)
+        ? campaign.players
+            .filter(
+              (player) =>
+                typeof player === "string" && player.trim() !== ""
+            )
+            .map((player) => player.trim())
+        : [];
+
+      const gameMode =
+        typeof campaign.gameMode === "string" &&
+        campaign.gameMode.trim() !== ""
+          ? campaign.gameMode.trim()
+          : null;
+
+      return {
+        campaignName,
+        players,
+        ...(dm ? { dm } : {}),
+        ...(gameMode ? { gameMode } : {}),
+      };
+    })
+    .filter(Boolean);
+};
+
 export default function useCampaignActions() {
   const navigate = useNavigate();
   const user = useUser();
@@ -46,15 +96,16 @@ export default function useCampaignActions() {
         return [];
       }
 
-      const record = await response.json();
-      if (!record) {
+      const payload = await response.json();
+      if (!payload) {
         setNotification("Record not found");
         navigate("/");
         return [];
       }
 
-      setPlayerCampaigns(record);
-      return record;
+      const normalized = normalizeCampaignSummaries(payload);
+      setPlayerCampaigns(normalized);
+      return normalized;
     } catch (error) {
       setNotification(error.message || "An unexpected error has occurred");
       return [];
@@ -75,15 +126,16 @@ export default function useCampaignActions() {
         return [];
       }
 
-      const record = await response.json();
-      if (!record) {
+      const payload = await response.json();
+      if (!payload) {
         setNotification("Record not found");
         navigate("/");
         return [];
       }
 
-      setDmCampaigns(record);
-      return record;
+      const normalized = normalizeCampaignSummaries(payload);
+      setDmCampaigns(normalized);
+      return normalized;
     } catch (error) {
       setNotification(error.message || "An unexpected error has occurred");
       return [];

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -281,13 +281,22 @@ module.exports = (router) => {
     }
   );
 
-    // This section will get a list of all the campaigns.
+  const CAMPAIGN_SUMMARY_PROJECTION = {
+    projection: {
+      campaignName: 1,
+      dm: 1,
+      players: 1,
+      gameMode: 1,
+    },
+  };
+
+  // This section will get a list of all the campaigns.
   campaignRouter.route('/player/:player').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
         .collection("Campaigns")
-        .find({ players: { $in: [req.params.player] } })
+        .find({ players: { $in: [req.params.player] } }, CAMPAIGN_SUMMARY_PROJECTION)
         .toArray();
       res.json(applyDefaultCombat(result));
     } catch (err) {
@@ -295,19 +304,19 @@ module.exports = (router) => {
     }
   });
 
-    // This section will be for the DM
+  // This section will be for the DM
   campaignRouter.route('/dm/:DM').get(async (req, res, next) => {
     try {
       const db_connect = req.db;
       const result = await db_connect
         .collection("Campaigns")
-        .find({ dm: req.params.DM })
+        .find({ dm: req.params.DM }, CAMPAIGN_SUMMARY_PROJECTION)
         .toArray();
       res.json(applyDefaultCombat(result));
     } catch (err) {
       next(err);
     }
-   });
+  });
 
   campaignRouter.route('/dm/:DM/:campaign').get(async (req, res, next) => {
     try {


### PR DESCRIPTION
## Summary
- limit `/campaigns/player` and `/campaigns/dm` queries to campaign metadata by projecting only lightweight fields
- normalize campaign list handling on the client so UI components work with the slimmer payloads

## Testing
- `npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js` *(terminated early after prolonged React act() warnings; no regressions observed before stopping)*

------
https://chatgpt.com/codex/tasks/task_e_68dc64567ee0832e858b7e6b356dce9c