### PR TITLE
Parse healing spell dice for rollers

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -236,6 +236,51 @@ describe('PlayerTurnActions weapon damage display', () => {
     expect(necrotic.textContent).toBe('2d8 Necrotic');
   });
 
+  test('healing spells roll for numeric totals', async () => {
+    const spell = {
+      name: 'Healing Word',
+      level: 1,
+      damage: '1d4',
+      castingTime: '1 bonus action',
+      range: '60 feet',
+      duration: 'Instantaneous',
+      casterType: 'Cleric',
+    };
+    const originalRandom = Math.random;
+    Math.random = () => 0;
+    try {
+      render(
+        <PlayerTurnActions
+          form={{ diceColor: '#000000', weapon: [], spells: [spell] }}
+          strMod={0}
+          dexMod={0}
+        />
+      );
+      act(() => {
+        fireEvent.click(screen.getByTitle('Attack'));
+      });
+      const card = screen.getByText('Healing Word').closest('.attack-card');
+      expect(card).not.toBeNull();
+      const rollButton = within(card).getByLabelText('roll');
+      await act(async () => {
+        fireEvent.click(rollButton);
+      });
+      await waitFor(() => {
+        const valueNode = document.getElementById('damageValue');
+        if (!valueNode) throw new Error('missing damage value');
+        const text = valueNode.textContent;
+        if (!text || text === '0' || !/^\d+$/.test(text)) {
+          throw new Error('waiting');
+        }
+      });
+      const result = document.getElementById('damageValue').textContent;
+      expect(result).toMatch(/^\d+$/);
+      expect(result).not.toBe('0');
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
   test('shows breath attack details for dragonborn ancestry', () => {
     const ancestry = {
       label: 'Gold (Fire)',

--- a/server/__tests__/spells.test.js
+++ b/server/__tests__/spells.test.js
@@ -56,6 +56,13 @@ describe('Spells routes', () => {
     expect(res.body.damage).toBe('8d6');
   });
 
+  test('healing spells include parsed damage field', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app).get('/spells/healing-word');
+    expect(res.status).toBe(200);
+    expect(res.body.damage).toBe('1d4');
+  });
+
   test('upcastable spells include higherLevels field', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app).get('/spells/burning-hands');

--- a/server/routes/spells.js
+++ b/server/routes/spells.js
@@ -2,10 +2,26 @@ const express = require('express');
 
 const SPELLS_MODULE_PATH = require.resolve('../data/spells');
 
-// Extract a basic damage dice string (e.g., "8d6" or "1d8+2") from spell descriptions
-function extractDamage(description = '') {
-  const match = description.match(/(\d+d\d+(?:\s*[+\-]\s*\d+)?)[^\n]*damage/i);
-  return match ? match[1].replace(/\s+/g, '') : undefined;
+// Extract a basic damage/healing dice string (e.g., "8d6" or "1d8+2") from spell descriptions
+function extractDiceExpression(description = '') {
+  const dicePattern = /\d+d\d+(?:\s*[+\-]\s*\d+)?/gi;
+  let match;
+  while ((match = dicePattern.exec(description))) {
+    const raw = match[0];
+    const sanitized = raw.replace(/\s+/g, '');
+    const start = Math.max(0, match.index - 80);
+    const end = Math.min(description.length, match.index + raw.length + 80);
+    const contextWindow = description.slice(start, end).toLowerCase();
+
+    if (contextWindow.includes('damage')) {
+      return sanitized;
+    }
+
+    if (/(regains|heals|gains)[\s\S]{0,100}hit points/.test(contextWindow)) {
+      return sanitized;
+    }
+  }
+  return undefined;
 }
 
 // Extract "At Higher Levels" text if present
@@ -28,7 +44,7 @@ function extractScaling(description = '') {
 function augmentSpell(spell = {}) {
   const enhanced = { ...spell };
   if (!enhanced.damage) {
-    const dmg = extractDamage(enhanced.description);
+    const dmg = extractDiceExpression(enhanced.description);
     if (dmg) enhanced.damage = dmg;
   }
   if (!enhanced.higherLevels) {


### PR DESCRIPTION
## Summary
- extend spell dice extraction to recognize healing phrases alongside damage descriptions
- ensure healing-word exposes its dice expression through the API
- add a player turn action regression test that verifies healing spells roll numeric results

## Testing
- npm --prefix server test
- CI=true npm --prefix client test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd38ad2590832e8eb6f0db3046a0c3