### PR TITLE
Preserve token size metadata in map token updates

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1638,12 +1638,23 @@ export default function ZombiesDM() {
         const previousActiveTokens = activeMapTokensRef.current || {};
         const previousCampaignMap = campaignMap;
 
+        const candidateSizes = [
+          tokenMetaById?.[normalizedCharacterId]?.size,
+          previousTokens?.[normalizedMapId]?.[normalizedCharacterId]?.size,
+          previousCampaignMap?.tokens?.[normalizedCharacterId]?.size,
+          previousActiveTokens?.[normalizedCharacterId]?.size,
+        ];
+        const normalizedSize = candidateSizes
+          .map((value) => normalizeCreatureSize(value))
+          .find(Boolean) || null;
+
         const optimisticToken = {
           ...(previousTokens?.[normalizedMapId]?.[normalizedCharacterId] || {}),
           characterId: normalizedCharacterId,
           x: clampedX,
           y: clampedY,
           updatedAt: new Date().toISOString(),
+          ...(normalizedSize ? { size: normalizedSize } : {}),
         };
 
         setMapTokens((prev) => {
@@ -1682,7 +1693,11 @@ export default function ZombiesDM() {
             {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ x: clampedX, y: clampedY }),
+              body: JSON.stringify(
+                normalizedSize
+                  ? { x: clampedX, y: clampedY, size: normalizedSize }
+                  : { x: clampedX, y: clampedY }
+              ),
             }
           );
 
@@ -1704,7 +1719,14 @@ export default function ZombiesDM() {
           setCampaignMap(previousCampaignMap || null);
         }
       },
-      [activeMapId, campaignMap, encodedCampaign, parseErrorMessage, setStatus]
+      [
+        activeMapId,
+        campaignMap,
+        encodedCampaign,
+        parseErrorMessage,
+        setStatus,
+        tokenMetaById,
+      ]
     );
 
     const persistCombatState = useCallback(

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -678,7 +678,7 @@ describe('Campaign routes', () => {
 
       const res = await request(app)
         .put(`/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`)
-        .send({ x: 1.5, y: -0.25 });
+        .send({ x: 1.5, y: -0.25, size: ' Large ' });
 
       expect(res.status).toBe(200);
       expect(res.body).not.toHaveProperty('map');
@@ -690,12 +690,13 @@ describe('Campaign routes', () => {
             characterId: 'hero-1',
             x: 1,
             y: 0,
+            size: 'large',
             updatedAt: expect.any(String),
           }),
         },
       });
       expect(res.body.activeMapTokens).toEqual({
-        'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+        'hero-1': expect.objectContaining({ x: 1, y: 0, size: 'large' }),
       });
       const lastUpdateCall =
         updateOne.mock.calls[updateOne.mock.calls.length - 1];
@@ -710,13 +711,13 @@ describe('Campaign routes', () => {
         expect.objectContaining({
           mapTokens: {
             [storedMap.mapId]: expect.objectContaining({
-              'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+              'hero-1': expect.objectContaining({ x: 1, y: 0, size: 'large' }),
             }),
           },
           'map.tokens': expect.objectContaining({
-            'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+            'hero-1': expect.objectContaining({ x: 1, y: 0, size: 'large' }),
           }),
-        })
+      })
       );
       expect(updateDoc.$set).not.toHaveProperty('map');
       expect(updateDoc.$set).not.toHaveProperty('maps');
@@ -728,13 +729,13 @@ describe('Campaign routes', () => {
       expect(emittedPayload.tokensByMapId).toEqual(
         expect.objectContaining({
           [storedMap.mapId]: expect.objectContaining({
-            'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+            'hero-1': expect.objectContaining({ x: 1, y: 0, size: 'large' }),
           }),
         })
       );
       expect(emittedPayload.activeMapTokens).toEqual(
         expect.objectContaining({
-          'hero-1': expect.objectContaining({ x: 1, y: 0 }),
+          'hero-1': expect.objectContaining({ x: 1, y: 0, size: 'large' }),
         })
       );
     });

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -13,6 +13,7 @@ const {
   prepareStoredMap,
   buildCampaignMapPayload,
   normalizeMapTokens,
+  normalizeCreatureSize,
 } = require('../utils/campaignMaps');
 const { uploadMapImage, deleteMapImage } = require('../utils/cloudinary');
 
@@ -1004,6 +1005,10 @@ module.exports = (router) => {
           .withMessage('characterId is required'),
         body('x').isFloat().withMessage('x must be a number').toFloat(),
         body('y').isFloat().withMessage('y must be a number').toFloat(),
+        body('size')
+          .optional({ nullable: true, checkFalsy: true })
+          .isString()
+          .withMessage('size must be a string'),
       ],
       handleValidationErrors,
       async (req, res, next) => {
@@ -1062,11 +1067,23 @@ module.exports = (router) => {
             nextTokens[mapId] = {};
           }
 
+          const existingToken =
+            nextTokens[mapId][trimmedCharacterId] &&
+            typeof nextTokens[mapId][trimmedCharacterId] === 'object'
+              ? nextTokens[mapId][trimmedCharacterId]
+              : null;
+
+          const sizeInput = typeof req.body.size === 'string' ? req.body.size : null;
+          const normalizedSize =
+            normalizeCreatureSize(sizeInput) ||
+            normalizeCreatureSize(existingToken?.size);
+
           nextTokens[mapId][trimmedCharacterId] = {
             characterId: trimmedCharacterId,
             x: req.body.x,
             y: req.body.y,
             updatedAt: now,
+            ...(normalizedSize ? { size: normalizedSize } : {}),
           };
 
           const { tokensByMapId } = normalizeMapTokens({

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -6,6 +6,36 @@ let mapSchemas;
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
+
+const normalizeCreatureSize = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (CREATURE_SIZE_KEYS.includes(trimmed)) {
+    return trimmed;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  const tokenMatch = CREATURE_SIZE_KEYS.find((size) => tokens.includes(size));
+  if (tokenMatch) {
+    return tokenMatch;
+  }
+
+  const prefixMatch = CREATURE_SIZE_KEYS.find((size) => trimmed.startsWith(size));
+  if (prefixMatch) {
+    return prefixMatch;
+  }
+
+  return null;
+};
+
 const getMapSchemas = () => {
   if (!mapSchemas) {
     const { z } = require('zod');
@@ -146,11 +176,14 @@ const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
         didMutate = true;
       }
 
+      const normalizedSize = normalizeCreatureSize(candidate.size);
+
       const sanitizedToken = {
         characterId,
         x: clampedX,
         y: clampedY,
         updatedAt: resolvedUpdatedAt,
+        ...(normalizedSize ? { size: normalizedSize } : {}),
       };
 
       const originalComparable = JSON.stringify({
@@ -158,6 +191,7 @@ const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
         x: rawValue.x,
         y: rawValue.y,
         updatedAt: rawValue.updatedAt,
+        ...(rawValue.size !== undefined ? { size: rawValue.size } : {}),
       });
       const sanitizedComparable = JSON.stringify(sanitizedToken);
       if (originalComparable !== sanitizedComparable) {
@@ -468,4 +502,5 @@ module.exports = {
   normalizeCampaignMapState,
   getMapSchemas,
   normalizeMapTokens,
+  normalizeCreatureSize,
 };


### PR DESCRIPTION
## Summary
- propagate known token size metadata through optimistic updates and API payloads
- normalize and persist optional size strings when storing campaign map tokens
- keep sanitized size values during token normalization and update tests to cover the behavior

## Testing
- npm --prefix server test -- --runTestsByPath __tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68def80083cc8323b2a4e05171a8a67f