### PR TITLE
Add size support to race data and character validation

### DIFF
--- a/server/data/races.js
+++ b/server/data/races.js
@@ -1,6 +1,8 @@
 const races = {
   human: {
     name: "Human",
+    size: "Medium",
+    sizeOptions: ["Medium", "Small"],
     speed: 30,
     abilities: { str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1 },
     skills: {},
@@ -8,6 +10,8 @@ const races = {
   },
   dwarf: {
     name: "Dwarf",
+    size: "Medium",
+    sizeOptions: ["Medium"],
     speed: 25,
     abilities: { con: 2 },
     skills: {},
@@ -21,6 +25,8 @@ const races = {
   },
   elf: {
     name: "Elf",
+    size: "Medium",
+    sizeOptions: ["Medium"],
     speed: 30,
     abilities: { dex: 2 },
     skills: { perception: { proficient: true } },
@@ -34,6 +40,8 @@ const races = {
   },
   halfling: {
     name: "Halfling",
+    size: "Small",
+    sizeOptions: ["Small"],
     speed: 25,
     abilities: { dex: 2 },
     skills: {},
@@ -41,6 +49,8 @@ const races = {
   },
   dragonborn: {
     name: "Dragonborn",
+    size: "Medium",
+    sizeOptions: ["Medium"],
     speed: 30,
     abilities: { str: 2, cha: 1 },
     skills: {},
@@ -110,6 +120,8 @@ const races = {
   },
   gnome: {
     name: "Gnome",
+    size: "Small",
+    sizeOptions: ["Small"],
     speed: 25,
     abilities: { int: 2 },
     skills: {},
@@ -117,6 +129,8 @@ const races = {
   },
   "half-elf": {
     name: "Half-Elf",
+    size: "Medium",
+    sizeOptions: ["Medium"],
     speed: 30,
     abilities: { cha: 2 },
     abilityChoices: { count: 2, options: ["str", "dex", "con", "int", "wis"] },
@@ -124,8 +138,10 @@ const races = {
     skills: {},
     languages: ["Common", "Elvish", "Choice"],
   },
-  "half-orc": {
-    name: "Half-Orc",
+  orc: {
+    name: "Orc",
+    size: "Medium",
+    sizeOptions: ["Medium"],
     speed: 30,
     abilities: { str: 2, con: 1 },
     skills: { intimidation: { proficient: true } },
@@ -133,6 +149,8 @@ const races = {
   },
   tiefling: {
     name: "Tiefling",
+    size: "Medium",
+    sizeOptions: ["Medium", "Small"],
     speed: 30,
     abilities: { cha: 2, int: 1 },
     skills: {},
@@ -140,6 +158,8 @@ const races = {
   },
   goliath: {
     name: "Goliath",
+    size: "Medium",
+    sizeOptions: ["Medium"],
     speed: 35,
     abilities: { str: 2, con: 1 },
     skills: {},

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -4,7 +4,12 @@ const express = require('express');
 const authenticateToken = require('../../middleware/auth');
 const handleValidationErrors = require('../../middleware/validation');
 const logger = require('../../utils/logger');
-const { numericFields, skillFields, skillNames } = require('../fieldConstants');
+const {
+  numericFields,
+  stringFields,
+  skillFields,
+  skillNames,
+} = require('../fieldConstants');
 const proficiencyBonus = require('../../utils/proficiency');
 const collectAllowedSkills = require('../../utils/collectAllowedSkills');
 const collectAllowedExpertise = require('../../utils/collectAllowedExpertise');
@@ -217,6 +222,7 @@ module.exports = (router) => {
   // This section will create a new character.
   // Includes numeric stats like initiative, AC, speed, passive scores, and HP bonuses.
   const numericCharacterFields = [...numericFields];
+  const stringCharacterFields = [...stringFields];
   const currencyFields = ['cp', 'sp', 'gp', 'pp'];
 
   characterRouter.post(
@@ -253,6 +259,9 @@ module.exports = (router) => {
       body('diceColor').optional().trim(),
       ...currencyFields.map((field) => body(field).optional().isInt().toInt()),
       ...numericCharacterFields.map((field) => body(field).optional().isInt().toInt()),
+      ...stringCharacterFields.map((field) =>
+        body(field).optional().isString().trim()
+      ),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -264,6 +273,10 @@ module.exports = (router) => {
           myobj[field] = 0;
         }
       });
+
+      if (!myobj.size && myobj.race && typeof myobj.race.size === 'string') {
+        myobj.size = myobj.race.size;
+      }
 
       // initialize skills structure with proficiency/expertise flags if not provided
       if (!myobj.skills) {

--- a/server/routes/fieldConstants.js
+++ b/server/routes/fieldConstants.js
@@ -1,6 +1,5 @@
 const numericFields = [
   'age',
-  'height',
   'weight',
   'str',
   'dex',
@@ -17,6 +16,8 @@ const numericFields = [
   'hpMaxBonus',
   'hpMaxBonusPerLevel',
 ];
+
+const stringFields = ['size'];
 
 // Define the list of available skills
 const skillNames = [
@@ -48,6 +49,7 @@ const skillFields = skillNames.reduce((acc, skill) => {
 
 module.exports = {
   numericFields,
+  stringFields,
   skillFields,
   skillNames,
 };


### PR DESCRIPTION
## Summary
- add canonical size metadata and options to each race and swap half-orc for SRD orc data
- expose size as a string field while keeping numeric validation for number-based stats
- default characters to their race size when not provided explicitly

## Testing
- npm test (server)


------
https://chatgpt.com/codex/tasks/task_e_68def2272a288323a45ee5cdb94eb159