### PR TITLE
feat: add explicit goliath ancestry names

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -74,8 +74,11 @@ export default function CharacterInfo({
         ? giantAncestries[form.giantAncestryKey]
         : null)
     : null;
-  const goliathAncestryLabel = goliathAncestry
-    ? goliathAncestry.label || goliathAncestry.name || 'Giant Boon'
+  const goliathAncestryName = goliathAncestry
+    ? goliathAncestry.ancestryName ||
+      goliathAncestry.name ||
+      goliathAncestry.label ||
+      "Giant Ancestry"
     : null;
 
   return (
@@ -117,8 +120,8 @@ export default function CharacterInfo({
               <div className="character-info-label">Race</div>
               <div className="character-info-value character-info-value--stacked">
                 <span>{form.race?.name || "—"}</span>
-                {isGoliath && goliathAncestryLabel && (
-                  <span className="character-info-subtext">{goliathAncestryLabel}</span>
+                {isGoliath && goliathAncestryName && (
+                  <span className="character-info-subtext">{goliathAncestryName}</span>
                 )}
               </div>
             </div>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -94,7 +94,7 @@ test('renders goliath subrace within race card when ancestry selected', () => {
       languages: [],
       selectedAncestryKey: 'cloud',
       giantAncestries: {
-        cloud: { label: 'Cloud Giant' },
+        cloud: { label: "Cloud's Jaunt", ancestryName: 'Cloud Giant' },
       },
     },
   };

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -144,6 +144,7 @@ test('goliath ancestry features include boon, Powerful Build, and Large Form at 
 
   const ancestry = {
     label: "Cloud's Jaunt",
+    ancestryName: 'Cloud Giant',
     description: 'As a bonus action, teleport up to 30 feet to an unoccupied space you can see.',
     usage: 'Bonus action • Proficiency bonus per long rest',
   };

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -1060,7 +1060,9 @@ const getAvailableSkillOptions = (index) => {
             >
               <option value="" disabled>Select your giant ancestry</option>
               {Object.entries(form.race.giantAncestries || {}).map(([key, ancestry]) => (
-                <option key={key} value={key}>{ancestry.label}</option>
+                <option key={key} value={key}>
+                  {ancestry.ancestryName || ancestry.label || ancestry.name || "Giant Ancestry"}
+                </option>
               ))}
             </Form.Select>
           </>

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -147,36 +147,42 @@ const races = {
     giantAncestries: {
       cloud: {
         label: "Cloud's Jaunt",
+        ancestryName: "Cloud Giant",
         description:
           "As a bonus action, teleport up to 30 feet to an unoccupied space you can see.",
         usage: "Bonus action • Proficiency bonus per long rest",
       },
       fire: {
         label: "Fire's Burn",
+        ancestryName: "Fire Giant",
         description:
           "When you hit a target, deal an extra 1d10 fire damage. The extra damage can be applied once per turn.",
         usage: "No action • Proficiency bonus per long rest",
       },
       frost: {
         label: "Frost's Chill",
+        ancestryName: "Frost Giant",
         description:
           "When you hit a target, reduce its speed by 10 feet until the start of your next turn. The effect can be applied once per turn.",
         usage: "No action • Proficiency bonus per long rest",
       },
       hill: {
         label: "Hill's Tumble",
+        ancestryName: "Hill Giant",
         description:
           "When you hit a Large or smaller target, it must succeed on a Strength save or be knocked prone.",
         usage: "No action • Proficiency bonus per long rest",
       },
       stone: {
         label: "Stone's Endurance",
+        ancestryName: "Stone Giant",
         description:
           "As a reaction when you take damage, roll a d12 and add your Constitution modifier to reduce the incoming damage.",
         usage: "Reaction • Proficiency bonus per long rest",
       },
       storm: {
         label: "Storm's Thunder",
+        ancestryName: "Storm Giant",
         description:
           "As a reaction when you take damage, force the attacker within 60 feet to make a Constitution save or take 1d8 thunder damage.",
         usage: "Reaction • Proficiency bonus per long rest",


### PR DESCRIPTION
## Summary
- add explicit ancestryName metadata to each goliath ancestry while preserving boon labels
- surface ancestry names in character info and the manual selector so subrace text reflects the new field
- update related tests to cover the ancestry name expectations

## Testing
- CI=true npm test *(fails: existing ZombiesCharacterSheet and ZombiesDM tests timeout/fail in main branch)*
- CI=true npm test -- CharacterInfo.test.js
- CI=true npm test -- Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68deb8ba0e6c83239a72752aca6d8d89