### PR TITLE
Add gnome racial traits and test coverage

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -165,7 +165,23 @@ export default function Features({
           hideUseButton: true,
         }
       );
-    } else if (darkvisionRange) {
+    }
+
+    if (raceName === 'gnome') {
+      const gnomishCunningDescription =
+        'You have advantage on Intelligence, Wisdom, and Charisma saving throws against magic.';
+
+      raceFeatures.push({
+        id: 'gnome-gnomish-cunning',
+        name: 'Gnomish Cunning',
+        meta: 'Gnome',
+        description: gnomishCunningDescription,
+        desc: gnomishCunningDescription,
+        hideUseButton: true,
+      });
+    }
+
+    if (darkvisionRange && raceName !== 'dwarf' && raceName !== 'orc') {
       const darkvisionDescription =
         `You can see in dim light within ${darkvisionRange} ` +
         'feet of you as if it were bright light, and in darkness as if it were dim light. You cannot discern color in darkness, only shades of gray.';

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -334,6 +334,82 @@ test('halfling characters display racial trait feature cards with descriptions',
   }
 });
 
+test('gnome characters display darkvision and Gnomish Cunning', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const form = {
+    race: { name: 'Gnome', darkvisionRange: 60 },
+    occupation: [],
+  };
+
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+    />
+  );
+
+  const darkvisionTitle = await screen.findByText('Darkvision');
+  const darkvisionCard = darkvisionTitle.closest('.feature-card');
+  expect(darkvisionCard).not.toBeNull();
+  expect(within(darkvisionCard).getByText('Gnome')).toBeInTheDocument();
+
+  const darkvisionViewButton = within(darkvisionCard).getByRole('button', {
+    name: /view feature/i,
+  });
+
+  expect(
+    screen.queryByText(/dim light within 60 feet of you as if it were bright light/i)
+  ).not.toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(darkvisionViewButton);
+  });
+
+  const darkvisionDescription = await screen.findByText(
+    /dim light within 60 feet of you as if it were bright light/i
+  );
+  const darkvisionModal = darkvisionDescription.closest('.modal-content');
+  expect(darkvisionModal).not.toBeNull();
+
+  const closeDarkvisionButton = within(darkvisionModal).getByRole('button', {
+    name: /close/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(closeDarkvisionButton);
+  });
+
+  const gnomishCunningTitle = await screen.findByText('Gnomish Cunning');
+  const gnomishCunningCard = gnomishCunningTitle.closest('.feature-card');
+  expect(gnomishCunningCard).not.toBeNull();
+  expect(within(gnomishCunningCard).getByText('Gnome')).toBeInTheDocument();
+
+  const gnomishCunningViewButton = within(gnomishCunningCard).getByRole('button', {
+    name: /view feature/i,
+  });
+
+  expect(
+    screen.queryByText(
+      /advantage on intelligence, wisdom, and charisma saving throws against magic/i
+    )
+  ).not.toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(gnomishCunningViewButton);
+  });
+
+  expect(
+    await screen.findByText(
+      /advantage on intelligence, wisdom, and charisma saving throws against magic/i
+    )
+  ).toBeInTheDocument();
+});
+
 test('orc characters display racial traits and track Adrenaline Rush uses with rests', async () => {
   apiFetch.mockResolvedValue({
     ok: true,

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -127,10 +127,12 @@ const races = {
     name: "Gnome",
     size: "Small",
     sizeOptions: ["Small"],
-    speed: 25,
+    speed: 30,
     abilities: { int: 2 },
     skills: {},
     languages: ["Common", "Gnomish"],
+    creatureType: "Humanoid",
+    darkvisionRange: 60,
   },
   orc: {
     name: "Orc",


### PR DESCRIPTION
## Summary
- update the gnome race data to include humanoid type, faster speed, and darkvision
- surface a Gnomish Cunning feature card and generalize darkvision handling
- add unit coverage that exercises the gnome features

## Testing
- CI=true npm --prefix client test -- Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e01c46a38c83238c7ade1f7745bd53