### PR TITLE
Enforce alt text requirement for campaign map creation

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -757,6 +757,27 @@ export default function ZombiesDM() {
       }
     }, [mapEditorErrors.imageSource, mapEditorState.imageUrl, mapEditorState.imageBase64]);
 
+    useEffect(() => {
+      if (!mapEditorErrors.altText || mapEditorState.mode !== 'create') {
+        return;
+      }
+
+      const hasAltText =
+        typeof mapEditorState.altText === 'string' &&
+        mapEditorState.altText.trim() !== '';
+
+      if (hasAltText) {
+        setMapEditorErrors((prev) => {
+          if (!prev.altText) {
+            return prev;
+          }
+
+          const { altText, ...rest } = prev;
+          return Object.keys(rest).length ? rest : {};
+        });
+      }
+    }, [mapEditorErrors.altText, mapEditorState.altText, mapEditorState.mode]);
+
     const imageSourceDescribedBy = useMemo(() => {
       const ids = ['map-editor-image-requirement'];
       if (mapEditorErrors.imageSource) {
@@ -3471,6 +3492,10 @@ export default function ZombiesDM() {
           errors.imageSource = 'Provide an image URL or upload a file.';
         }
 
+        if (mode === 'create' && !trimmedAltText) {
+          errors.altText = 'Alt text is required.';
+        }
+
         if (Object.keys(errors).length > 0) {
           setMapEditorErrors(errors);
           return;
@@ -3491,8 +3516,13 @@ export default function ZombiesDM() {
         const payloadMap = {
           ...sanitizedBaseMap,
           title: normalizedTitle,
-          altText: trimmedAltText,
         };
+
+        if (trimmedAltText) {
+          payloadMap.altText = trimmedAltText;
+        } else {
+          delete payloadMap.altText;
+        }
 
         if (trimmedImageUrl) {
           payloadMap.imageUrl = trimmedImageUrl;
@@ -7167,14 +7197,27 @@ const resolveIcon = (category, iconMap, fallback) => {
               </div>
             )}
             <Form.Group className="mb-3" controlId="map-editor-alt-text">
-              <Form.Label>Alt Text</Form.Label>
+              <Form.Label>
+                Alt Text
+                {mapEditorState.mode === 'create' && (
+                  <span className="text-danger" aria-hidden="true">*</span>
+                )}
+              </Form.Label>
               <Form.Control
                 type="text"
                 placeholder="Describe the map image"
                 value={mapEditorState.altText}
                 onChange={handleMapEditorInputChange('altText')}
                 disabled={mapEditorSaving}
+                required={mapEditorState.mode === 'create'}
+                aria-required={mapEditorState.mode === 'create'}
+                isInvalid={Boolean(mapEditorErrors.altText)}
               />
+              {mapEditorErrors.altText && (
+                <Form.Control.Feedback type="invalid" className="d-block">
+                  {mapEditorErrors.altText}
+                </Form.Control.Feedback>
+              )}
             </Form.Group>
             {mapEditorState.mode === 'create' && (
               <Form.Check

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -154,6 +154,7 @@ describe('ZombiesDM AI generation', () => {
 
     expect(getRequiredLabel('Image URL')).toBeInTheDocument();
     expect(getRequiredLabel('Image File')).toBeInTheDocument();
+    expect(getRequiredLabel('Alt Text')).toBeInTheDocument();
     const helperText = modalQueries.getByText(/At least one source is required\./i);
     expect(helperText).toBeInTheDocument();
 
@@ -175,6 +176,7 @@ describe('ZombiesDM AI generation', () => {
 
     const imageUrlInput = modalQueries.getByLabelText(/^Image URL/);
     const imageFileInput = modalQueries.getByLabelText(/^Image File/);
+    const altTextInput = modalQueries.getByLabelText(/^Alt Text/);
 
     expect(imageUrlInput).toHaveAttribute(
       'aria-describedby',
@@ -192,6 +194,8 @@ describe('ZombiesDM AI generation', () => {
       'aria-describedby',
       expect.stringContaining('map-editor-image-error')
     );
+
+    expect(altTextInput).toBeRequired();
 
     await userEvent.type(imageUrlInput, 'https://example.com/map.png');
 
@@ -208,6 +212,18 @@ describe('ZombiesDM AI generation', () => {
     const imageFileDescribedBy = imageFileInput.getAttribute('aria-describedby') || '';
     expect(imageFileDescribedBy).toContain('map-editor-image-requirement');
     expect(imageFileDescribedBy).not.toContain('map-editor-image-error');
+
+    await userEvent.click(submitButton);
+
+    const altTextError = await modalQueries.findByText('Alt text is required.');
+    expect(altTextError).toBeInTheDocument();
+    expect(getMapPostCalls()).toHaveLength(0);
+
+    await userEvent.type(altTextInput, 'Forest clearing battle map');
+
+    await waitFor(() =>
+      expect(modalQueries.queryByText('Alt text is required.')).not.toBeInTheDocument()
+    );
 
     await userEvent.click(submitButton);
 
@@ -948,7 +964,7 @@ describe('ZombiesDM AI generation', () => {
       const titleInput = within(modal).getByLabelText(/^Title/);
       await userEvent.type(titleInput, 'Uploaded Map');
 
-      const altTextInput = within(modal).getByLabelText('Alt Text');
+      const altTextInput = within(modal).getByLabelText(/^Alt Text/);
       await userEvent.type(altTextInput, 'Uploaded alt text');
 
       const fileInput = within(modal).getByLabelText(/^Image File/);
@@ -1045,7 +1061,7 @@ describe('ZombiesDM AI generation', () => {
       expect(modalQueries.getByLabelText(/^Image URL/)).toHaveValue(
         'https://example.com/map.png'
       );
-      expect(modalQueries.getByLabelText('Alt Text')).toHaveValue('Existing map alt text');
+      expect(modalQueries.getByLabelText(/^Alt Text/)).toHaveValue('Existing map alt text');
 
       const renameFileInput = modalQueries.getByLabelText(/^Image File/);
       const file = new File(['data'], 'existing.png', { type: 'image/png' });
@@ -1064,7 +1080,7 @@ describe('ZombiesDM AI generation', () => {
         expect(createModalQueries.getByLabelText(/^Title/)).toHaveValue('')
       );
       expect(createModalQueries.getByLabelText(/^Image URL/)).toHaveValue('');
-      expect(createModalQueries.getByLabelText('Alt Text')).toHaveValue('');
+      expect(createModalQueries.getByLabelText(/^Alt Text/)).toHaveValue('');
 
       const createFileInput = createModalQueries.getByLabelText(/^Image File/);
       expect(createFileInput.files).toHaveLength(0);


### PR DESCRIPTION
## Summary
- validate alt text when creating maps and clear the error as the user types
- mark the map editor alt text field as required and surface its feedback state
- update the map editor test to cover the new alt text requirement scenario

## Testing
- CI=true npm --prefix client test -- --testPathPattern=ZombiesDM.test.js --testNamePattern="map editor indicates required fields"

------
https://chatgpt.com/codex/tasks/task_e_68e155b29488832e8536c851592395e3