### PR TITLE
Persist zombies active effects in local storage

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -79,6 +79,19 @@ const toFiniteNumberOrNull = (value) => {
 
 const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
 
+const getActiveEffectStorageKey = (characterId) => {
+  if (typeof characterId !== 'string') {
+    return null;
+  }
+
+  const trimmedId = characterId.trim();
+  if (!trimmedId) {
+    return null;
+  }
+
+  return `zombies-character-${trimmedId}-active-effects`;
+};
+
 const normalizeCreatureSize = (value) => {
   if (typeof value !== 'string') {
     return null;
@@ -771,6 +784,33 @@ export default function ZombiesCharacterSheet() {
         : null;
   }, [campaignActiveMapId]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined' || !characterId) {
+      return;
+    }
+
+    const storageKey = getActiveEffectStorageKey(characterId);
+    if (!storageKey || typeof window.localStorage === 'undefined') {
+      return;
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(storageKey);
+      if (!storedValue) {
+        return;
+      }
+
+      const parsed = JSON.parse(storedValue);
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+
+      setActiveEffects(parsed);
+    } catch (error) {
+      // Ignore hydration errors and fall back to the current state
+    }
+  }, [characterId]);
+
   const applyMapPayload = useCallback(
     (payload = {}) => {
       const normalizedMaps = Array.isArray(payload?.maps)
@@ -1164,6 +1204,28 @@ export default function ZombiesCharacterSheet() {
       return rest;
     });
   }, [activeEffects, temporarySize, temporarySpeedBonus]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+      return;
+    }
+
+    const storageKey = getActiveEffectStorageKey(characterId);
+    if (!storageKey) {
+      return;
+    }
+
+    if (!Array.isArray(activeEffects) || activeEffects.length === 0) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(activeEffects));
+    } catch (error) {
+      // Ignore persistence errors
+    }
+  }, [characterId, activeEffects]);
 
   const consumeCircle = useCallback(
     (type, index) => {


### PR DESCRIPTION
## Summary
- add a helper to generate the Zombies character active effect storage key and hydrate previously saved effects once a character is available
- persist the active effects list to localStorage and remove stale entries when cleared so Large Form and rest flows stay in sync after refreshes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df02a751a48323bb1ff45e978cfb8f