### PR TITLE
Preserve Zombies character active effects until rest

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -708,6 +708,10 @@ export default function ZombiesCharacterSheet() {
   const [activeEffects, setActiveEffects] = useState(() =>
     getStoredActiveEffects(characterId)
   );
+  const previousRestCountsRef = useRef({
+    long: longRestCount,
+    short: shortRestCount,
+  });
   const handleRemoveEffect = useCallback((effectKey) => {
     setActiveEffects((prev) =>
       prev.filter((effect, index) => {
@@ -1143,6 +1147,19 @@ export default function ZombiesCharacterSheet() {
   }, []);
 
   useEffect(() => {
+    const previousCounts = previousRestCountsRef.current;
+    const didLongRestIncrement = longRestCount > previousCounts.long;
+    const didShortRestIncrement = shortRestCount > previousCounts.short;
+
+    previousRestCountsRef.current = {
+      long: longRestCount,
+      short: shortRestCount,
+    };
+
+    if (!didLongRestIncrement && !didShortRestIncrement) {
+      return;
+    }
+
     // Clear effects on rest
     setActiveEffects([]);
   }, [longRestCount, shortRestCount]);


### PR DESCRIPTION
## Summary
- skip the rest effect on initial mount by tracking previous rest counters
- only clear active effects when rest counters increment so stored effects persist across reloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df0a17ec78832e862c375d9a885ac7