### PR TITLE
feat: share d20 roller component

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -5,6 +5,7 @@ import React, {
   useMemo,
 } from 'react';
 import { Button, Modal, Card, OverlayTrigger, Popover } from "react-bootstrap";
+import D20RollerModal from '../common/D20RollerModal';
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -532,13 +533,6 @@ const sortedSpells = useMemo(() => {
 }, [form.spells]);
 
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
-const opacity = 0.85;
-// Calculate RGBA color with opacity
-const rgbaColor = `rgba(${parseInt(form.diceColor.slice(1, 3), 16)}, ${parseInt(form.diceColor.slice(3, 5), 16)}, ${parseInt(form.diceColor.slice(5, 7), 16)}, ${opacity})`;
-
-// Apply the calculated RGBA color to the element
-document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
-
 const [loading, setLoading] = useState(false);
 const [damageValue, setDamageValue] = useState(0);
 const [damageLog, setDamageLog] = useState([]);
@@ -597,74 +591,6 @@ useEffect(() => {
     return () => clearTimeout(timer);
   }
 }, [loading]);
-//-------------------------------------------D20 Dice Roller--------------------------------------------------------------------------
-const [sides] = useState(20);
-const [initialSide] = useState(1);
-const [timeoutId, setTimeoutId] = useState(null);
-const [animationDuration] = useState('3000ms');
-const [activeFace, setActiveFace] = useState(null);
-const [rolling, setRolling] = useState(false);
-const face = Math.floor(Math.random() * sides) + initialSide;
-
-const randomFace = () => {
-  return face === activeFace ? randomFace() : face;
-};
-
-const rollTo = (face) => {
-  clearTimeout(timeoutId);
-  setActiveFace(face);
-  setRolling(false);
-
-  if (face === 20 || face === 1) {
-    showSparklesEffect({ x: 100 / 2, y: 100 / 2 });
-    setTimeout(() => {
-      showSparklesEffect();
-    }, 5000);
-  }
-};
-
-const handleRandomizeClick = (e) => {
-  e.preventDefault(); // Prevent page refresh
-  setRolling(true);
-  clearTimeout(timeoutId);
-
-  const newTimeoutId = setTimeout(() => {
-    setRolling(false);
-    rollTo(randomFace());
-  }, parseInt(animationDuration, 10));
-
-  setTimeoutId(newTimeoutId);
-};
-
-useEffect(() => {
-  // Cleanup effect
-  return () => clearTimeout(timeoutId);
-}, [timeoutId]);
-
-const faceElements = [];
-for (let i = 1; i <= 20; i++) {
-  faceElements.push(
-    <figure className={`face face-${i}`} key={i}></figure>
-  );
-}
-const [showSparkles, setShowSparkles] = useState(false);
-const [showSparkles1, setShowSparkles1] = useState(false);
-
-// Create a function to display sparkles
-const showSparklesEffect = () => {
-  if (face === 20) {
-    setShowSparkles(true);
-    setTimeout(() => {
-      setShowSparkles(false);
-    }, 2000);
-  } else if (face === 1) {
-    setShowSparkles1(true);
-    setTimeout(() => {
-      setShowSparkles1(false);
-    }, 2000);
-  }
-};
-//-------------------------------------------------------------Display-----------------------------------------------------------------------------------------
   const passDisabled = !canPassTurn || isPassTurnInProgress;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
@@ -830,23 +756,7 @@ const showSparklesEffect = () => {
             onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
             title="Attack"
           />
-          <div className="attack-roll-controls__die">
-            <div className="content">
-              {showSparkles && (
-                <div className="sparkle"></div>
-              )}
-              {showSparkles1 && (
-                <div className="sparkle1"></div>
-              )}
-              <div
-                onClick={handleRandomizeClick}
-                className={`die ${rolling ? 'rolling' : ''}`}
-                data-face={activeFace}
-              >
-                {faceElements}
-              </div>
-            </div>
-          </div>
+          <D20RollerModal renderInline diceColor={form?.diceColor} />
         </div>
       </div>
 {/* Attack Modal */}

--- a/client/src/components/Zombies/common/D20RollerModal.js
+++ b/client/src/components/Zombies/common/D20RollerModal.js
@@ -1,0 +1,170 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Modal } from 'react-bootstrap';
+
+const DEFAULT_DICE_COLOR = '#3366ff';
+const SPARKLE_DURATION_MS = 2000;
+const SPARKLE_REPEAT_DELAY_MS = 5000;
+const DICE_SIDES = 20;
+const INITIAL_SIDE = 1;
+const ANIMATION_DURATION_MS = 3000;
+const DICE_OPACITY = 0.85;
+
+const normalizeDiceColor = (value) => {
+  if (typeof value !== 'string') {
+    return DEFAULT_DICE_COLOR;
+  }
+
+  const trimmed = value.trim();
+  return /^#([0-9a-fA-F]{6})$/.test(trimmed) ? `#${trimmed.slice(1).toLowerCase()}` : DEFAULT_DICE_COLOR;
+};
+
+const toRgba = (hexColor, opacity) => {
+  const hex = hexColor.replace('#', '');
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};
+
+const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInline = false }) => {
+  const normalizedColor = useMemo(() => normalizeDiceColor(diceColor), [diceColor]);
+  const [activeFace, setActiveFace] = useState(INITIAL_SIDE);
+  const [rolling, setRolling] = useState(false);
+  const [showCriticalSparkles, setShowCriticalSparkles] = useState(false);
+  const [showFumbleSparkles, setShowFumbleSparkles] = useState(false);
+
+  const rollTimeoutRef = useRef(null);
+  const sparkleTimeoutRef = useRef(null);
+  const sparkleRepeatTimeoutRef = useRef(null);
+  const previousColorRef = useRef(null);
+
+  const shouldApplyColor = renderInline || show;
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || !shouldApplyColor) {
+      return undefined;
+    }
+
+    const root = document.documentElement;
+    previousColorRef.current = root.style.getPropertyValue('--dice-face-color');
+    root.style.setProperty('--dice-face-color', toRgba(normalizedColor, DICE_OPACITY));
+
+    return () => {
+      if (previousColorRef.current) {
+        root.style.setProperty('--dice-face-color', previousColorRef.current);
+      } else {
+        root.style.removeProperty('--dice-face-color');
+      }
+    };
+  }, [normalizedColor, shouldApplyColor]);
+
+  useEffect(() => () => {
+    clearTimeout(rollTimeoutRef.current);
+    clearTimeout(sparkleTimeoutRef.current);
+    clearTimeout(sparkleRepeatTimeoutRef.current);
+  }, []);
+
+  const getRandomFace = () => Math.floor(Math.random() * DICE_SIDES) + INITIAL_SIDE;
+
+  const triggerSparkles = (face, isRepeat = false) => {
+    clearTimeout(sparkleTimeoutRef.current);
+
+    if (face === 20) {
+      setShowCriticalSparkles(true);
+      sparkleTimeoutRef.current = setTimeout(
+        () => setShowCriticalSparkles(false),
+        SPARKLE_DURATION_MS
+      );
+    } else if (face === 1) {
+      setShowFumbleSparkles(true);
+      sparkleTimeoutRef.current = setTimeout(
+        () => setShowFumbleSparkles(false),
+        SPARKLE_DURATION_MS
+      );
+    }
+
+    clearTimeout(sparkleRepeatTimeoutRef.current);
+    if (!isRepeat && (face === 20 || face === 1)) {
+      sparkleRepeatTimeoutRef.current = setTimeout(
+        () => triggerSparkles(face, true),
+        SPARKLE_REPEAT_DELAY_MS
+      );
+    }
+  };
+
+  const rollTo = (face) => {
+    clearTimeout(rollTimeoutRef.current);
+    setActiveFace(face);
+    setRolling(false);
+
+    if (face === 20 || face === 1) {
+      triggerSparkles(face);
+    } else {
+      clearTimeout(sparkleTimeoutRef.current);
+      clearTimeout(sparkleRepeatTimeoutRef.current);
+      setShowCriticalSparkles(false);
+      setShowFumbleSparkles(false);
+    }
+  };
+
+  const handleRandomizeClick = (event) => {
+    event.preventDefault();
+    setRolling(true);
+    clearTimeout(rollTimeoutRef.current);
+
+    rollTimeoutRef.current = setTimeout(() => {
+      setRolling(false);
+      let nextFace = getRandomFace();
+      while (nextFace === activeFace) {
+        nextFace = getRandomFace();
+      }
+      rollTo(nextFace);
+    }, ANIMATION_DURATION_MS);
+  };
+
+  const faceElements = useMemo(() => {
+    const faces = [];
+    for (let i = 1; i <= DICE_SIDES; i += 1) {
+      faces.push(<figure className={`face face-${i}`} key={i}></figure>);
+    }
+    return faces;
+  }, []);
+
+  const dieContent = (
+    <div className="attack-roll-controls__die">
+      <div className="content">
+        {showCriticalSparkles && <div className="sparkle"></div>}
+        {showFumbleSparkles && <div className="sparkle1"></div>}
+        <div
+          role="button"
+          aria-label="Roll a d20"
+          onClick={handleRandomizeClick}
+          className={`die ${rolling ? 'rolling' : ''}`}
+          data-face={activeFace}
+        >
+          {faceElements}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (renderInline) {
+    return dieContent;
+  }
+
+  return (
+    <Modal centered show={show} onHide={onHide} aria-label="Roll D20 Modal">
+      <Modal.Header closeButton>
+        <Modal.Title>Roll D20</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="attack-roll-controls">
+          {dieContent}
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default D20RollerModal;
+export { DEFAULT_DICE_COLOR };

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -29,6 +29,7 @@ import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import { calculateDamage } from '../attributes/PlayerTurnActions';
+import D20RollerModal, { DEFAULT_DICE_COLOR } from '../common/D20RollerModal';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import {
   GiCharacter,
@@ -395,6 +396,7 @@ export default function ZombiesDM() {
       enemyId: null,
       enemyName: null,
     });
+    const [showDiceRoller, setShowDiceRoller] = useState(false);
     const socketRef = useRef(null);
     const mapTokensRef = useRef(mapTokens);
     const activeMapTokensRef = useRef(activeMapTokens);
@@ -2195,6 +2197,35 @@ export default function ZombiesDM() {
 
       return { ...combatState.participants[activeTurn], index: activeTurn };
     }, [combatState]);
+
+    const activeDiceColor = useMemo(() => {
+      const normalizeColor = (value) => {
+        if (typeof value !== 'string') {
+          return null;
+        }
+        const trimmed = value.trim();
+        return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed : null;
+      };
+
+      if (activeParticipant) {
+        const character = characterLookup.get(activeParticipant.characterId);
+        const color = normalizeColor(character?.diceColor);
+        if (color) {
+          return color;
+        }
+      }
+
+      if (Array.isArray(records)) {
+        for (const record of records) {
+          const color = normalizeColor(record?.diceColor);
+          if (color) {
+            return color;
+          }
+        }
+      }
+
+      return DEFAULT_DICE_COLOR;
+    }, [activeParticipant, characterLookup, records]);
 
     const activeTurnDisplayName = useMemo(() => {
       if (!activeParticipant) {
@@ -5094,23 +5125,33 @@ const resolveIcon = (category, iconMap, fallback) => {
                       </Form.Group>
                     </Col>
                     <Col md={6} className="d-flex justify-content-center justify-content-md-end">
-                      <Button
-                        type="submit"
-                        variant="outline-light"
-                        className="rounded-pill mt-3 mt-md-0"
-                        disabled={!selectedMonsterIndex || addingEnemy}
-                      >
-                        {addingEnemy && (
-                          <Spinner
-                            animation="border"
-                            size="sm"
-                            role="status"
-                            aria-hidden="true"
-                            className="me-2"
-                          />
-                        )}
-                        Add Enemy
-                      </Button>
+                      <div className="d-flex flex-column flex-md-row gap-2 mt-3 mt-md-0">
+                        <Button
+                          type="submit"
+                          variant="outline-light"
+                          className="rounded-pill"
+                          disabled={!selectedMonsterIndex || addingEnemy}
+                        >
+                          {addingEnemy && (
+                            <Spinner
+                              animation="border"
+                              size="sm"
+                              role="status"
+                              aria-hidden="true"
+                              className="me-2"
+                            />
+                          )}
+                          Add Enemy
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline-light"
+                          className="rounded-pill"
+                          onClick={() => setShowDiceRoller(true)}
+                        >
+                          Roll
+                        </Button>
+                      </div>
                     </Col>
                   </Row>
                 </Form>
@@ -6493,6 +6534,11 @@ const resolveIcon = (category, iconMap, fallback) => {
     </Tab.Pane>
   </Tab.Content>
         </Tab.Container>
+        <D20RollerModal
+          show={showDiceRoller}
+          onHide={() => setShowDiceRoller(false)}
+          diceColor={activeDiceColor}
+        />
       </Container>
 
       <Modal

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1257,4 +1257,63 @@ describe('ZombiesDM AI generation', () => {
       );
     });
   });
+  test('opens the d20 roller modal when clicking the Roll button in enemies form', async () => {
+    const characters = [
+      { _id: 'hero-1', characterName: 'Hero One', diceColor: '#3366ff' },
+    ];
+
+    apiFetch.mockImplementation((url) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => characters });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              participants: [{ characterId: 'hero-1', initiative: 15 }],
+              activeTurn: 0,
+            }),
+          });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/maps':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              maps: [],
+              activeMapId: null,
+              map: null,
+              tokensByMapId: {},
+              activeMapTokens: {},
+            }),
+          });
+        case '/monsters':
+          return Promise.resolve({
+            ok: true,
+            json: async () => [{ index: 'goblin', name: 'Goblin' }],
+          });
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    render(<ZombiesDM />);
+
+    const enemiesTab = await screen.findByRole('tab', { name: 'Enemies' });
+    await userEvent.click(enemiesTab);
+
+    const rollButton = await screen.findByRole('button', { name: /^Roll$/i });
+    await userEvent.click(rollButton);
+
+    const modal = await screen.findByRole('dialog', { name: /Roll D20/i });
+    expect(
+      within(modal).getByRole('button', { name: /roll a d20/i })
+    ).toBeInTheDocument();
+  });
+
+
 });


### PR DESCRIPTION
## Summary
- factor the reusable d20 roller into `D20RollerModal` with shared dice color handling
- replace the player sheet’s inline die with the shared component
- surface the d20 modal on the DM screen with a Roll button and add coverage for the flow

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js *(fails: suite already emits numerous unwrapped act warnings in upstream tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dd80ed6428832e8f414dc2cedc91d2