### PR TITLE
Add draconic flight feature handling

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -4,6 +4,7 @@ import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import actionSurgeIcon from '../../../images/action-surge-icon.png';
 import largeFormIcon from '../../../images/large-form-icon.png';
+import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 
 export default function Features({
   form,
@@ -11,6 +12,7 @@ export default function Features({
   handleCloseFeatures,
   onActionSurge,
   onLargeForm,
+  onDraconicFlight,
   longRestCount,
   shortRestCount,
   isDocked = false,
@@ -24,6 +26,7 @@ export default function Features({
   const [error, setError] = useState(null);
   const [surgeUsed, setSurgeUsed] = useState(false);
   const [largeFormUsed, setLargeFormUsed] = useState(false);
+  const [draconicFlightUsed, setDraconicFlightUsed] = useState(false);
 
   const totalCharacterLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) return 0;
@@ -195,6 +198,7 @@ export default function Features({
   useEffect(() => {
     setSurgeUsed(false);
     setLargeFormUsed(false);
+    setDraconicFlightUsed(false);
   }, [longRestCount, shortRestCount]);
 
   const dialogClassName = useMemo(() => {
@@ -261,6 +265,8 @@ export default function Features({
                     const featKey = feat.id || `${feat.name}-${idx}`;
                     const isActionSurge = feat.name?.includes('Action Surge');
                     const isLargeForm = feat.id === 'goliath-large-form';
+                    const isDraconicFlight =
+                      feat.id === 'dragonborn-draconic-flight';
                     return (
                       <div className="feature-card" key={featKey}>
                         <div className="feature-card-header">
@@ -316,6 +322,28 @@ export default function Features({
                                 <img
                                   src={largeFormIcon}
                                   alt="Large Form"
+                                  width={36}
+                                  height={36}
+                                />
+                              </Button>
+                            ) : isDraconicFlight ? (
+                              <Button
+                                aria-label="use feature"
+                                variant="link"
+                                className={`p-0 border-0 ${
+                                  draconicFlightUsed ? 'opacity-50' : ''
+                                }`}
+                                onClick={() => {
+                                  if (!draconicFlightUsed) {
+                                    onDraconicFlight?.();
+                                    setDraconicFlightUsed(true);
+                                  }
+                                }}
+                                disabled={draconicFlightUsed}
+                              >
+                                <img
+                                  src={dragonWingsIcon}
+                                  alt="Draconic Flight"
                                   width={36}
                                   height={36}
                                 />

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -88,12 +88,15 @@ test('dragonborn always has damage resistance and gains draconic flight at level
     },
   };
 
+  const onDraconicFlight = jest.fn();
+
   const renderFeatures = (occupation) =>
     render(
       <Features
         form={{ ...baseForm, occupation }}
         showFeatures={true}
         handleCloseFeatures={() => {}}
+        onDraconicFlight={onDraconicFlight}
       />
     );
 
@@ -118,6 +121,9 @@ test('dragonborn always has damage resistance and gains draconic flight at level
   const viewButton = within(flightCard).getByRole('button', {
     name: /view feature/i,
   });
+  const useButton = within(flightCard).getByRole('button', {
+    name: /use feature/i,
+  });
 
   expect(
     screen.queryByText(
@@ -134,6 +140,16 @@ test('dragonborn always has damage resistance and gains draconic flight at level
       'When you reach character level 5, you can use a bonus action to manifest spectral wings on your back. The wings last for 1 minute or until you dismiss them as a bonus action. During this time, you gain a flying speed equal to your walking speed.'
     )
   ).toBeInTheDocument();
+
+  expect(useButton).toBeEnabled();
+  expect(onDraconicFlight).not.toHaveBeenCalled();
+
+  await act(async () => {
+    await userEvent.click(useButton);
+  });
+
+  expect(onDraconicFlight).toHaveBeenCalledTimes(1);
+  expect(useButton).toBeDisabled();
 });
 
 test('goliath ancestry features include boon, Powerful Build, and Large Form at level 5', async () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -32,6 +32,7 @@ import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import hasteIcon from "../../../images/spell-haste-icon.png";
 import largeFormIcon from "../../../images/large-form-icon.png";
+import dragonWingsIcon from "../../../images/dragon-wings-icon.png";
 import ShopModal from "../attributes/ShopModal";
 import InventoryModal from "../attributes/InventoryModal";
 import EquipmentModal from "../attributes/EquipmentModal";
@@ -1521,6 +1522,15 @@ export default function ZombiesCharacterSheet() {
         return prev;
       }
       return [...prev, { name: 'Large Form', icon: largeFormIcon }];
+    });
+  }, [setActiveEffects]);
+
+  const handleDraconicFlight = useCallback(() => {
+    setActiveEffects((prev) => {
+      if (prev.some((effect) => effect.name === 'Draconic Flight')) {
+        return prev;
+      }
+      return [...prev, { name: 'Draconic Flight', icon: dragonWingsIcon }];
     });
   }, [setActiveEffects]);
 
@@ -4180,6 +4190,7 @@ export default function ZombiesCharacterSheet() {
           handleCloseFeatures={handleCloseFeatures}
           onActionSurge={handleActionSurge}
           onLargeForm={handleLargeForm}
+          onDraconicFlight={handleDraconicFlight}
           longRestCount={longRestCount}
           shortRestCount={shortRestCount}
           actionCount={actionCount}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import hasteIcon from '../../../images/spell-haste-icon.png';
+import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
 
 jest.mock('../../../utils/apiFetch');
@@ -52,7 +53,6 @@ jest.mock('../../Armor/ArmorList', () => () => null);
 jest.mock('../../Items/ItemList', () => () => null);
 jest.mock('../attributes/Help', () => () => null);
 jest.mock('../attributes/BackgroundModal', () => () => null);
-jest.mock('../attributes/Features', () => () => null);
 const mockInventoryModalProps = { current: null };
 jest.mock('../attributes/InventoryModal', () => (props) => {
   mockInventoryModalProps.current = props;
@@ -82,6 +82,12 @@ jest.mock('../attributes/SpellSelector', () => (props) => {
   return props.show ? <div data-testid="spell-selector" /> : null;
 });
 jest.mock('../attributes/HealthDefense', () => () => null);
+
+const mockFeaturesModalProps = { current: null };
+jest.mock('../attributes/Features', () => (props) => {
+  mockFeaturesModalProps.current = props;
+  return null;
+});
 
 import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
@@ -131,6 +137,7 @@ beforeEach(() => {
   mockInventoryModalProps.current = null;
   mockEquipmentModalProps.current = null;
   mockMapModalProps.current = null;
+  mockFeaturesModalProps.current = null;
   mockSkillsModalProps.current = null;
   mockDockedSkillsModalProps.current = null;
   window.matchMedia = jest.fn().mockImplementation((query) => {
@@ -230,6 +237,78 @@ test('reapplies Large Form bonuses after persisted effects and refetch', async (
     expect(mockEquipmentModalProps.current?.form?.temporarySize).toBe('Large')
   );
   expect(mockEquipmentModalProps.current?.form?.temporarySpeedBonus).toBe(10);
+
+  window.localStorage.removeItem('zombiesActiveEffects:1');
+  window.localStorage.clear();
+});
+
+test('activating Draconic Flight adds a persistent effect without duplicates', async () => {
+  window.localStorage.clear();
+
+  const baseCharacter = {
+    _id: 'character-1',
+    occupation: [],
+    spells: [],
+    str: 10,
+    dex: 10,
+    con: 10,
+    int: 10,
+    wis: 10,
+    cha: 10,
+    startStatTotal: 60,
+    proficiencyPoints: 0,
+    skills: {},
+    item: [],
+    feat: [],
+    weapon: [],
+    armor: [],
+    campaign: null,
+    race: { name: 'Dragonborn' },
+  };
+
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseCharacter,
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseCharacter,
+    });
+
+  render(<ZombiesCharacterSheet />);
+
+  await waitFor(() => {
+    expect(mockFeaturesModalProps.current).not.toBeNull();
+  });
+
+  expect(typeof mockFeaturesModalProps.current.onDraconicFlight).toBe('function');
+
+  await act(async () => {
+    mockFeaturesModalProps.current.onDraconicFlight();
+  });
+
+  await waitFor(() => {
+    const stored = window.localStorage.getItem('zombiesActiveEffects:1');
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored);
+    expect(parsed).toEqual([
+      { name: 'Draconic Flight', icon: dragonWingsIcon },
+    ]);
+  });
+
+  await act(async () => {
+    mockFeaturesModalProps.current.onDraconicFlight();
+  });
+
+  await waitFor(() => {
+    const stored = window.localStorage.getItem('zombiesActiveEffects:1');
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored);
+    expect(parsed).toEqual([
+      { name: 'Draconic Flight', icon: dragonWingsIcon },
+    ]);
+  });
 
   window.localStorage.removeItem('zombiesActiveEffects:1');
   window.localStorage.clear();
@@ -675,7 +754,8 @@ test('persists used spell slots and actions to localStorage', async () => {
     json: async () => baseCharacter,
   });
 
-  const user = userEvent.setup();
+  const user =
+    typeof userEvent.setup === 'function' ? userEvent.setup() : userEvent;
   const { container, unmount } = render(<ZombiesCharacterSheet />);
 
   await waitFor(() =>
@@ -1805,8 +1885,10 @@ test('pass-turn event resets action and bonus usage', async () => {
   await waitFor(() => expect(container.querySelector('.action-circle')).toBeTruthy());
   const action = container.querySelector('.action-circle');
   const bonus = container.querySelector('.bonus-circle');
-  fireEvent.click(action);
-  fireEvent.click(bonus);
+  await act(async () => {
+    fireEvent.click(action);
+    fireEvent.click(bonus);
+  });
   expect(action).toHaveClass('slot-used');
   expect(bonus).toHaveClass('slot-used');
 


### PR DESCRIPTION
## Summary
- add a draconic flight use button that mirrors Large Form handling in the Features dialog
- persist a Draconic Flight active effect when triggered from the character sheet while preventing duplicates
- expand unit tests for Features and ZombiesCharacterSheet to cover the new behavior and persistence logic

## Testing
- CI=true npm test -- Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df4f8a41b48323ae8a5031ef017649