### PR TITLE
Fix pointer events for docked modals

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -235,6 +235,14 @@
   }
 }
 
+.docked-modal-container {
+  pointer-events: none;
+}
+
+.docked-modal-container .modal-dialog {
+  pointer-events: auto;
+}
+
 .docked-modal.modal-dialog {
   position: fixed;
   top: var(--docked-modal-top-offset, 0);
@@ -250,7 +258,6 @@
   );
   display: flex;
   align-items: stretch;
-  pointer-events: none;
   transition: transform 0.2s ease;
 }
 
@@ -297,12 +304,15 @@
     max-width: 100%;
     height: auto;
     margin: 1.5rem auto;
-    pointer-events: auto;
   }
 
   .docked-modal.modal-dialog .modal-content {
     height: auto;
     border-radius: var(--bs-modal-border-radius, var(--bs-border-radius-lg));
+  }
+
+  .docked-modal-container {
+    pointer-events: auto;
   }
 }
 

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -678,6 +678,14 @@ const MapModal = ({
     return classes.join(' ');
   }, [isDocked, dockedSide]);
 
+  const modalClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    return 'docked-modal-container';
+  }, [isDocked]);
+
   const handleModalHide = useCallback(() => {
     if (isDocked) {
       if (typeof onDockClose === 'function') {
@@ -691,6 +699,7 @@ const MapModal = ({
 
   return (
     <Modal
+      className={modalClassName}
       show={show}
       onHide={handleModalHide}
       size={hasManagementFeatures ? 'xl' : 'lg'}

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -207,6 +207,14 @@ export default function Skills({
     return classes.join(' ');
   }, [isDocked, dockedSide]);
 
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
   const handleModalHide = useCallback(() => {
     if (isDocked) {
       if (typeof onDockClose === 'function') {
@@ -321,7 +329,7 @@ export default function Skills({
   return (
     <>
       <Modal
-        className="dnd-modal modern-modal"
+        className={modalClassName}
         show={showSkill}
         onHide={handleModalHide}
         size="lg"


### PR DESCRIPTION
## Summary
- append a docked modal container class to the skills and map modals when docked
- move pointer-event handling onto the container so docked panels allow outside clicks while remaining interactive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddaa68c374832e903a6e9c9e4cd5a1