### PR TITLE
Remove half-elf race references

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -1189,7 +1189,7 @@ const getAvailableSkillOptions = (index) => {
        <Modal className="dnd-modal" centered show={showAbilitySkillModal} onHide={() => setShowAbilitySkillModal(false)}>
        <div className="text-center">
         <Card className="dnd-background">
-          <Card.Title>Choose Half-Elf Bonuses</Card.Title>
+          <Card.Title>Choose Bonus Options</Card.Title>
         <Card.Body>
         {form.race?.abilityChoices && abilitySelections.map((sel, idx) => (
           <Form.Group className="mb-2" key={`ability-${idx}`}>

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -132,17 +132,6 @@ const races = {
     skills: {},
     languages: ["Common", "Gnomish"],
   },
-  "half-elf": {
-    name: "Half-Elf",
-    size: "Medium",
-    sizeOptions: ["Medium"],
-    speed: 30,
-    abilities: { cha: 2 },
-    abilityChoices: { count: 2, options: ["str", "dex", "con", "int", "wis"] },
-    skillChoices: { count: 2 },
-    skills: {},
-    languages: ["Common", "Elvish", "Choice"],
-  },
   orc: {
     name: "Orc",
     size: "Medium",


### PR DESCRIPTION
## Summary
- remove the half-elf race definition from the server data set
- generalize the Zombies character creation bonus-selection modal title so it no longer references half-elves

## Testing
- CI=true npm test -- --watch=false *(fails: existing ZombiesDM tests timeout and emit act() warnings)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0115d08808323a48b1e99f8e0a6e7