### PR TITLE
Defer AI map uploads to campaign endpoints

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -109,15 +109,11 @@ jest.mock(
   { virtual: true }
 );
 
-jest.mock('../utils/cloudinary', () => ({
-  uploadMapImage: jest.fn(),
-}));
+jest.mock('../utils/cloudinary', () => ({}));
 
 const OpenAI = require('openai');
 const mockParse = OpenAI.__parse;
 const mockGenerate = OpenAI.__generate;
-
-const { uploadMapImage: mockUploadMapImage } = require('../utils/cloudinary');
 
 const routes = require('../routes');
 const {
@@ -285,8 +281,6 @@ describe('AI map route', () => {
   beforeEach(() => {
     mockParse.mockReset();
     mockGenerate.mockReset();
-    mockUploadMapImage.mockReset();
-    mockUploadMapImage.mockRejectedValue(new Error('Cloudinary disabled'));
     process.env.OPENAI_IMAGE_MODEL = 'gpt-image-1';
     process.env.OPENAI_IMAGE_STYLE = 'vivid';
     delete process.env.OPENAI_IMAGE_STYLE_MODELS;
@@ -339,55 +333,6 @@ describe('AI map route', () => {
         response_format: 'b64_json',
       })
     );
-  });
-
-  test('uploads generated maps to Cloudinary when available', async () => {
-    mockUploadMapImage.mockResolvedValue({
-      secure_url: 'https://res.cloudinary.com/demo/map.png',
-      public_id: 'maps/demo/map',
-    });
-    mockGenerate.mockResolvedValue({
-      data: [
-        {
-          b64_json: 'ZGF0YQ==',
-          mime_type: 'image/png',
-        },
-      ],
-    });
-
-    const res = await request(app)
-      .post('/ai/map')
-      .send({ prompt: 'cloud-hosted map' });
-
-    expect(res.status).toBe(200);
-    expect(mockUploadMapImage).toHaveBeenCalledWith(
-      'data:image/png;base64,ZGF0YQ=='
-    );
-    expect(res.body.imageUrl).toBe('https://res.cloudinary.com/demo/map.png');
-    expect(res.body.imageBase64).toBeUndefined();
-    expect(res.body.prompt).toBe('cloud-hosted map');
-    expect(res.body.cloudinaryPublicId).toBe('maps/demo/map');
-  });
-
-  test('falls back to base64 data when Cloudinary upload fails', async () => {
-    mockUploadMapImage.mockRejectedValue(new Error('Upload failed'));
-    mockGenerate.mockResolvedValue({
-      data: [
-        {
-          b64_json: 'QUJD',
-          mime_type: 'image/png',
-        },
-      ],
-    });
-
-    const res = await request(app)
-      .post('/ai/map')
-      .send({ prompt: 'base64 fallback map' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.imageBase64).toBe('QUJD');
-    expect(res.body.imageUrl).toBeUndefined();
-    expect(res.body.cloudinaryPublicId).toBeUndefined();
   });
 
   test('derives a title from the user prompt when no revision is provided', async () => {

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -24,12 +24,13 @@ jest.mock('../utils/monsters', () => ({
   buildEnemyRecord: jest.fn(),
 }));
 jest.mock('../utils/cloudinary', () => ({
+  uploadMapImage: jest.fn(),
   deleteMapImage: jest.fn(),
 }));
 const { emitCombatUpdate, emitEnemiesUpdate, emitMapUpdate } = require('../utils/socket');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
 const { buildEnemyRecord } = require('../utils/monsters');
-const { deleteMapImage } = require('../utils/cloudinary');
+const { uploadMapImage, deleteMapImage } = require('../utils/cloudinary');
 const registerCampaignRoutes = require('../routes/campaigns');
 
 const app = express();
@@ -57,7 +58,13 @@ describe('Campaign routes', () => {
     dbo.mockReset();
     getMonsterByIndex.mockReset();
     buildEnemyRecord.mockReset();
+    uploadMapImage.mockReset();
     deleteMapImage.mockReset();
+    uploadMapImage.mockResolvedValue({
+      secure_url:
+        'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/default.png',
+      public_id: 'maps/default/map',
+    });
     deleteMapImage.mockResolvedValue({ result: 'ok' });
     mockUser = { username: 'DM' };
   });
@@ -170,7 +177,8 @@ describe('Campaign routes', () => {
     const baseMap = {
       title: 'Dungeon',
       summary: 'An underground lair',
-      imageUrl: 'https://example.com/dungeon.png',
+      imageUrl:
+        'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/base/dungeon.png',
       altText: 'Dungeon entrance map',
       cloudinaryPublicId: 'maps/base/dungeon-1111',
     };
@@ -278,52 +286,69 @@ describe('Campaign routes', () => {
         }),
       });
 
+      uploadMapImage.mockResolvedValueOnce({
+        secure_url:
+          'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/new-map.png',
+        public_id: 'maps/demo/new-map',
+      });
+
+      const incomingMap = {
+        title: 'Dungeon',
+        summary: 'An underground lair',
+        imageBase64: 'QUJD',
+        imageType: 'image/png',
+      };
+
       const res = await request(app)
         .post('/campaigns/Test/maps')
-        .send({ map: baseMap, prompt: 'Create a dungeon map' });
+        .send({ map: incomingMap, prompt: 'Create a dungeon map' });
 
-    expect(res.status).toBe(200);
-    expect(res.body.activeMapId).toEqual(expect.any(String));
-    expect(res.body.map).toEqual(
-      expect.objectContaining({
-        title: baseMap.title,
-        originalPrompt: 'Create a dungeon map',
-        mapId: res.body.activeMapId,
-      })
-    );
-    expect(res.body.map.tokens).toEqual({});
-    expect(res.body.activeMapTokens).toEqual({});
-    expect(res.body.tokensByMapId).toEqual({});
-    expect(res.body.maps).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
-      ])
-    );
-    const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
-    expect(lastUpdate).toEqual(
-      expect.objectContaining({
-        $set: expect.objectContaining({
+      expect(res.status).toBe(200);
+      expect(res.body.activeMapId).toEqual(expect.any(String));
+      expect(res.body.map).toEqual(
+        expect.objectContaining({
+          title: baseMap.title,
+          originalPrompt: 'Create a dungeon map',
+          mapId: res.body.activeMapId,
+          imageUrl:
+            'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/new-map.png',
+          cloudinaryPublicId: 'maps/demo/new-map',
+        })
+      );
+      expect(res.body.map.tokens).toEqual({});
+      expect(res.body.activeMapTokens).toEqual({});
+      expect(res.body.tokensByMapId).toEqual({});
+      expect(res.body.maps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+        ])
+      );
+      expect(uploadMapImage).toHaveBeenCalledWith('data:image/png;base64,QUJD');
+      const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
+      expect(lastUpdate).toEqual(
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            activeMapId: res.body.activeMapId,
+            map: expect.objectContaining({ mapId: res.body.activeMapId }),
+            maps: expect.arrayContaining([
+              expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+            ]),
+            mapTokens: {},
+          }),
+        })
+      );
+      expect(emitMapUpdate).toHaveBeenCalledWith(
+        'Test',
+        expect.objectContaining({
           activeMapId: res.body.activeMapId,
           map: expect.objectContaining({ mapId: res.body.activeMapId }),
           maps: expect.arrayContaining([
             expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
           ]),
-          mapTokens: {},
-        }),
-      })
-    );
-    expect(emitMapUpdate).toHaveBeenCalledWith(
-      'Test',
-      expect.objectContaining({
-        activeMapId: res.body.activeMapId,
-        map: expect.objectContaining({ mapId: res.body.activeMapId }),
-        maps: expect.arrayContaining([
-          expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
-        ]),
-        tokensByMapId: {},
-        activeMapTokens: {},
-      })
-    );
+          tokensByMapId: {},
+          activeMapTokens: {},
+        })
+      );
   });
 
     test('legacy map update success', async () => {
@@ -468,6 +493,56 @@ describe('Campaign routes', () => {
           activeMapId: secondaryMap.mapId,
           activeMapTokens: {},
           tokensByMapId: {},
+        })
+      );
+    });
+
+    test('update map uploads new assets when provided', async () => {
+      const campaignDoc = buildCampaignWithMap();
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: () => ({
+          findOne: async () => campaignDoc,
+          updateOne,
+        }),
+      });
+
+      uploadMapImage.mockResolvedValueOnce({
+        secure_url:
+          'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/updated-map.png',
+        public_id: 'maps/demo/updated-map',
+      });
+
+      const res = await request(app)
+        .patch(`/campaigns/Test/maps/${storedMap.mapId}`)
+        .send({
+          map: {
+            title: 'Updated Dungeon',
+            imageBase64: 'Rk9P',
+            imageType: 'image/jpeg',
+          },
+          prompt: 'Updated map prompt',
+        });
+
+      expect(res.status).toBe(200);
+      expect(uploadMapImage).toHaveBeenCalledWith('data:image/jpeg;base64,Rk9P');
+      expect(res.body.maps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            mapId: storedMap.mapId,
+            title: 'Updated Dungeon',
+            imageUrl:
+              'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/updated-map.png',
+            cloudinaryPublicId: 'maps/demo/updated-map',
+          }),
+        ])
+      );
+      expect(res.body.map).toEqual(
+        expect.objectContaining({
+          mapId: storedMap.mapId,
+          title: 'Updated Dungeon',
+          originalPrompt: 'Updated map prompt',
+          cloudinaryPublicId: 'maps/demo/updated-map',
         })
       );
     });

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -17,7 +17,6 @@ const {
 const { skillNames } = require('./fieldConstants');
 const createMapSchema = require('../schemas/map');
 const { deriveMapTitle } = require('../utils/mapTitle');
-const { uploadMapImage } = require('../utils/cloudinary');
 
 const resolveOpenAI = () => {
   if (!OpenAI) {
@@ -381,36 +380,6 @@ module.exports = (router) => {
             }
           : {}),
       };
-
-      if (typeof uploadMapImage === 'function' && (image.url || image.b64_json)) {
-        try {
-          const mimeType =
-            (typeof image.mime_type === 'string' && image.mime_type.trim() !== ''
-              ? image.mime_type.trim()
-              : mapPayload.imageType) || 'image/png';
-          const uploadSource = image.url
-            ? image.url
-            : `data:${mimeType};base64,${image.b64_json}`;
-          const uploadResult = await uploadMapImage(uploadSource);
-          if (uploadResult?.secure_url) {
-            mapPayload.imageUrl = uploadResult.secure_url;
-            delete mapPayload.imageBase64;
-            delete mapPayload.imageType;
-          }
-
-          const publicIdCandidate =
-            typeof uploadResult?.public_id === 'string'
-              ? uploadResult.public_id.trim()
-              : '';
-          if (publicIdCandidate) {
-            mapPayload.cloudinaryPublicId = publicIdCandidate;
-          }
-        } catch (uploadError) {
-          logger.warn('Failed to upload map image to Cloudinary', {
-            error: uploadError.message,
-          });
-        }
-      }
 
       if (!mapSchemas) {
         return res.json(mapPayload);

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -14,7 +14,7 @@ const {
   buildCampaignMapPayload,
   normalizeMapTokens,
 } = require('../utils/campaignMaps');
-const { deleteMapImage } = require('../utils/cloudinary');
+const { uploadMapImage, deleteMapImage } = require('../utils/cloudinary');
 
 const deriveCloudinaryPublicIdFromUrl = (url) => {
   if (typeof url !== 'string' || url.trim() === '') {
@@ -69,6 +69,115 @@ const deriveCloudinaryPublicIdFromUrl = (url) => {
 
   const publicId = remainder.join('/').trim();
   return publicId || null;
+};
+
+const isCloudinaryUrl = (url) => {
+  const publicId = deriveCloudinaryPublicIdFromUrl(url);
+  return typeof publicId === 'string' && publicId.trim() !== '';
+};
+
+const prepareMapAssetsForStorage = async (mapInput) => {
+  if (!mapInput || typeof mapInput !== 'object') {
+    return mapInput;
+  }
+
+  const prepared = { ...mapInput };
+
+  const rawBase64 =
+    typeof prepared.imageBase64 === 'string' ? prepared.imageBase64.trim() : '';
+  const rawType =
+    typeof prepared.imageType === 'string' ? prepared.imageType.trim() : '';
+  const rawUrl =
+    typeof prepared.imageUrl === 'string' ? prepared.imageUrl.trim() : '';
+
+  const hasCloudinaryUrl = rawUrl ? isCloudinaryUrl(rawUrl) : false;
+  if (hasCloudinaryUrl && !prepared.cloudinaryPublicId) {
+    const derivedId = deriveCloudinaryPublicIdFromUrl(rawUrl);
+    if (derivedId) {
+      prepared.cloudinaryPublicId = derivedId;
+    }
+  }
+
+  if (typeof uploadMapImage !== 'function') {
+    if (rawUrl) {
+      prepared.imageUrl = rawUrl;
+    }
+    if (rawBase64) {
+      prepared.imageBase64 = rawBase64;
+    }
+    if (rawType) {
+      prepared.imageType = rawType;
+    }
+    return prepared;
+  }
+
+  const shouldUploadFromBase64 = rawBase64 !== '';
+  const shouldUploadFromUrl =
+    !shouldUploadFromBase64 && rawUrl && (!hasCloudinaryUrl || rawUrl.startsWith('data:'));
+
+  if (!shouldUploadFromBase64 && !shouldUploadFromUrl) {
+    if (rawUrl) {
+      prepared.imageUrl = rawUrl;
+    }
+    if (rawBase64) {
+      prepared.imageBase64 = rawBase64;
+    }
+    if (rawType) {
+      prepared.imageType = rawType;
+    }
+    return prepared;
+  }
+
+  let uploadSource = rawUrl;
+  if (shouldUploadFromBase64) {
+    const mimeType = rawType || 'image/png';
+    uploadSource = `data:${mimeType};base64,${rawBase64}`;
+  }
+
+  try {
+    const uploadResult = await uploadMapImage(uploadSource);
+    const secureUrl =
+      typeof uploadResult?.secure_url === 'string' ? uploadResult.secure_url : null;
+    const publicId =
+      typeof uploadResult?.public_id === 'string'
+        ? uploadResult.public_id.trim()
+        : '';
+
+    if (secureUrl) {
+      prepared.imageUrl = secureUrl;
+      delete prepared.imageBase64;
+      delete prepared.imageType;
+    } else {
+      if (rawUrl) {
+        prepared.imageUrl = rawUrl;
+      }
+      if (rawBase64) {
+        prepared.imageBase64 = rawBase64;
+      }
+      if (rawType) {
+        prepared.imageType = rawType;
+      }
+    }
+
+    if (publicId) {
+      prepared.cloudinaryPublicId = publicId;
+    }
+  } catch (error) {
+    logger.warn('Failed to upload map image to Cloudinary', {
+      error: error.message,
+    });
+    if (rawUrl) {
+      prepared.imageUrl = rawUrl;
+    }
+    if (rawBase64) {
+      prepared.imageBase64 = rawBase64;
+    }
+    if (rawType) {
+      prepared.imageType = rawType;
+    }
+  }
+
+  return prepared;
 };
 
 module.exports = (router) => {
@@ -591,8 +700,10 @@ module.exports = (router) => {
             collection,
           });
 
+          const mapInput = await prepareMapAssetsForStorage(req.body.map);
+
           const prepared = prepareStoredMap({
-            mapInput: req.body.map,
+            mapInput,
             existingMap: null,
             prompt:
               typeof req.body.prompt === 'string' && req.body.prompt.trim() !== ''
@@ -722,8 +833,10 @@ module.exports = (router) => {
           let storedMap = targetMap;
 
           if (hasMapUpdate) {
+            const mapInput = await prepareMapAssetsForStorage(req.body.map);
+
             const prepared = prepareStoredMap({
-              mapInput: req.body.map,
+              mapInput,
               existingMap: targetMap,
               prompt:
                 typeof req.body.prompt === 'string' && req.body.prompt.trim() !== ''


### PR DESCRIPTION
## Summary
- stop uploading AI-generated map images during response handling and return the provider payload directly
- upload raw campaign map images during creation and update by deriving Cloudinary URLs/public IDs before persistence
- adjust AI and campaign route tests to reflect the deferred upload behavior and cover the new helper logic

## Testing
- npm --prefix server test -- ai.test.js campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc7a840794832eb3de004a4def1632