### PR TITLE
Update Zombies character HP resolution order

### DIFF
--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -117,9 +117,19 @@ export const calculateCharacterHitPoints = (character, overrides = {}) => {
     overrides.baseHealth !== undefined ? overrides.baseHealth : character?.health
   );
 
-  const currentHp = toFiniteNumberOrNull(
-    overrides.currentHp !== undefined ? overrides.currentHp : character?.tempHealth
-  );
+  const currentHpCandidates = [
+    overrides.currentHp,
+    character?.currentHp,
+    character?.hpCurrent,
+    character?.tempHealth,
+  ];
+
+  const currentHp = currentHpCandidates.reduce((resolved, candidate) => {
+    if (resolved !== null) {
+      return resolved;
+    }
+    return toFiniteNumberOrNull(candidate);
+  }, null);
 
   const { hpMaxBonus: fallbackBonus, hpMaxBonusPerLevel: fallbackPerLevel } =
     resolveHpBonusFromSource(character);
@@ -135,7 +145,13 @@ export const calculateCharacterHitPoints = (character, overrides = {}) => {
   const resolvedCurrent =
     currentHp !== null
       ? currentHp
-      : toFiniteNumberOrNull(overrides.fallbackCurrentHp ?? character?.health);
+      : (() => {
+          const fallbackOverride = toFiniteNumberOrNull(overrides.fallbackCurrentHp);
+          if (fallbackOverride !== null) {
+            return fallbackOverride;
+          }
+          return toFiniteNumberOrNull(character?.health);
+        })();
 
   const maxHp =
     baseHealth === null

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -67,4 +67,32 @@ describe('calculateCharacterHitPoints', () => {
 
     expect(result).toEqual({ currentHp: null, maxHp: null });
   });
+
+  it('uses character.currentHp when provided', () => {
+    const character = {
+      health: 12,
+      tempHealth: 4,
+      currentHp: '9',
+      con: 10,
+      occupation: [{ Level: 1 }],
+    };
+
+    const result = calculateCharacterHitPoints(character);
+
+    expect(result.currentHp).toBe(9);
+  });
+
+  it('uses character.hpCurrent when provided', () => {
+    const character = {
+      health: 15,
+      tempHealth: 5,
+      hpCurrent: 11,
+      con: 10,
+      occupation: [{ Level: 1 }],
+    };
+
+    const result = calculateCharacterHitPoints(character);
+
+    expect(result.currentHp).toBe(11);
+  });
 });


### PR DESCRIPTION
## Summary
- prioritize current HP sources to match combat tracker expectations
- extend characterMetrics tests to cover currentHp and hpCurrent handling

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/utils/characterMetrics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e090cdb7a8832ebee224a04800155b