### PR TITLE
Refactor docked modal handling on character sheet

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import { Card, Modal, Button } from "react-bootstrap";
 import levelup from "../../../images/levelup.png";
 import LevelUp from "./LevelUp"; // Import LevelUp component
@@ -10,6 +10,9 @@ export default function CharacterInfo({
   onShowBackground,
   onLongRest = () => {},
   onShortRest = () => {},
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
@@ -26,14 +29,50 @@ export default function CharacterInfo({
     .filter((language) => language && !language.includes("Choice"))
     .join(", ");
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--characterInfo');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleClose?.();
+  }, [handleClose, isDocked, onDockClose]);
+
   return (
     <Modal
-      className="dnd-modal modern-modal"
+      className={modalClassName}
       show={show}
-      onHide={handleClose}
+      onHide={handleModalHide}
       size="lg"
-      centered
+      centered={!isDocked}
       scrollable
+      backdrop={isDocked ? false : true}
+      enforceFocus={!isDocked}
+      restoreFocus={!isDocked}
+      dialogClassName={dialogClassName}
     >
       <Card className="modern-card text-center">
         <Card.Header className="modal-header">
@@ -127,7 +166,7 @@ export default function CharacterInfo({
           <Button
             className="action-btn close-btn"
             variant="primary"
-            onClick={handleClose}
+            onClick={handleModalHide}
           >
             Close
           </Button>

--- a/client/src/components/Zombies/attributes/EquipmentModal.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { Modal, Card, Button } from 'react-bootstrap';
 import EquipmentRack from './EquipmentRack';
 import { normalizeEquipmentMap } from './equipmentNormalization';
@@ -15,6 +15,9 @@ export default function EquipmentModal({
   form = {},
   onEquipmentChange,
   onEquipmentSlotChange,
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const normalizedWeapons = useMemo(
     () => normalizeWeapons(form.weapon || []),
@@ -37,15 +40,51 @@ export default function EquipmentModal({
     [form.equipment]
   );
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--equipment');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    onHide?.();
+  }, [isDocked, onDockClose, onHide]);
+
   return (
     <Modal
-      className="dnd-modal modern-modal"
+      className={modalClassName}
       show={show}
-      onHide={onHide}
+      onHide={handleModalHide}
       size="lg"
-      centered
+      centered={!isDocked}
       scrollable
       fullscreen="sm-down"
+      backdrop={isDocked ? false : true}
+      enforceFocus={!isDocked}
+      restoreFocus={!isDocked}
+      dialogClassName={dialogClassName}
     >
       <Card className="modern-card">
         <Card.Header className="modal-header">
@@ -70,7 +109,7 @@ export default function EquipmentModal({
           )}
         </Card.Body>
         <Card.Footer className="modal-footer">
-          <Button className="action-btn close-btn" onClick={onHide}>
+          <Button className="action-btn close-btn" onClick={handleModalHide}>
             Close
           </Button>
         </Card.Footer>

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Button, Form, Col, Row, Alert } from 'react-bootstrap';
 import { useNavigate, useParams } from "react-router-dom";
@@ -55,7 +55,14 @@ const ALL_SKILLS = [...SKILLS, ...TOOL_OPTIONS];
 // Maximum number of selectable proficiencies a feat may grant.
 const SKILL_SELECT_LIMIT = 3;
 
-export default function Feats({ form, showFeats, handleCloseFeats }) {
+export default function Feats({
+  form,
+  showFeats,
+  handleCloseFeats,
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
+}) {
   const params = useParams();
   const navigate = useNavigate();
   //----------------------------------------------Feats Section-----------------------------------------------------------------
@@ -286,6 +293,38 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
     { label: 'HP Max Bonus/Level', key: 'hpMaxBonusPerLevel' },
   ];
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--feats');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleCloseFeats?.();
+  }, [handleCloseFeats, isDocked, onDockClose]);
+
   return (
     <div>
       {notification && (
@@ -294,7 +333,17 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
         </Alert>
       )}
       {/* -----------------------------------------Feats Render------------------------------------------------------------------------------------------------------------------------------------ */}
-      <Modal className="dnd-modal modern-modal" show={showFeats} onHide={handleCloseFeats} size="lg" centered>
+      <Modal
+        className={modalClassName}
+        show={showFeats}
+        onHide={handleModalHide}
+        size="lg"
+        centered={!isDocked}
+        backdrop={isDocked ? false : true}
+        enforceFocus={!isDocked}
+        restoreFocus={!isDocked}
+        dialogClassName={dialogClassName}
+      >
         <div className="text-center">
           <Card className="modern-card">
             <Card.Header className="modal-header">
@@ -514,7 +563,7 @@ export default function Feats({ form, showFeats, handleCloseFeats }) {
               </Row>
             </Card.Body>
             <Card.Footer className="modal-footer">
-              <Button className="action-btn close-btn" onClick={handleCloseFeats}>
+              <Button className="action-btn close-btn" onClick={handleModalHide}>
                 Close
               </Button>
             </Card.Footer>

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { Modal, Card, Button, Spinner } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
@@ -11,6 +11,9 @@ export default function Features({
   onActionSurge,
   longRestCount,
   shortRestCount,
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const [features, setFeatures] = useState([]);
   const [modalFeature, setModalFeature] = useState(null);
@@ -136,14 +139,50 @@ export default function Features({
     setSurgeUsed(false);
   }, [longRestCount, shortRestCount]);
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--features');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleCloseFeatures?.();
+  }, [handleCloseFeatures, isDocked, onDockClose]);
+
   return (
     <>
       <Modal
-        className="dnd-modal modern-modal"
+        className={modalClassName}
         show={showFeatures}
-        onHide={handleCloseFeatures}
+        onHide={handleModalHide}
         size="lg"
-        centered
+        centered={!isDocked}
+        backdrop={isDocked ? false : true}
+        enforceFocus={!isDocked}
+        restoreFocus={!isDocked}
+        dialogClassName={dialogClassName}
       >
         <div className="text-center">
           <Card className="modern-card">
@@ -239,7 +278,7 @@ export default function Features({
             <Card.Footer className="modal-footer">
               <Button
                 className="action-btn close-btn"
-                onClick={handleCloseFeatures}
+                onClick={handleModalHide}
               >
                 Close
               </Button>

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'; // Import useState and React
+import React, { useState, useEffect, useCallback, useMemo } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
 import { Modal, Card, Table, Button, Alert } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
@@ -22,6 +22,9 @@ export default function Help({
   showHelpModal,
   handleCloseHelpModal,
   onDiceColorChange,
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const params = useParams();
   const navigate = useNavigate();
@@ -133,16 +136,53 @@ export default function Help({
       // Swallow fetch errors silently for now.
     }
   }
+
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--help');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal', 'text-center'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleCloseHelpModal?.();
+  }, [handleCloseHelpModal, isDocked, onDockClose]);
+
   return (
     <div>
       <Modal
-        className="dnd-modal modern-modal text-center"
+        className={modalClassName}
         size="lg"
         aria-labelledby="contained-modal-title-vcenter"
-        centered
+        centered={!isDocked}
         scrollable
         show={showHelpModal}
-        onHide={handleCloseHelpModal}
+        onHide={handleModalHide}
+        backdrop={isDocked ? false : true}
+        enforceFocus={!isDocked}
+        restoreFocus={!isDocked}
+        dialogClassName={dialogClassName}
       >
         <Card className="modern-card text-center">
           <Card.Header className="modal-header">
@@ -221,7 +261,7 @@ export default function Help({
             <Button className="action-btn btn-danger" onClick={handleShowDeleteCharacter}>
               Delete Character
             </Button>
-            <Button className="action-btn close-btn" onClick={handleCloseHelpModal}>
+            <Button className="action-btn close-btn" onClick={handleModalHide}>
               Close
             </Button>
           </Card.Footer>

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { Modal, Card, Tab, Nav, Button } from 'react-bootstrap';
 import WeaponList from '../../Weapons/WeaponList';
 import ArmorList from '../../Armor/ArmorList';
@@ -20,6 +20,9 @@ export default function InventoryModal({
   onTabChange,
   form = {},
   characterId,
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -150,15 +153,51 @@ export default function InventoryModal({
     ]
   );
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--inventory');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    onHide?.();
+  }, [isDocked, onDockClose, onHide]);
+
   return (
     <Modal
-      className="dnd-modal modern-modal"
+      className={modalClassName}
       show={show}
-      onHide={onHide}
+      onHide={handleModalHide}
       size="lg"
-      centered
+      centered={!isDocked}
       scrollable
       fullscreen="sm-down"
+      backdrop={isDocked ? false : true}
+      enforceFocus={!isDocked}
+      restoreFocus={!isDocked}
+      dialogClassName={dialogClassName}
     >
       <Card className="modern-card">
         <Card.Header className="modal-header">
@@ -191,7 +230,7 @@ export default function InventoryModal({
           </Tab.Container>
         </Card.Body>
         <Card.Footer className="modal-footer">
-          <Button className="action-btn close-btn" onClick={onHide}>
+          <Button className="action-btn close-btn" onClick={handleModalHide}>
             Close
           </Button>
         </Card.Footer>

--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -416,6 +416,9 @@ export default function ShopModal({
   onTabChange,
   currency = {},
   onPurchase = () => {},
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const [cart, setCart] = useState([]);
   const [showCart, setShowCart] = useState(false);
@@ -640,17 +643,53 @@ export default function ShopModal({
     ]
   );
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--shop');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    onHide?.();
+  }, [isDocked, onDockClose, onHide]);
+
   return (
     <>
       <Modal
-      className="dnd-modal modern-modal"
-      show={show}
-      onHide={onHide}
-      size="lg"
-      centered
-      scrollable
-      fullscreen="sm-down"
-    >
+        className={modalClassName}
+        show={show}
+        onHide={handleModalHide}
+        size="lg"
+        centered={!isDocked}
+        scrollable
+        fullscreen="sm-down"
+        backdrop={isDocked ? false : true}
+        enforceFocus={!isDocked}
+        restoreFocus={!isDocked}
+        dialogClassName={dialogClassName}
+      >
       <Card className="modern-card">
         <Card.Header className="modal-header">
           <Card.Title className="modal-title">Shop</Card.Title>
@@ -700,7 +739,7 @@ export default function ShopModal({
           </Tab.Container>
         </Card.Body>
         <Card.Footer className="modal-footer">
-          <Button className="action-btn close-btn" onClick={onHide}>
+          <Button className="action-btn close-btn" onClick={handleModalHide}>
             Close
           </Button>
         </Card.Footer>

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -111,6 +111,9 @@ export default function SpellSelector({
   onSpellsChange,
   onCastSpell,
   availableSlots = { regular: {}, warlock: {} },
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
 }) {
   const params = useParams();
 
@@ -261,7 +264,7 @@ export default function SpellSelector({
     });
     setShowUpcast(false);
     setPendingSpell(null);
-    handleClose();
+    handleModalHide();
   };
 
   const chaMod = useMemo(() => {
@@ -447,7 +450,7 @@ export default function SpellSelector({
                           castingTime: spell.castingTime,
                           name: spell.name,
                         });
-                        handleClose();
+                        handleModalHide();
                       }
                     }}
                   >
@@ -531,14 +534,50 @@ export default function SpellSelector({
     }
   }
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--spells');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleClose?.();
+  }, [handleClose, isDocked, onDockClose]);
+
   return (
     <>
       <Modal
-        className="dnd-modal modern-modal"
+        className={modalClassName}
         show={show}
-        onHide={handleClose}
+        onHide={handleModalHide}
         size="lg"
-        centered
+        centered={!isDocked}
+        backdrop={isDocked ? false : true}
+        enforceFocus={!isDocked}
+        restoreFocus={!isDocked}
+        dialogClassName={dialogClassName}
       >
         <Card className="modern-card">
           <Card.Header className="modal-header">
@@ -638,9 +677,10 @@ export default function SpellSelector({
             )}
           </Card.Body>
           <Card.Footer className="modal-footer">
-            <Button 
-            className="action-btn close-btn"
-            onClick={handleClose}>
+            <Button
+              className="action-btn close-btn"
+              onClick={handleModalHide}
+            >
               Close
             </Button>
           </Card.Footer>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import { Modal, Button } from "react-bootstrap";
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
@@ -15,7 +15,14 @@ const createEmptyStatMap = () => ({
   cha: 0,
 });
 
-export default function Stats({ form, showStats, handleCloseStats }) {
+export default function Stats({
+  form,
+  showStats,
+  handleCloseStats,
+  isDocked = false,
+  dockedSide = null,
+  onDockClose,
+}) {
   const [stats] = useState({
     str: form.str || 0,
     dex: form.dex || 0,
@@ -127,15 +134,51 @@ export default function Stats({ form, showStats, handleCloseStats }) {
     setShowBreakdown(false);
   };
 
+  const dialogClassName = useMemo(() => {
+    if (!isDocked) {
+      return undefined;
+    }
+
+    const classes = ['docked-modal'];
+    if (dockedSide) {
+      classes.push(`docked-modal--${dockedSide}`);
+    }
+    classes.push('docked-modal--stats');
+    return classes.join(' ');
+  }, [isDocked, dockedSide]);
+
+  const modalClassName = useMemo(() => {
+    const classes = ['dnd-modal', 'modern-modal'];
+    if (isDocked) {
+      classes.push('docked-modal-container');
+    }
+    return classes.join(' ');
+  }, [isDocked]);
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleCloseStats?.();
+  }, [handleCloseStats, isDocked, onDockClose]);
+
   return (
     <>
       <Modal
         show={showStats}
-        onHide={handleCloseStats}
+        onHide={handleModalHide}
         size="lg"
         scrollable
-        centered
-        className="dnd-modal modern-modal"
+        centered={!isDocked}
+        className={modalClassName}
+        backdrop={isDocked ? false : true}
+        enforceFocus={!isDocked}
+        restoreFocus={!isDocked}
+        dialogClassName={dialogClassName}
       >
         <Modal.Header className="modal-header">
           <Modal.Title className="modal-title">Stats</Modal.Title>
@@ -173,7 +216,7 @@ export default function Stats({ form, showStats, handleCloseStats }) {
           </div>
         </Modal.Body>
         <Modal.Footer className="modal-footer">
-          <Button className="action-btn close-btn" onClick={handleCloseStats}>Close</Button>
+          <Button className="action-btn close-btn" onClick={handleModalHide}>Close</Button>
         </Modal.Footer>
       </Modal>
       <StatBreakdownModal

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -44,10 +44,25 @@ import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 
 const HEADER_PADDING = 16;
+const DOCKABLE_MODAL_DEFINITIONS = {
+  characterInfo: { label: 'Character Info', component: CharacterInfo },
+  stats: { label: 'Stats', component: Stats },
+  skills: { label: 'Skills', component: Skills },
+  feats: { label: 'Feats', component: Feats },
+  features: { label: 'Features', component: Features },
+  spells: { label: 'Spells', component: SpellSelector },
+  equipment: { label: 'Equipment', component: EquipmentModal },
+  inventory: { label: 'Inventory', component: InventoryModal },
+  shop: { label: 'Shop', component: ShopModal },
+  map: { label: 'Campaign Map', component: MapModal },
+  help: { label: 'Help', component: Help },
+};
 const DOCKABLE_MODAL_OPTIONS = [
   { key: null, label: 'None' },
-  { key: 'skills', label: 'Skills' },
-  { key: 'map', label: 'Campaign Map' },
+  ...Object.entries(DOCKABLE_MODAL_DEFINITIONS).map(([key, { label }]) => ({
+    key,
+    label,
+  })),
 ];
 const WIDE_SCREEN_QUERY = '(min-width: 1200px)';
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
@@ -1592,10 +1607,13 @@ export default function ZombiesCharacterSheet() {
     };
   }, [characterId, applyMapPayload]);
 
-  const handleShowCharacterInfo = () => setShowCharacterInfo(true);
-  const handleCloseCharacterInfo = () => setShowCharacterInfo(false);
-  const handleShowStats = () => setShowStats(true);
-  const handleCloseStats = () => setShowStats(false);
+  const handleShowCharacterInfo = useCallback(() => setShowCharacterInfo(true), []);
+  const handleCloseCharacterInfo = useCallback(
+    () => setShowCharacterInfo(false),
+    []
+  );
+  const handleShowStats = useCallback(() => setShowStats(true), []);
+  const handleCloseStats = useCallback(() => setShowStats(false), []);
   const handleDockClose = useCallback((modalKey) => {
     setDockedModals((prev) => {
       const leftMatch = prev.left === modalKey;
@@ -1627,67 +1645,56 @@ export default function ZombiesCharacterSheet() {
     });
   }, []);
 
-  const handleShowSkill = () => setShowSkill(true); // Handler to show skills modal
+  const handleShowSkill = useCallback(() => setShowSkill(true), []);
   const handleCloseSkill = useCallback(() => {
     setShowSkill(false);
-  }, []); // Handler to close skills modal
-  const handleShowFeats = () => setShowFeats(true);
-  const handleCloseFeats = () => setShowFeats(false);
-  const handleShowFeatures = () => setShowFeatures(true);
-  const handleCloseFeatures = () => setShowFeatures(false);
-  const handleShowShop = (tab) => {
+  }, []);
+  const handleShowFeats = useCallback(() => setShowFeats(true), []);
+  const handleCloseFeats = useCallback(() => setShowFeats(false), []);
+  const handleShowFeatures = useCallback(() => setShowFeatures(true), []);
+  const handleCloseFeatures = useCallback(() => setShowFeatures(false), []);
+  const handleShowShop = useCallback((tab) => {
     setShopTab((prevTab) => tab ?? prevTab ?? 'weapons');
     setShowShop(true);
-  };
-  const handleCloseShop = () => setShowShop(false);
-  const handleShowInventory = (tab) => {
+  }, []);
+  const handleCloseShop = useCallback(() => setShowShop(false), []);
+  const handleShowInventory = useCallback((tab) => {
     setInventoryTab((prevTab) => tab ?? prevTab ?? 'weapons');
     setShowInventory(true);
-  };
-  const handleCloseInventory = () => setShowInventory(false);
-  const handleShowEquipment = () => setShowEquipment(true);
-  const handleCloseEquipment = () => setShowEquipment(false);
-  const handleShowSpells = () => setShowSpells(true);
-  const handleCloseSpells = () => setShowSpells(false);
-  const handleShowHelpModal = () => setShowHelpModal(true);
-  const handleCloseHelpModal = () => setShowHelpModal(false);
-  const handleShowBackground = () => setShowBackground(true);
-  const handleCloseBackground = () => setShowBackground(false);
-  const handleShowMapModal = () => setShowMapModal(true);
+  }, []);
+  const handleCloseInventory = useCallback(() => setShowInventory(false), []);
+  const handleShowEquipment = useCallback(() => setShowEquipment(true), []);
+  const handleCloseEquipment = useCallback(() => setShowEquipment(false), []);
+  const handleShowSpells = useCallback(() => setShowSpells(true), []);
+  const handleCloseSpells = useCallback(() => setShowSpells(false), []);
+  const handleShowHelpModal = useCallback(() => setShowHelpModal(true), []);
+  const handleCloseHelpModal = useCallback(() => setShowHelpModal(false), []);
+  const handleShowBackground = useCallback(() => setShowBackground(true), []);
+  const handleCloseBackground = useCallback(() => setShowBackground(false), []);
+  const handleShowMapModal = useCallback(() => setShowMapModal(true), []);
   const handleCloseMapModal = useCallback(() => {
     setShowMapModal(false);
   }, []);
 
-  const handleCloseDockedSkill = useCallback(() => {
-    handleDockClose('skills');
-  }, [handleDockClose]);
+  const getDockedSide = useCallback(
+    (modalKey) => {
+      if (!modalKey) {
+        return null;
+      }
 
-  const handleCloseDockedMap = useCallback(() => {
-    handleDockClose('map');
-  }, [handleDockClose]);
+      if (dockedModals.left === modalKey) {
+        return 'left';
+      }
 
-  const skillsDockedSide = useMemo(() => {
-    if (dockedModals.left === 'skills') {
-      return 'left';
-    }
-    if (dockedModals.right === 'skills') {
-      return 'right';
-    }
-    return null;
-  }, [dockedModals.left, dockedModals.right]);
+      if (dockedModals.right === modalKey) {
+        return 'right';
+      }
 
-  const mapDockedSide = useMemo(() => {
-    if (dockedModals.left === 'map') {
-      return 'left';
-    }
-    if (dockedModals.right === 'map') {
-      return 'right';
-    }
-    return null;
-  }, [dockedModals.left, dockedModals.right]);
+      return null;
+    },
+    [dockedModals.left, dockedModals.right]
+  );
 
-  const isSkillsDocked = Boolean(skillsDockedSide);
-  const isMapDocked = Boolean(mapDockedSide);
   const shouldShowSkillsModal = showSkill;
   const shouldShowMapModal = showMapModal;
 
@@ -1699,13 +1706,21 @@ export default function ZombiesCharacterSheet() {
     );
   };
 
-  const handleLongRest = () => {
-    setLongRestCount((c) => c + 1);
-  };
+  const handleSkillsChange = useCallback((skills) => {
+    setForm((prev) => ({ ...prev, skills }));
+  }, []);
 
-  const handleShortRest = () => {
+  const handleSpellsChange = useCallback((spells, spellPoints) => {
+    setForm((prev) => ({ ...prev, spells, spellPoints }));
+  }, []);
+
+  const handleLongRest = useCallback(() => {
+    setLongRestCount((c) => c + 1);
+  }, []);
+
+  const handleShortRest = useCallback(() => {
     setShortRestCount((c) => c + 1);
-  };
+  }, []);
 
   const handleCastSpell = useCallback(
     (arg, lvl, idx) => {
@@ -2970,6 +2985,259 @@ const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
 const featsGold = featPointsLeft > 0 ? "gold" : "#6C757D";
 const spellsGold =
   hasSpellcasting && spellPointsLeft > 0 ? 'gold' : '#6C757D';
+
+  const isFormReady = Boolean(form);
+
+  const DOCKABLE_MODAL_CONFIG = useMemo(
+    () => ({
+      characterInfo: {
+        ...DOCKABLE_MODAL_DEFINITIONS.characterInfo,
+        showProp: 'show',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          handleClose: handleCloseCharacterInfo,
+          onShowBackground: handleShowBackground,
+          onLongRest: handleLongRest,
+          onShortRest: handleShortRest,
+        }),
+      },
+      stats: {
+        ...DOCKABLE_MODAL_DEFINITIONS.stats,
+        showProp: 'showStats',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          handleCloseStats,
+        }),
+      },
+      skills: {
+        ...DOCKABLE_MODAL_DEFINITIONS.skills,
+        showProp: 'showSkill',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          handleCloseSkill,
+          totalLevel,
+          strMod: statMods.str,
+          dexMod: statMods.dex,
+          conMod: statMods.con,
+          intMod: statMods.int,
+          chaMod: statMods.cha,
+          wisMod: statMods.wis,
+          onSkillsChange: handleSkillsChange,
+          onRollResult: handleRollResult,
+        }),
+      },
+      feats: {
+        ...DOCKABLE_MODAL_DEFINITIONS.feats,
+        showProp: 'showFeats',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          handleCloseFeats,
+        }),
+      },
+      features: {
+        ...DOCKABLE_MODAL_DEFINITIONS.features,
+        showProp: 'showFeatures',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          handleCloseFeatures,
+          onActionSurge: handleActionSurge,
+          longRestCount,
+          shortRestCount,
+        }),
+      },
+      spells: {
+        ...DOCKABLE_MODAL_DEFINITIONS.spells,
+        showProp: 'show',
+        isEnabled: isFormReady && hasSpellcasting,
+        getBaseProps: () => ({
+          form,
+          handleClose: handleCloseSpells,
+          onSpellsChange: handleSpellsChange,
+          onCastSpell: handleCastSpell,
+          availableSlots,
+        }),
+      },
+      equipment: {
+        ...DOCKABLE_MODAL_DEFINITIONS.equipment,
+        showProp: 'show',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          onHide: handleCloseEquipment,
+          onEquipmentChange: handleEquipmentChange,
+        }),
+      },
+      inventory: {
+        ...DOCKABLE_MODAL_DEFINITIONS.inventory,
+        showProp: 'show',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          activeTab: inventoryTab,
+          onHide: handleCloseInventory,
+          onTabChange: setInventoryTab,
+          characterId,
+        }),
+      },
+      shop: {
+        ...DOCKABLE_MODAL_DEFINITIONS.shop,
+        showProp: 'show',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          activeTab: shopTab,
+          onHide: handleCloseShop,
+          onTabChange: setShopTab,
+          characterId,
+          strength: computedStats.str,
+          onWeaponsChange: handleWeaponsChange,
+          onArmorChange: handleArmorChange,
+          onItemsChange: handleItemsChange,
+          onAccessoriesChange: handleAccessoriesChange,
+          currency: {
+            cp: form?.cp ?? 0,
+            sp: form?.sp ?? 0,
+            gp: form?.gp ?? 0,
+            pp: form?.pp ?? 0,
+          },
+          onPurchase: handleShopPurchase,
+        }),
+      },
+      map: {
+        ...DOCKABLE_MODAL_DEFINITIONS.map,
+        showProp: 'show',
+        isEnabled: true,
+        getBaseProps: () => ({
+          map: campaignMap,
+          maps: campaignMaps,
+          activeMapId: campaignActiveMapId,
+          tokensByMapId: modalTokensByMapId,
+          currentCharacterId: resolvedCharacterId,
+          activeCharacterId: activeTurnParticipantId,
+          characterLookup: tokenMetaById,
+          onTokenMove: handleTokenMove,
+          onHide: handleCloseMapModal,
+        }),
+      },
+      help: {
+        ...DOCKABLE_MODAL_DEFINITIONS.help,
+        showProp: 'showHelpModal',
+        isEnabled: isFormReady,
+        getBaseProps: () => ({
+          form,
+          handleCloseHelpModal,
+          onDiceColorChange: handleDiceColorChange,
+        }),
+      },
+    }),
+    [
+      activeTurnParticipantId,
+      availableSlots,
+      campaignActiveMapId,
+      campaignMap,
+      campaignMaps,
+      characterId,
+      computedStats.str,
+      form,
+      handleAccessoriesChange,
+      handleActionSurge,
+      handleArmorChange,
+      handleCastSpell,
+      handleCloseCharacterInfo,
+      handleCloseEquipment,
+      handleCloseFeatures,
+      handleCloseFeats,
+      handleCloseHelpModal,
+      handleCloseInventory,
+      handleCloseMapModal,
+      handleCloseShop,
+      handleCloseSkill,
+      handleCloseSpells,
+      handleCloseStats,
+      handleDiceColorChange,
+      handleEquipmentChange,
+      handleItemsChange,
+      handleLongRest,
+      handleRollResult,
+      handleShortRest,
+      handleShopPurchase,
+      handleShowBackground,
+      handleSkillsChange,
+      handleSpellsChange,
+      handleTokenMove,
+      handleWeaponsChange,
+      hasSpellcasting,
+      inventoryTab,
+      isFormReady,
+      longRestCount,
+      modalTokensByMapId,
+      resolvedCharacterId,
+      setInventoryTab,
+      setShopTab,
+      shopTab,
+      shortRestCount,
+      statMods.cha,
+      statMods.con,
+      statMods.dex,
+      statMods.int,
+      statMods.str,
+      statMods.wis,
+      totalLevel,
+      tokenMetaById,
+    ]
+  );
+
+  useEffect(() => {
+    setDockedModals((prev) => {
+      let nextState = prev;
+      ['left', 'right'].forEach((side) => {
+        const modalKey = prev[side];
+        if (modalKey && DOCKABLE_MODAL_CONFIG[modalKey]?.isEnabled === false) {
+          if (nextState === prev) {
+            nextState = { ...prev };
+          }
+          nextState[side] = null;
+        }
+      });
+      return nextState;
+    });
+  }, [DOCKABLE_MODAL_CONFIG]);
+
+  const dockedModalElements = useMemo(() => {
+    return Object.entries(DOCKABLE_MODAL_CONFIG)
+      .map(([modalKey, config]) => {
+        if (config.isEnabled === false) {
+          return null;
+        }
+
+        const dockedSide = getDockedSide(modalKey);
+        if (!dockedSide) {
+          return null;
+        }
+
+        const Component = config.component;
+        const baseProps =
+          typeof config.getBaseProps === 'function' ? config.getBaseProps() : {};
+
+        return (
+          <Component
+            key={`docked-${modalKey}`}
+            {...baseProps}
+            {...{ [config.showProp]: true }}
+            isDocked
+            dockedSide={dockedSide}
+            onDockClose={() => handleDockClose(modalKey)}
+          />
+        );
+      })
+      .filter(Boolean);
+  }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockClose]);
+
   return (
     <div
       ref={rootContainerRef}
@@ -3014,11 +3282,19 @@ const spellsGold =
                 handleDockSelectionChange('left', event.target.value)
               }
             >
-              {DOCKABLE_MODAL_OPTIONS.map(({ key, label }) => (
-                <option key={key ?? 'none'} value={key ?? ''}>
-                  {label}
-                </option>
-              ))}
+              {DOCKABLE_MODAL_OPTIONS.map(({ key, label }) => {
+                const config = key ? DOCKABLE_MODAL_CONFIG[key] : null;
+                const isDisabled = key ? config?.isEnabled === false : false;
+                return (
+                  <option
+                    key={key ?? 'none'}
+                    value={key ?? ''}
+                    disabled={isDisabled}
+                  >
+                    {label}
+                  </option>
+                );
+              })}
             </Form.Select>
           </div>
           <div className="dock-selector dock-selector--right">
@@ -3037,11 +3313,19 @@ const spellsGold =
                 handleDockSelectionChange('right', event.target.value)
               }
             >
-              {DOCKABLE_MODAL_OPTIONS.map(({ key, label }) => (
-                <option key={key ?? 'none'} value={key ?? ''}>
-                  {label}
-                </option>
-              ))}
+              {DOCKABLE_MODAL_OPTIONS.map(({ key, label }) => {
+                const config = key ? DOCKABLE_MODAL_CONFIG[key] : null;
+                const isDisabled = key ? config?.isEnabled === false : false;
+                return (
+                  <option
+                    key={key ?? 'none'}
+                    value={key ?? ''}
+                    disabled={isDisabled}
+                  >
+                    {label}
+                  </option>
+                );
+              })}
             </Form.Select>
           </div>
         </>
@@ -3291,25 +3575,8 @@ const spellsGold =
       intMod={statMods.int}
       chaMod={statMods.cha}
       wisMod={statMods.wis}
-      onSkillsChange={(skills) => setForm((prev) => ({ ...prev, skills }))}
+      onSkillsChange={handleSkillsChange}
       onRollResult={handleRollResult}
-    />
-    <Skills
-      form={form}
-      showSkill={Boolean(skillsDockedSide)}
-      handleCloseSkill={handleCloseDockedSkill}
-      totalLevel={totalLevel}
-      strMod={statMods.str}
-      dexMod={statMods.dex}
-      conMod={statMods.con}
-      intMod={statMods.int}
-      chaMod={statMods.cha}
-      wisMod={statMods.wis}
-      onSkillsChange={(skills) => setForm((prev) => ({ ...prev, skills }))}
-      onRollResult={handleRollResult}
-      isDocked={isSkillsDocked}
-      dockedSide={skillsDockedSide}
-      onDockClose={handleCloseDockedSkill}
     />
     <Stats form={form} showStats={showStats} handleCloseStats={handleCloseStats} />
     <BackgroundModal
@@ -3366,9 +3633,7 @@ const spellsGold =
         form={form}
         show={showSpells}
         handleClose={handleCloseSpells}
-        onSpellsChange={(spells, spellPoints) =>
-          setForm((prev) => ({ ...prev, spells, spellPoints }))
-        }
+        onSpellsChange={handleSpellsChange}
         onCastSpell={handleCastSpell}
         availableSlots={availableSlots}
       />
@@ -3391,21 +3656,7 @@ const spellsGold =
       characterLookup={tokenMetaById}
       onTokenMove={handleTokenMove}
     />
-    <MapModal
-      show={Boolean(mapDockedSide)}
-      onHide={handleCloseDockedMap}
-      map={campaignMap}
-      maps={campaignMaps}
-      activeMapId={campaignActiveMapId}
-      tokensByMapId={modalTokensByMapId}
-      currentCharacterId={resolvedCharacterId}
-      activeCharacterId={activeTurnParticipantId}
-      characterLookup={tokenMetaById}
-      onTokenMove={handleTokenMove}
-      isDocked={isMapDocked}
-      dockedSide={mapDockedSide}
-      onDockClose={handleCloseDockedMap}
-    />
+    {dockedModalElements}
   </div>
 );
 }


### PR DESCRIPTION
## Summary
- expand the dockable modal selector to support every footer modal and drive rendering from a shared configuration
- generalize the character sheet docking logic so each modal can be docked independently while keeping floating instances unchanged
- update all relevant modal components to support docked presentation with shared styling and close-handling behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb075707c832e8820506155ca0ec1