### PR TITLE
Add manual status effect removal for Zombies character sheet

### DIFF
--- a/client/src/components/Zombies/attributes/StatusEffectBar.js
+++ b/client/src/components/Zombies/attributes/StatusEffectBar.js
@@ -1,11 +1,38 @@
 import React from 'react';
 
-export default function StatusEffectBar({ effects = [] }) {
+export default function StatusEffectBar({ effects = [], onRemoveEffect }) {
   if (!effects.length) return null;
+  const hasRemoveHandler = typeof onRemoveEffect === 'function';
   return (
     <div style={{ display: 'flex', gap: '8px', justifyContent: 'center' }}>
       {effects.map((e, idx) => (
         <div key={e.name || idx} style={{ position: 'relative' }}>
+          {hasRemoveHandler && (
+            <button
+              type="button"
+              aria-label={`Remove ${e.name || 'status effect'}`}
+              onClick={() => onRemoveEffect(idx)}
+              style={{
+                position: 'absolute',
+                top: '-6px',
+                right: '-6px',
+                width: '18px',
+                height: '18px',
+                borderRadius: '50%',
+                border: 'none',
+                backgroundColor: '#dc3545',
+                color: 'white',
+                fontSize: '12px',
+                lineHeight: '12px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+              }}
+            >
+              ×
+            </button>
+          )}
           <img
             src={e.icon}
             alt={e.name}

--- a/client/src/components/Zombies/attributes/StatusEffectBar.test.js
+++ b/client/src/components/Zombies/attributes/StatusEffectBar.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import StatusEffectBar from './StatusEffectBar';
 
 test('renders nothing when no effects', () => {
@@ -15,4 +16,31 @@ test('renders icons with remaining count', () => {
   );
   expect(screen.getByAltText('Haste')).toBeInTheDocument();
   expect(screen.getByText('x10')).toBeInTheDocument();
+});
+
+test('renders remove button when handler provided', async () => {
+  render(
+    <StatusEffectBar
+      effects={[{ name: 'Haste', icon: 'haste.png' }]}
+      onRemoveEffect={jest.fn()}
+    />
+  );
+  const removeButton = screen.getByRole('button', { name: /remove haste/i });
+  expect(removeButton).toBeInTheDocument();
+  expect(removeButton).toHaveTextContent('×');
+  expect(removeButton).toHaveStyle({ backgroundColor: '#dc3545' });
+});
+
+test('invokes removal handler when remove button clicked', async () => {
+  const handleRemove = jest.fn();
+  render(
+    <StatusEffectBar
+      effects={[{ name: 'Haste', icon: 'haste.png' }]}
+      onRemoveEffect={handleRemove}
+    />
+  );
+  const removeButton = screen.getByRole('button', { name: /remove haste/i });
+  await userEvent.click(removeButton);
+  expect(handleRemove).toHaveBeenCalledTimes(1);
+  expect(handleRemove).toHaveBeenCalledWith(0);
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -686,6 +686,20 @@ export default function ZombiesCharacterSheet() {
   const [longRestCount, setLongRestCount] = useState(0);
   const [shortRestCount, setShortRestCount] = useState(0);
   const [activeEffects, setActiveEffects] = useState([]);
+  const handleRemoveEffect = useCallback((effectKey) => {
+    setActiveEffects((prev) =>
+      prev.filter((effect, index) => {
+        if (typeof effectKey === 'number') {
+          return index !== effectKey;
+        }
+        const name = typeof effect?.name === 'string' ? effect.name : null;
+        if (!name) {
+          return true;
+        }
+        return name !== effectKey;
+      })
+    );
+  }, []);
   const baseActionCount = form?.features?.actionCount ?? 1;
   const [actionCount, setActionCount] = useState(baseActionCount);
   const initCircleState = () => ({
@@ -3529,7 +3543,10 @@ export default function ZombiesCharacterSheet() {
                 flexShrink: 0,
               }}
             >
-              <StatusEffectBar effects={activeEffects} />
+              <StatusEffectBar
+                effects={activeEffects}
+                onRemoveEffect={handleRemoveEffect}
+              />
             </div>
             <PlayerTurnActions
               form={form}


### PR DESCRIPTION
## Summary
- add an optional remove control to StatusEffectBar so users can clear effects directly
- plumb a handler through ZombiesCharacterSheet that updates activeEffects when removal is requested
- expand StatusEffectBar tests to validate the removal UI and callback behaviour

## Testing
- CI=1 npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/StatusEffectBar.test.js

------
https://chatgpt.com/codex/tasks/task_e_68defe77c2c483238e734d14853efc29