### PR TITLE
Add Speak with Animals status effect handling

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -585,6 +585,11 @@ export default function Features({
   const handleSpeakWithAnimalsFreeCast = useCallback(() => {
     if (!canUseSpeakWithAnimals || speakWithAnimalsUses <= 0) return;
     setSpeakWithAnimalsUses((prev) => Math.max(0, prev - 1));
+    onCastSpell?.({
+      castingTime: '1 action',
+      name: 'Speak with Animals',
+      pendingEffectOnly: true,
+    });
     onCastSpell?.('action');
     setShowUpcast(false);
     setPendingSpell(null);

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -443,7 +443,12 @@ test('forest gnome lineage shows lineage spells with ability text and tracking',
     ).not.toBeInTheDocument()
   );
 
-  expect(onCastSpell).toHaveBeenCalledWith('action');
+  expect(onCastSpell).toHaveBeenNthCalledWith(1, {
+    castingTime: '1 action',
+    name: 'Speak with Animals',
+    pendingEffectOnly: true,
+  });
+  expect(onCastSpell).toHaveBeenNthCalledWith(2, 'action');
   expect(
     speakWithin.getByText('Uses remaining: 2')
   ).toBeInTheDocument();
@@ -616,7 +621,12 @@ test('Speak with Animals is available to forest gnomes at level 1 using proficie
     ).not.toBeInTheDocument()
   );
 
-  expect(onCastSpell).toHaveBeenCalledWith('action');
+  expect(onCastSpell).toHaveBeenNthCalledWith(1, {
+    castingTime: '1 action',
+    name: 'Speak with Animals',
+    pendingEffectOnly: true,
+  });
+  expect(onCastSpell).toHaveBeenNthCalledWith(2, 'action');
   expect(
     speakWithin.getByText('Uses remaining: 1')
   ).toBeInTheDocument();

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -34,6 +34,7 @@ import hasteIcon from "../../../images/spell-haste-icon.png";
 import largeFormIcon from "../../../images/large-form-icon.png";
 import dragonWingsIcon from "../../../images/dragon-wings-icon.png";
 import adrenalineRushIcon from "../../../images/adrenaline-rush.png";
+import speakWithAnimalsIcon from "../../../images/speak-with-animal.png";
 import ShopModal from "../attributes/ShopModal";
 import InventoryModal from "../attributes/InventoryModal";
 import EquipmentModal from "../attributes/EquipmentModal";
@@ -1672,6 +1673,7 @@ export default function ZombiesCharacterSheet() {
   ]);
 
   const playerTurnActionsRef = useRef(null);
+  const speakWithAnimalsPendingRef = useRef(false);
   const socketRef = useRef(null);
 
   const rootContainerRef = useRef(null);
@@ -2213,6 +2215,20 @@ export default function ZombiesCharacterSheet() {
     (arg, lvl, idx) => {
       if (arg === 'action' || arg === 'bonus') {
         consumeCircle(arg, lvl);
+        if (arg === 'action' && speakWithAnimalsPendingRef.current) {
+          setActiveEffects((prev = []) => {
+            if (prev.some((effect) => effect?.name === 'Speak with Animals')) {
+              return prev;
+            }
+            return [
+              ...prev,
+              { name: 'Speak with Animals', icon: speakWithAnimalsIcon },
+            ];
+          });
+        }
+        if (arg === 'action') {
+          speakWithAnimalsPendingRef.current = false;
+        }
         return;
       }
       const consumeSlot = (level, preferredType) => {
@@ -2277,7 +2293,15 @@ export default function ZombiesCharacterSheet() {
           castingTime,
           name,
           spellName: altName,
+          pendingEffectOnly,
         } = arg;
+        const spellLabel = name || altName;
+        if (pendingEffectOnly) {
+          if (spellLabel === 'Speak with Animals') {
+            speakWithAnimalsPendingRef.current = true;
+          }
+          return;
+        }
         const castLevel = typeof slotLevel === 'number' ? slotLevel : level;
         consumeSlot(castLevel, slotType);
         if (castingTime?.includes('1 action')) consumeCircle('action');
@@ -2305,7 +2329,6 @@ export default function ZombiesCharacterSheet() {
           const spellLabel = name || altName;
           result = { total: spellLabel || 'Spell Cast' };
         }
-        const spellLabel = name || altName;
         playerTurnActionsRef.current?.updateDamageValueWithAnimation(
           result?.total,
           result?.breakdown,
@@ -2316,6 +2339,20 @@ export default function ZombiesCharacterSheet() {
             ...prev,
             { name: 'Haste', icon: hasteIcon, remaining: 10 },
           ]);
+        }
+        if (spellLabel === 'Speak with Animals') {
+          setActiveEffects((prev = []) => {
+            if (prev.some((effect) => effect?.name === 'Speak with Animals')) {
+              return prev;
+            }
+            return [
+              ...prev,
+              { name: 'Speak with Animals', icon: speakWithAnimalsIcon },
+            ];
+          });
+          speakWithAnimalsPendingRef.current = false;
+        } else {
+          speakWithAnimalsPendingRef.current = false;
         }
         return;
       }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import hasteIcon from '../../../images/spell-haste-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
+import speakWithAnimalsIcon from '../../../images/speak-with-animal.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
 
 jest.mock('../../../utils/apiFetch');
@@ -1130,6 +1131,85 @@ test('casting Haste adds status icon and extra action circle', async () => {
   );
   const icon = screen.getByAltText('Haste');
   expect(icon).toHaveAttribute('src', hasteIcon);
+});
+
+test('casting Speak with Animals adds status icon for free and slot casts', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+  const { unmount } = render(<ZombiesCharacterSheet />);
+  await waitFor(() =>
+    expect(mockFeaturesModalProps.current?.onCastSpell).toBeTruthy()
+  );
+  act(() => {
+    mockFeaturesModalProps.current?.onCastSpell?.({
+      castingTime: '1 action',
+      name: 'Speak with Animals',
+      pendingEffectOnly: true,
+    });
+    mockFeaturesModalProps.current?.onCastSpell?.('action');
+  });
+  let icon = await screen.findByAltText('Speak with Animals');
+  expect(icon).toHaveAttribute('src', speakWithAnimalsIcon);
+  expect(screen.getAllByAltText('Speak with Animals')).toHaveLength(1);
+
+  unmount();
+  mockFeaturesModalProps.current = null;
+
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+  await waitFor(() =>
+    expect(mockFeaturesModalProps.current?.onCastSpell).toBeTruthy()
+  );
+
+  act(() => {
+    mockFeaturesModalProps.current?.onCastSpell?.({
+      name: 'Speak with Animals',
+      level: 1,
+      castingTime: '1 action',
+    });
+  });
+
+  icon = await screen.findByAltText('Speak with Animals');
+  expect(icon).toHaveAttribute('src', speakWithAnimalsIcon);
+  expect(screen.getAllByAltText('Speak with Animals')).toHaveLength(1);
 });
 
 test('feats button includes points-glow when feat points available', async () => {


### PR DESCRIPTION
## Summary
- add the Speak with Animals icon and effect handling to the zombie character sheet
- flag free Speak with Animals casts so the status buff is added without duplicates
- update feature and character sheet tests to cover the new buff behavior

## Testing
- npm test -- Features.test.js ZombiesCharacterSheet.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e054a2d6cc83239720cb5fd96fe0a1