### PR TITLE
Display selected Dragonborn ancestry in character info

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -62,7 +62,9 @@ export default function CharacterInfo({
   }, [handleClose, isDocked, onDockClose]);
 
   const raceName = form?.race?.name?.toLowerCase?.();
+  const isDragonborn = raceName === 'dragonborn';
   const isGoliath = raceName === 'goliath';
+  const dragonAncestries = isDragonborn ? form?.race?.dragonAncestries || {} : {};
   const giantAncestries = isGoliath ? form?.race?.giantAncestries || {} : {};
   const goliathAncestry = isGoliath
     ? form?.race?.selectedAncestry ||
@@ -79,6 +81,24 @@ export default function CharacterInfo({
       goliathAncestry.name ||
       goliathAncestry.label ||
       "Giant Ancestry"
+    : null;
+  const dragonbornAncestry = isDragonborn
+    ? form?.race?.selectedAncestry ||
+      (form?.race?.selectedAncestryKey && dragonAncestries
+        ? dragonAncestries[form.race.selectedAncestryKey]
+        : null) ||
+      form?.dragonAncestry ||
+      (form?.dragonAncestryKey && dragonAncestries
+        ? dragonAncestries[form.dragonAncestryKey]
+        : null)
+    : null;
+  const dragonbornAncestryName = dragonbornAncestry
+    ? dragonbornAncestry.label ||
+      dragonbornAncestry.ancestryName ||
+      dragonbornAncestry.name ||
+      form?.dragonAncestryKey ||
+      form?.race?.selectedAncestryKey ||
+      "Draconic Ancestry"
     : null;
   const displaySize =
     form?.temporarySize || form?.size || form?.height || "—";
@@ -124,6 +144,9 @@ export default function CharacterInfo({
                 <span>{form.race?.name || "—"}</span>
                 {isGoliath && goliathAncestryName && (
                   <span className="character-info-subtext">{goliathAncestryName}</span>
+                )}
+                {isDragonborn && dragonbornAncestryName && (
+                  <span className="character-info-subtext">{dragonbornAncestryName}</span>
                 )}
               </div>
             </div>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -125,3 +125,37 @@ test('renders goliath subrace within race card when ancestry selected', () => {
   expect(queryByText('Subrace')).not.toBeInTheDocument();
 });
 
+test('renders dragonborn ancestry within race card when ancestry selected', () => {
+  const form = {
+    occupation: [],
+    race: {
+      name: 'Dragonborn',
+      languages: [],
+      selectedAncestryKey: 'bronze',
+      dragonAncestries: {
+        bronze: { label: 'Bronze Dragon', ancestryName: 'Bronze' },
+      },
+    },
+    size: 'Medium',
+  };
+
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={() => {}}
+      onLongRest={() => {}}
+      onShortRest={() => {}}
+    />
+  );
+
+  const raceItem = screen.getByText('Race').closest('.character-info-item');
+  expect(raceItem).not.toBeNull();
+
+  const { getByText, queryByText } = within(raceItem);
+  expect(getByText('Dragonborn')).toBeInTheDocument();
+  expect(getByText('Bronze Dragon')).toBeInTheDocument();
+  expect(queryByText('Subrace')).not.toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- derive the selected draconic ancestry for dragonborn characters alongside the existing goliath logic
- surface the ancestry label under the race name in the character info modal
- cover the dragonborn display with a dedicated unit test

## Testing
- CI=true npm test -- CharacterInfo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df52e62b648323b2db3b838a594766