### PR TITLE
Add Cloudinary upload integration for AI-generated maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ The server uses a `config.env` file for configuration. Ensure the following vari
 |----------|-------------|
 | `CLIENT_ORIGINS` | Comma-separated list of client application URLs allowed to make cross-origin requests, e.g., `http://localhost,http://example.com`. |
 | `OPENAI_API_KEY` | API key used by the server to access OpenAI for item generation. |
-| `OPENAI_IMAGE_RESPONSE_FORMAT` | Optional override for the battle map response format. Defaults to `b64_json`, which stores generated maps as base64 strings in the `imageBase64` field. Set to `url` only if you plan to manage persistent image hosting yourself. |
+| `CLOUDINARY_CLOUD_NAME` | Cloudinary cloud name used when uploading generated battle maps. Required for Cloudinary hosting. |
+| `CLOUDINARY_API_KEY` | Cloudinary API key used for authenticating uploads. |
+| `CLOUDINARY_API_SECRET` | Cloudinary API secret used for authenticating uploads. |
+| `CLOUDINARY_MAP_FOLDER` | Optional Cloudinary folder for generated maps. Defaults to `Realm Tracker Maps` when omitted. |
+| `OPENAI_IMAGE_RESPONSE_FORMAT` | Optional override for the battle map response format. Defaults to `b64_json`, which stores generated maps as base64 strings in the `imageBase64` field when Cloudinary upload is unavailable. Set to `url` only if you plan to manage persistent image hosting yourself. |
 
 ### Client Environment Variables
 

--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -109,9 +109,15 @@ jest.mock(
   { virtual: true }
 );
 
+jest.mock('../utils/cloudinary', () => ({
+  uploadMapImage: jest.fn(),
+}));
+
 const OpenAI = require('openai');
 const mockParse = OpenAI.__parse;
 const mockGenerate = OpenAI.__generate;
+
+const { uploadMapImage: mockUploadMapImage } = require('../utils/cloudinary');
 
 const routes = require('../routes');
 const {
@@ -279,6 +285,8 @@ describe('AI map route', () => {
   beforeEach(() => {
     mockParse.mockReset();
     mockGenerate.mockReset();
+    mockUploadMapImage.mockReset();
+    mockUploadMapImage.mockRejectedValue(new Error('Cloudinary disabled'));
     process.env.OPENAI_IMAGE_MODEL = 'gpt-image-1';
     process.env.OPENAI_IMAGE_STYLE = 'vivid';
     delete process.env.OPENAI_IMAGE_STYLE_MODELS;
@@ -331,6 +339,52 @@ describe('AI map route', () => {
         response_format: 'b64_json',
       })
     );
+  });
+
+  test('uploads generated maps to Cloudinary when available', async () => {
+    mockUploadMapImage.mockResolvedValue({
+      secure_url: 'https://res.cloudinary.com/demo/map.png',
+    });
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          b64_json: 'ZGF0YQ==',
+          mime_type: 'image/png',
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/ai/map')
+      .send({ prompt: 'cloud-hosted map' });
+
+    expect(res.status).toBe(200);
+    expect(mockUploadMapImage).toHaveBeenCalledWith(
+      'data:image/png;base64,ZGF0YQ=='
+    );
+    expect(res.body.imageUrl).toBe('https://res.cloudinary.com/demo/map.png');
+    expect(res.body.imageBase64).toBeUndefined();
+    expect(res.body.prompt).toBe('cloud-hosted map');
+  });
+
+  test('falls back to base64 data when Cloudinary upload fails', async () => {
+    mockUploadMapImage.mockRejectedValue(new Error('Upload failed'));
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          b64_json: 'QUJD',
+          mime_type: 'image/png',
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/ai/map')
+      .send({ prompt: 'base64 fallback map' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.imageBase64).toBe('QUJD');
+    expect(res.body.imageUrl).toBeUndefined();
   });
 
   test('derives a title from the user prompt when no revision is provided', async () => {

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "express": "^4.18.2",
     "express-validator": "^6.15.0",
     "jsonwebtoken": "^9.0.2",
+    "cloudinary": "^1.41.1",
     "mongodb": "^4.4.0",
     "winston": "^3.10.0",
     "helmet": "^7.0.0",

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -17,6 +17,7 @@ const {
 const { skillNames } = require('./fieldConstants');
 const createMapSchema = require('../schemas/map');
 const { deriveMapTitle } = require('../utils/mapTitle');
+const { uploadMapImage } = require('../utils/cloudinary');
 
 const resolveOpenAI = () => {
   if (!OpenAI) {
@@ -380,6 +381,28 @@ module.exports = (router) => {
             }
           : {}),
       };
+
+      if (typeof uploadMapImage === 'function' && (image.url || image.b64_json)) {
+        try {
+          const mimeType =
+            (typeof image.mime_type === 'string' && image.mime_type.trim() !== ''
+              ? image.mime_type.trim()
+              : mapPayload.imageType) || 'image/png';
+          const uploadSource = image.url
+            ? image.url
+            : `data:${mimeType};base64,${image.b64_json}`;
+          const uploadResult = await uploadMapImage(uploadSource);
+          if (uploadResult?.secure_url) {
+            mapPayload.imageUrl = uploadResult.secure_url;
+            delete mapPayload.imageBase64;
+            delete mapPayload.imageType;
+          }
+        } catch (uploadError) {
+          logger.warn('Failed to upload map image to Cloudinary', {
+            error: uploadError.message,
+          });
+        }
+      }
 
       if (!mapSchemas) {
         return res.json(mapPayload);

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -1,0 +1,52 @@
+let cloudinary;
+let isConfigured = false;
+
+const resolveCloudinary = () => {
+  if (!cloudinary) {
+    try {
+      ({ v2: cloudinary } = require('cloudinary'));
+    } catch (error) {
+      const missingSdkError = new Error('Cloudinary SDK is not available');
+      missingSdkError.cause = error;
+      throw missingSdkError;
+    }
+  }
+  return cloudinary;
+};
+
+const configure = () => {
+  if (isConfigured) {
+    return;
+  }
+
+  const {
+    CLOUDINARY_CLOUD_NAME: cloud_name,
+    CLOUDINARY_API_KEY: api_key,
+    CLOUDINARY_API_SECRET: api_secret,
+  } = process.env;
+
+  if (!cloud_name || !api_key || !api_secret) {
+    throw new Error('Cloudinary environment variables are not configured');
+  }
+
+  const sdk = resolveCloudinary();
+  sdk.config({ cloud_name, api_key, api_secret });
+  isConfigured = true;
+};
+
+const getMapFolder = () => process.env.CLOUDINARY_MAP_FOLDER || 'Realm Tracker Maps';
+
+const uploadMapImage = async (image, options = {}) => {
+  configure();
+  const sdk = resolveCloudinary();
+  return sdk.uploader.upload(image, {
+    folder: getMapFolder(),
+    resource_type: 'image',
+    ...options,
+  });
+};
+
+module.exports = {
+  uploadMapImage,
+  getMapFolder,
+};


### PR DESCRIPTION
## Summary
- add a Cloudinary helper that configures the v2 SDK once and centralizes the map folder default
- upload AI-generated maps to Cloudinary when possible while retaining the base64 fallback on errors
- document the new Cloudinary environment variables and extend the AI map route tests to cover upload success and failure

## Testing
- npm test --prefix server -- ai.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc7259a2a8832e8e722173ff607354