### PR TITLE
Add finesse ability selection for weapon attacks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -3,8 +3,9 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useCallback,
 } from 'react';
-import { Button, Modal, Card, OverlayTrigger, Popover } from "react-bootstrap";
+import { Button, Modal, Card, OverlayTrigger, Popover, Form } from "react-bootstrap";
 import D20RollerModal from '../common/D20RollerModal';
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
@@ -281,12 +282,72 @@ const [isFumble, setIsFumble] = useState(false);
       weapon,
     }));
   }, [equipmentProvided, normalizedEquipment, form.weapon]);
-  // --------------------------------Breaks down weapon damage into useable numbers--------------------------------
-  const abilityForWeapon = (weapon) => {
+
+  const [weaponAbilitySelections, setWeaponAbilitySelections] = useState({});
+
+  const numericStrMod = Number(strMod) || 0;
+  const numericDexMod = Number(dexMod) || 0;
+
+  const formatModifier = (value) => (value >= 0 ? `+${value}` : `${value}`);
+
+  const isRangedWeapon = (weapon) => {
     const category = weapon?.category;
-    return typeof category === 'string' && category.toLowerCase().includes('ranged')
-      ? dexMod
-      : strMod;
+    return (
+      typeof category === 'string' && category.toLowerCase().includes('ranged')
+    );
+  };
+
+  const isFinesseWeapon = useCallback(
+    (weapon) =>
+      Array.isArray(weapon?.properties) &&
+      weapon.properties.some(
+        (prop) => typeof prop === 'string' && prop.toLowerCase().includes('finesse')
+      ),
+    []
+  );
+
+  const getAbilityKeyForWeapon = (slot, weapon) => {
+    if (isFinesseWeapon(weapon)) {
+      const stored = weaponAbilitySelections[slot];
+      if (stored === 'str' || stored === 'dex') {
+        return stored;
+      }
+      return numericDexMod >= numericStrMod ? 'dex' : 'str';
+    }
+    if (isRangedWeapon(weapon)) {
+      return 'dex';
+    }
+    return 'str';
+  };
+
+  useEffect(() => {
+    setWeaponAbilitySelections((prev) => {
+      const next = {};
+      equippedWeapons.forEach(({ slot, weapon }) => {
+        if (isFinesseWeapon(weapon)) {
+          const existing = prev[slot];
+          if (existing === 'dex' || existing === 'str') {
+            next[slot] = existing;
+          }
+        }
+      });
+      const prevKeys = Object.keys(prev);
+      const nextKeys = Object.keys(next);
+      if (
+        prevKeys.length === nextKeys.length &&
+        nextKeys.every((key) => prev[key] === next[key])
+      ) {
+        return prev;
+      }
+      return next;
+    });
+  }, [equippedWeapons, isFinesseWeapon]);
+  // --------------------------------Breaks down weapon damage into useable numbers--------------------------------
+  const abilityForWeapon = (weapon, slot) => {
+    const key = getAbilityKeyForWeapon(slot, weapon);
+    if (key === 'dex') return numericDexMod;
+    if (key === 'str') return numericStrMod;
+    return numericStrMod;
   };
 
   const formatWeaponLabel = (value) => {
@@ -396,9 +457,9 @@ const [isFumble, setIsFumble] = useState(false);
     };
   }, [dragonbornAncestry, conMod, profBonus, totalLevel]);
 
-  const getAttackBonus = (weapon) =>
+  const getAttackBonus = (slot, weapon) =>
     profBonus +
-    abilityForWeapon(weapon) +
+    abilityForWeapon(weapon, slot) +
     Number(weapon?.attackBonus ?? weapon?.bonus ?? 0);
     
   const normalizeDamageTypeForClass = (type) => {
@@ -427,13 +488,13 @@ const [isFumble, setIsFumble] = useState(false);
         );
       });
 
-  const getDamageString = (weapon) => {
-    const ability = abilityForWeapon(weapon);
+  const getDamageString = (slot, weapon) => {
+    const ability = abilityForWeapon(weapon, slot);
     return formatDamageSegments(weapon.damage, ability);
   };
 
-  const handleWeaponAttack = (weapon) => {
-    const ability = abilityForWeapon(weapon);
+  const handleWeaponAttack = (slot, weapon) => {
+    const ability = abilityForWeapon(weapon, slot);
     if (typeof weapon?.damage !== 'string' || !weapon.damage.trim()) return;
     const result = calculateDamage(weapon.damage, ability, isCritical);
     if (!result) return;
@@ -816,13 +877,40 @@ useEffect(() => {
                         <div className="attack-card__row">
                           <span className="attack-card__label">Attack Bonus</span>
                           <span className="attack-card__value">
-                            {getAttackBonus(weapon)}
+                            {getAttackBonus(slot, weapon)}
                           </span>
                         </div>
+                        {isFinesseWeapon(weapon) && (
+                          <div className="attack-card__row">
+                            <span className="attack-card__label">Ability</span>
+                            <span className="attack-card__value">
+                              <Form.Select
+                                id={`weapon-ability-${slot}`}
+                                aria-label={`Select ability for ${weapon.name || slot}`}
+                                value={getAbilityKeyForWeapon(slot, weapon)}
+                                onChange={(event) => {
+                                  const selected = event.target.value === 'dex' ? 'dex' : 'str';
+                                  setWeaponAbilitySelections((prev) => ({
+                                    ...prev,
+                                    [slot]: selected,
+                                  }));
+                                }}
+                                size="sm"
+                              >
+                                <option value="str">
+                                  Strength ({formatModifier(numericStrMod)})
+                                </option>
+                                <option value="dex">
+                                  Dexterity ({formatModifier(numericDexMod)})
+                                </option>
+                              </Form.Select>
+                            </span>
+                          </div>
+                        )}
                         <div className="attack-card__row">
                           <span className="attack-card__label">Damage</span>
                           <span className="attack-card__value">
-                            {getDamageString(weapon)}
+                            {getDamageString(slot, weapon)}
                           </span>
                         </div>
                         <div className="attack-card__row attack-card__row--properties">
@@ -852,7 +940,7 @@ useEffect(() => {
                       <div className="attack-card__actions">
                         <Button
                           onClick={() => {
-                            handleWeaponAttack(weapon);
+                            handleWeaponAttack(slot, weapon);
                             handleCloseAttack();
                           }}
                           variant="link"

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -146,6 +146,60 @@ describe('PlayerTurnActions weapon damage display', () => {
     });
   });
 
+  test('finesse ability selection updates attack bonus and damage modifier', async () => {
+    const weapon = {
+      name: 'Rapier',
+      damage: '1d8 piercing',
+      category: 'melee',
+      source: 'weapon',
+      properties: ['Finesse'],
+    };
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          spells: [],
+        }}
+        strMod={5}
+        dexMod={2}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const card = screen.getByText('Rapier').closest('.attack-card');
+    expect(card).not.toBeNull();
+
+    const attackRow = within(card).getByText('Attack Bonus').closest('.attack-card__row');
+    const attackValue = attackRow.querySelector('.attack-card__value');
+    expect(attackValue).not.toBeNull();
+    expect(attackValue?.textContent).toBe(String(7));
+
+    const damageRow = within(card).getByText('Damage').closest('.attack-card__row');
+    expect(damageRow).not.toBeNull();
+    expect(
+      within(damageRow).getByText('1d8+5 Piercing')
+    ).toBeInTheDocument();
+
+    const abilitySelect = within(card).getByRole('combobox', {
+      name: /select ability for rapier/i,
+    });
+
+    await act(async () => {
+      fireEvent.change(abilitySelect, { target: { value: 'dex' } });
+    });
+
+    await waitFor(() => {
+      expect(attackValue?.textContent).toBe(String(4));
+      expect(
+        within(damageRow).getByText('1d8+2 Piercing')
+      ).toBeInTheDocument();
+    });
+  });
+
   test('multi-part weapon damage applies ability modifier once', () => {
     const weapon = {
       name: 'Storm Blade',


### PR DESCRIPTION
## Summary
- store the chosen ability modifier per weapon slot when a weapon has the finesse property
- use the stored ability when calculating attack bonuses, damage strings, and weapon attack rolls
- cover the dexterity selection flow for finesse weapons with a focused unit test

## Testing
- CI=1 npm test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0660a834083239a1449a24cd11aa4