### PR TITLE
Adjust Zombies docked modals layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -237,10 +237,17 @@
 
 .docked-modal.modal-dialog {
   position: fixed;
-  inset: 0 auto 0 0;
+  top: var(--docked-modal-top-offset, 0);
+  bottom: 1.5rem;
   margin: 0;
-  width: min(420px, 32vw);
-  max-width: min(420px, 32vw);
+  width: var(
+    --docked-modal-max-width,
+    clamp(520px, 40vw, 640px)
+  );
+  max-width: var(
+    --docked-modal-max-width,
+    clamp(520px, 40vw, 640px)
+  );
   display: flex;
   align-items: stretch;
   pointer-events: none;
@@ -248,15 +255,17 @@
 }
 
 .docked-modal--left {
-  inset: 0 auto 0 0;
+  left: 0;
+  right: auto;
 }
 
 .docked-modal--right {
-  inset: 0 0 0 auto;
+  left: auto;
+  right: 0;
 }
 
 .docked-modal.modal-dialog .modal-content {
-  height: 100vh;
+  height: calc(100vh - var(--docked-modal-top-offset, 0) - 1.5rem);
   border-radius: 0;
   pointer-events: auto;
   display: flex;
@@ -270,6 +279,7 @@
 .docked-modal.modal-dialog.modal-dialog-scrollable .modal-body,
 .docked-modal.modal-dialog .modal-body {
   overflow-y: auto;
+  max-height: calc(100vh - var(--docked-modal-top-offset, 0) - 1.5rem);
 }
 
 @media (max-width: 1199.98px) {
@@ -279,7 +289,10 @@
 
   .docked-modal.modal-dialog {
     position: static;
-    inset: auto;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
     width: auto;
     max-width: 100%;
     height: auto;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -679,9 +679,13 @@ const MapModal = ({
   }, [isDocked, dockedSide]);
 
   const handleModalHide = useCallback(() => {
-    if (isDocked && typeof onDockClose === 'function') {
-      onDockClose();
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
     }
+
     onHide?.();
   }, [isDocked, onDockClose, onHide]);
 

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -208,9 +208,13 @@ export default function Skills({
   }, [isDocked, dockedSide]);
 
   const handleModalHide = useCallback(() => {
-    if (isDocked && typeof onDockClose === 'function') {
-      onDockClose();
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
     }
+
     handleCloseSkill?.();
   }, [isDocked, onDockClose, handleCloseSkill]);
 
@@ -300,7 +304,9 @@ export default function Skills({
       })
     );
 
-    handleCloseSkill?.();
+    if (!isDocked) {
+      handleCloseSkill?.();
+    }
   };
 
   const handleView = (skill) => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1202,6 +1202,8 @@ export default function ZombiesCharacterSheet() {
   const playerTurnActionsRef = useRef(null);
   const socketRef = useRef(null);
 
+  const rootContainerRef = useRef(null);
+  const contentColumnRef = useRef(null);
   const headerRef = useRef(null);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [navHeight, setNavHeight] = useState(0);
@@ -1246,6 +1248,92 @@ export default function ZombiesCharacterSheet() {
       setHeaderHeight(headerRef.current.offsetHeight + navHeight + HEADER_PADDING);
     }
   }, [form, navHeight, participantsWithDetails]);
+
+  const updateDockedModalMetrics = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const rootElement = rootContainerRef.current;
+    const contentElement = contentColumnRef.current;
+
+    if (!rootElement || !contentElement || typeof contentElement.getBoundingClientRect !== 'function') {
+      return;
+    }
+
+    const contentRect = contentElement.getBoundingClientRect();
+    const headerElement = headerRef.current;
+    const headerRect =
+      headerElement && typeof headerElement.getBoundingClientRect === 'function'
+        ? headerElement.getBoundingClientRect()
+        : null;
+    const rootRect =
+      typeof rootElement.getBoundingClientRect === 'function'
+        ? rootElement.getBoundingClientRect()
+        : { top: 0 };
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+
+    const rootTop = rootRect?.top ?? 0;
+    const topOffset = headerRect?.bottom != null
+      ? Math.max(0, headerRect.bottom - rootTop)
+      : Math.max(0, contentRect.top - rootTop);
+
+    const leftGutter = Math.max(0, contentRect.left);
+    const rightGutter = Math.max(0, viewportWidth - contentRect.right);
+    const largestGutter = Math.max(leftGutter, rightGutter);
+    const BUFFER = 24;
+    const computedMaxWidth = largestGutter > BUFFER ? largestGutter - BUFFER : 0;
+
+    rootElement.style.setProperty('--docked-modal-top-offset', `${Math.round(topOffset)}px`);
+
+    if (computedMaxWidth > 0) {
+      rootElement.style.setProperty('--docked-modal-max-width', `${Math.round(computedMaxWidth)}px`);
+    } else {
+      rootElement.style.removeProperty('--docked-modal-max-width');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    updateDockedModalMetrics();
+
+    const handleResize = () => {
+      updateDockedModalMetrics();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    let resizeObserver;
+    if (typeof ResizeObserver === 'function') {
+      resizeObserver = new ResizeObserver(() => {
+        updateDockedModalMetrics();
+      });
+
+      const contentElement = contentColumnRef.current;
+      if (contentElement) {
+        resizeObserver.observe(contentElement);
+      }
+
+      const headerElement = headerRef.current;
+      if (headerElement) {
+        resizeObserver.observe(headerElement);
+      }
+    }
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  }, [updateDockedModalMetrics]);
+
+  useEffect(() => {
+    updateDockedModalMetrics();
+  }, [updateDockedModalMetrics, headerHeight, isWideScreen]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -1514,19 +1602,12 @@ export default function ZombiesCharacterSheet() {
       }
       return next;
     });
-
-    if (normalizedValue === 'skills') {
-      setShowSkill(true);
-    } else if (normalizedValue === 'map') {
-      setShowMapModal(true);
-    }
   }, []);
 
   const handleShowSkill = () => setShowSkill(true); // Handler to show skills modal
   const handleCloseSkill = useCallback(() => {
     setShowSkill(false);
-    handleDockClose('skills');
-  }, [handleDockClose]); // Handler to close skills modal
+  }, []); // Handler to close skills modal
   const handleShowFeats = () => setShowFeats(true);
   const handleCloseFeats = () => setShowFeats(false);
   const handleShowFeatures = () => setShowFeatures(true);
@@ -1552,6 +1633,13 @@ export default function ZombiesCharacterSheet() {
   const handleShowMapModal = () => setShowMapModal(true);
   const handleCloseMapModal = useCallback(() => {
     setShowMapModal(false);
+  }, []);
+
+  const handleCloseDockedSkill = useCallback(() => {
+    handleDockClose('skills');
+  }, [handleDockClose]);
+
+  const handleCloseDockedMap = useCallback(() => {
     handleDockClose('map');
   }, [handleDockClose]);
 
@@ -1577,8 +1665,8 @@ export default function ZombiesCharacterSheet() {
 
   const isSkillsDocked = Boolean(skillsDockedSide);
   const isMapDocked = Boolean(mapDockedSide);
-  const shouldShowSkillsModal = showSkill || isSkillsDocked;
-  const shouldShowMapModal = showMapModal || isMapDocked;
+  const shouldShowSkillsModal = showSkill;
+  const shouldShowMapModal = showMapModal;
 
   const handleRollResult = (result, breakdown, source) => {
     playerTurnActionsRef.current?.updateDamageValueWithAnimation(
@@ -2861,6 +2949,7 @@ const spellsGold =
   hasSpellcasting && spellPointsLeft > 0 ? 'gold' : '#6C757D';
   return (
     <div
+      ref={rootContainerRef}
       className="text-center"
       style={{
         fontFamily: 'Raleway, sans-serif',
@@ -2874,7 +2963,17 @@ const spellsGold =
         flexDirection: 'column',
       }}
     >
-      {isWideScreen && (
+      <div
+        ref={contentColumnRef}
+        className="zombies-character-sheet__content"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: '1 1 auto',
+          minHeight: 0,
+        }}
+      >
+        {isWideScreen && (
         <>
           <div className="dock-selector dock-selector--left">
             <label
@@ -3003,7 +3102,7 @@ const spellsGold =
         onActionSurge={handleActionSurge}
       />
     )}
-    <Navbar
+        <Navbar
       fixed="bottom"
       data-bs-theme="dark"
       style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
@@ -3147,6 +3246,7 @@ const spellsGold =
         </Nav>
       </Container>
     </Navbar>
+      </div>
     <CharacterInfo
       form={form}
       show={showCharacterInfo}
@@ -3168,9 +3268,23 @@ const spellsGold =
       wisMod={statMods.wis}
       onSkillsChange={(skills) => setForm((prev) => ({ ...prev, skills }))}
       onRollResult={handleRollResult}
+    />
+    <Skills
+      form={form}
+      showSkill={Boolean(skillsDockedSide)}
+      handleCloseSkill={handleCloseDockedSkill}
+      totalLevel={totalLevel}
+      strMod={statMods.str}
+      dexMod={statMods.dex}
+      conMod={statMods.con}
+      intMod={statMods.int}
+      chaMod={statMods.cha}
+      wisMod={statMods.wis}
+      onSkillsChange={(skills) => setForm((prev) => ({ ...prev, skills }))}
+      onRollResult={handleRollResult}
       isDocked={isSkillsDocked}
       dockedSide={skillsDockedSide}
-      onDockClose={() => handleDockClose('skills')}
+      onDockClose={handleCloseDockedSkill}
     />
     <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
     <BackgroundModal
@@ -3234,27 +3348,39 @@ const spellsGold =
         availableSlots={availableSlots}
       />
     )}
-      <Help
-        form={form}
-        showHelpModal={showHelpModal}
-        handleCloseHelpModal={handleCloseHelpModal}
-        onDiceColorChange={handleDiceColorChange}
-      />
-      <MapModal
-        show={shouldShowMapModal}
-        onHide={handleCloseMapModal}
-        map={campaignMap}
-        maps={campaignMaps}
-        activeMapId={campaignActiveMapId}
-        tokensByMapId={modalTokensByMapId}
-        currentCharacterId={resolvedCharacterId}
-        activeCharacterId={activeTurnParticipantId}
-        characterLookup={tokenMetaById}
-        onTokenMove={handleTokenMove}
-        isDocked={isMapDocked}
-        dockedSide={mapDockedSide}
-        onDockClose={() => handleDockClose('map')}
-      />
+    <Help
+      form={form}
+      showHelpModal={showHelpModal}
+      handleCloseHelpModal={handleCloseHelpModal}
+      onDiceColorChange={handleDiceColorChange}
+    />
+    <MapModal
+      show={shouldShowMapModal}
+      onHide={handleCloseMapModal}
+      map={campaignMap}
+      maps={campaignMaps}
+      activeMapId={campaignActiveMapId}
+      tokensByMapId={modalTokensByMapId}
+      currentCharacterId={resolvedCharacterId}
+      activeCharacterId={activeTurnParticipantId}
+      characterLookup={tokenMetaById}
+      onTokenMove={handleTokenMove}
+    />
+    <MapModal
+      show={Boolean(mapDockedSide)}
+      onHide={handleCloseDockedMap}
+      map={campaignMap}
+      maps={campaignMaps}
+      activeMapId={campaignActiveMapId}
+      tokensByMapId={modalTokensByMapId}
+      currentCharacterId={resolvedCharacterId}
+      activeCharacterId={activeTurnParticipantId}
+      characterLookup={tokenMetaById}
+      onTokenMove={handleTokenMove}
+      isDocked={isMapDocked}
+      dockedSide={mapDockedSide}
+      onDockClose={handleCloseDockedMap}
+    />
   </div>
 );
 }


### PR DESCRIPTION
## Summary
- add layout measurements for the Zombies character sheet to expose docked modal sizing variables
- render dedicated docked Skills and Campaign Map modals that close independently from floating dialogs
- update docked modal styles and hide handlers so docked panels respect new sizing constraints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda22dee04832eb893a3d2f4212a5e