### PR TITLE
Add forest gnome lineage spell support to features

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { Modal, Card, Button, Spinner } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
+import UpcastModal from './UpcastModal';
 import actionSurgeIcon from '../../../images/action-surge-icon.png';
 import largeFormIcon from '../../../images/large-form-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
@@ -16,8 +17,10 @@ export default function Features({
   onAdrenalineRush,
   onLargeForm,
   onDraconicFlight,
+  onCastSpell,
   longRestCount,
   shortRestCount,
+  availableSlots = { regular: {}, warlock: {} },
   isDocked = false,
   dockedSide = null,
   onDockClose,
@@ -31,6 +34,9 @@ export default function Features({
   const [largeFormUsed, setLargeFormUsed] = useState(false);
   const [draconicFlightUsed, setDraconicFlightUsed] = useState(false);
   const [adrenalineRushUses, setAdrenalineRushUses] = useState(0);
+  const [speakWithAnimalsUses, setSpeakWithAnimalsUses] = useState(0);
+  const [showUpcast, setShowUpcast] = useState(false);
+  const [pendingSpell, setPendingSpell] = useState(null);
 
   const totalCharacterLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) return 0;
@@ -56,9 +62,79 @@ export default function Features({
       : 0;
   }, [profBonus]);
 
+  const { gnomeLineage, gnomeLineageKey, gnomeLineageAbility } = useMemo(() => {
+    const race = form?.race || {};
+    const lineageFromForm =
+      typeof form?.gnomeLineage === 'object' ? form.gnomeLineage : null;
+    const lineageKeyFromForm =
+      typeof form?.gnomeLineageKey === 'string' ? form.gnomeLineageKey : '';
+    const abilityFromForm =
+      typeof form?.gnomeLineageAbility === 'string'
+        ? form.gnomeLineageAbility
+        : '';
+
+    let lineage = lineageFromForm;
+    let lineageKey = lineageKeyFromForm;
+    if (!lineage) {
+      if (lineageKey && race?.gnomeLineages?.[lineageKey]) {
+        lineage = race.gnomeLineages[lineageKey];
+      } else if (race?.selectedAncestry) {
+        lineage = race.selectedAncestry;
+        lineageKey =
+          typeof race?.selectedAncestryKey === 'string'
+            ? race.selectedAncestryKey
+            : '';
+      } else if (
+        typeof race?.selectedAncestryKey === 'string' &&
+        race?.gnomeLineages?.[race.selectedAncestryKey]
+      ) {
+        lineage = race.gnomeLineages[race.selectedAncestryKey];
+        lineageKey = race.selectedAncestryKey;
+      }
+    }
+
+    let ability = abilityFromForm;
+    if (!ability) {
+      ability =
+        typeof race?.selectedLineageAbility === 'string'
+          ? race.selectedLineageAbility
+          : '';
+    }
+    if (!ability && lineage?.spellcastingAbilities?.length) {
+      ability = lineage.spellcastingAbilities[0];
+    }
+
+    return { gnomeLineage: lineage, gnomeLineageKey: lineageKey, gnomeLineageAbility: ability };
+  }, [form?.gnomeLineage, form?.gnomeLineageAbility, form?.gnomeLineageKey, form?.race]);
+
+  const gnomeSpellAbilityLabel = useMemo(() => {
+    if (typeof gnomeLineageAbility !== 'string') return '';
+    return gnomeLineageAbility.trim();
+  }, [gnomeLineageAbility]);
+
+  const isForestGnomeLineage = useMemo(() => {
+    if (!gnomeLineageKey) return false;
+    return gnomeLineageKey.toLowerCase() === 'forest';
+  }, [gnomeLineageKey]);
+
+  const canUseSpeakWithAnimals = useMemo(() => {
+    return isForestGnomeLineage && totalCharacterLevel >= 3;
+  }, [isForestGnomeLineage, totalCharacterLevel]);
+
+  const speakWithAnimalsMaxUses = useMemo(() => {
+    if (!canUseSpeakWithAnimals) return 0;
+    return Number.isFinite(profBonus) && profBonus > 0
+      ? Math.floor(profBonus)
+      : 0;
+  }, [canUseSpeakWithAnimals, profBonus]);
+
   useEffect(() => {
     setAdrenalineRushUses(adrenalineRushMaxUses);
   }, [adrenalineRushMaxUses]);
+
+  useEffect(() => {
+    setSpeakWithAnimalsUses(speakWithAnimalsMaxUses);
+  }, [speakWithAnimalsMaxUses]);
 
   const ancestryFeatures = useMemo(() => {
     const race = form?.race;
@@ -177,6 +253,45 @@ export default function Features({
         desc: gnomishCunningDescription,
         hideUseButton: true,
       });
+
+      const lineageLabel =
+        typeof gnomeLineage?.label === 'string'
+          ? gnomeLineage.label
+          : 'Gnome Lineage';
+      const abilityText = gnomeSpellAbilityLabel
+        ? ` This lineage uses ${gnomeSpellAbilityLabel} for its spells.`
+        : '';
+
+      if (gnomeLineage && isForestGnomeLineage) {
+        const minorIllusionDescription =
+          'You know the Minor Illusion cantrip. It creates a sound or an image of an object within range that lasts for the duration.' +
+          abilityText;
+
+        raceFeatures.push({
+          id: 'gnome-forest-minor-illusion',
+          name: 'Minor Illusion',
+          meta: `${lineageLabel}${
+            gnomeSpellAbilityLabel ? ` • Spellcasting Ability: ${gnomeSpellAbilityLabel}` : ''
+          }`,
+          description: minorIllusionDescription,
+          desc: minorIllusionDescription,
+          hideUseButton: true,
+        });
+
+        const speakWithAnimalsDescription =
+          'Starting at 3rd level, you can cast Speak with Animals without expending a spell slot a number of times equal to your proficiency bonus. You regain all expended uses when you finish a long rest.' +
+          abilityText;
+
+        raceFeatures.push({
+          id: 'gnome-forest-speak-with-animals',
+          name: 'Speak with Animals',
+          meta: `${lineageLabel}${
+            gnomeSpellAbilityLabel ? ` • Spellcasting Ability: ${gnomeSpellAbilityLabel}` : ''
+          }`,
+          description: speakWithAnimalsDescription,
+          desc: speakWithAnimalsDescription,
+        });
+      }
     }
 
     if (darkvisionRange && raceName !== 'dwarf' && raceName !== 'orc') {
@@ -343,6 +458,9 @@ export default function Features({
     form?.giantAncestry,
     form?.giantAncestryKey,
     totalCharacterLevel,
+    gnomeLineage,
+    gnomeSpellAbilityLabel,
+    isForestGnomeLineage,
   ]);
 
   const displayFeatures = useMemo(() => {
@@ -393,7 +511,42 @@ export default function Features({
     setLargeFormUsed(false);
     setDraconicFlightUsed(false);
     setAdrenalineRushUses(adrenalineRushMaxUses);
-  }, [adrenalineRushMaxUses, longRestCount, shortRestCount]);
+    setSpeakWithAnimalsUses(speakWithAnimalsMaxUses);
+  }, [
+    adrenalineRushMaxUses,
+    longRestCount,
+    shortRestCount,
+    speakWithAnimalsMaxUses,
+  ]);
+
+  const handleSpeakWithAnimalsFreeCast = useCallback(() => {
+    if (!canUseSpeakWithAnimals || speakWithAnimalsUses <= 0) return;
+    setSpeakWithAnimalsUses((prev) => Math.max(0, prev - 1));
+    onCastSpell?.('action');
+  }, [canUseSpeakWithAnimals, onCastSpell, speakWithAnimalsUses]);
+
+  const handleSpeakWithAnimalsSlotCast = useCallback(
+    (level, slotType) => {
+      if (!canUseSpeakWithAnimals) {
+        setShowUpcast(false);
+        setPendingSpell(null);
+        return;
+      }
+      onCastSpell?.({
+        level: 1,
+        slotLevel: level,
+        slotType,
+        castingTime: '1 action',
+        name: 'Speak with Animals',
+      });
+      setShowUpcast(false);
+      setPendingSpell(null);
+    },
+    [canUseSpeakWithAnimals, onCastSpell]
+  );
+
+  const speakWithAnimalsAbilityMeta =
+    gnomeSpellAbilityLabel || 'Spellcasting ability not set';
 
   const dialogClassName = useMemo(() => {
     if (!isDocked) {
@@ -462,6 +615,8 @@ export default function Features({
                     const isDraconicFlight =
                       feat.id === 'dragonborn-draconic-flight';
                     const isAdrenalineRush = feat.id === 'orc-adrenaline-rush';
+                    const isSpeakWithAnimals =
+                      feat.id === 'gnome-forest-speak-with-animals';
                     return (
                       <div className="feature-card" key={featKey}>
                         <div className="feature-card-header">
@@ -567,6 +722,41 @@ export default function Features({
                                   height={36}
                                 />
                               </Button>
+                            ) : isSpeakWithAnimals ? (
+                              <div className="d-flex align-items-center gap-1">
+                                <Button
+                                  aria-label="cast Speak with Animals using proficiency"
+                                  variant="outline-light"
+                                  size="sm"
+                                  className={
+                                    speakWithAnimalsUses <= 0 || !canUseSpeakWithAnimals
+                                      ? 'opacity-50'
+                                      : ''
+                                  }
+                                  onClick={handleSpeakWithAnimalsFreeCast}
+                                  disabled={
+                                    speakWithAnimalsUses <= 0 || !canUseSpeakWithAnimals
+                                  }
+                                >
+                                  P
+                                </Button>
+                                <Button
+                                  aria-label="cast Speak with Animals using a spell slot"
+                                  variant="link"
+                                  className="p-0 border-0"
+                                  onClick={() => {
+                                    if (!canUseSpeakWithAnimals) return;
+                                    setPendingSpell({
+                                      name: 'Speak with Animals',
+                                      level: 1,
+                                    });
+                                    setShowUpcast(true);
+                                  }}
+                                  disabled={!canUseSpeakWithAnimals}
+                                >
+                                  <i className="fa-solid fa-wand-sparkles" />
+                                </Button>
+                              </div>
                             ) : !feat.hideUseButton ? (
                               <Button aria-label="use feature" variant="outline-light" size="sm">
                                 Use
@@ -589,6 +779,16 @@ export default function Features({
                         {isAdrenalineRush && (
                           <div className="feature-card-uses text-muted small mt-2">
                             Uses remaining: {adrenalineRushUses}
+                          </div>
+                        )}
+                        {isSpeakWithAnimals && (
+                          <div className="feature-card-uses text-muted small mt-2">
+                            Uses remaining: {speakWithAnimalsUses}
+                          </div>
+                        )}
+                        {isSpeakWithAnimals && (
+                          <div className="feature-card-uses text-muted small">
+                            Spellcasting ability: {speakWithAnimalsAbilityMeta}
                           </div>
                         )}
                       </div>
@@ -614,6 +814,16 @@ export default function Features({
         show={showModal}
         onHide={() => setShowModal(false)}
         feature={modalFeature}
+      />
+      <UpcastModal
+        show={showUpcast}
+        onHide={() => {
+          setShowUpcast(false);
+          setPendingSpell(null);
+        }}
+        baseLevel={pendingSpell?.level || 1}
+        slots={availableSlots}
+        onSelect={handleSpeakWithAnimalsSlotCast}
       />
     </>
   );

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -334,22 +334,43 @@ test('halfling characters display racial trait feature cards with descriptions',
   }
 });
 
-test('gnome characters display darkvision and Gnomish Cunning', async () => {
+test('forest gnome lineage shows lineage spells with ability text and tracking', async () => {
   apiFetch.mockResolvedValue({
     ok: true,
     json: async () => ({ features: [] }),
   });
 
+  const onCastSpell = jest.fn();
   const form = {
-    race: { name: 'Gnome', darkvisionRange: 60 },
-    occupation: [],
+    race: {
+      name: 'Gnome',
+      darkvisionRange: 60,
+      gnomeLineages: {
+        forest: {
+          label: 'Forest Gnome',
+          spellcastingAbilities: ['Intelligence', 'Wisdom'],
+        },
+      },
+    },
+    gnomeLineageKey: 'forest',
+    gnomeLineage: {
+      label: 'Forest Gnome',
+      spellcastingAbilities: ['Intelligence', 'Wisdom'],
+    },
+    gnomeLineageAbility: 'Wisdom',
+    occupation: [{ Name: 'Wizard', Level: 3 }],
+    proficiencyBonus: 2,
   };
 
-  render(
+  const { rerender } = render(
     <Features
       form={form}
       showFeatures={true}
       handleCloseFeatures={() => {}}
+      onCastSpell={onCastSpell}
+      availableSlots={{ regular: { 1: 2 } }}
+      longRestCount={0}
+      shortRestCount={0}
     />
   );
 
@@ -358,54 +379,91 @@ test('gnome characters display darkvision and Gnomish Cunning', async () => {
   expect(darkvisionCard).not.toBeNull();
   expect(within(darkvisionCard).getByText('Gnome')).toBeInTheDocument();
 
-  const darkvisionViewButton = within(darkvisionCard).getByRole('button', {
-    name: /view feature/i,
+  expect(await screen.findByText('Gnomish Cunning')).toBeInTheDocument();
+
+  const speakTitle = await screen.findByText('Speak with Animals');
+  const speakCard = speakTitle.closest('.feature-card');
+  expect(speakCard).not.toBeNull();
+  const speakWithin = within(speakCard);
+  expect(
+    speakWithin.getByText('Spellcasting ability: Wisdom')
+  ).toBeInTheDocument();
+  expect(
+    speakWithin.getByText('Uses remaining: 2')
+  ).toBeInTheDocument();
+
+  const freeCastButton = speakWithin.getByRole('button', {
+    name: /cast speak with animals using proficiency/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(freeCastButton);
+  });
+
+  expect(onCastSpell).toHaveBeenCalledWith('action');
+  expect(
+    speakWithin.getByText('Uses remaining: 1')
+  ).toBeInTheDocument();
+
+  const slotButton = speakWithin.getByRole('button', {
+    name: /cast speak with animals using a spell slot/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(slotButton);
+  });
+
+  const dialogs = await screen.findAllByRole('dialog');
+  const upcastModal = dialogs[dialogs.length - 1];
+  const levelOneSlot = within(upcastModal).getByText('I');
+
+  await act(async () => {
+    await userEvent.click(levelOneSlot);
+  });
+
+  const castConfirm = within(upcastModal).getByRole('button', { name: /cast/i });
+
+  await act(async () => {
+    await userEvent.click(castConfirm);
+  });
+
+  expect(onCastSpell).toHaveBeenLastCalledWith({
+    level: 1,
+    slotLevel: 1,
+    slotType: 'regular',
+    castingTime: '1 action',
+    name: 'Speak with Animals',
   });
 
   expect(
-    screen.queryByText(/dim light within 60 feet of you as if it were bright light/i)
-  ).not.toBeInTheDocument();
+    speakWithin.getByText('Uses remaining: 1')
+  ).toBeInTheDocument();
 
-  await act(async () => {
-    await userEvent.click(darkvisionViewButton);
-  });
-
-  const darkvisionDescription = await screen.findByText(
-    /dim light within 60 feet of you as if it were bright light/i
+  rerender(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      onCastSpell={onCastSpell}
+      availableSlots={{ regular: { 1: 2 } }}
+      longRestCount={1}
+      shortRestCount={0}
+    />
   );
-  const darkvisionModal = darkvisionDescription.closest('.modal-content');
-  expect(darkvisionModal).not.toBeNull();
-
-  const closeDarkvisionButton = within(darkvisionModal).getByRole('button', {
-    name: /close/i,
-  });
-
-  await act(async () => {
-    await userEvent.click(closeDarkvisionButton);
-  });
-
-  const gnomishCunningTitle = await screen.findByText('Gnomish Cunning');
-  const gnomishCunningCard = gnomishCunningTitle.closest('.feature-card');
-  expect(gnomishCunningCard).not.toBeNull();
-  expect(within(gnomishCunningCard).getByText('Gnome')).toBeInTheDocument();
-
-  const gnomishCunningViewButton = within(gnomishCunningCard).getByRole('button', {
-    name: /view feature/i,
-  });
 
   expect(
-    screen.queryByText(
-      /advantage on intelligence, wisdom, and charisma saving throws against magic/i
-    )
-  ).not.toBeInTheDocument();
-
-  await act(async () => {
-    await userEvent.click(gnomishCunningViewButton);
-  });
-
+    (await screen.findByText('Speak with Animals')).closest('.feature-card')
+  ).not.toBeNull();
   expect(
-    await screen.findByText(
-      /advantage on intelligence, wisdom, and charisma saving throws against magic/i
+    await screen.findByText('Uses remaining: 2')
+  ).toBeInTheDocument();
+
+  const minorIllusionTitle = await screen.findByText('Minor Illusion');
+  const minorIllusionCard = minorIllusionTitle.closest('.feature-card');
+  expect(minorIllusionCard).not.toBeNull();
+  expect(
+    within(minorIllusionCard).getByText(
+      /forest gnome • spellcasting ability: wisdom/i
     )
   ).toBeInTheDocument();
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -4244,8 +4244,10 @@ export default function ZombiesCharacterSheet() {
           onAdrenalineRush={handleAdrenalineRush}
           onLargeForm={handleLargeForm}
           onDraconicFlight={handleDraconicFlight}
+          onCastSpell={handleCastSpell}
           longRestCount={longRestCount}
           shortRestCount={shortRestCount}
+          availableSlots={availableSlots}
           actionCount={actionCount}
         />
         <InventoryModal


### PR DESCRIPTION
## Summary
- add lineage detection for gnome features and render forest spell cards with ability context and casting options
- track proficiency-based Speak with Animals uses, integrate the Upcast modal, and surface spellcasting ability details on the card

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e028c6a45c83239487340040f1c30a