### PR TITLE
Add rock gnome lineage spell features

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -117,6 +117,11 @@ export default function Features({
     return gnomeLineageKey.toLowerCase() === 'forest';
   }, [gnomeLineageKey]);
 
+  const isRockGnomeLineage = useMemo(() => {
+    if (!gnomeLineageKey) return false;
+    return gnomeLineageKey.toLowerCase() === 'rock';
+  }, [gnomeLineageKey]);
+
   const canUseSpeakWithAnimals = useMemo(() => {
     return isForestGnomeLineage && totalCharacterLevel >= 3;
   }, [isForestGnomeLineage, totalCharacterLevel]);
@@ -316,6 +321,37 @@ export default function Features({
           }`,
           description: speakWithAnimalsDescription,
           desc: speakWithAnimalsDescription,
+        });
+      } else if (gnomeLineage && isRockGnomeLineage) {
+        const mendingDescription =
+          'You know the Mending cantrip, allowing you to repair small breaks or tears in objects.' +
+          abilityText;
+
+        raceFeatures.push({
+          id: 'gnome-rock-mending',
+          name: 'Mending',
+          meta: `${lineageLabel}${
+            gnomeSpellAbilityLabel ? ` • Spellcasting Ability: ${gnomeSpellAbilityLabel}` : ''
+          }`,
+          description: mendingDescription,
+          desc: mendingDescription,
+          hideUseButton: true,
+        });
+
+        const prestidigitationDescription =
+          'You know the Prestidigitation cantrip, letting you create minor magical effects.' +
+          abilityText +
+          ' Additionally, whenever you finish a long rest, you can spend 10 minutes to create a Tiny clockwork device (AC 5, 1 hp). The device ceases to function after 24 hours (unless you spend 1 minute repairing it), when you use this trait again, or when you take an action to dismantle it; at that time, you can reclaim the materials used to create it.';
+
+        raceFeatures.push({
+          id: 'gnome-rock-prestidigitation',
+          name: 'Prestidigitation',
+          meta: `${lineageLabel}${
+            gnomeSpellAbilityLabel ? ` • Spellcasting Ability: ${gnomeSpellAbilityLabel}` : ''
+          }`,
+          description: prestidigitationDescription,
+          desc: prestidigitationDescription,
+          hideUseButton: true,
         });
       }
     }

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -699,6 +699,74 @@ test('orc characters display racial traits and track Adrenaline Rush uses with r
   ).toBeInTheDocument();
 });
 
+test('rock gnome lineage surfaces cantrips and clockwork device guidance', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const rockLineage = {
+    label: 'Rock Gnome',
+    spellcastingAbilities: ['Intelligence'],
+  };
+
+  const form = {
+    race: {
+      name: 'Gnome',
+      gnomeLineages: { rock: rockLineage },
+    },
+    gnomeLineage: rockLineage,
+    gnomeLineageKey: 'rock',
+    occupation: [],
+  };
+
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+    />
+  );
+
+  const mendingTitle = await screen.findByText('Mending');
+  const mendingCard = mendingTitle.closest('.feature-card');
+  expect(mendingCard).not.toBeNull();
+  const mendingWithin = within(mendingCard);
+  expect(
+    mendingWithin.getByText('Rock Gnome • Spellcasting Ability: Intelligence')
+  ).toBeInTheDocument();
+  expect(
+    mendingWithin.getByRole('button', { name: /view feature/i })
+  ).toBeInTheDocument();
+  expect(
+    mendingWithin.queryByRole('button', { name: /use feature/i })
+  ).not.toBeInTheDocument();
+
+  const prestidigitationTitle = await screen.findByText('Prestidigitation');
+  const prestidigitationCard = prestidigitationTitle.closest('.feature-card');
+  expect(prestidigitationCard).not.toBeNull();
+  const prestidigitationWithin = within(prestidigitationCard);
+  expect(
+    prestidigitationWithin.getByText(
+      'Rock Gnome • Spellcasting Ability: Intelligence'
+    )
+  ).toBeInTheDocument();
+
+  const prestidigitationView = prestidigitationWithin.getByRole('button', {
+    name: /view feature/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(prestidigitationView);
+  });
+
+  expect(
+    await screen.findByText(
+      /spend 10 minutes to create a Tiny clockwork device \(AC 5, 1 hp\)/i
+    )
+  ).toBeInTheDocument();
+});
+
 test('goliath ancestry features include boon, Powerful Build, and Large Form at level 5', async () => {
   apiFetch.mockResolvedValue({
     ok: true,

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -156,9 +156,23 @@ const races = {
       },
       rock: {
         label: "Rock Gnome",
-        description: "Additional lineage details coming soon.",
-        spells: [],
-        spellcastingAbilities: [],
+        description:
+          "You know the Mending and Prestidigitation cantrips. Whenever you finish a long rest, you can spend 10 minutes to create a Tiny clockwork device (AC 5, 1 hp). The device ceases to function after 24 hours (unless you spend 1 minute repairing it), when you use this trait again, or when you take an action to dismantle it; at that time, you can reclaim the materials used to create it.",
+        spells: [
+          {
+            name: "Mending",
+            description:
+              "You know the Mending cantrip, allowing you to repair a break or tear in an object you touch.",
+            usage: "At will",
+          },
+          {
+            name: "Prestidigitation",
+            description:
+              "You know the Prestidigitation cantrip, letting you create minor magical effects. Additionally, whenever you finish a long rest, you can spend 10 minutes to create a Tiny clockwork device (AC 5, 1 hp). The device ceases to function after 24 hours (unless you spend 1 minute repairing it), when you use this trait again, or when you take an action to dismantle it; at that time, you can reclaim the materials used to create it.",
+            usage: "At will",
+          },
+        ],
+        spellcastingAbilities: ["Intelligence"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- populate the Rock Gnome lineage data with cantrip details and spellcasting ability metadata
- render Rock Gnome cantrip feature cards with the clockwork device guidance in the Zombies view
- cover the Rock Gnome lineage with unit tests to assert the cards and modal text

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e041670394832387d6259ed7863fd2