### PR TITLE
Align MapModal styling with other modals

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -679,11 +679,13 @@ const MapModal = ({
   }, [isDocked, dockedSide]);
 
   const modalClassName = useMemo(() => {
-    if (!isDocked) {
-      return undefined;
+    const classes = ['dnd-modal', 'modern-modal'];
+
+    if (isDocked) {
+      classes.push('docked-modal-container');
     }
 
-    return 'docked-modal-container';
+    return classes.join(' ');
   }, [isDocked]);
 
   const handleModalHide = useCallback(() => {


### PR DESCRIPTION
## Summary
- ensure MapModal always applies the shared dnd/modern modal styling
- only add the docked container class when the modal is docked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb8107704832eac6fb3aeaa0f4d3d