### PR TITLE
Preserve racial HP bonuses when overrides are zero

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -84,16 +84,27 @@ export default function HealthDefense({
   const spellSaveDC =
     spellAbilityMod != null ? 8 + profBonus + spellAbilityMod : null;
 
-  const { currentHp: computedCurrentHp, maxHp } = useMemo(
-    () =>
-      calculateCharacterHitPoints(form, {
-        conMod,
-        totalLevel: derivedTotalLevel,
-        hpMaxBonus,
-        hpMaxBonusPerLevel,
-      }),
-    [form, conMod, derivedTotalLevel, hpMaxBonus, hpMaxBonusPerLevel]
-  );
+  const { currentHp: computedCurrentHp, maxHp } = useMemo(() => {
+    const overrides = {
+      conMod,
+      totalLevel: derivedTotalLevel,
+    };
+
+    const numericHpMaxBonus = Number(hpMaxBonus);
+    if (Number.isFinite(numericHpMaxBonus) && numericHpMaxBonus !== 0) {
+      overrides.hpMaxBonus = numericHpMaxBonus;
+    }
+
+    const numericHpMaxBonusPerLevel = Number(hpMaxBonusPerLevel);
+    if (
+      Number.isFinite(numericHpMaxBonusPerLevel) &&
+      numericHpMaxBonusPerLevel !== 0
+    ) {
+      overrides.hpMaxBonusPerLevel = numericHpMaxBonusPerLevel;
+    }
+
+    return calculateCharacterHitPoints(form, overrides);
+  }, [form, conMod, derivedTotalLevel, hpMaxBonus, hpMaxBonusPerLevel]);
 
   const safeInitialHealth = Number.isFinite(computedCurrentHp) ? computedCurrentHp : 0;
   const [health, setHealth] = useState(safeInitialHealth);

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -130,3 +130,27 @@ test('updates health when slider is dragged', () => {
   fireEvent.mouseUp(slider);
   expect(screen.getByText('8/10')).toBeInTheDocument();
 });
+
+test('includes racial hp bonus when feat overrides are zero', () => {
+  const dwarfForm = {
+    ...baseForm,
+    race: { name: 'Dwarf', hpMaxBonusPerLevel: 1 },
+    tempHealth: 10,
+    health: 10,
+  };
+
+  render(
+    <HealthDefense
+      form={dwarfForm}
+      conMod={2}
+      dexMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+
+  expect(screen.getByText('10/25')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- avoid passing zeroed hp max overrides from HealthDefense so racial bonuses are preserved
- add a regression test ensuring dwarf racial hp increases apply when feat bonuses are zero

## Testing
- CI=true npm --prefix client test -- HealthDefense

------
https://chatgpt.com/codex/tasks/task_e_68dffa5d0fe883239c29127b37f42123