### PR TITLE
Add orc darkvision range and accompanying test

### DIFF
--- a/server/__tests__/races.test.js
+++ b/server/__tests__/races.test.js
@@ -1,0 +1,35 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/conn');
+const dbo = require('../db/conn');
+jest.mock('../middleware/auth', () => (req, res, next) => next());
+const routes = require('../routes');
+
+const app = express();
+app.use(express.json());
+app.use(routes);
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+  res.status(status).json({ message });
+});
+
+describe('Races API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbo.mockResolvedValue({});
+  });
+
+  test('reports darkvision range for orc', async () => {
+    const res = await request(app).get('/races/orc');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      darkvisionRange: 120,
+    });
+  });
+});

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -151,6 +151,7 @@ const races = {
     abilities: { str: 2, con: 1 },
     skills: { intimidation: { proficient: true } },
     languages: ["Common", "Orc"],
+    darkvisionRange: 120,
   },
   tiefling: {
     name: "Tiefling",


### PR DESCRIPTION
## Summary
- add the orc race's darkvision range to the race data
- add an API test that verifies the orc endpoint reports the darkvision value

## Testing
- npm --prefix server test -- races.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e007e478708323aaf13678a1ec5668