### PR TITLE
Support uploading map images from files

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -662,6 +662,8 @@ export default function ZombiesDM() {
       map: null,
       title: '',
       imageUrl: '',
+      imageBase64: '',
+      imageType: '',
       altText: '',
       activateOnSave: true,
     });
@@ -3268,6 +3270,10 @@ export default function ZombiesDM() {
         map: safeMap,
         title: typeof safeMap.title === 'string' ? safeMap.title : '',
         imageUrl: typeof safeMap.imageUrl === 'string' ? safeMap.imageUrl : '',
+        imageBase64:
+          typeof safeMap.imageBase64 === 'string' ? safeMap.imageBase64 : '',
+        imageType:
+          typeof safeMap.imageType === 'string' ? safeMap.imageType : '',
         altText: typeof safeMap.altText === 'string' ? safeMap.altText : '',
         activateOnSave: maps.length === 0,
       });
@@ -3287,6 +3293,10 @@ export default function ZombiesDM() {
         map: safeMap,
         title: typeof safeMap.title === 'string' ? safeMap.title : '',
         imageUrl: typeof safeMap.imageUrl === 'string' ? safeMap.imageUrl : '',
+        imageBase64:
+          typeof safeMap.imageBase64 === 'string' ? safeMap.imageBase64 : '',
+        imageType:
+          typeof safeMap.imageType === 'string' ? safeMap.imageType : '',
         altText: typeof safeMap.altText === 'string' ? safeMap.altText : '',
         activateOnSave: false,
       });
@@ -3310,6 +3320,60 @@ export default function ZombiesDM() {
       setMapEditorState((prev) => ({ ...prev, activateOnSave: checked }));
     }, []);
 
+    const handleMapEditorFileChange = useCallback((event) => {
+      const file = event?.target?.files?.[0];
+      if (!file) {
+        setMapEditorState((prev) => ({
+          ...prev,
+          imageBase64: '',
+          imageType: '',
+        }));
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = typeof reader.result === 'string' ? reader.result : '';
+        if (!result) {
+          setMapEditorState((prev) => ({
+            ...prev,
+            imageBase64: '',
+            imageType: '',
+          }));
+          return;
+        }
+
+        let nextImageType = file.type || '';
+        let nextImageBase64 = result;
+
+        const commaIndex = result.indexOf(',');
+        if (result.startsWith('data:') && commaIndex !== -1) {
+          const meta = result.substring(5, commaIndex);
+          const semicolonIndex = meta.indexOf(';');
+          nextImageType =
+            semicolonIndex !== -1 ? meta.substring(0, semicolonIndex) : meta;
+          nextImageBase64 = result.substring(commaIndex + 1);
+        }
+
+        setMapEditorState((prev) => ({
+          ...prev,
+          imageBase64: nextImageBase64,
+          imageType: nextImageType,
+          imageUrl: '',
+        }));
+      };
+
+      reader.onerror = () => {
+        setMapEditorState((prev) => ({
+          ...prev,
+          imageBase64: '',
+          imageType: '',
+        }));
+      };
+
+      reader.readAsDataURL(file);
+    }, []);
+
     const handleSubmitMapEditor = useCallback(
       async (event) => {
         event.preventDefault();
@@ -3322,6 +3386,8 @@ export default function ZombiesDM() {
           map: editorMap,
           title,
           imageUrl,
+          imageBase64,
+          imageType,
           altText,
           activateOnSave,
         } = mapEditorState;
@@ -3333,6 +3399,10 @@ export default function ZombiesDM() {
 
         const trimmedTitle = typeof title === 'string' ? title.trim() : '';
         const trimmedImageUrl = typeof imageUrl === 'string' ? imageUrl.trim() : '';
+        const trimmedImageBase64 =
+          typeof imageBase64 === 'string' ? imageBase64.trim() : '';
+        const trimmedImageType =
+          typeof imageType === 'string' ? imageType.trim() : '';
         const trimmedAltText = typeof altText === 'string' ? altText.trim() : '';
 
         const normalizedTitle = trimmedTitle || getMapDisplayTitle(baseMap, DEFAULT_MAP_TITLE);
@@ -3341,13 +3411,24 @@ export default function ZombiesDM() {
           baseMap && typeof baseMap === 'object' ? { ...baseMap } : {};
         delete sanitizedBaseMap.summary;
         delete sanitizedBaseMap.caption;
+        delete sanitizedBaseMap.imageUrl;
+        delete sanitizedBaseMap.imageBase64;
+        delete sanitizedBaseMap.imageType;
 
         const payloadMap = {
           ...sanitizedBaseMap,
           title: normalizedTitle,
-          imageUrl: trimmedImageUrl,
           altText: trimmedAltText,
         };
+
+        if (trimmedImageUrl) {
+          payloadMap.imageUrl = trimmedImageUrl;
+        } else if (trimmedImageBase64) {
+          payloadMap.imageBase64 = trimmedImageBase64;
+          if (trimmedImageType) {
+            payloadMap.imageType = trimmedImageType;
+          }
+        }
 
         if (mode === 'create') {
           delete payloadMap.mapId;
@@ -6966,6 +7047,15 @@ const resolveIcon = (category, iconMap, fallback) => {
                 placeholder="https://example.com/map.png"
                 value={mapEditorState.imageUrl}
                 onChange={handleMapEditorInputChange('imageUrl')}
+                disabled={mapEditorSaving}
+              />
+            </Form.Group>
+            <Form.Group className="mb-3" controlId="map-editor-image-file">
+              <Form.Label>Image File</Form.Label>
+              <Form.Control
+                type="file"
+                accept="image/*"
+                onChange={handleMapEditorFileChange}
                 disabled={mapEditorSaving}
               />
             </Form.Group>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -764,6 +764,110 @@ describe('ZombiesDM AI generation', () => {
     });
   });
 
+  test('allows uploading a map image file when creating a campaign map', async () => {
+    const mockBase64 = 'Zm9vYmFy';
+    const originalFileReader = global.FileReader;
+    const fileReaderMock = jest.fn(() => ({
+      onload: null,
+      onerror: null,
+      readAsDataURL(file) {
+        if (this.onload) {
+          this.result = `data:${file.type};base64,${mockBase64}`;
+          this.onload({ target: { result: this.result } });
+        }
+      },
+    }));
+    global.FileReader = fileReaderMock;
+
+    const createdMap = {
+      mapId: 'map-file',
+      title: 'Uploaded Map',
+      imageBase64: mockBase64,
+      imageType: 'image/png',
+      altText: 'Uploaded alt text',
+    };
+    let savedPayload;
+
+    apiFetch.mockImplementation((url, options = {}) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/maps':
+          if (options.method === 'POST') {
+            savedPayload = JSON.parse(options.body);
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({
+                maps: [createdMap],
+                activeMapId: createdMap.mapId,
+                map: createdMap,
+              }),
+            });
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ maps: [], activeMapId: null, map: null }),
+          });
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    try {
+      render(<ZombiesDM />);
+
+      const mapTab = await screen.findByRole('tab', { name: 'Map' });
+      await userEvent.click(mapTab);
+
+      const createButton = await screen.findByTestId('create-map-button');
+      await userEvent.click(createButton);
+
+      const modal = await screen.findByTestId('map-editor-modal');
+      const titleInput = within(modal).getByLabelText('Title');
+      await userEvent.type(titleInput, 'Uploaded Map');
+
+      const altTextInput = within(modal).getByLabelText('Alt Text');
+      await userEvent.type(altTextInput, 'Uploaded alt text');
+
+      const fileInput = within(modal).getByLabelText('Image File');
+      const file = new File(['file-data'], 'map.png', { type: 'image/png' });
+      await userEvent.upload(fileInput, file);
+
+      await waitFor(() => expect(fileReaderMock).toHaveBeenCalled());
+
+      const submitButton = within(modal).getByTestId('map-editor-submit-button');
+      await userEvent.click(submitButton);
+
+      await screen.findByText('Map saved.');
+
+      await waitFor(() => expect(savedPayload).toBeDefined());
+
+      expect(savedPayload).toEqual({
+        map: {
+          title: 'Uploaded Map',
+          altText: 'Uploaded alt text',
+          imageBase64: mockBase64,
+          imageType: 'image/png',
+        },
+        activate: true,
+      });
+    } finally {
+      if (originalFileReader) {
+        global.FileReader = originalFileReader;
+      } else {
+        delete global.FileReader;
+      }
+    }
+  });
+
   test('allows the DM to activate a different saved map', async () => {
     const primaryMap = {
       mapId: 'map-1',


### PR DESCRIPTION
## Summary
- extend the map editor state to retain uploaded image data and provide a file input in the modal
- ensure save payloads clear stale image fields and send either a URL or base64 image metadata
- cover the upload flow with a focused frontend test that verifies the payload contents

## Testing
- CI=true npm --prefix client run test -- --watchAll=false --testPathPattern=ZombiesDM.test.js --testNamePattern="allows uploading a map image file when creating a campaign map"

------
https://chatgpt.com/codex/tasks/task_e_68e147d25bb0832e83d633b504396721