### PR TITLE
Inline Goliath subrace in race card

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -115,14 +115,13 @@ export default function CharacterInfo({
             </div>
             <div className="character-info-item">
               <div className="character-info-label">Race</div>
-              <div className="character-info-value">{form.race?.name || "—"}</div>
-            </div>
-            {goliathAncestryLabel && (
-              <div className="character-info-item">
-                <div className="character-info-label">Subrace</div>
-                <div className="character-info-value">{goliathAncestryLabel}</div>
+              <div className="character-info-value character-info-value--stacked">
+                <span>{form.race?.name || "—"}</span>
+                {isGoliath && goliathAncestryLabel && (
+                  <span className="character-info-subtext">{goliathAncestryLabel}</span>
+                )}
               </div>
-            )}
+            </div>
             <div className="character-info-item">
               <div className="character-info-label">Background</div>
               <div className="character-info-value">

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import CharacterInfo from './CharacterInfo';
 
 jest.mock('./LevelUp', () => () => <div />);
@@ -86,7 +86,7 @@ test('calls rest handlers when buttons clicked', () => {
   expect(onShortRest).toHaveBeenCalled();
 });
 
-test('renders goliath subrace when ancestry selected', () => {
+test('renders goliath subrace within race card when ancestry selected', () => {
   const form = {
     occupation: [],
     race: {
@@ -110,7 +110,12 @@ test('renders goliath subrace when ancestry selected', () => {
     />
   );
 
-  expect(screen.getByText('Subrace')).toBeInTheDocument();
-  expect(screen.getByText('Cloud Giant')).toBeInTheDocument();
+  const raceItem = screen.getByText('Race').closest('.character-info-item');
+  expect(raceItem).not.toBeNull();
+
+  const { getByText, queryByText } = within(raceItem);
+  expect(getByText('Goliath')).toBeInTheDocument();
+  expect(getByText('Cloud Giant')).toBeInTheDocument();
+  expect(queryByText('Subrace')).not.toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary
- render goliath ancestry details within the race card instead of a separate subrace entry
- ensure race markup keeps fallback for characters without selected ancestries
- update the character info tests to align with the consolidated race display

## Testing
- CI=true npm test -- CharacterInfo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68deb80fde708323bd204e1364a672a8