### PR TITLE
Include equipment bonuses when deriving zombie hit points

### DIFF
--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -1,4 +1,10 @@
-import { aggregateStatEffects, collectFeatAbilityBonuses, collectFeatNumericBonuses, STAT_KEYS } from './derivedStats';
+import { normalizeEquipmentMap } from '../attributes/equipmentNormalization';
+import {
+  aggregateStatEffects,
+  collectFeatAbilityBonuses,
+  collectFeatNumericBonuses,
+  STAT_KEYS,
+} from './derivedStats';
 
 const toFiniteNumberOrNull = (value) => {
   if (value === null || value === undefined || value === '') {
@@ -44,6 +50,11 @@ const calculateEffectiveAbilityScores = (character) => {
   }, {});
 
   const { bonuses: itemBonuses, overrides: itemOverrides } = aggregateStatEffects(character?.item);
+  const normalizedEquipment = normalizeEquipmentMap(character?.equipment);
+  const equipmentEntries = Object.values(normalizedEquipment || {}).filter(Boolean);
+  const { bonuses: equipmentBonuses, overrides: equipmentOverrides } = aggregateStatEffects(
+    equipmentEntries
+  );
   const { bonuses: accessoryBonuses, overrides: accessoryOverrides } = aggregateStatEffects(
     normalizeAccessoryCollection(character)
   );
@@ -54,11 +65,16 @@ const calculateEffectiveAbilityScores = (character) => {
     const total =
       baseStats[key] +
       itemBonuses[key] +
+      equipmentBonuses[key] +
       accessoryBonuses[key] +
       featAbilityBonuses[key] +
       toFiniteNumberOrZero(raceBonuses[key]);
 
-    const overrideCandidates = [itemOverrides?.[key], accessoryOverrides?.[key]];
+    const overrideCandidates = [
+      itemOverrides?.[key],
+      equipmentOverrides?.[key],
+      accessoryOverrides?.[key],
+    ];
     const highestOverride = overrideCandidates.reduce((max, candidate) => {
       const numeric = toFiniteNumberOrNull(candidate);
       if (numeric === null) {
@@ -88,15 +104,53 @@ const resolveHpBonusFromSource = (character) => {
     character?.race?.hpMaxBonusPerLevel
   );
 
+  const collectHpBonuses = (collection) => {
+    const entries = Array.isArray(collection) ? collection : [];
+    return entries.reduce(
+      (acc, item) => {
+        if (!item || typeof item !== 'object') {
+          return acc;
+        }
+
+        const contributionSources = [item, item.numericBonuses];
+        contributionSources.forEach((source) => {
+          if (!source || typeof source !== 'object') {
+            return;
+          }
+          const bonus = toFiniteNumberOrNull(source.hpMaxBonus);
+          if (bonus !== null) {
+            acc.hpMaxBonus += bonus;
+          }
+          const perLevel = toFiniteNumberOrNull(source.hpMaxBonusPerLevel);
+          if (perLevel !== null) {
+            acc.hpMaxBonusPerLevel += perLevel;
+          }
+        });
+
+        return acc;
+      },
+      { hpMaxBonus: 0, hpMaxBonusPerLevel: 0 }
+    );
+  };
+
+  const normalizedEquipment = normalizeEquipmentMap(character?.equipment);
+  const equipmentEntries = Object.values(normalizedEquipment || {}).filter(Boolean);
+  const equipmentHpBonuses = collectHpBonuses(equipmentEntries);
+  const accessoryHpBonuses = collectHpBonuses(normalizeAccessoryCollection(character));
+
   return {
     hpMaxBonus:
       (directHpBonus !== null ? directHpBonus : 0) +
       (raceHpBonus !== null ? raceHpBonus : 0) +
-      toFiniteNumberOrZero(featBonuses.hpMaxBonus),
+      toFiniteNumberOrZero(featBonuses.hpMaxBonus) +
+      equipmentHpBonuses.hpMaxBonus +
+      accessoryHpBonuses.hpMaxBonus,
     hpMaxBonusPerLevel:
       (directHpBonusPerLevel !== null ? directHpBonusPerLevel : 0) +
       (raceHpBonusPerLevel !== null ? raceHpBonusPerLevel : 0) +
-      toFiniteNumberOrZero(featBonuses.hpMaxBonusPerLevel),
+      toFiniteNumberOrZero(featBonuses.hpMaxBonusPerLevel) +
+      equipmentHpBonuses.hpMaxBonusPerLevel +
+      accessoryHpBonuses.hpMaxBonusPerLevel,
   };
 };
 

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -95,4 +95,43 @@ describe('calculateCharacterHitPoints', () => {
 
     expect(result.currentHp).toBe(11);
   });
+
+  it('derives con modifier and hp bonuses from equipped items', () => {
+    const baseCharacter = {
+      health: 10,
+      con: 10,
+      occupation: [{ Level: 2 }],
+      equipment: {},
+    };
+
+    const equippedCharacter = {
+      ...baseCharacter,
+      equipment: {
+        head: {
+          name: 'Helm of Vitality',
+          statBonuses: { con: 4 },
+          hpMaxBonus: 5,
+          numericBonuses: { hpMaxBonusPerLevel: 1 },
+        },
+      },
+    };
+
+    const baseResult = calculateCharacterHitPoints(baseCharacter);
+    const equippedResult = calculateCharacterHitPoints(equippedCharacter);
+
+    expect(baseResult.maxHp).toBe(10);
+
+    const expectedConMod = Math.floor(((baseCharacter.con + 4) - 10) / 2);
+    const totalLevel = baseCharacter.occupation.reduce((sum, entry) => sum + Number(entry.Level), 0);
+    const expectedMaxHp =
+      baseCharacter.health +
+      expectedConMod * totalLevel +
+      5 +
+      1 * totalLevel;
+
+    expect(equippedResult.maxHp).toBe(expectedMaxHp);
+    expect(equippedResult.maxHp - baseResult.maxHp).toBe(
+      expectedConMod * totalLevel + 5 + totalLevel
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend effective ability score calculation to fold in normalized equipment slots
- include equipment and accessory HP bonuses when resolving max HP values
- add coverage ensuring equipment-only CON and HP boosts propagate into hit point totals

## Testing
- CI=1 npm test -- characterMetrics.test.js
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68e095b9f5e4832eac03d20f4d5d2c2a