### PR TITLE
Handle Speak with Animals proficiency casting via modal

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -128,6 +128,32 @@ export default function Features({
       : 0;
   }, [canUseSpeakWithAnimals, profBonus]);
 
+  const hasAvailableSlotOfLevel = useMemo(() => {
+    const normalizedRegular = availableSlots?.regular || {};
+    const normalizedWarlock = availableSlots?.warlock || {};
+
+    return (minimumLevel = 1) => {
+      const hasRegularSlot = Object.entries(normalizedRegular).some(
+        ([level, count]) =>
+          Number(level) >= minimumLevel && Number(count) > 0
+      );
+
+      if (hasRegularSlot) {
+        return true;
+      }
+
+      return Object.entries(normalizedWarlock).some(
+        ([level, count]) =>
+          Number(level) >= minimumLevel && Number(count) > 0
+      );
+    };
+  }, [availableSlots]);
+
+  const speakWithAnimalsHasSlot = useMemo(
+    () => hasAvailableSlotOfLevel(1),
+    [hasAvailableSlotOfLevel]
+  );
+
   useEffect(() => {
     setAdrenalineRushUses(adrenalineRushMaxUses);
   }, [adrenalineRushMaxUses]);
@@ -523,6 +549,8 @@ export default function Features({
     if (!canUseSpeakWithAnimals || speakWithAnimalsUses <= 0) return;
     setSpeakWithAnimalsUses((prev) => Math.max(0, prev - 1));
     onCastSpell?.('action');
+    setShowUpcast(false);
+    setPendingSpell(null);
   }, [canUseSpeakWithAnimals, onCastSpell, speakWithAnimalsUses]);
 
   const handleSpeakWithAnimalsSlotCast = useCallback(
@@ -725,34 +753,34 @@ export default function Features({
                             ) : isSpeakWithAnimals ? (
                               <div className="d-flex align-items-center gap-1">
                                 <Button
-                                  aria-label="cast Speak with Animals using proficiency"
-                                  variant="outline-light"
-                                  size="sm"
-                                  className={
-                                    speakWithAnimalsUses <= 0 || !canUseSpeakWithAnimals
-                                      ? 'opacity-50'
-                                      : ''
-                                  }
-                                  onClick={handleSpeakWithAnimalsFreeCast}
-                                  disabled={
-                                    speakWithAnimalsUses <= 0 || !canUseSpeakWithAnimals
-                                  }
-                                >
-                                  P
-                                </Button>
-                                <Button
                                   aria-label="cast Speak with Animals using a spell slot"
                                   variant="link"
                                   className="p-0 border-0"
                                   onClick={() => {
-                                    if (!canUseSpeakWithAnimals) return;
+                                    if (
+                                      !canUseSpeakWithAnimals ||
+                                      (speakWithAnimalsUses <= 0 &&
+                                        !speakWithAnimalsHasSlot)
+                                    ) {
+                                      return;
+                                    }
                                     setPendingSpell({
                                       name: 'Speak with Animals',
                                       level: 1,
+                                      supportsProficiency: true,
+                                      proficiencyLabel: 'P',
+                                      proficiencyAriaLabel:
+                                        'cast Speak with Animals using proficiency',
+                                      proficiencyRemainingLabel: 'Uses remaining',
+                                      onFreeCast: handleSpeakWithAnimalsFreeCast,
                                     });
                                     setShowUpcast(true);
                                   }}
-                                  disabled={!canUseSpeakWithAnimals}
+                                  disabled={
+                                    !canUseSpeakWithAnimals ||
+                                    (speakWithAnimalsUses <= 0 &&
+                                      !speakWithAnimalsHasSlot)
+                                  }
                                 >
                                   <i className="fa-solid fa-wand-sparkles" />
                                 </Button>
@@ -824,6 +852,21 @@ export default function Features({
         baseLevel={pendingSpell?.level || 1}
         slots={availableSlots}
         onSelect={handleSpeakWithAnimalsSlotCast}
+        proficiencyAction={
+          pendingSpell?.supportsProficiency
+            ? {
+                label: pendingSpell?.proficiencyLabel || 'P',
+                ariaLabel:
+                  pendingSpell?.proficiencyAriaLabel ||
+                  'cast using proficiency feature',
+                remainingText: pendingSpell?.proficiencyRemainingLabel
+                  ? `${pendingSpell.proficiencyRemainingLabel}: ${speakWithAnimalsUses}`
+                  : `Uses remaining: ${speakWithAnimalsUses}`,
+                disabled: speakWithAnimalsUses <= 0,
+                onClick: pendingSpell?.onFreeCast,
+              }
+            : undefined
+        }
       />
     </>
   );

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within, act } from '@testing-library/react';
+import { render, screen, within, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Features from './Features';
 
@@ -411,20 +411,6 @@ test('forest gnome lineage shows lineage spells with ability text and tracking',
     await userEvent.click(speakClose);
   });
 
-  const freeCastButton = speakWithin.getByRole('button', {
-    name: /cast speak with animals using proficiency/i,
-  });
-  expect(freeCastButton).toBeEnabled();
-
-  await act(async () => {
-    await userEvent.click(freeCastButton);
-  });
-
-  expect(onCastSpell).toHaveBeenCalledWith('action');
-  expect(
-    speakWithin.getByText('Uses remaining: 2')
-  ).toBeInTheDocument();
-
   const slotButton = speakWithin.getByRole('button', {
     name: /cast speak with animals using a spell slot/i,
   });
@@ -434,19 +420,63 @@ test('forest gnome lineage shows lineage spells with ability text and tracking',
     await userEvent.click(slotButton);
   });
 
-  const dialogs = await screen.findAllByRole('dialog');
-  const upcastModal = dialogs[dialogs.length - 1];
-  const levelOneSlot = within(upcastModal).getByText('I');
+  let dialogs = await screen.findAllByRole('dialog');
+  let upcastModal = dialogs[dialogs.length - 1];
+  let upcastWithin = within(upcastModal);
+
+  const proficiencyButton = upcastWithin.getByRole('button', {
+    name: /cast speak with animals using proficiency/i,
+  });
+  expect(proficiencyButton).toBeEnabled();
+  expect(
+    upcastWithin.getByText('Uses remaining: 3')
+  ).toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(proficiencyButton);
+  });
+
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('dialog', { name: /cast at level/i })
+    ).not.toBeInTheDocument()
+  );
+
+  expect(onCastSpell).toHaveBeenCalledWith('action');
+  expect(
+    speakWithin.getByText('Uses remaining: 2')
+  ).toBeInTheDocument();
+
+  await act(async () => {
+    await userEvent.click(slotButton);
+  });
+
+  dialogs = await screen.findAllByRole('dialog');
+  upcastModal = dialogs[dialogs.length - 1];
+  upcastWithin = within(upcastModal);
+
+  expect(
+    upcastWithin.getByText('Uses remaining: 2')
+  ).toBeInTheDocument();
+
+  const levelOneSlot = upcastWithin.getByText('I');
 
   await act(async () => {
     await userEvent.click(levelOneSlot);
   });
 
-  const castConfirm = within(upcastModal).getByRole('button', { name: /cast/i });
+  const castButtons = upcastWithin.getAllByRole('button', { name: /^cast$/i });
+  const castConfirm = castButtons[castButtons.length - 1];
 
   await act(async () => {
     await userEvent.click(castConfirm);
   });
+
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('dialog', { name: /cast at level/i })
+    ).not.toBeInTheDocument()
+  );
 
   expect(onCastSpell).toHaveBeenLastCalledWith({
     level: 1,
@@ -505,6 +535,85 @@ test('forest gnome lineage shows lineage spells with ability text and tracking',
   await act(async () => {
     await userEvent.click(minorClose);
   });
+});
+
+test('Speak with Animals wand button respects available uses and slots', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const baseRace = {
+    name: 'Gnome',
+    darkvisionRange: 60,
+    gnomeLineages: {
+      forest: { label: 'Forest Gnome' },
+    },
+  };
+
+  const baseForm = {
+    race: baseRace,
+    gnomeLineageKey: 'forest',
+    gnomeLineage: { label: 'Forest Gnome' },
+    occupation: [{ Name: 'Wizard', Level: 3 }],
+  };
+
+  const { rerender } = render(
+    <Features
+      form={{ ...baseForm, proficiencyBonus: 2 }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      availableSlots={{ regular: { 1: 0 }, warlock: {} }}
+    />
+  );
+
+  const getSpeakCard = () => {
+    const speakTitle = screen.getByText('Speak with Animals');
+    const speakCard = speakTitle.closest('.feature-card');
+    expect(speakCard).not.toBeNull();
+    return speakCard;
+  };
+
+  const getWandButton = () =>
+    within(getSpeakCard()).getByRole('button', {
+      name: /cast speak with animals using a spell slot/i,
+    });
+
+  const waitForUses = async (value) => {
+    await waitFor(() =>
+      expect(
+        within(getSpeakCard()).getByText(`Uses remaining: ${value}`)
+      ).toBeInTheDocument()
+    );
+  };
+
+  await screen.findByText('Speak with Animals');
+  await waitForUses(2);
+  await waitFor(() => expect(getWandButton()).toBeEnabled());
+
+  rerender(
+    <Features
+      form={{ ...baseForm, proficiencyBonus: 0.5 }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      availableSlots={{ regular: { 1: 1 }, warlock: {} }}
+    />
+  );
+
+  await waitForUses(0);
+  await waitFor(() => expect(getWandButton()).toBeEnabled());
+
+  rerender(
+    <Features
+      form={{ ...baseForm, proficiencyBonus: 0.5 }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      availableSlots={{ regular: { 1: 0 }, warlock: {} }}
+    />
+  );
+
+  await waitForUses(0);
+  await waitFor(() => expect(getWandButton()).toBeDisabled());
 });
 
 test('orc characters display racial traits and track Adrenaline Rush uses with rests', async () => {

--- a/client/src/components/Zombies/attributes/UpcastModal.js
+++ b/client/src/components/Zombies/attributes/UpcastModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Modal, Button } from 'react-bootstrap';
 
 const toRoman = (n) => ['I','II','III','IV','V','VI','VII','VIII','IX','X'][n-1] || n;
@@ -23,6 +23,7 @@ export default function UpcastModal({
   used = {},
   onSelect,
   higherLevels,
+  proficiencyAction,
 }) {
   const regularLevels = Object.keys(slots.regular || {})
     .map(Number)
@@ -53,12 +54,48 @@ export default function UpcastModal({
     if (onHide) onHide();
   };
 
+  const handleProficiencyClick = useMemo(() => {
+    if (!proficiencyAction?.onClick) {
+      return null;
+    }
+
+    return () => {
+      proficiencyAction.onClick();
+      if (onHide) {
+        onHide();
+      }
+    };
+  }, [onHide, proficiencyAction]);
+
   return (
     <Modal show={show} onHide={onHide} centered>
       <Modal.Header closeButton>
         <Modal.Title>Cast at Level</Modal.Title>
       </Modal.Header>
       <Modal.Body>
+        {proficiencyAction && (
+          <div className="d-flex flex-column align-items-center mb-3">
+            <Button
+              variant="outline-light"
+              size="sm"
+              aria-label={
+                proficiencyAction.ariaLabel || 'cast using proficiency feature'
+              }
+              onClick={handleProficiencyClick || undefined}
+              disabled={
+                proficiencyAction.disabled ||
+                typeof handleProficiencyClick !== 'function'
+              }
+            >
+              {proficiencyAction.icon || proficiencyAction.label || 'P'}
+            </Button>
+            {proficiencyAction.remainingText && (
+              <small className="text-muted mt-1">
+                {proficiencyAction.remainingText}
+              </small>
+            )}
+          </div>
+        )}
         {higherLevels && (
           <p className="text-muted mb-2">{higherLevels}</p>
         )}


### PR DESCRIPTION
## Summary
- gate Speak with Animals casting behind the wand control and expose proficiency metadata for the upcast modal
- extend the upcast modal to show an optional proficiency action with remaining use text
- update feature tests to cover the modal proficiency button and slot availability rules

## Testing
- CI=true npm test -- --testPathPattern=Features

------
https://chatgpt.com/codex/tasks/task_e_68e0345cd3dc8323a092fe4d7ae9d67f