### PR TITLE
Fix Skills modal hooks initialization order

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -194,6 +194,26 @@ export default function Skills({
   const selectableSkills = new Set(safeForm.allowedSkills || []);
   const selectableExpertise = new Set(safeForm.allowedExpertise || []);
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--skills');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked && typeof onDockClose === 'function') {
+      onDockClose();
+    }
+    handleCloseSkill?.();
+  }, [isDocked, onDockClose, handleCloseSkill]);
+
   if (!form) {
     return <div>Loading...</div>;
   }
@@ -291,26 +311,6 @@ export default function Skills({
   const handleCloseSkillInfo = () => {
     setShowSkillInfo(false);
   };
-
-  const dialogClassName = useMemo(() => {
-    if (!isDocked) {
-      return undefined;
-    }
-
-    const classes = ['docked-modal'];
-    if (dockedSide) {
-      classes.push(`docked-modal--${dockedSide}`);
-    }
-    classes.push('docked-modal--skills');
-    return classes.join(' ');
-  }, [isDocked, dockedSide]);
-
-  const handleModalHide = useCallback(() => {
-    if (isDocked && typeof onDockClose === 'function') {
-      onDockClose();
-    }
-    handleCloseSkill?.();
-  }, [isDocked, onDockClose, handleCloseSkill]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- move the Skills modal dialogClassName memo and handleModalHide callback so they run on every render

## Testing
- npx eslint src/components/Zombies/attributes/Skills.js
- CI=true npm test -- Skills.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd942a8dc8832e8e3029e72c41ad16