### PR TITLE
Adjust HealthDefense speed for Adrenaline Rush

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -16,6 +16,7 @@ export default function HealthDefense({
   hpMaxBonusPerLevel = 0,
   initiative = 0,
   speed = 0,
+  speedMultiplier = 1,
   spellAbilityMod,
   onTempHealthChange,
 }) {
@@ -188,10 +189,18 @@ export default function HealthDefense({
       : healthValue >= 0
         ? "#2ecc71"
         : "#c0392b";
-  const totalSpeed =
+  const numericSpeedMultiplier = Number(speedMultiplier);
+  const safeSpeedMultiplier =
+    Number.isFinite(numericSpeedMultiplier) && numericSpeedMultiplier > 0
+      ? numericSpeedMultiplier
+      : 1;
+
+  const baseSpeed =
     Number(form?.speed ?? 0) +
     Number(speed ?? 0) +
     Number(form?.temporarySpeedBonus ?? 0);
+
+  const totalSpeed = baseSpeed * safeSpeedMultiplier;
 
 return (
 <div

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1415,6 +1415,16 @@ export default function ZombiesCharacterSheet() {
     });
   }, [baseActionCount, activeEffects]);
 
+  const adrenalineRushActive = useMemo(
+    () => activeEffects.some((effect) => effect?.name === 'Adrenaline Rush'),
+    [activeEffects]
+  );
+
+  const speedMultiplier = useMemo(
+    () => (adrenalineRushActive ? 2 : 1),
+    [adrenalineRushActive]
+  );
+
   const temporarySize = form?.temporarySize;
   const temporarySpeedBonus = form?.temporarySpeedBonus;
 
@@ -3975,6 +3985,7 @@ export default function ZombiesCharacterSheet() {
               hpMaxBonus={featBonuses.hpMaxBonus}
               hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
               onTempHealthChange={handleHealthChange}
+              speedMultiplier={speedMultiplier}
               {...(spellAbilityMod !== null && { spellAbilityMod })}
             />
           </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -86,7 +86,11 @@ jest.mock('../attributes/SpellSelector', () => (props) => {
   mockHandleClose.current = props.handleClose;
   return props.show ? <div data-testid="spell-selector" /> : null;
 });
-jest.mock('../attributes/HealthDefense', () => () => null);
+const mockHealthDefenseProps = { current: null };
+jest.mock('../attributes/HealthDefense', () => (props) => {
+  mockHealthDefenseProps.current = props;
+  return null;
+});
 
 const mockFeaturesModalProps = { current: null };
 jest.mock('../attributes/Features', () => (props) => {
@@ -146,6 +150,7 @@ beforeEach(() => {
   mockSkillsModalProps.current = null;
   mockDockedSkillsModalProps.current = null;
   mockCharacterInfoProps.current = null;
+  mockHealthDefenseProps.current = null;
   window.localStorage.clear();
   window.matchMedia = jest.fn().mockImplementation((query) => {
     const matches = matchMediaState[query] ?? false;
@@ -289,6 +294,10 @@ test('activating Draconic Flight adds a persistent effect without duplicates', a
     expect(mockFeaturesModalProps.current).not.toBeNull();
   });
 
+  await waitFor(() => {
+    expect(mockHealthDefenseProps.current?.speedMultiplier).toBe(1);
+  });
+
   expect(typeof mockFeaturesModalProps.current.onDraconicFlight).toBe('function');
 
   await act(async () => {
@@ -396,6 +405,10 @@ test('adrenaline rush consumes a bonus action, persists once, grants temp HP, an
   });
 
   await waitFor(() => {
+    expect(mockHealthDefenseProps.current?.speedMultiplier).toBe(2);
+  });
+
+  await waitFor(() => {
     const stored = window.localStorage.getItem('zombiesActiveEffects:1');
     const parsed = stored ? JSON.parse(stored) : [];
     expect(parsed).toEqual([
@@ -417,6 +430,10 @@ test('adrenaline rush consumes a bonus action, persists once, grants temp HP, an
 
   await waitFor(() => {
     expect(mockFeaturesModalProps.current?.form?.tempHealth).toBe(0);
+  });
+
+  await waitFor(() => {
+    expect(mockHealthDefenseProps.current?.speedMultiplier).toBe(1);
   });
 
   window.localStorage.clear();


### PR DESCRIPTION
## Summary
- derive the Adrenaline Rush effect state on the character sheet and pass a speed multiplier into HealthDefense
- update HealthDefense to default the multiplier to 1 and double speed while Adrenaline Rush is active
- extend the character sheet tests to capture HealthDefense props and assert the multiplier toggles with the effect

## Testing
- npm test -- ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e00f66575c832396ee35a68dd48ed5