### PR TITLE
Add Large Form feature activation handling for Goliaths

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -3,12 +3,14 @@ import { Modal, Card, Button, Spinner } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import actionSurgeIcon from '../../../images/action-surge-icon.png';
+import largeFormIcon from '../../../images/large-form-icon.png';
 
 export default function Features({
   form,
   showFeatures,
   handleCloseFeatures,
   onActionSurge,
+  onLargeForm,
   longRestCount,
   shortRestCount,
   isDocked = false,
@@ -21,6 +23,7 @@ export default function Features({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [surgeUsed, setSurgeUsed] = useState(false);
+  const [largeFormUsed, setLargeFormUsed] = useState(false);
 
   const totalCharacterLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) return 0;
@@ -191,6 +194,7 @@ export default function Features({
 
   useEffect(() => {
     setSurgeUsed(false);
+    setLargeFormUsed(false);
   }, [longRestCount, shortRestCount]);
 
   const dialogClassName = useMemo(() => {
@@ -256,6 +260,7 @@ export default function Features({
                   {displayFeatures.map((feat, idx) => {
                     const featKey = feat.id || `${feat.name}-${idx}`;
                     const isActionSurge = feat.name?.includes('Action Surge');
+                    const isLargeForm = feat.id === 'goliath-large-form';
                     return (
                       <div className="feature-card" key={featKey}>
                         <div className="feature-card-header">
@@ -291,6 +296,26 @@ export default function Features({
                                 <img
                                   src={actionSurgeIcon}
                                   alt="Action Surge"
+                                  width={36}
+                                  height={36}
+                                />
+                              </Button>
+                            ) : isLargeForm ? (
+                              <Button
+                                aria-label="use feature"
+                                variant="link"
+                                className={`p-0 border-0 ${largeFormUsed ? 'opacity-50' : ''}`}
+                                onClick={() => {
+                                  if (!largeFormUsed) {
+                                    onLargeForm?.();
+                                    setLargeFormUsed(true);
+                                  }
+                                }}
+                                disabled={largeFormUsed}
+                              >
+                                <img
+                                  src={largeFormIcon}
+                                  alt="Large Form"
                                   width={36}
                                   height={36}
                                 />

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -156,11 +156,14 @@ test('goliath ancestry features include boon, Powerful Build, and Large Form at 
     selectedAncestry: ancestry,
   };
 
+  const onLargeForm = jest.fn();
+
   const { rerender } = render(
     <Features
       form={{ race, occupation: [{ Name: 'Barbarian', Level: 4 }] }}
       showFeatures={true}
       handleCloseFeatures={() => {}}
+      onLargeForm={onLargeForm}
     />
   );
 
@@ -205,6 +208,7 @@ test('goliath ancestry features include boon, Powerful Build, and Large Form at 
       form={{ race, occupation: [{ Name: 'Barbarian', Level: 5 }] }}
       showFeatures={true}
       handleCloseFeatures={() => {}}
+      onLargeForm={onLargeForm}
     />
   );
 
@@ -216,6 +220,13 @@ test('goliath ancestry features include boon, Powerful Build, and Large Form at 
   const largeFormView = within(largeFormCard).getByRole('button', {
     name: /view feature/i,
   });
+
+  const largeFormUse = within(largeFormCard).getByRole('button', {
+    name: /use feature/i,
+  });
+
+  expect(largeFormUse).toBeEnabled();
+  expect(onLargeForm).not.toHaveBeenCalled();
 
   expect(
     screen.queryByText(
@@ -232,6 +243,13 @@ test('goliath ancestry features include boon, Powerful Build, and Large Form at 
       "Starting at 5th level, you can use a bonus action to magically grow to Large size for 10 minutes. While Large, your speed increases by 10 feet, and you have advantage on Strength checks. Once you use this trait, you can't use it again until you finish a long rest."
     )
   ).toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(largeFormUse);
+  });
+
+  expect(onLargeForm).toHaveBeenCalledTimes(1);
+  expect(largeFormUse).toBeDisabled();
 });
 
 test('features are sorted by class then level', async () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -31,6 +31,7 @@ import Features from "../attributes/Features";
 import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import hasteIcon from "../../../images/spell-haste-icon.png";
+import largeFormIcon from "../../../images/large-form-icon.png";
 import ShopModal from "../attributes/ShopModal";
 import InventoryModal from "../attributes/InventoryModal";
 import EquipmentModal from "../attributes/EquipmentModal";
@@ -1131,6 +1132,15 @@ export default function ZombiesCharacterSheet() {
       return next;
     });
   }, []);
+
+  const handleLargeForm = useCallback(() => {
+    setActiveEffects((prev) => {
+      if (prev.some((effect) => effect.name === 'Large Form')) {
+        return prev;
+      }
+      return [...prev, { name: 'Large Form', icon: largeFormIcon }];
+    });
+  }, [setActiveEffects]);
 
   const handlePassTurn = useCallback(async () => {
     if (isPassingTurn || !encodedCampaignId) {
@@ -3179,6 +3189,7 @@ export default function ZombiesCharacterSheet() {
           form,
           handleCloseFeatures,
           onActionSurge: handleActionSurge,
+          onLargeForm: handleLargeForm,
           longRestCount,
           shortRestCount,
         }),
@@ -3751,6 +3762,7 @@ export default function ZombiesCharacterSheet() {
           showFeatures={showFeatures}
           handleCloseFeatures={handleCloseFeatures}
           onActionSurge={handleActionSurge}
+          onLargeForm={handleLargeForm}
           longRestCount={longRestCount}
           shortRestCount={shortRestCount}
           actionCount={actionCount}


### PR DESCRIPTION
## Summary
- add a dedicated Large Form activation button to the Features modal and reset its usage on rests
- track the Large Form effect on the character sheet when triggered from the modal
- expand feature tests to cover Large Form activation, disabling, and callbacks

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68deebcf4d2083239d978dbb95cb64d8