### PR TITLE
Prevent Speak with Animals hydration from resetting on load

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -40,6 +40,11 @@ export default function Features({
   const [showUpcast, setShowUpcast] = useState(false);
   const [pendingSpell, setPendingSpell] = useState(null);
   const hasInitializedRestRef = useRef(false);
+  const hasHydratedSpeakWithAnimalsRef = useRef(false);
+  const previousRestCountsRef = useRef({
+    long: longRestCount,
+    short: shortRestCount,
+  });
 
   const totalCharacterLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) return 0;
@@ -188,6 +193,7 @@ export default function Features({
 
     if (!canUseSpeakWithAnimals) {
       setSpeakWithAnimalsUses((prev) => (prev === 0 ? prev : 0));
+      hasHydratedSpeakWithAnimalsRef.current = false;
       return;
     }
 
@@ -195,6 +201,7 @@ export default function Features({
       setSpeakWithAnimalsUses((prev) =>
         prev === fallbackUses ? prev : fallbackUses
       );
+      hasHydratedSpeakWithAnimalsRef.current = true;
       return;
     }
 
@@ -210,6 +217,7 @@ export default function Features({
     const clamped = Math.min(nextValue, fallbackUses);
 
     setSpeakWithAnimalsUses((prev) => (prev === clamped ? prev : clamped));
+    hasHydratedSpeakWithAnimalsRef.current = true;
   }, [
     canUseSpeakWithAnimals,
     speakWithAnimalsMaxUses,
@@ -618,14 +626,27 @@ export default function Features({
   }, [form.occupation, showFeatures]);
 
   useEffect(() => {
+    const previousRestCounts = previousRestCountsRef.current;
+    const restCountChanged =
+      previousRestCounts.long !== longRestCount ||
+      previousRestCounts.short !== shortRestCount;
+
     setSurgeUsed(false);
     setLargeFormUsed(false);
     setDraconicFlightUsed(false);
     setAdrenalineRushUses(adrenalineRushMaxUses);
-    if (hasInitializedRestRef.current) {
+    if (
+      hasInitializedRestRef.current &&
+      hasHydratedSpeakWithAnimalsRef.current &&
+      restCountChanged
+    ) {
       setSpeakWithAnimalsUses(speakWithAnimalsMaxUses);
     }
     hasInitializedRestRef.current = true;
+    previousRestCountsRef.current = {
+      long: longRestCount,
+      short: shortRestCount,
+    };
   }, [
     adrenalineRushMaxUses,
     longRestCount,

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -599,6 +599,76 @@ test('Speak with Animals uses restore from local storage when available', async 
   ).toBeInTheDocument();
 });
 
+test('Speak with Animals stored uses persist when enabling the feature', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const baseForm = {
+    race: {
+      name: 'Gnome',
+      darkvisionRange: 60,
+      gnomeLineages: {
+        forest: { label: 'Forest Gnome', spellcastingAbilities: ['Wisdom'] },
+        rock: { label: 'Rock Gnome' },
+      },
+    },
+    occupation: [{ Name: 'Wizard', Level: 3 }],
+    proficiencyBonus: 3,
+  };
+
+  const { rerender } = render(
+    <Features
+      form={{
+        ...baseForm,
+        gnomeLineageKey: 'rock',
+        gnomeLineage: { label: 'Rock Gnome' },
+        gnomeLineageAbility: 'Intelligence',
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      onCastSpell={jest.fn()}
+      availableSlots={{ regular: { 1: 2 } }}
+      longRestCount={0}
+      shortRestCount={0}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(screen.queryByText('Speak with Animals')).toBeNull();
+
+  window.localStorage.setItem(
+    `zombiesSpeakWithAnimalsUses:${TEST_CHARACTER_ID}`,
+    '2'
+  );
+
+  rerender(
+    <Features
+      form={{
+        ...baseForm,
+        gnomeLineageKey: 'forest',
+        gnomeLineage: { label: 'Forest Gnome' },
+        gnomeLineageAbility: 'Wisdom',
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      onCastSpell={jest.fn()}
+      availableSlots={{ regular: { 1: 2 } }}
+      longRestCount={0}
+      shortRestCount={0}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const speakTitle = await screen.findByText('Speak with Animals');
+  const speakCard = speakTitle.closest('.feature-card');
+  expect(speakCard).not.toBeNull();
+  expect(
+    within(speakCard).getByText('Uses remaining: 2')
+  ).toBeInTheDocument();
+});
+
 test('Speak with Animals is available to forest gnomes at level 1 using proficiency', async () => {
   apiFetch.mockResolvedValue({
     ok: true,


### PR DESCRIPTION
## Summary
- add a hydration guard for Speak with Animals uses so rest resets only occur after initialization
- preserve stored Speak with Animals usage when toggling race data

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e05c6f46648323992ef679a1f2b0c2