### PR TITLE
Add temporary Large Form overrides to zombie character sheet

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -80,6 +80,8 @@ export default function CharacterInfo({
       goliathAncestry.label ||
       "Giant Ancestry"
     : null;
+  const displaySize =
+    form?.temporarySize || form?.size || form?.height || "—";
 
   return (
     <Modal
@@ -156,7 +158,7 @@ export default function CharacterInfo({
             </div>
             <div className="character-info-item">
               <div className="character-info-label">Size</div>
-              <div className="character-info-value">{form.size || form.height || "—"}</div>
+              <div className="character-info-value">{displaySize}</div>
             </div>
             <div className="character-info-item">
               <div className="character-info-label">Weight</div>

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -177,6 +177,10 @@ export default function HealthDefense({
       : healthValue >= 0
         ? "#2ecc71"
         : "#c0392b";
+  const totalSpeed =
+    Number(form?.speed ?? 0) +
+    Number(speed ?? 0) +
+    Number(form?.temporarySpeedBonus ?? 0);
 
 return (
 <div
@@ -327,7 +331,7 @@ return (
   <div style={{ display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
     <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
     <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
-    <div><strong>Speed:</strong> {(form.speed || 0) + Number(speed)}</div>
+    <div><strong>Speed:</strong> {totalSpeed}</div>
   </div>
 
   {/* Second row */}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1118,6 +1118,53 @@ export default function ZombiesCharacterSheet() {
     });
   }, [baseActionCount, activeEffects]);
 
+  const temporarySize = form?.temporarySize;
+  const temporarySpeedBonus = form?.temporarySpeedBonus;
+
+  useEffect(() => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const hasLargeForm = activeEffects.some(
+        (effect) => effect && effect.name === 'Large Form'
+      );
+
+      if (hasLargeForm) {
+        const desiredSize = 'Large';
+        const desiredSpeedBonus = 10;
+        const nextSize = prev.temporarySize;
+        const nextSpeedBonus = Number(prev.temporarySpeedBonus ?? 0);
+
+        if (
+          nextSize === desiredSize &&
+          nextSpeedBonus === desiredSpeedBonus
+        ) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          temporarySize: desiredSize,
+          temporarySpeedBonus: desiredSpeedBonus,
+        };
+      }
+
+      const hasTemporaryFields =
+        Object.prototype.hasOwnProperty.call(prev, 'temporarySize') ||
+        Object.prototype.hasOwnProperty.call(prev, 'temporarySpeedBonus');
+
+      if (!hasTemporaryFields) {
+        return prev;
+      }
+
+      const { temporarySize: _ignoredSize, temporarySpeedBonus: _ignoredSpeed, ...rest } =
+        prev;
+      return rest;
+    });
+  }, [activeEffects, temporarySize, temporarySpeedBonus]);
+
   const consumeCircle = useCallback(
     (type, index) => {
       setUsedSlots((prev) => {
@@ -2598,7 +2645,8 @@ export default function ZombiesCharacterSheet() {
         const { currentHp, maxHp } = calculateCharacterHitPoints(value);
 
         const recordSize = normalizeCreatureSize(
-          value?.size ??
+          value?.temporarySize ??
+            value?.size ??
             value?.characterSize ??
             value?.character?.size ??
             value?.creature?.size ??
@@ -2681,7 +2729,8 @@ export default function ZombiesCharacterSheet() {
         const { currentHp, maxHp } = calculateCharacterHitPoints(form);
 
         const fallbackSize = normalizeCreatureSize(
-          form?.size ??
+          form?.temporarySize ??
+            form?.size ??
             form?.characterSize ??
             form?.character?.size ??
             form?.creature?.size ??
@@ -2701,7 +2750,8 @@ export default function ZombiesCharacterSheet() {
         };
       } else {
         const fallbackSize = normalizeCreatureSize(
-          form?.size ??
+          form?.temporarySize ??
+            form?.size ??
             form?.characterSize ??
             form?.character?.size ??
             form?.creature?.size ??


### PR DESCRIPTION
## Summary
- apply Large Form temporary size and speed overrides to the active character sheet state and combat tokens
- surface temporary size and speed adjustments in character info and health/defense displays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df000d67c0832396be767e6199a715