### PR TITLE
Add goliath race data with giant ancestries

### DIFF
--- a/server/data/races.js
+++ b/server/data/races.js
@@ -138,6 +138,51 @@ const races = {
     skills: {},
     languages: ["Common", "Infernal"],
   },
+  goliath: {
+    name: "Goliath",
+    speed: 35,
+    abilities: { str: 2, con: 1 },
+    skills: {},
+    languages: ["Common", "Giant"],
+    giantAncestries: {
+      cloud: {
+        label: "Cloud's Jaunt",
+        description:
+          "As a bonus action, teleport up to 30 feet to an unoccupied space you can see.",
+        usage: "Bonus action • Proficiency bonus per long rest",
+      },
+      fire: {
+        label: "Fire's Burn",
+        description:
+          "When you hit a target, deal an extra 1d10 fire damage. The extra damage can be applied once per turn.",
+        usage: "No action • Proficiency bonus per long rest",
+      },
+      frost: {
+        label: "Frost's Chill",
+        description:
+          "When you hit a target, reduce its speed by 10 feet until the start of your next turn. The effect can be applied once per turn.",
+        usage: "No action • Proficiency bonus per long rest",
+      },
+      hill: {
+        label: "Hill's Tumble",
+        description:
+          "When you hit a Large or smaller target, it must succeed on a Strength save or be knocked prone.",
+        usage: "No action • Proficiency bonus per long rest",
+      },
+      stone: {
+        label: "Stone's Endurance",
+        description:
+          "As a reaction when you take damage, roll a d12 and add your Constitution modifier to reduce the incoming damage.",
+        usage: "Reaction • Proficiency bonus per long rest",
+      },
+      storm: {
+        label: "Storm's Thunder",
+        description:
+          "As a reaction when you take damage, force the attacker within 60 feet to make a Constitution save or take 1d8 thunder damage.",
+        usage: "Reaction • Proficiency bonus per long rest",
+      },
+    },
+  },
 };
 
 module.exports = races;


### PR DESCRIPTION
## Summary
- add the goliath race to the race data set with speed, ability boosts, and languages
- define giant ancestry options with labels, descriptions, and usage information for UI display
- ensure existing race helpers continue to receive the expanded payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deaa23043c8323807bf5fbfd85d581