### PR TITLE
Clean up Cloudinary assets when campaign maps are deleted

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -344,6 +344,7 @@ describe('AI map route', () => {
   test('uploads generated maps to Cloudinary when available', async () => {
     mockUploadMapImage.mockResolvedValue({
       secure_url: 'https://res.cloudinary.com/demo/map.png',
+      public_id: 'maps/demo/map',
     });
     mockGenerate.mockResolvedValue({
       data: [
@@ -365,6 +366,7 @@ describe('AI map route', () => {
     expect(res.body.imageUrl).toBe('https://res.cloudinary.com/demo/map.png');
     expect(res.body.imageBase64).toBeUndefined();
     expect(res.body.prompt).toBe('cloud-hosted map');
+    expect(res.body.cloudinaryPublicId).toBe('maps/demo/map');
   });
 
   test('falls back to base64 data when Cloudinary upload fails', async () => {
@@ -385,6 +387,7 @@ describe('AI map route', () => {
     expect(res.status).toBe(200);
     expect(res.body.imageBase64).toBe('QUJD');
     expect(res.body.imageUrl).toBeUndefined();
+    expect(res.body.cloudinaryPublicId).toBeUndefined();
   });
 
   test('derives a title from the user prompt when no revision is provided', async () => {

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -23,9 +23,13 @@ jest.mock('../utils/dnd5eApi', () => ({
 jest.mock('../utils/monsters', () => ({
   buildEnemyRecord: jest.fn(),
 }));
+jest.mock('../utils/cloudinary', () => ({
+  deleteMapImage: jest.fn(),
+}));
 const { emitCombatUpdate, emitEnemiesUpdate, emitMapUpdate } = require('../utils/socket');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
 const { buildEnemyRecord } = require('../utils/monsters');
+const { deleteMapImage } = require('../utils/cloudinary');
 const registerCampaignRoutes = require('../routes/campaigns');
 
 const app = express();
@@ -53,6 +57,8 @@ describe('Campaign routes', () => {
     dbo.mockReset();
     getMonsterByIndex.mockReset();
     buildEnemyRecord.mockReset();
+    deleteMapImage.mockReset();
+    deleteMapImage.mockResolvedValue({ result: 'ok' });
     mockUser = { username: 'DM' };
   });
 
@@ -166,6 +172,7 @@ describe('Campaign routes', () => {
       summary: 'An underground lair',
       imageUrl: 'https://example.com/dungeon.png',
       altText: 'Dungeon entrance map',
+      cloudinaryPublicId: 'maps/base/dungeon-1111',
     };
 
     const storedMap = {
@@ -470,6 +477,7 @@ describe('Campaign routes', () => {
         ...storedMap,
         mapId: '22222222-2222-4222-8222-222222222222',
         title: 'Forest',
+        cloudinaryPublicId: 'maps/forest/secondary-map',
       };
       const campaignDoc = {
         campaignName: 'Test',
@@ -491,12 +499,18 @@ describe('Campaign routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.activeMapId).toBe(storedMap.mapId);
       expect(res.body.map).toEqual(
-        expect.objectContaining({ mapId: storedMap.mapId, title: storedMap.title })
+        expect.objectContaining({
+          mapId: storedMap.mapId,
+          title: storedMap.title,
+          cloudinaryPublicId: storedMap.cloudinaryPublicId,
+        })
       );
       expect(res.body.map.tokens).toEqual({});
       expect(res.body.activeMapTokens).toEqual({});
       expect(res.body.tokensByMapId).toEqual({});
       expect(res.body.maps).toHaveLength(1);
+      expect(deleteMapImage).toHaveBeenCalledTimes(1);
+      expect(deleteMapImage).toHaveBeenCalledWith('maps/forest/secondary-map');
       expect(emitMapUpdate).toHaveBeenCalledWith(
         'Test',
         expect.objectContaining({
@@ -505,6 +519,68 @@ describe('Campaign routes', () => {
           tokensByMapId: {},
         })
       );
+    });
+
+    test('delete map tolerates Cloudinary deletion failures', async () => {
+      deleteMapImage.mockRejectedValueOnce(new Error('Delete failed'));
+      const secondaryMap = {
+        ...storedMap,
+        mapId: '33333333-3333-4333-8333-333333333333',
+        title: 'Cavern',
+        cloudinaryPublicId: 'maps/cavern/secondary-map',
+      };
+      const campaignDoc = {
+        campaignName: 'Test',
+        dm: 'DM',
+        maps: [storedMap, secondaryMap],
+        activeMapId: secondaryMap.mapId,
+        map: secondaryMap,
+      };
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => campaignDoc,
+          updateOne,
+        }),
+      });
+
+      const res = await request(app).delete(`/campaigns/Test/maps/${secondaryMap.mapId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.activeMapId).toBe(storedMap.mapId);
+      expect(deleteMapImage).toHaveBeenCalledWith('maps/cavern/secondary-map');
+      expect(emitMapUpdate).toHaveBeenCalled();
+    });
+
+    test('delete map derives Cloudinary public id from URL when available', async () => {
+      const secondaryMap = {
+        ...storedMap,
+        mapId: '44444444-4444-4444-8444-444444444444',
+        title: 'Citadel',
+        imageUrl:
+          'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/test-citadel.png',
+      };
+      delete secondaryMap.cloudinaryPublicId;
+      const campaignDoc = {
+        campaignName: 'Test',
+        dm: 'DM',
+        maps: [storedMap, secondaryMap],
+        activeMapId: secondaryMap.mapId,
+        map: secondaryMap,
+      };
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => campaignDoc,
+          updateOne,
+        }),
+      });
+
+      const res = await request(app).delete(`/campaigns/Test/maps/${secondaryMap.mapId}`);
+
+      expect(res.status).toBe(200);
+      expect(deleteMapImage).toHaveBeenCalledWith('maps/test-citadel');
+      expect(emitMapUpdate).toHaveBeenCalled();
     });
 
     test('update map token success as DM', async () => {

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -397,6 +397,14 @@ module.exports = (router) => {
             delete mapPayload.imageBase64;
             delete mapPayload.imageType;
           }
+
+          const publicIdCandidate =
+            typeof uploadResult?.public_id === 'string'
+              ? uploadResult.public_id.trim()
+              : '';
+          if (publicIdCandidate) {
+            mapPayload.cloudinaryPublicId = publicIdCandidate;
+          }
         } catch (uploadError) {
           logger.warn('Failed to upload map image to Cloudinary', {
             error: uploadError.message,

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -14,6 +14,62 @@ const {
   buildCampaignMapPayload,
   normalizeMapTokens,
 } = require('../utils/campaignMaps');
+const { deleteMapImage } = require('../utils/cloudinary');
+
+const deriveCloudinaryPublicIdFromUrl = (url) => {
+  if (typeof url !== 'string' || url.trim() === '') {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url.trim());
+  } catch (error) {
+    return null;
+  }
+
+  if (!parsed.hostname || !parsed.hostname.includes('cloudinary.com')) {
+    return null;
+  }
+
+  const segments = parsed.pathname.split('/').filter(Boolean).map((segment) => {
+    try {
+      return decodeURIComponent(segment);
+    } catch (error) {
+      return segment;
+    }
+  });
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const uploadIndex = segments.findIndex((segment) => segment === 'upload');
+  if (uploadIndex === -1) {
+    return null;
+  }
+
+  let remainder = segments.slice(uploadIndex + 1);
+
+  const versionIndex = remainder.findIndex((segment) => /^v\d+$/.test(segment));
+  if (versionIndex !== -1) {
+    remainder = remainder.slice(versionIndex + 1);
+  }
+
+  while (remainder.length > 0 && /[,=]/.test(remainder[0])) {
+    remainder = remainder.slice(1);
+  }
+
+  if (remainder.length === 0) {
+    return null;
+  }
+
+  const lastIndex = remainder.length - 1;
+  remainder[lastIndex] = remainder[lastIndex].replace(/\.[^.]+$/, '');
+
+  const publicId = remainder.join('/').trim();
+  return publicId || null;
+};
 
 module.exports = (router) => {
   const campaignRouter = express.Router();
@@ -752,6 +808,37 @@ module.exports = (router) => {
           if (!existingMap) {
             return res.status(404).json({ message: 'Map not found' });
           }
+
+          const attemptCloudinaryDeletion = async () => {
+            if (typeof deleteMapImage !== 'function') {
+              return;
+            }
+
+            const explicitId =
+              typeof existingMap.cloudinaryPublicId === 'string'
+                ? existingMap.cloudinaryPublicId.trim()
+                : '';
+            const derivedId =
+              !explicitId && typeof existingMap.imageUrl === 'string'
+                ? deriveCloudinaryPublicIdFromUrl(existingMap.imageUrl)
+                : null;
+            const targetPublicId = explicitId || derivedId;
+
+            if (!targetPublicId) {
+              return;
+            }
+
+            try {
+              await deleteMapImage(targetPublicId);
+            } catch (cloudinaryError) {
+              logger.warn('Failed to delete map image from Cloudinary', {
+                error: cloudinaryError.message,
+                publicId: targetPublicId,
+              });
+            }
+          };
+
+          await attemptCloudinaryDeletion();
 
           const remainingMaps = normalizedCampaign.maps.filter(
             (map) => map.mapId !== mapId

--- a/server/schemas/map.js
+++ b/server/schemas/map.js
@@ -25,6 +25,7 @@ const createMapSchema = (z) => {
       .regex(/^[A-Za-z0-9+/=]+$/, 'imageBase64 must be a base64-encoded string')
       .optional(),
     imageType: z.string().trim().min(1).optional(),
+    cloudinaryPublicId: z.string().trim().min(1).optional(),
     width: z.number().int().positive().optional(),
     height: z.number().int().positive().optional(),
     provider: z.string().trim().min(1).optional(),
@@ -84,6 +85,18 @@ const createMapSchema = (z) => {
           delete map.imageType;
         } else {
           map.imageType = trimmedType;
+        }
+      }
+
+      if (
+        map.cloudinaryPublicId &&
+        typeof map.cloudinaryPublicId === 'string'
+      ) {
+        const trimmedId = map.cloudinaryPublicId.trim();
+        if (trimmedId) {
+          map.cloudinaryPublicId = trimmedId;
+        } else {
+          delete map.cloudinaryPublicId;
         }
       }
 

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -288,6 +288,23 @@ const prepareStoredMap = ({
     storedMap.title = existing.title.trim();
   }
 
+  if (typeof storedMap.cloudinaryPublicId === 'string') {
+    const trimmedId = storedMap.cloudinaryPublicId.trim();
+    if (trimmedId) {
+      storedMap.cloudinaryPublicId = trimmedId;
+    } else {
+      delete storedMap.cloudinaryPublicId;
+    }
+  }
+
+  if (
+    storedMap.cloudinaryPublicId === undefined &&
+    typeof existing.cloudinaryPublicId === 'string' &&
+    existing.cloudinaryPublicId.trim() !== ''
+  ) {
+    storedMap.cloudinaryPublicId = existing.cloudinaryPublicId.trim();
+  }
+
   if (typeof prompt === 'string' && prompt.trim() !== '') {
     storedMap.originalPrompt = prompt.trim();
   } else if (

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -46,7 +46,21 @@ const uploadMapImage = async (image, options = {}) => {
   });
 };
 
+const deleteMapImage = async (publicId, options = {}) => {
+  if (!publicId || typeof publicId !== 'string') {
+    throw new Error('A Cloudinary public ID is required to delete an image');
+  }
+
+  configure();
+  const sdk = resolveCloudinary();
+  return sdk.uploader.destroy(publicId, {
+    resource_type: 'image',
+    ...options,
+  });
+};
+
 module.exports = {
   uploadMapImage,
+  deleteMapImage,
   getMapFolder,
 };


### PR DESCRIPTION
## Summary
- add a Cloudinary deletion helper and propagate uploaded map public IDs through the AI map route and schema
- preserve stored Cloudinary IDs when updating maps and remove linked assets when campaign maps are deleted
- expand campaign and AI tests to cover Cloudinary clean-up flows and tolerant error handling

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68dc76a3b0cc832e943294c60715a95a