### PR TITLE
Adjust upcast proficiency button Bootstrap variables

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1104,6 +1104,19 @@
 }
 
 .upcast-proficiency-button {
+  --bs-btn-bg: #808080;
+  --bs-btn-border-color: #808080;
+  --bs-btn-hover-bg: #6f6f6f;
+  --bs-btn-hover-border-color: #6f6f6f;
+  --bs-btn-active-bg: #6f6f6f;
+  --bs-btn-active-border-color: #6f6f6f;
+  --bs-btn-disabled-bg: #a0a0a0;
+  --bs-btn-disabled-border-color: #a0a0a0;
+  --bs-btn-color: #ffffff;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-disabled-color: #ffffff;
+  --bs-btn-focus-shadow-rgb: 255, 255, 255;
+
   background-color: #808080;
   border-color: #808080;
   color: #ffffff;
@@ -1125,7 +1138,7 @@
 .upcast-proficiency-button.disabled {
   background-color: #a0a0a0;
   border-color: #a0a0a0;
-  color: #f5f5f5;
+  color: #ffffff;
 }
 
 .skill-checkbox .form-check-input {


### PR DESCRIPTION
## Summary
- override the Bootstrap button CSS variables for the upcast proficiency button to match the gray tile palette across all states
- retain fallback background and border colors for older browsers while ensuring disabled text stays white

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03c4cd8d083239e16523f90488550