### PR TITLE
Add dwarf racial traits metadata and bonuses

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -45,6 +45,63 @@ export default function Features({
     const raceName =
       typeof race?.name === 'string' ? race.name.toLowerCase() : '';
 
+    if (raceName === 'dwarf') {
+      const darkvisionRange =
+        Number.isFinite(race?.darkvisionRange) && race.darkvisionRange > 0
+          ? race.darkvisionRange
+          : 60;
+
+      const darkvisionDescription =
+        `Accustomed to life underground, you can see in dim light within ${darkvisionRange} ` +
+        'feet of you as if it were bright light, and in darkness as if it were dim light. You cannot discern color in darkness, only shades of gray.';
+
+      const resilienceDescription =
+        'You have resistance to poison damage, and you have advantage on saving throws you make to avoid or end the Poisoned condition.';
+
+      const toughnessDescription =
+        'Your hit point maximum increases by 1, and it increases by 1 again whenever you gain a level.';
+
+      const stonecunningUsage = 'Bonus action • Proficiency bonus per long rest';
+      const stonecunningDescription =
+        'As a bonus action, you gain tremorsense with a range of 60 feet for 10 minutes. You can use this bonus action a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.';
+      const stonecunningFullDescription = `${stonecunningDescription} ${stonecunningUsage}`;
+
+      return [
+        {
+          id: 'dwarf-darkvision',
+          name: 'Darkvision',
+          meta: 'Dwarf',
+          description: darkvisionDescription,
+          desc: darkvisionDescription,
+          hideUseButton: true,
+        },
+        {
+          id: 'dwarf-resilience',
+          name: 'Dwarven Resilience',
+          meta: 'Dwarf',
+          description: resilienceDescription,
+          desc: resilienceDescription,
+          hideUseButton: true,
+        },
+        {
+          id: 'dwarf-toughness',
+          name: 'Dwarven Toughness',
+          meta: 'Dwarf',
+          description: toughnessDescription,
+          desc: toughnessDescription,
+          hideUseButton: true,
+        },
+        {
+          id: 'dwarf-stonecunning',
+          name: 'Stonecunning',
+          meta: 'Dwarf',
+          description: stonecunningFullDescription,
+          desc: stonecunningFullDescription,
+          hideUseButton: true,
+        },
+      ];
+    }
+
     if (raceName === 'dragonborn') {
       const ancestry =
         race.selectedAncestry ||

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -152,6 +152,91 @@ test('dragonborn always has damage resistance and gains draconic flight at level
   expect(useButton).toBeDisabled();
 });
 
+test('dwarf characters display racial trait feature cards', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const form = {
+    race: {
+      name: 'Dwarf',
+      darkvisionRange: 120,
+    },
+    occupation: [],
+  };
+
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+    />
+  );
+
+  const traitNames = [
+    'Darkvision',
+    'Dwarven Resilience',
+    'Dwarven Toughness',
+    'Stonecunning',
+  ];
+
+  for (const name of traitNames) {
+    // eslint-disable-next-line no-await-in-loop
+    expect(await screen.findByText(name)).toBeInTheDocument();
+  }
+
+  const stonecunningCard = screen.getByText('Stonecunning').closest('.feature-card');
+  expect(stonecunningCard).not.toBeNull();
+
+  const stonecunningViewButton = within(stonecunningCard).getByRole('button', {
+    name: /view feature/i,
+  });
+
+  expect(
+    screen.queryByText(
+      /As a bonus action, you gain tremorsense with a range of 60 feet for 10 minutes\./
+    )
+  ).not.toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(stonecunningViewButton);
+  });
+
+  const stonecunningDescription = await screen.findByText(
+    /As a bonus action, you gain tremorsense with a range of 60 feet for 10 minutes\./
+  );
+  const stonecunningModal = stonecunningDescription.closest('.modal-content');
+  expect(stonecunningModal).not.toBeNull();
+  const stonecunningWithin = within(stonecunningModal);
+  expect(
+    stonecunningWithin.getByText(/Bonus action • Proficiency bonus per long rest/)
+  ).toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(
+      stonecunningWithin.getByRole('button', { name: /close/i })
+    );
+  });
+
+  const darkvisionCard = screen.getByText('Darkvision').closest('.feature-card');
+  expect(darkvisionCard).not.toBeNull();
+
+  const darkvisionViewButton = within(darkvisionCard).getByRole('button', {
+    name: /view feature/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(darkvisionViewButton);
+  });
+
+  expect(
+    await screen.findByText(
+      /dim light within 120 feet of you as if it were bright light/i
+    )
+  ).toBeInTheDocument();
+});
+
 test('goliath ancestry features include boon, Powerful Build, and Large Form at level 5', async () => {
   apiFetch.mockResolvedValue({
     ok: true,

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -83,13 +83,20 @@ const resolveHpBonusFromSource = (character) => {
   const directHpBonus = toFiniteNumberOrNull(character?.hpMaxBonus);
   const directHpBonusPerLevel = toFiniteNumberOrNull(character?.hpMaxBonusPerLevel);
 
+  const raceHpBonus = toFiniteNumberOrNull(character?.race?.hpMaxBonus);
+  const raceHpBonusPerLevel = toFiniteNumberOrNull(
+    character?.race?.hpMaxBonusPerLevel
+  );
+
   return {
     hpMaxBonus:
-      directHpBonus !== null ? directHpBonus : toFiniteNumberOrZero(featBonuses.hpMaxBonus),
+      (directHpBonus !== null ? directHpBonus : 0) +
+      (raceHpBonus !== null ? raceHpBonus : 0) +
+      toFiniteNumberOrZero(featBonuses.hpMaxBonus),
     hpMaxBonusPerLevel:
-      directHpBonusPerLevel !== null
-        ? directHpBonusPerLevel
-        : toFiniteNumberOrZero(featBonuses.hpMaxBonusPerLevel),
+      (directHpBonusPerLevel !== null ? directHpBonusPerLevel : 0) +
+      (raceHpBonusPerLevel !== null ? raceHpBonusPerLevel : 0) +
+      toFiniteNumberOrZero(featBonuses.hpMaxBonusPerLevel),
   };
 };
 

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -28,6 +28,21 @@ describe('calculateCharacterHitPoints', () => {
     expect(result).toEqual({ currentHp: 35, maxHp: 40 });
   });
 
+  it('includes race hp bonuses when present', () => {
+    const character = {
+      health: 24,
+      tempHealth: 24,
+      con: 14,
+      occupation: [{ Level: 2 }, { Level: 1 }],
+      race: { name: 'Dwarf', hpMaxBonusPerLevel: 1 },
+    };
+
+    const result = calculateCharacterHitPoints(character);
+
+    // Base 24 + (Con mod 2 * 3 levels) + 1 per level racial bonus
+    expect(result).toEqual({ currentHp: 24, maxHp: 33 });
+  });
+
   it('respects override values when provided', () => {
     const character = {
       health: 1,

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -16,6 +16,9 @@ const races = {
     abilities: { con: 2 },
     skills: {},
     languages: ["Common", "Dwarvish"],
+    darkvisionRange: 120,
+    resistances: ["Poison"],
+    hpMaxBonusPerLevel: 1,
     weaponProficiencies: [
       "battleaxe",
       "handaxe",


### PR DESCRIPTION
## Summary
- add metadata for the Dwarf race so its darkvision, resilience, and toughness traits can be surfaced
- show Dwarf racial trait cards in the Zombies Features modal
- include racial hit point bonuses in the character metrics helper with updated test coverage

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js client/src/components/Zombies/utils/characterMetrics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dff6a8182c8323a907c80d02fa51ba