### PR TITLE
Style upcast proficiency button

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1103,6 +1103,31 @@
   transform: scale(1.1);
 }
 
+.upcast-proficiency-button {
+  background-color: #808080;
+  border-color: #808080;
+  color: #ffffff;
+}
+
+.upcast-proficiency-button:hover,
+.upcast-proficiency-button:focus,
+.upcast-proficiency-button:active {
+  background-color: #6f6f6f;
+  border-color: #6f6f6f;
+  color: #ffffff;
+}
+
+.upcast-proficiency-button:focus-visible {
+  box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.35);
+}
+
+.upcast-proficiency-button:disabled,
+.upcast-proficiency-button.disabled {
+  background-color: #a0a0a0;
+  border-color: #a0a0a0;
+  color: #f5f5f5;
+}
+
 .skill-checkbox .form-check-input {
   width: 1.25rem;
   height: 1.25rem;

--- a/client/src/components/Zombies/attributes/UpcastModal.js
+++ b/client/src/components/Zombies/attributes/UpcastModal.js
@@ -76,7 +76,7 @@ export default function UpcastModal({
         {proficiencyAction && (
           <div className="d-flex flex-column align-items-center mb-3">
             <Button
-              variant="outline-light"
+              className="upcast-proficiency-button"
               size="sm"
               aria-label={
                 proficiencyAction.ariaLabel || 'cast using proficiency feature'


### PR DESCRIPTION
## Summary
- add a dedicated class to the upcast proficiency action button
- style the button to mirror the gray spell slot tile with hover, focus, and disabled treatments

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e039cd2c9c832382566804f57b42b5