### PR TITLE
Display Goliath subrace in character info

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -61,6 +61,23 @@ export default function CharacterInfo({
     handleClose?.();
   }, [handleClose, isDocked, onDockClose]);
 
+  const raceName = form?.race?.name?.toLowerCase?.();
+  const isGoliath = raceName === 'goliath';
+  const giantAncestries = isGoliath ? form?.race?.giantAncestries || {} : {};
+  const goliathAncestry = isGoliath
+    ? form?.race?.selectedAncestry ||
+      (form?.race?.selectedAncestryKey && giantAncestries
+        ? giantAncestries[form.race.selectedAncestryKey]
+        : null) ||
+      form?.giantAncestry ||
+      (form?.giantAncestryKey && giantAncestries
+        ? giantAncestries[form.giantAncestryKey]
+        : null)
+    : null;
+  const goliathAncestryLabel = goliathAncestry
+    ? goliathAncestry.label || goliathAncestry.name || 'Giant Boon'
+    : null;
+
   return (
     <Modal
       className={modalClassName}
@@ -100,6 +117,12 @@ export default function CharacterInfo({
               <div className="character-info-label">Race</div>
               <div className="character-info-value">{form.race?.name || "—"}</div>
             </div>
+            {goliathAncestryLabel && (
+              <div className="character-info-item">
+                <div className="character-info-label">Subrace</div>
+                <div className="character-info-value">{goliathAncestryLabel}</div>
+              </div>
+            )}
             <div className="character-info-item">
               <div className="character-info-label">Background</div>
               <div className="character-info-value">

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -86,3 +86,31 @@ test('calls rest handlers when buttons clicked', () => {
   expect(onShortRest).toHaveBeenCalled();
 });
 
+test('renders goliath subrace when ancestry selected', () => {
+  const form = {
+    occupation: [],
+    race: {
+      name: 'Goliath',
+      languages: [],
+      selectedAncestryKey: 'cloud',
+      giantAncestries: {
+        cloud: { label: 'Cloud Giant' },
+      },
+    },
+  };
+
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={() => {}}
+      onLongRest={() => {}}
+      onShortRest={() => {}}
+    />
+  );
+
+  expect(screen.getByText('Subrace')).toBeInTheDocument();
+  expect(screen.getByText('Cloud Giant')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- derive the selected Goliath giant ancestry in the character info modal
- render a subrace row when a Goliath ancestry is present
- cover the new behaviour with a CharacterInfo unit test

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/CharacterInfo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68deb0a817d08323a7668e7af60db183