### PR TITLE
Add Adrenaline Rush feature support

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -13,6 +13,7 @@ export default function Features({
   showFeatures,
   handleCloseFeatures,
   onActionSurge,
+  onAdrenalineRush,
   onLargeForm,
   onDraconicFlight,
   longRestCount,
@@ -495,6 +496,7 @@ export default function Features({
                                 }`}
                                 onClick={() => {
                                   if (adrenalineRushUses > 0) {
+                                    onAdrenalineRush?.();
                                     setAdrenalineRushUses((prev) =>
                                       Math.max(0, prev - 1)
                                     );

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -33,6 +33,7 @@ import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import hasteIcon from "../../../images/spell-haste-icon.png";
 import largeFormIcon from "../../../images/large-form-icon.png";
 import dragonWingsIcon from "../../../images/dragon-wings-icon.png";
+import adrenalineRushIcon from "../../../images/adrenaline-rush.png";
 import ShopModal from "../attributes/ShopModal";
 import InventoryModal from "../attributes/InventoryModal";
 import EquipmentModal from "../attributes/EquipmentModal";
@@ -44,6 +45,7 @@ import { normalizeEquipmentMap } from "../attributes/equipmentNormalization";
 import MapModal from "../attributes/MapModal";
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
+import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 const HEADER_PADDING = 16;
 const DOCKABLE_MODAL_DEFINITIONS = {
@@ -917,6 +919,13 @@ export default function ZombiesCharacterSheet() {
       })
     );
   }, []);
+  const occupations = useMemo(() => form?.occupation || [], [form?.occupation]);
+  const totalLevel = useMemo(() => {
+    return occupations.reduce((total, el) => {
+      const level = Number(el?.Level);
+      return total + (Number.isFinite(level) ? level : 0);
+    }, 0);
+  }, [occupations]);
   const baseActionCount = form?.features?.actionCount ?? 1;
   const [actionCount, setActionCount] = useState(baseActionCount);
   const [usedSlots, setUsedSlots] = useState(() =>
@@ -1387,7 +1396,8 @@ export default function ZombiesCharacterSheet() {
 
     // Clear effects on rest
     setActiveEffects([]);
-  }, [longRestCount, shortRestCount]);
+    handleHealthChange(0);
+  }, [handleHealthChange, longRestCount, shortRestCount]);
 
   useEffect(() => {
     const hasteActive = activeEffects.some((e) => e.name === 'Haste');
@@ -1533,6 +1543,41 @@ export default function ZombiesCharacterSheet() {
       return [...prev, { name: 'Draconic Flight', icon: dragonWingsIcon }];
     });
   }, [setActiveEffects]);
+
+  const handleAdrenalineRush = useCallback(() => {
+    consumeCircle('bonus');
+
+    setActiveEffects((prev = []) => {
+      const effectPayload = { name: 'Adrenaline Rush', icon: adrenalineRushIcon };
+      const existingIndex = prev.findIndex(
+        (effect) => effect && effect.name === 'Adrenaline Rush'
+      );
+
+      if (existingIndex === -1) {
+        return [...prev, effectPayload];
+      }
+
+      const existing = prev[existingIndex] || {};
+      if (existing.icon === adrenalineRushIcon) {
+        return prev;
+      }
+
+      const next = [...prev];
+      next[existingIndex] = { ...existing, ...effectPayload };
+      return next;
+    });
+
+    const providedProf = Number(form?.proficiencyBonus);
+    const profBonus = Number.isFinite(providedProf)
+      ? providedProf
+      : proficiencyBonus(totalLevel);
+    const currentTemp = Number(form?.tempHealth);
+    const safeCurrent = Number.isFinite(currentTemp) ? currentTemp : 0;
+    const nextTempHealth = safeCurrent + profBonus;
+    if (Number.isFinite(nextTempHealth)) {
+      handleHealthChange(nextTempHealth);
+    }
+  }, [consumeCircle, form, handleHealthChange, totalLevel]);
 
   const handlePassTurn = useCallback(async () => {
     if (isPassingTurn || !encodedCampaignId) {
@@ -2105,7 +2150,8 @@ export default function ZombiesCharacterSheet() {
   const handleShowMapModal = useCallback(() => setShowMapModal(true), []);
   const handleCloseMapModal = useCallback(() => {
     setShowMapModal(false);
-  }, []);
+    handleDockClose('map');
+  }, [handleDockClose]);
 
   const getDockedSide = useCallback(
     (modalKey) => {
@@ -3515,11 +3561,6 @@ export default function ZombiesCharacterSheet() {
   }, [form, hasSpellcasting, statMods.cha, statMods.wis]);
 
   const statNames = [...STAT_KEYS];
-  const occupations = form?.occupation || [];
-  const totalLevel = occupations.reduce((total, el) => {
-    const level = Number(el?.Level);
-    return total + (Number.isFinite(level) ? level : 0);
-  }, 0);
   const statTotal = statNames.reduce((sum, stat) => {
     const value = Number(form?.[stat]);
     return sum + (Number.isFinite(value) ? value : 0);
@@ -4189,6 +4230,7 @@ export default function ZombiesCharacterSheet() {
           showFeatures={showFeatures}
           handleCloseFeatures={handleCloseFeatures}
           onActionSurge={handleActionSurge}
+          onAdrenalineRush={handleAdrenalineRush}
           onLargeForm={handleLargeForm}
           onDraconicFlight={handleDraconicFlight}
           longRestCount={longRestCount}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent, act, within } from '@testing-librar
 import userEvent from '@testing-library/user-event';
 import hasteIcon from '../../../images/spell-haste-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
+import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
 
 jest.mock('../../../utils/apiFetch');
@@ -17,7 +18,11 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ id: '1' }),
 }));
 
-jest.mock('../attributes/CharacterInfo', () => () => null);
+const mockCharacterInfoProps = { current: null };
+jest.mock('../attributes/CharacterInfo', () => (props) => {
+  mockCharacterInfoProps.current = props;
+  return null;
+});
 jest.mock('../attributes/Stats', () => () => null);
 const mockSkillsModalProps = { current: null };
 const mockDockedSkillsModalProps = { current: null };
@@ -140,6 +145,8 @@ beforeEach(() => {
   mockFeaturesModalProps.current = null;
   mockSkillsModalProps.current = null;
   mockDockedSkillsModalProps.current = null;
+  mockCharacterInfoProps.current = null;
+  window.localStorage.clear();
   window.matchMedia = jest.fn().mockImplementation((query) => {
     const matches = matchMediaState[query] ?? false;
     return {
@@ -311,6 +318,107 @@ test('activating Draconic Flight adds a persistent effect without duplicates', a
   });
 
   window.localStorage.removeItem('zombiesActiveEffects:1');
+  window.localStorage.clear();
+});
+
+test('adrenaline rush consumes a bonus action, persists once, grants temp HP, and resets on rest', async () => {
+  window.localStorage.clear();
+
+  const baseCharacter = {
+    _id: 'character-1',
+    occupation: [{ Name: 'Fighter', Level: 7 }],
+    spells: [],
+    str: 10,
+    dex: 10,
+    con: 10,
+    int: 10,
+    wis: 10,
+    cha: 10,
+    startStatTotal: 60,
+    proficiencyPoints: 0,
+    skills: {},
+    item: [],
+    feat: [],
+    weapon: [],
+    armor: [],
+    campaign: null,
+    race: { name: 'Orc' },
+    proficiencyBonus: 4,
+    tempHealth: 1,
+  };
+
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseCharacter,
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseCharacter,
+    });
+
+  render(<ZombiesCharacterSheet />);
+
+  await waitFor(() => {
+    expect(mockFeaturesModalProps.current).not.toBeNull();
+  });
+
+  expect(typeof mockFeaturesModalProps.current.onAdrenalineRush).toBe('function');
+
+  const initialTempHealth = Number(
+    mockFeaturesModalProps.current?.form?.tempHealth
+  );
+
+  await act(async () => {
+    mockFeaturesModalProps.current.onAdrenalineRush();
+  });
+
+  await waitFor(() => {
+    const stored = window.localStorage.getItem('zombiesActiveEffects:1');
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored);
+    expect(parsed).toEqual([
+      { name: 'Adrenaline Rush', icon: adrenalineRushIcon },
+    ]);
+  });
+
+  await waitFor(() => {
+    const slots = window.localStorage.getItem('zombiesUsedSlots:1');
+    expect(slots).toBeTruthy();
+    const parsed = JSON.parse(slots);
+    expect(parsed).toEqual({ bonus: { 0: 'used' } });
+  });
+
+  await waitFor(() => {
+    expect(mockFeaturesModalProps.current?.form?.tempHealth).toBe(
+      Number.isFinite(initialTempHealth) ? initialTempHealth + 4 : 4
+    );
+  });
+
+  await waitFor(() => {
+    const stored = window.localStorage.getItem('zombiesActiveEffects:1');
+    const parsed = stored ? JSON.parse(stored) : [];
+    expect(parsed).toEqual([
+      { name: 'Adrenaline Rush', icon: adrenalineRushIcon },
+    ]);
+  });
+
+  await waitFor(() => {
+    expect(mockCharacterInfoProps.current).not.toBeNull();
+  });
+
+  await act(async () => {
+    mockCharacterInfoProps.current.onShortRest();
+  });
+
+  await waitFor(() => {
+    expect(window.localStorage.getItem('zombiesActiveEffects:1')).toBeNull();
+  });
+
+  await waitFor(() => {
+    expect(mockFeaturesModalProps.current?.form?.tempHealth).toBe(0);
+  });
+
   window.localStorage.clear();
 });
 


### PR DESCRIPTION
## Summary
- add a Zombies character sheet handler that consumes the bonus-action circle, ensures a single Adrenaline Rush effect, and awards temporary hit points by proficiency bonus
- wire the handler through the Features modal so the Adrenaline Rush button invokes it alongside the other feature toggles
- extend the character sheet tests to cover Adrenaline Rush persistence, bonus action usage, temporary HP updates, and rest resets

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e008e22fd08323a56be356ca1496bc