### PR TITLE
Adjust map modal close button styling

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -737,7 +737,7 @@ const MapModal = ({
         )}
       </Modal.Body>
       <Modal.Footer>
-        <Button variant="secondary" onClick={onHide} data-testid="map-modal-close">
+        <Button className="action-btn close-btn" onClick={handleModalHide} data-testid="map-modal-close">
           Close
         </Button>
       </Modal.Footer>


### PR DESCRIPTION
## Summary
- update the map modal close button to use the shared action button styling
- ensure the close action routes through handleModalHide for docked modals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb93d4e60832ea8de5e8afe63b6c1