### PR TITLE
Adjust dock selector positioning

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -201,8 +201,11 @@
 
 .dock-selector {
   position: fixed;
-  top: 50%;
-  transform: translateY(-50%);
+  top: clamp(
+    1rem,
+    calc(var(--docked-modal-top-offset, 0) - 2.75rem),
+    calc(100vh - 4rem)
+  );
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- anchor the dock selector to the docked modal top offset so it appears above the panel while staying within the viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddae21a5f4832ebb644c0ee44be1c0