### PR TITLE
Add token removal interactions to campaign maps

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -116,6 +116,7 @@ const CampaignMapBoard = ({
   onTokenDragEnd,
   onTokenPositionChange,
   onBackgroundClick,
+  onTokenRemove,
   disabled,
   className,
   children,
@@ -489,6 +490,26 @@ const CampaignMapBoard = ({
                       );
                       handlePointerCancel(event);
                     }}
+                    onContextMenu={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      if (
+                        interactionDisabled ||
+                        typeof onTokenRemove !== 'function' ||
+                        !characterId
+                      ) {
+                        return;
+                      }
+
+                      onTokenRemove({
+                        characterId,
+                        token,
+                        mapId:
+                          typeof safeMap?.mapId === 'string' && safeMap.mapId.trim() !== ''
+                            ? safeMap.mapId.trim()
+                            : null,
+                      });
+                    }}
                     data-token-id={characterId}
                   >
                     {hasHealth && safeCurrentHp !== null && safeMaxHp !== null && safeMaxHp > 0 && (
@@ -566,6 +587,7 @@ CampaignMapBoard.propTypes = {
   onTokenDragEnd: PropTypes.func,
   onTokenPositionChange: PropTypes.func,
   onBackgroundClick: PropTypes.func,
+  onTokenRemove: PropTypes.func,
   disabled: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
@@ -579,6 +601,7 @@ CampaignMapBoard.defaultProps = {
   onTokenDragEnd: null,
   onTokenPositionChange: null,
   onBackgroundClick: null,
+  onTokenRemove: null,
   disabled: false,
   className: '',
   children: null,

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -125,6 +125,7 @@ const MapModal = ({
   activeCharacterId,
   characterLookup,
   onTokenMove,
+  onTokenRemove,
   readOnly,
   isDocked = false,
   dockedSide = null,
@@ -464,6 +465,49 @@ const MapModal = ({
     [currentToken, handleCommitMove, isInteractive, normalizedCurrentCharacterId, placementPending]
   );
 
+  const handleTokenRemove = useCallback(
+    ({ characterId, token }) => {
+      if (!isInteractive || placementPending) {
+        return false;
+      }
+
+      if (typeof onTokenRemove !== 'function' || !previewMapId) {
+        return false;
+      }
+
+      const normalizedCharacterId = normalizeMapId(characterId);
+      if (!normalizedCharacterId) {
+        return false;
+      }
+
+      if (readOnly && normalizedCharacterId !== normalizedCurrentCharacterId) {
+        return false;
+      }
+
+      const payload = {
+        mapId: previewMapId,
+        characterId: normalizedCharacterId,
+      };
+
+      if (token) {
+        payload.token = token;
+      } else if (tokensDictionary[normalizedCharacterId]) {
+        payload.token = tokensDictionary[normalizedCharacterId];
+      }
+
+      return onTokenRemove(payload);
+    },
+    [
+      isInteractive,
+      placementPending,
+      onTokenRemove,
+      previewMapId,
+      readOnly,
+      normalizedCurrentCharacterId,
+      tokensDictionary,
+    ]
+  );
+
   const canClickToPlace = useMemo(
     () =>
       Boolean(
@@ -638,6 +682,7 @@ const MapModal = ({
             disabled={placementPending}
             onTokenPositionChange={handleTokenPositionChange}
             onBackgroundClick={handleBackgroundPlacement}
+            onTokenRemove={handleTokenRemove}
           />
           {placementPending && (
             <div
@@ -769,6 +814,7 @@ MapModal.propTypes = {
     })
   ),
   onTokenMove: PropTypes.func,
+  onTokenRemove: PropTypes.func,
   readOnly: PropTypes.bool,
   isDocked: PropTypes.bool,
   dockedSide: PropTypes.oneOf(['left', 'right']),
@@ -794,6 +840,7 @@ MapModal.defaultProps = {
   activeCharacterId: null,
   characterLookup: {},
   onTokenMove: null,
+  onTokenRemove: null,
   readOnly: true,
   isDocked: false,
   dockedSide: null,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2791,7 +2791,12 @@ export default function ZombiesCharacterSheet() {
         return next;
       });
 
-      if (campaignActiveMapIdRef.current === normalizedMapId) {
+      const shouldUpdateActiveTokens =
+        campaignActiveMapIdRef.current === normalizedMapId ||
+        campaignActiveMapIdRef.current === null ||
+        Boolean(activeMapTokensRef.current?.[normalizedCharacterId]);
+
+      if (shouldUpdateActiveTokens) {
         setActiveMapTokens((prev) => ({
           ...(prev || {}),
           [normalizedCharacterId]: {
@@ -2856,6 +2861,127 @@ export default function ZombiesCharacterSheet() {
         }
 
         throw new Error('Failed to update figurine position.');
+      }
+    },
+    [campaignId]
+  );
+
+  const handleTokenRemove = useCallback(
+    async ({ mapId, characterId: tokenCharacterId }) => {
+      const normalizedCampaign =
+        typeof campaignId === 'string' && campaignId.trim() !== '' ? campaignId.trim() : null;
+      const normalizedMapId =
+        typeof mapId === 'string' && mapId.trim() !== ''
+          ? mapId.trim()
+          : typeof campaignMapRef.current?.mapId === 'string' &&
+              campaignMapRef.current.mapId.trim() !== ''
+            ? campaignMapRef.current.mapId.trim()
+            : null;
+      const normalizedCharacterId =
+        typeof tokenCharacterId === 'string' && tokenCharacterId.trim() !== ''
+          ? tokenCharacterId.trim()
+          : null;
+      const resolvedId = resolvedCharacterIdRef.current;
+
+      if (
+        !normalizedCampaign ||
+        !normalizedMapId ||
+        !normalizedCharacterId ||
+        !resolvedId ||
+        normalizedCharacterId !== resolvedId
+      ) {
+        return false;
+      }
+
+      const previousCampaignTokens = campaignMapTokensRef.current || {};
+      const previousActiveTokens = activeMapTokensRef.current || {};
+      const previousCampaignMap = campaignMapRef.current || null;
+      const existingMapTokens = previousCampaignTokens?.[normalizedMapId] || {};
+
+      if (!Object.prototype.hasOwnProperty.call(existingMapTokens, normalizedCharacterId)) {
+        return true;
+      }
+
+      const encodedCampaign = encodeURIComponent(normalizedCampaign);
+      const encodedMapId = encodeURIComponent(normalizedMapId);
+      const encodedCharacterId = encodeURIComponent(normalizedCharacterId);
+
+      setCampaignMapTokens((prev) => {
+        if (!prev || !prev[normalizedMapId]?.[normalizedCharacterId]) {
+          return prev;
+        }
+        const next = { ...(prev || {}) };
+        const mapTokens = { ...(next[normalizedMapId] || {}) };
+        delete mapTokens[normalizedCharacterId];
+        if (Object.keys(mapTokens).length === 0) {
+          delete next[normalizedMapId];
+        } else {
+          next[normalizedMapId] = mapTokens;
+        }
+        return next;
+      });
+
+      if (campaignActiveMapIdRef.current === normalizedMapId) {
+        setActiveMapTokens((prev) => {
+          if (!prev || !prev[normalizedCharacterId]) {
+            return prev;
+          }
+          const next = { ...(prev || {}) };
+          delete next[normalizedCharacterId];
+          return next;
+        });
+      }
+
+      setCampaignMap((prev) => {
+        if (!prev) {
+          return prev;
+        }
+
+        const prevMapId =
+          typeof prev.mapId === 'string' && prev.mapId.trim() !== '' ? prev.mapId.trim() : null;
+
+        if (prevMapId !== normalizedMapId) {
+          return prev;
+        }
+
+        if (!prev.tokens || !prev.tokens[normalizedCharacterId]) {
+          return prev;
+        }
+
+        const nextTokens = { ...(prev.tokens || {}) };
+        delete nextTokens[normalizedCharacterId];
+        return { ...prev, tokens: nextTokens };
+      });
+
+      try {
+        const response = await apiFetch(
+          `/campaigns/${encodedCampaign}/maps/${encodedMapId}/tokens/${encodedCharacterId}`,
+          { method: 'DELETE' }
+        );
+
+        if (response && response.status === 404) {
+          return true;
+        }
+
+        if (!response || !response.ok) {
+          const message = await parseErrorMessage(
+            response,
+            'Failed to remove figurine from map.'
+          );
+          throw new Error(message);
+        }
+
+        return true;
+      } catch (error) {
+        setCampaignMapTokens(previousCampaignTokens || {});
+        setActiveMapTokens(previousActiveTokens || {});
+        setCampaignMap(previousCampaignMap || null);
+
+        if (error instanceof Error && error.message) {
+          throw error;
+        }
+
+        throw new Error('Failed to remove figurine from map.');
       }
     },
     [campaignId]
@@ -3692,6 +3818,7 @@ export default function ZombiesCharacterSheet() {
       activeCharacterId={activeTurnParticipantId}
       characterLookup={tokenMetaById}
       onTokenMove={handleTokenMove}
+      onTokenRemove={handleTokenRemove}
     />
     {dockedModalElements}
   </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1752,10 +1752,13 @@ test('loads campaign map tokens and updates them after placement', async () => {
       });
     }
 
-    if (url === `/campaigns/${campaignId}/maps/${mapId}/tokens/char-1`) {
-      expect(options.method).toBe('PUT');
+    if (url === `/campaigns/${campaignId}/maps/${mapId}/tokens/char-1` && options.method === 'PUT') {
       expect(JSON.parse(options.body)).toEqual({ x: 0.5, y: 0.6 });
       return Promise.resolve({ ok: true, json: async () => ({}) });
+    }
+
+    if (url === `/campaigns/${campaignId}/maps/${mapId}/tokens/char-1` && options.method === 'DELETE') {
+      return Promise.resolve({ ok: true });
     }
 
     return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
@@ -1794,5 +1797,28 @@ test('loads campaign map tokens and updates them after placement', async () => {
     expect(updatedToken).toBeDefined();
     expect(updatedToken.x).toBeCloseTo(0.5);
     expect(updatedToken.y).toBeCloseTo(0.6);
+  });
+
+  apiFetch.mockClear();
+
+  await act(async () => {
+    const result = await mockMapModalProps.current.onTokenRemove({
+      mapId,
+      characterId: 'char-1',
+    });
+    expect(result).toBe(true);
+  });
+
+  await waitFor(() => {
+    expect(apiFetch).toHaveBeenCalledWith(
+      `/campaigns/${campaignId}/maps/${mapId}/tokens/char-1`,
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  await waitFor(() => {
+    const remainingToken =
+      mockMapModalProps.current.tokensByMapId?.[mapId]?.['char-1'];
+    expect(remainingToken).toBeUndefined();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -787,10 +787,19 @@ export default function ZombiesDM() {
     );
 
     const removeCharacterTokensFromMaps = useCallback(
-      async (characterId) => {
+      async (character) => {
         const normalizedCharacterId =
-          typeof characterId === 'string' && characterId.trim() !== ''
-            ? characterId.trim()
+          typeof character === 'string'
+            ? character.trim()
+            : typeof character?.characterId === 'string' && character.characterId.trim() !== ''
+            ? character.characterId.trim()
+            : null;
+
+        const normalizedMapHint =
+          typeof character === 'object' &&
+          typeof character?.mapId === 'string' &&
+          character.mapId.trim() !== ''
+            ? character.mapId.trim()
             : null;
 
         if (!normalizedCharacterId || !encodedCampaign) {
@@ -835,6 +844,10 @@ export default function ZombiesDM() {
           )
         ) {
           mapsWithToken.add(activeMapId);
+        }
+
+        if (normalizedMapHint) {
+          mapsWithToken.add(normalizedMapHint);
         }
 
         const shouldClosePlacement =
@@ -949,6 +962,22 @@ export default function ZombiesDM() {
         parseErrorMessage,
         setStatus,
       ]
+    );
+
+    const handleMapTokenRemove = useCallback(
+      async ({ characterId, mapId }) => {
+        if (typeof characterId !== 'string' || characterId.trim() === '') {
+          return false;
+        }
+
+        const payload = { characterId: characterId.trim() };
+        if (typeof mapId === 'string' && mapId.trim() !== '') {
+          payload.mapId = mapId.trim();
+        }
+
+        return removeCharacterTokensFromMaps(payload);
+      },
+      [removeCharacterTokensFromMaps]
     );
 
     const handleRemoveEnemy = useCallback(
@@ -4942,6 +4971,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                               onTokenPositionChange={
                                 shouldShowCampaignTokens ? handleTokenPositionChange : undefined
                               }
+                              onTokenRemove={handleMapTokenRemove}
                             />
                           ) : (
                             <p className="text-muted mb-0">No map selected.</p>
@@ -6666,6 +6696,7 @@ const resolveIcon = (category, iconMap, fallback) => {
         activeCharacterId={activeParticipant?.characterId}
         characterLookup={tokenMetaById}
         onTokenMove={handleMapModalTokenMove}
+        onTokenRemove={handleMapTokenRemove}
         readOnly={false}
       />
 

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -98,7 +98,7 @@ describe('ZombiesDM AI generation', () => {
   });
 
   test.skip('generates armor via AI and populates form', async () => {
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => [] });
@@ -186,7 +186,7 @@ describe('ZombiesDM AI generation', () => {
     const armorRecords = [
       { _id: 'armor1', armorName: 'Custom Armor', slot: 'chest' },
     ];
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => [] });
@@ -385,7 +385,7 @@ describe('ZombiesDM AI generation', () => {
   });
 
   test('generates item via AI and populates bonus fields', async () => {
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => [] });
@@ -446,7 +446,7 @@ describe('ZombiesDM AI generation', () => {
   });
 
   test('normalizes AI bonuses with full names', async () => {
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => [] });
@@ -507,7 +507,7 @@ describe('ZombiesDM AI generation', () => {
   });
 
   test('generates accessory via AI and populates slots and bonuses', async () => {
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => [] });
@@ -588,7 +588,7 @@ describe('ZombiesDM AI generation', () => {
       },
     ];
 
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => characters });
@@ -810,7 +810,7 @@ describe('ZombiesDM AI generation', () => {
     };
     const socketMaps = [initialMap];
 
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => [] });
@@ -894,7 +894,7 @@ describe('ZombiesDM AI generation', () => {
       tokens: mapTokens['map-1'],
     };
 
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => characters });
@@ -920,9 +920,16 @@ describe('ZombiesDM AI generation', () => {
               activeMapTokens: mapTokens['map-1'],
             }),
           });
+        case '/campaigns/Camp1/maps/map-1/tokens/hero-1':
+          if (options.method === 'DELETE') {
+            return Promise.resolve({ ok: true });
+          }
+          break;
         default:
           return Promise.resolve({ ok: true, json: async () => ({}) });
       }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
     });
 
     render(<ZombiesDM />);
@@ -988,6 +995,34 @@ describe('ZombiesDM AI generation', () => {
           }),
         ])
       );
+    });
+
+    apiFetch.mockClear();
+
+    const latestBoardProps = CampaignMapBoard.mock.calls[CampaignMapBoard.mock.calls.length - 1][0];
+    expect(typeof latestBoardProps.onTokenRemove).toBe('function');
+
+    await act(async () => {
+      const result = await latestBoardProps.onTokenRemove({
+        characterId: 'hero-1',
+        mapId: 'map-1',
+      });
+      expect(result).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/campaigns/Camp1/maps/map-1/tokens/hero-1',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+
+    await waitFor(() => {
+      const updatedProps = CampaignMapBoard.mock.calls[CampaignMapBoard.mock.calls.length - 1][0];
+      const hasHeroToken = (updatedProps.tokens || []).some(
+        (token) => token.characterId === 'hero-1'
+      );
+      expect(hasHeroToken).toBe(false);
     });
   });
 
@@ -1208,6 +1243,12 @@ describe('ZombiesDM AI generation', () => {
           ) {
             return Promise.resolve({ ok: true, json: async () => ({}) });
           }
+          if (
+            url.startsWith('/campaigns/Camp1/maps/') &&
+            options.method === 'DELETE'
+          ) {
+            return Promise.resolve({ ok: true });
+          }
           return Promise.resolve({ ok: true, json: async () => ({}) });
       }
     });
@@ -1256,13 +1297,29 @@ describe('ZombiesDM AI generation', () => {
         })
       );
     });
+
+    apiFetch.mockClear();
+
+    await expect(
+      placementProps.onTokenRemove({
+        mapId: 'map-123',
+        characterId: 'enemy-1',
+      })
+    ).resolves.toBe(true);
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/campaigns/Camp1/maps/map-123/tokens/enemy-1',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
   });
   test('opens the d20 roller modal when clicking the Roll button in enemies form', async () => {
     const characters = [
       { _id: 'hero-1', characterName: 'Hero One', diceColor: '#3366ff' },
     ];
 
-    apiFetch.mockImplementation((url) => {
+    apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
         case '/campaigns/Camp1/characters':
           return Promise.resolve({ ok: true, json: async () => characters });


### PR DESCRIPTION
## Summary
- add context menu token removal support to `CampaignMapBoard` and `MapModal`
- implement character token delete handling for the player sheet and DM dashboard
- extend related Jest suites to cover right-click removal flows for both roles

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js client/src/components/Zombies/pages/ZombiesDM.test.js *(fails: tests exceeded timeout while running full suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbbfaebb8832e8bff68dd99b28ef6