### PR TITLE
Normalize equipment stat aggregation for zombie character sheet

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2646,18 +2646,38 @@ export default function ZombiesCharacterSheet() {
     ]
   );
 
-  const { bonuses: itemBonus, overrides: itemOverrides } = aggregateStatEffects(
-    form?.item
+  const hasEquipmentData =
+    typeof form?.equipment === 'object' && form.equipment !== null;
+
+  const normalizedEquipment = useMemo(
+    () => normalizeEquipmentMap(form?.equipment),
+    [form?.equipment]
   );
 
-  const accessorySource = Array.isArray(form?.accessories)
-    ? form.accessories
-    : Array.isArray(form?.accessory)
-      ? form.accessory
-      : [];
+  const fallbackItems = useMemo(
+    () => (Array.isArray(form?.item) ? form.item.filter(Boolean) : []),
+    [form?.item]
+  );
 
-  const { bonuses: accessoryBonus, overrides: accessoryOverrides } =
-    aggregateStatEffects(accessorySource);
+  const fallbackAccessories = useMemo(() => {
+    if (Array.isArray(form?.accessories)) {
+      return form.accessories.filter(Boolean);
+    }
+    if (Array.isArray(form?.accessory)) {
+      return form.accessory.filter(Boolean);
+    }
+    return [];
+  }, [form?.accessories, form?.accessory]);
+
+  const equippedInventory = useMemo(() => {
+    if (hasEquipmentData) {
+      return Object.values(normalizedEquipment).filter(Boolean);
+    }
+    return [...fallbackItems, ...fallbackAccessories];
+  }, [fallbackAccessories, fallbackItems, hasEquipmentData, normalizedEquipment]);
+
+  const { bonuses: equipmentBonuses, overrides: equipmentOverrides } =
+    useMemo(() => aggregateStatEffects(equippedInventory), [equippedInventory]);
 
   const featAbilityBonuses = collectFeatAbilityBonuses(form?.feat);
 
@@ -3518,11 +3538,10 @@ export default function ZombiesCharacterSheet() {
     const base = Number(form?.[key] || 0);
     const total =
       base +
-      itemBonus[key] +
-      accessoryBonus[key] +
+      equipmentBonuses[key] +
       featAbilityBonuses[key] +
       Number(raceBonus[key] || 0);
-    const overrideCandidates = [itemOverrides[key], accessoryOverrides[key]];
+    const overrideCandidates = [equipmentOverrides[key]];
     const overrideValue = overrideCandidates.reduce((max, value) => {
       if (value === undefined || value === null) return max;
       return max === null ? value : Math.max(max, value);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1947,6 +1947,76 @@ test('equipment changes are normalized and persisted', async () => {
   });
 });
 
+test('strength override from inventory applies only when equipped', async () => {
+  const initialCharacter = {
+    occupation: [],
+    spells: [],
+    str: 10,
+    dex: 10,
+    con: 10,
+    int: 10,
+    wis: 10,
+    cha: 10,
+    startStatTotal: 60,
+    proficiencyPoints: 0,
+    skills: {},
+    item: [],
+    feat: [],
+    weapon: [],
+    armor: [],
+    equipment: {},
+  };
+
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => initialCharacter,
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  await waitFor(() => expect(mockSkillsModalProps.current).not.toBeNull());
+  await waitFor(() => expect(mockEquipmentModalProps.current).not.toBeNull());
+
+  expect(mockSkillsModalProps.current.strMod).toBe(0);
+
+  const strengthBelt = {
+    type: 'item',
+    name: 'Belt of Giant Strength',
+    statOverrides: { str: 18 },
+    owned: true,
+  };
+
+  apiFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ cp: 0, sp: 0, gp: 0, pp: 0 }),
+    })
+    .mockResolvedValueOnce({ ok: true });
+
+  await act(async () => {
+    await mockShopModalProps.current.onPurchase([strengthBelt], 0);
+  });
+
+  await waitFor(() => expect(mockSkillsModalProps.current.strMod).toBe(0));
+
+  const equipmentPayload = {
+    ...mockEquipmentModalProps.current.form.equipment,
+    waist: {
+      name: 'Belt of Giant Strength',
+      statOverrides: { str: 18 },
+      source: 'item',
+    },
+  };
+
+  apiFetch.mockResolvedValueOnce({ ok: true });
+
+  await act(async () => {
+    await mockEquipmentModalProps.current.onEquipmentChange(equipmentPayload);
+  });
+
+  await waitFor(() => expect(mockSkillsModalProps.current.strMod).toBe(4));
+});
+
 test('handleCastSpell closes modal and outputs spell name', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- normalize equipped inventory in the zombie character sheet by preferring form.equipment and aggregating ability effects from slotted gear
- fall back to legacy inventory lists only when equipment data is missing
- add a regression test to ensure strength overrides apply only when the item is equipped

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e079ba7d18832ea2942cfca920b5c5