### PR TITLE
Handle campaign updates when deleting characters

### DIFF
--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -8,9 +8,16 @@ const express = require('express');
 jest.mock('../db/conn');
 const dbo = require('../db/conn');
 jest.mock('../middleware/auth', () => (req, res, next) => next());
+jest.mock('../utils/socket', () => ({
+  emitCharacterMetadataUpdate: jest.fn(),
+  emitMapUpdate: jest.fn(),
+  emitCombatUpdate: jest.fn(),
+}));
 const charactersRouter = require('../routes');
 const classes = require('../data/classes');
 const { EQUIPMENT_SLOT_KEYS } = require('../constants/equipmentSlots');
+const { emitMapUpdate, emitCombatUpdate } = require('../utils/socket');
+const { ObjectId } = require('mongodb');
 
 const app = express();
 app.use(express.json());
@@ -19,6 +26,11 @@ app.use((err, req, res, next) => {
   const status = err.status || 500;
   const message = status === 500 ? 'Internal Server Error' : err.message;
   res.status(status).json({ message });
+});
+
+beforeEach(() => {
+  dbo.mockReset();
+  jest.clearAllMocks();
 });
 
 describe('Character routes', () => {
@@ -776,6 +788,155 @@ describe('Character routes', () => {
     expect(captured.$set.feat).toEqual(newFeat);
     expect(captured.$set.skills.acrobatics.proficient).toBe(true);
     expect(captured.$set.allowedSkills).toEqual(['acrobatics']);
+  });
+
+  test('delete character returns 404 when not found', async () => {
+    const deletedId = new ObjectId('507f1f77bcf86cd799439011');
+    const charactersCollection = {
+      findOneAndDelete: jest.fn().mockResolvedValue({ value: null }),
+    };
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return charactersCollection;
+        }
+        return {};
+      },
+    });
+
+    const res = await request(app).delete(
+      `/characters/delete-character/${deletedId.toString()}`
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: 'Character not found' });
+  });
+
+  test('delete character updates campaign maps and combat', async () => {
+    const deletedId = new ObjectId('507f1f77bcf86cd799439011');
+    const mapId = '11111111-1111-4111-8111-111111111111';
+    const timestamp = new Date(0).toISOString();
+
+    const charactersCollection = {
+      findOneAndDelete: jest.fn().mockResolvedValue({
+        value: {
+          _id: deletedId,
+          campaign: 'Test Campaign',
+          characterId: 'char-123',
+        },
+      }),
+    };
+
+    const campaignDoc = {
+      campaignName: 'Test Campaign',
+      maps: [
+        {
+          mapId,
+          title: 'Dungeon',
+          imageUrl: 'https://example.com/map.png',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      activeMapId: mapId,
+      map: null,
+      mapTokens: {
+        [mapId]: {
+          [deletedId.toString()]: {
+            characterId: deletedId.toString(),
+            x: 0.5,
+            y: 0.5,
+            updatedAt: timestamp,
+          },
+          ally: {
+            characterId: 'ally',
+            x: 0.25,
+            y: 0.75,
+            updatedAt: timestamp,
+          },
+        },
+      },
+      combat: {
+        participants: [
+          { characterId: 'char-123', initiative: 18 },
+          { characterId: 'ally', initiative: 12 },
+        ],
+        activeTurn: 1,
+      },
+    };
+
+    const campaignsCollection = {
+      findOne: jest.fn().mockResolvedValue(campaignDoc),
+      updateOne: jest.fn().mockResolvedValue({ acknowledged: true }),
+    };
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Characters') {
+          return charactersCollection;
+        }
+        if (name === 'Campaigns') {
+          return campaignsCollection;
+        }
+        return {};
+      },
+    });
+
+    const res = await request(app).delete(
+      `/characters/delete-character/${deletedId.toString()}`
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ acknowledged: true, deletedCount: 1 });
+
+    expect(charactersCollection.findOneAndDelete).toHaveBeenCalledWith({
+      _id: deletedId,
+    });
+
+    expect(campaignsCollection.updateOne).toHaveBeenCalled();
+    const updateCalls = campaignsCollection.updateOne.mock.calls;
+    const [filter, update] = updateCalls[updateCalls.length - 1];
+    expect(filter).toEqual({ campaignName: 'Test Campaign' });
+    expect(update).toHaveProperty('$set');
+
+    const { $set: updatedFields } = update;
+    const resolvedMapId = updatedFields.activeMapId;
+    expect(typeof resolvedMapId).toBe('string');
+    expect(updatedFields.map).toMatchObject({
+      mapId: resolvedMapId,
+      tokens: { ally: expect.any(Object) },
+    });
+    expect(Object.keys(updatedFields.mapTokens)).toEqual([resolvedMapId]);
+    expect(updatedFields.mapTokens[resolvedMapId]).toEqual({
+      ally: {
+        characterId: 'ally',
+        x: 0.25,
+        y: 0.75,
+        updatedAt: timestamp,
+      },
+    });
+    expect(updatedFields.combat).toEqual({
+      participants: [{ characterId: 'ally', initiative: 12 }],
+      activeTurn: 0,
+    });
+
+    expect(emitMapUpdate).toHaveBeenCalledTimes(1);
+    expect(emitMapUpdate).toHaveBeenCalledWith(
+      'Test Campaign',
+      expect.objectContaining({ activeMapId: resolvedMapId })
+    );
+    const emittedPayload = emitMapUpdate.mock.calls[0][1];
+    expect(emittedPayload.tokensByMapId).toEqual(updatedFields.mapTokens);
+    expect(emittedPayload.map.tokens).toEqual(
+      updatedFields.mapTokens[resolvedMapId]
+    );
+
+    expect(emitCombatUpdate).toHaveBeenCalledTimes(1);
+    expect(emitCombatUpdate).toHaveBeenCalledWith(
+      'Test Campaign',
+      updatedFields.combat
+    );
   });
 
   test('removing feat strips granted skills', async () => {

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -9,7 +9,15 @@ const proficiencyBonus = require('../../utils/proficiency');
 const collectAllowedSkills = require('../../utils/collectAllowedSkills');
 const collectAllowedExpertise = require('../../utils/collectAllowedExpertise');
 const { normalizeEquipmentMap } = require('../../constants/equipmentSlots');
-const { emitCharacterMetadataUpdate } = require('../../utils/socket');
+const {
+  emitCharacterMetadataUpdate,
+  emitMapUpdate,
+  emitCombatUpdate,
+} = require('../../utils/socket');
+const {
+  buildCampaignMapPayload,
+  normalizeCampaignMapState,
+} = require('../../utils/campaignMaps');
 
 const countFeatProficiencies = (feat = []) => {
   const profs = new Set();
@@ -336,16 +344,161 @@ module.exports = (router) => {
   );
 
   // This section will delete a character
-  characterRouter.route('/delete-character/:id').delete(async (req, response, next) => {
+  characterRouter.route('/delete-character/:id').delete(async (req, res, next) => {
     if (!ObjectId.isValid(req.params.id)) {
-      return response.status(400).json({ message: 'Invalid ID' });
+      return res.status(400).json({ message: 'Invalid ID' });
     }
+
     const db_connect = req.db;
-    const myquery = { _id: ObjectId(req.params.id) };
+    const charactersCollection = db_connect.collection('Characters');
+    const query = { _id: ObjectId(req.params.id) };
+
     try {
-      const obj = await db_connect.collection('Characters').deleteOne(myquery);
+      const result = await charactersCollection.findOneAndDelete(query);
+      const deletedCharacter = result.value;
+
+      if (!deletedCharacter) {
+        return res.status(404).json({ message: 'Character not found' });
+      }
+
+      const deletedIds = new Set();
+      if (deletedCharacter._id) {
+        deletedIds.add(String(deletedCharacter._id));
+      }
+      if (
+        typeof deletedCharacter.characterId === 'string' &&
+        deletedCharacter.characterId.trim() !== ''
+      ) {
+        deletedIds.add(deletedCharacter.characterId.trim());
+      }
+
+      const campaignName =
+        typeof deletedCharacter.campaign === 'string' &&
+        deletedCharacter.campaign.trim() !== ''
+          ? deletedCharacter.campaign.trim()
+          : null;
+
+      if (campaignName) {
+        const campaignsCollection = db_connect.collection('Campaigns');
+        const campaign = await campaignsCollection.findOne({ campaignName });
+
+        if (campaign) {
+          const { campaign: normalizedCampaign } = await normalizeCampaignMapState({
+            campaign,
+            collection: campaignsCollection,
+          });
+
+          const nextTokens = {};
+
+          if (
+            normalizedCampaign.mapTokens &&
+            typeof normalizedCampaign.mapTokens === 'object'
+          ) {
+            Object.keys(normalizedCampaign.mapTokens).forEach((mapId) => {
+              const mapTokens = normalizedCampaign.mapTokens[mapId];
+              if (!mapTokens || typeof mapTokens !== 'object') {
+                return;
+              }
+
+              const filteredTokens = Object.keys(mapTokens).reduce(
+                (acc, tokenKey) => {
+                  const tokenEntry = mapTokens[tokenKey];
+                  if (!tokenEntry || typeof tokenEntry !== 'object') {
+                    return acc;
+                  }
+
+                  const candidateId =
+                    typeof tokenEntry.characterId === 'string' &&
+                    tokenEntry.characterId.trim() !== ''
+                      ? tokenEntry.characterId.trim()
+                      : typeof tokenKey === 'string' && tokenKey.trim() !== ''
+                      ? tokenKey.trim()
+                      : null;
+
+                  if (!candidateId) {
+                    return acc;
+                  }
+
+                  if (deletedIds.has(candidateId)) {
+                    return acc;
+                  }
+
+                  acc[candidateId] = { ...tokenEntry, characterId: candidateId };
+                  return acc;
+                },
+                {}
+              );
+
+              if (Object.keys(filteredTokens).length > 0) {
+                nextTokens[mapId] = filteredTokens;
+              }
+            });
+          }
+
+          const mapPayload = buildCampaignMapPayload(
+            normalizedCampaign.maps,
+            normalizedCampaign.activeMapId,
+            nextTokens
+          );
+
+          const existingParticipants = Array.isArray(
+            normalizedCampaign.combat?.participants
+          )
+            ? normalizedCampaign.combat.participants
+            : [];
+
+          const participants = existingParticipants.filter((participant) => {
+            if (!participant || typeof participant !== 'object') {
+              return false;
+            }
+
+            if (
+              typeof participant.characterId === 'string' &&
+              participant.characterId.trim() !== ''
+            ) {
+              return !deletedIds.has(participant.characterId.trim());
+            }
+
+            return true;
+          });
+
+          let activeTurn = Number(normalizedCampaign.combat?.activeTurn);
+          if (!Number.isInteger(activeTurn)) {
+            activeTurn = null;
+          }
+
+          if (activeTurn !== null) {
+            if (activeTurn < 0) {
+              activeTurn = participants.length > 0 ? 0 : null;
+            } else if (activeTurn >= participants.length) {
+              activeTurn =
+                participants.length > 0
+                  ? Math.min(activeTurn, participants.length - 1)
+                  : null;
+            }
+          }
+
+          const combatState = { participants, activeTurn };
+
+          await campaignsCollection.updateOne(
+            { campaignName },
+            {
+              $set: {
+                mapTokens: mapPayload.tokensByMapId,
+                activeMapId: mapPayload.activeMapId,
+                map: mapPayload.map || null,
+                combat: combatState,
+              },
+            }
+          );
+
+          emitMapUpdate(campaignName, mapPayload);
+          emitCombatUpdate(campaignName, combatState);
+        }
+      }
+
       logger.info('1 character deleted');
-      response.json(obj);
+      return res.json({ acknowledged: true, deletedCount: 1 });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary
- ensure character deletion fetches the document before removal so campaign identifiers survive and update the campaign state
- reuse the campaign map normalization helpers to strip deleted character tokens and emit refreshed map/combat payloads
- extend the character route tests to mock campaign collections and sockets and assert the emitted updates

## Testing
- npm --prefix server test -- characters

------
https://chatgpt.com/codex/tasks/task_e_68de9c276250832e9eb870238b65eb32