### PR TITLE
Use dedicated icon for Speak with Animals feature

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -7,6 +7,7 @@ import actionSurgeIcon from '../../../images/action-surge-icon.png';
 import largeFormIcon from '../../../images/large-form-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
+import speakWithAnimalIcon from '../../../images/speak-with-animal.png';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 export default function Features({
@@ -818,7 +819,12 @@ export default function Features({
                                       !speakWithAnimalsHasSlot)
                                   }
                                 >
-                                  <i className="fa-solid fa-wand-sparkles" />
+                                  <img
+                                    src={speakWithAnimalIcon}
+                                    alt="Speak with Animals"
+                                    width={36}
+                                    height={36}
+                                  />
                                 </Button>
                               </div>
                             ) : !feat.hideUseButton ? (

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -385,6 +385,7 @@ test('forest gnome lineage shows lineage spells with ability text and tracking',
   const speakCard = speakTitle.closest('.feature-card');
   expect(speakCard).not.toBeNull();
   const speakWithin = within(speakCard);
+  expect(speakWithin.getByAltText('Speak with Animals')).toBeInTheDocument();
   expect(
     speakWithin.getByText('Spellcasting ability: Wisdom')
   ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- show the Speak with Animals feature button using its icon instead of the font awesome wand
- cover the icon rendering with a test that checks for the alt text

## Testing
- CI=true npm test -- Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e054031d98832385a2024fcb41d7a0