### PR TITLE
Add elven lineage support for elf characters

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -64,8 +64,10 @@ export default function CharacterInfo({
   const raceName = form?.race?.name?.toLowerCase?.();
   const isDragonborn = raceName === 'dragonborn';
   const isGoliath = raceName === 'goliath';
+  const isElf = raceName === 'elf';
   const dragonAncestries = isDragonborn ? form?.race?.dragonAncestries || {} : {};
   const giantAncestries = isGoliath ? form?.race?.giantAncestries || {} : {};
+  const elvenLineages = isElf ? form?.race?.elvenLineages || {} : {};
   const goliathAncestry = isGoliath
     ? form?.race?.selectedAncestry ||
       (form?.race?.selectedAncestryKey && giantAncestries
@@ -99,6 +101,19 @@ export default function CharacterInfo({
       form?.dragonAncestryKey ||
       form?.race?.selectedAncestryKey ||
       "Draconic Ancestry"
+    : null;
+  const elvenLineage = isElf
+    ? form?.race?.selectedAncestry ||
+      (form?.race?.selectedAncestryKey && elvenLineages
+        ? elvenLineages[form.race.selectedAncestryKey]
+        : null) ||
+      form?.elvenLineage ||
+      (form?.elvenLineageKey && elvenLineages
+        ? elvenLineages[form.elvenLineageKey]
+        : null)
+    : null;
+  const elvenLineageName = elvenLineage
+    ? elvenLineage.label || elvenLineage.name || 'Elven Lineage'
     : null;
   const displaySize =
     form?.temporarySize || form?.size || form?.height || "—";
@@ -147,6 +162,9 @@ export default function CharacterInfo({
                 )}
                 {isDragonborn && dragonbornAncestryName && (
                   <span className="character-info-subtext">{dragonbornAncestryName}</span>
+                )}
+                {isElf && elvenLineageName && (
+                  <span className="character-info-subtext">{elvenLineageName}</span>
                 )}
               </div>
             </div>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -159,3 +159,36 @@ test('renders dragonborn ancestry within race card when ancestry selected', () =
   expect(queryByText('Subrace')).not.toBeInTheDocument();
 });
 
+test('renders elven lineage within race card when lineage selected', () => {
+  const form = {
+    occupation: [],
+    race: {
+      name: 'Elf',
+      languages: [],
+      selectedAncestryKey: 'wood',
+      elvenLineages: {
+        wood: { label: 'Wood Elf' },
+      },
+    },
+    elvenLineageKey: 'wood',
+    elvenLineage: { label: 'Wood Elf' },
+  };
+
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={() => {}}
+      onLongRest={() => {}}
+      onShortRest={() => {}}
+    />
+  );
+
+  const raceItem = screen.getByText('Race').closest('.character-info-item');
+  expect(raceItem).not.toBeNull();
+  const { getByText } = within(raceItem);
+  expect(getByText('Elf')).toBeInTheDocument();
+  expect(getByText('Wood Elf')).toBeInTheDocument();
+});
+

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -115,6 +115,69 @@ export default function Features({
     return gnomeLineageAbility.trim();
   }, [gnomeLineageAbility]);
 
+  const { elvenLineage, elvenLineageKey, elvenLineageAbility } = useMemo(() => {
+    const race = form?.race || {};
+    const lineageFromForm =
+      typeof form?.elvenLineage === 'object' ? form.elvenLineage : null;
+    const lineageKeyFromForm =
+      typeof form?.elvenLineageKey === 'string' ? form.elvenLineageKey : '';
+    const abilityFromForm =
+      typeof form?.elvenLineageAbility === 'string' ? form.elvenLineageAbility : '';
+
+    let lineage = lineageFromForm;
+    let lineageKey = lineageKeyFromForm;
+    if (!lineage) {
+      if (lineageKey && race?.elvenLineages?.[lineageKey]) {
+        lineage = race.elvenLineages[lineageKey];
+      } else if (race?.selectedAncestry && race?.elvenLineages) {
+        lineage = race.selectedAncestry;
+        lineageKey =
+          typeof race?.selectedAncestryKey === 'string'
+            ? race.selectedAncestryKey
+            : '';
+      } else if (
+        typeof race?.selectedAncestryKey === 'string' &&
+        race?.elvenLineages?.[race.selectedAncestryKey]
+      ) {
+        lineage = race.elvenLineages[race.selectedAncestryKey];
+        lineageKey = race.selectedAncestryKey;
+      }
+    }
+
+    let ability = abilityFromForm;
+    if (!ability) {
+      ability =
+        typeof race?.selectedLineageAbility === 'string'
+          ? race.selectedLineageAbility
+          : '';
+    }
+    if (!ability && lineage?.spellcastingAbilities?.length) {
+      ability = lineage.spellcastingAbilities[0];
+    }
+
+    return { elvenLineage: lineage, elvenLineageKey: lineageKey, elvenLineageAbility: ability };
+  }, [form?.elvenLineage, form?.elvenLineageAbility, form?.elvenLineageKey, form?.race]);
+
+  const elvenSpellAbilityLabel = useMemo(() => {
+    if (typeof elvenLineageAbility !== 'string') return '';
+    return elvenLineageAbility.trim();
+  }, [elvenLineageAbility]);
+
+  const isDrowElvenLineage = useMemo(() => {
+    if (!elvenLineageKey) return false;
+    return elvenLineageKey.toLowerCase() === 'drow';
+  }, [elvenLineageKey]);
+
+  const isHighElvenLineage = useMemo(() => {
+    if (!elvenLineageKey) return false;
+    return elvenLineageKey.toLowerCase() === 'high';
+  }, [elvenLineageKey]);
+
+  const isWoodElvenLineage = useMemo(() => {
+    if (!elvenLineageKey) return false;
+    return elvenLineageKey.toLowerCase() === 'wood';
+  }, [elvenLineageKey]);
+
   const isForestGnomeLineage = useMemo(() => {
     if (!gnomeLineageKey) return false;
     return gnomeLineageKey.toLowerCase() === 'forest';
@@ -321,6 +384,169 @@ export default function Features({
           hideUseButton: true,
         }
       );
+    } else if (raceName === 'elf') {
+      const feyAncestryDescription =
+        'You have advantage on saving throws against being charmed, and magic cannot put you to sleep.';
+      const tranceDescription =
+        'Elves do not need to sleep. Instead, you meditate deeply for 4 hours a day, remaining semiconscious. After resting in this way, you gain the same benefit that a human does from 8 hours of sleep.';
+      const keenSensesDescription =
+        'Your keen senses grant you proficiency in the Perception skill, and you choose one additional proficiency from Insight, Perception, or Survival.';
+
+      raceFeatures.push(
+        {
+          id: 'elf-fey-ancestry',
+          name: 'Fey Ancestry',
+          meta: 'Elf',
+          description: feyAncestryDescription,
+          desc: feyAncestryDescription,
+          hideUseButton: true,
+        },
+        {
+          id: 'elf-trance',
+          name: 'Trance',
+          meta: 'Elf',
+          description: tranceDescription,
+          desc: tranceDescription,
+          hideUseButton: true,
+        },
+        {
+          id: 'elf-keen-senses',
+          name: 'Keen Senses',
+          meta: 'Elf',
+          description: keenSensesDescription,
+          desc: keenSensesDescription,
+          hideUseButton: true,
+        }
+      );
+
+      if (elvenLineage) {
+        const lineageLabel =
+          typeof elvenLineage?.label === 'string'
+            ? elvenLineage.label
+            : 'Elven Lineage';
+        const lineageMeta = `${lineageLabel}${
+          elvenSpellAbilityLabel
+            ? ` • Spellcasting Ability: ${elvenSpellAbilityLabel}`
+            : ''
+        }`;
+        const abilityText = elvenSpellAbilityLabel
+          ? ` This lineage uses ${elvenSpellAbilityLabel} for its spells.`
+          : '';
+
+        if (isDrowElvenLineage) {
+          const dancingLightsDescription =
+            'You know the Dancing Lights cantrip and can cast it without expending a spell slot.' +
+            abilityText;
+          const faerieFireDescription =
+            'Starting at 3rd level, you can cast Faerie Fire with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            abilityText;
+          const darknessDescription =
+            'Starting at 5th level, you can cast Darkness with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            abilityText;
+
+          raceFeatures.push(
+            {
+              id: 'elf-drow-dancing-lights',
+              name: 'Dancing Lights',
+              meta: lineageMeta,
+              description: dancingLightsDescription,
+              desc: dancingLightsDescription,
+              hideUseButton: true,
+            },
+            {
+              id: 'elf-drow-faerie-fire',
+              name: 'Faerie Fire (Level 3)',
+              meta: lineageMeta,
+              description: faerieFireDescription,
+              desc: faerieFireDescription,
+              hideUseButton: true,
+            },
+            {
+              id: 'elf-drow-darkness',
+              name: 'Darkness (Level 5)',
+              meta: lineageMeta,
+              description: darknessDescription,
+              desc: darknessDescription,
+              hideUseButton: true,
+            }
+          );
+        } else if (isHighElvenLineage) {
+          const prestidigitationDescription =
+            'You know the Prestidigitation cantrip and can cast it without expending a spell slot.' +
+            abilityText;
+          const detectMagicDescription =
+            'Starting at 3rd level, you can cast Detect Magic with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            abilityText;
+          const mistyStepDescription =
+            'Starting at 5th level, you can cast Misty Step with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            abilityText;
+
+          raceFeatures.push(
+            {
+              id: 'elf-high-prestidigitation',
+              name: 'Prestidigitation',
+              meta: lineageMeta,
+              description: prestidigitationDescription,
+              desc: prestidigitationDescription,
+              hideUseButton: true,
+            },
+            {
+              id: 'elf-high-detect-magic',
+              name: 'Detect Magic (Level 3)',
+              meta: lineageMeta,
+              description: detectMagicDescription,
+              desc: detectMagicDescription,
+              hideUseButton: true,
+            },
+            {
+              id: 'elf-high-misty-step',
+              name: 'Misty Step (Level 5)',
+              meta: lineageMeta,
+              description: mistyStepDescription,
+              desc: mistyStepDescription,
+              hideUseButton: true,
+            }
+          );
+        } else if (isWoodElvenLineage) {
+          const druidcraftDescription =
+            'You know the Druidcraft cantrip and can cast it without expending a spell slot.' +
+            abilityText +
+            ' Your walking speed increases to 35 feet.';
+          const longstriderDescription =
+            'Starting at 3rd level, you can cast Longstrider with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            abilityText;
+          const passWithoutTraceDescription =
+            'Starting at 5th level, you can cast Pass without Trace with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            abilityText;
+
+          raceFeatures.push(
+            {
+              id: 'elf-wood-druidcraft',
+              name: 'Druidcraft',
+              meta: lineageMeta,
+              description: druidcraftDescription,
+              desc: druidcraftDescription,
+              hideUseButton: true,
+            },
+            {
+              id: 'elf-wood-longstrider',
+              name: 'Longstrider (Level 3)',
+              meta: lineageMeta,
+              description: longstriderDescription,
+              desc: longstriderDescription,
+              hideUseButton: true,
+            },
+            {
+              id: 'elf-wood-pass-without-trace',
+              name: 'Pass without Trace (Level 5)',
+              meta: lineageMeta,
+              description: passWithoutTraceDescription,
+              desc: passWithoutTraceDescription,
+              hideUseButton: true,
+            }
+          );
+        }
+      }
     } else if (raceName === 'gnome') {
       const gnomishCunningDescription =
         'You have advantage on Intelligence, Wisdom, and Charisma saving throws against magic.';

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -341,6 +341,195 @@ test('halfling characters display racial trait feature cards with descriptions',
   }
 });
 
+test('elf characters display baseline traits and drow lineage magic', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const form = {
+    race: {
+      name: 'Elf',
+      speed: 30,
+      darkvisionRange: 120,
+      elvenLineages: {
+        drow: {
+          label: 'Drow',
+          spellcastingAbilities: ['Charisma'],
+          darkvisionRange: 120,
+        },
+      },
+      selectedAncestryKey: 'drow',
+      selectedAncestry: {
+        label: 'Drow',
+        spellcastingAbilities: ['Charisma'],
+        darkvisionRange: 120,
+      },
+      selectedLineageAbility: 'Charisma',
+    },
+    elvenLineageKey: 'drow',
+    elvenLineage: {
+      label: 'Drow',
+      spellcastingAbilities: ['Charisma'],
+      darkvisionRange: 120,
+    },
+    elvenLineageAbility: 'Charisma',
+    occupation: [],
+  };
+
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Fey Ancestry')).toBeInTheDocument();
+  expect(screen.getByText('Trance')).toBeInTheDocument();
+  expect(screen.getByText('Keen Senses')).toBeInTheDocument();
+
+  const dancingLightsTitle = await screen.findByText('Dancing Lights');
+  const dancingCard = dancingLightsTitle.closest('.feature-card');
+  expect(dancingCard).not.toBeNull();
+  expect(
+    within(dancingCard).getByText(/Spellcasting Ability: Charisma/i)
+  ).toBeInTheDocument();
+
+  expect(screen.getByText('Faerie Fire (Level 3)')).toBeInTheDocument();
+  expect(screen.getByText('Darkness (Level 5)')).toBeInTheDocument();
+
+  const darkvisionCard = screen.getByText('Darkvision').closest('.feature-card');
+  expect(darkvisionCard).not.toBeNull();
+  const darkvisionViewButton = within(darkvisionCard).getByRole('button', {
+    name: /view feature/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(darkvisionViewButton);
+  });
+
+  expect(
+    await screen.findByText(/dim light within 120 feet of you/i)
+  ).toBeInTheDocument();
+});
+
+test('wood elf lineage notes speed increase and lineage spells', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const form = {
+    race: {
+      name: 'Elf',
+      speed: 35,
+      darkvisionRange: 60,
+      elvenLineages: {
+        wood: {
+          label: 'Wood Elf',
+          spellcastingAbilities: ['Wisdom'],
+          speed: 35,
+        },
+      },
+      selectedAncestryKey: 'wood',
+      selectedAncestry: {
+        label: 'Wood Elf',
+        spellcastingAbilities: ['Wisdom'],
+        speed: 35,
+      },
+      selectedLineageAbility: 'Wisdom',
+    },
+    elvenLineageKey: 'wood',
+    elvenLineage: {
+      label: 'Wood Elf',
+      spellcastingAbilities: ['Wisdom'],
+      speed: 35,
+    },
+    elvenLineageAbility: 'Wisdom',
+    occupation: [],
+  };
+
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const druidcraftTitle = await screen.findByText('Druidcraft');
+  const druidcraftCard = druidcraftTitle.closest('.feature-card');
+  expect(druidcraftCard).not.toBeNull();
+  const viewButton = within(druidcraftCard).getByRole('button', {
+    name: /view feature/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(viewButton);
+  });
+
+  expect(
+    await screen.findByText(/Your walking speed increases to 35 feet/i)
+  ).toBeInTheDocument();
+  expect(screen.getByText('Longstrider (Level 3)')).toBeInTheDocument();
+  expect(screen.getByText('Pass without Trace (Level 5)')).toBeInTheDocument();
+});
+
+test('high elf lineage lists arcane cantrip and future spell hooks', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const form = {
+    race: {
+      name: 'Elf',
+      speed: 30,
+      darkvisionRange: 60,
+      elvenLineages: {
+        high: {
+          label: 'High Elf',
+          spellcastingAbilities: ['Intelligence'],
+        },
+      },
+      selectedAncestryKey: 'high',
+      selectedAncestry: {
+        label: 'High Elf',
+        spellcastingAbilities: ['Intelligence'],
+      },
+      selectedLineageAbility: 'Intelligence',
+    },
+    elvenLineageKey: 'high',
+    elvenLineage: {
+      label: 'High Elf',
+      spellcastingAbilities: ['Intelligence'],
+    },
+    elvenLineageAbility: 'Intelligence',
+    occupation: [],
+  };
+
+  render(
+    <Features
+      form={form}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const prestidigitationTitle = await screen.findByText('Prestidigitation');
+  const prestidigitationCard = prestidigitationTitle.closest('.feature-card');
+  expect(prestidigitationCard).not.toBeNull();
+  expect(
+    within(prestidigitationCard).getByText(/Spellcasting Ability: Intelligence/i)
+  ).toBeInTheDocument();
+  expect(screen.getByText('Detect Magic (Level 3)')).toBeInTheDocument();
+  expect(screen.getByText('Misty Step (Level 5)')).toBeInTheDocument();
+});
+
 test('forest gnome lineage shows lineage spells with ability text and tracking', async () => {
   apiFetch.mockResolvedValue({
     ok: true,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -76,6 +76,9 @@ const createDefaultForm = useCallback((campaign) => {
     gnomeLineageKey: "",
     gnomeLineage: null,
     gnomeLineageAbility: "",
+    elvenLineageKey: "",
+    elvenLineage: null,
+    elvenLineageAbility: "",
     background: null,
     feat: [],
     weapon: [],
@@ -223,9 +226,35 @@ const attachSelectedAncestryToRace = useCallback((race, {
   gnomeLineageKey,
   gnomeLineage,
   gnomeLineageAbility,
+  elvenLineageKey,
+  elvenLineage,
+  elvenLineageAbility,
 }) => {
   if (!race) return race;
   const updatedRace = { ...race };
+
+  const baseSpeed =
+    typeof race.__baseSpeed === "number" ? race.__baseSpeed : race.speed;
+  if (typeof baseSpeed === "number") {
+    updatedRace.__baseSpeed = baseSpeed;
+  }
+
+  const hasStoredBaseDarkvision = Object.prototype.hasOwnProperty.call(
+    race,
+    "__baseDarkvisionRange"
+  );
+  const hasRaceDarkvision = Object.prototype.hasOwnProperty.call(
+    race,
+    "darkvisionRange"
+  );
+  const baseDarkvision = hasStoredBaseDarkvision
+    ? race.__baseDarkvisionRange
+    : hasRaceDarkvision
+    ? race.darkvisionRange
+    : undefined;
+  if (hasStoredBaseDarkvision || hasRaceDarkvision) {
+    updatedRace.__baseDarkvisionRange = baseDarkvision;
+  }
 
   delete updatedRace.selectedAncestryKey;
   delete updatedRace.selectedAncestry;
@@ -242,6 +271,47 @@ const attachSelectedAncestryToRace = useCallback((race, {
     updatedRace.selectedAncestry = gnomeLineage;
     if (gnomeLineageAbility) {
       updatedRace.selectedLineageAbility = gnomeLineageAbility;
+    }
+  } else if (race.elvenLineages && elvenLineageKey && elvenLineage) {
+    updatedRace.selectedAncestryKey = elvenLineageKey;
+    updatedRace.selectedAncestry = elvenLineage;
+    if (elvenLineageAbility) {
+      updatedRace.selectedLineageAbility = elvenLineageAbility;
+    }
+  }
+
+  if (race.elvenLineages) {
+    const hasExplicitElvenSelection =
+      typeof elvenLineageKey !== "undefined";
+    const lineageToApply = hasExplicitElvenSelection
+      ? elvenLineageKey && elvenLineage
+        ? elvenLineage
+        : null
+      : race.selectedAncestryKey && race.elvenLineages[race.selectedAncestryKey]
+      ? race.elvenLineages[race.selectedAncestryKey]
+      : null;
+
+    const lineageSpeed =
+      typeof lineageToApply?.speed === "number" ? lineageToApply.speed : null;
+    const lineageDarkvision =
+      typeof lineageToApply?.darkvisionRange === "number"
+        ? lineageToApply.darkvisionRange
+        : null;
+
+    if (typeof baseSpeed === "number") {
+      updatedRace.speed = lineageSpeed ?? baseSpeed;
+    } else if (lineageSpeed != null) {
+      updatedRace.speed = lineageSpeed;
+    }
+
+    if (lineageDarkvision != null) {
+      updatedRace.darkvisionRange = lineageDarkvision;
+    } else if (typeof baseDarkvision !== "undefined") {
+      if (baseDarkvision === null) {
+        delete updatedRace.darkvisionRange;
+      } else {
+        updatedRace.darkvisionRange = baseDarkvision;
+      }
     }
   }
 
@@ -363,8 +433,11 @@ function bigMaff() {
       delete chosenRace.abilityChoices;
     }
     if (chosenRace.skillChoices) {
-      const { count } = chosenRace.skillChoices;
-      const available = SKILLS.map((s) => s.key);
+      const { count, options } = chosenRace.skillChoices;
+      const available = (options && options.length
+        ? [...options]
+        : SKILLS.map((s) => s.key)
+      ).filter((skillKey) => !chosenRace.skills?.[skillKey]?.proficient);
       chosenRace.skills = chosenRace.skills || {};
       for (let i = 0; i < count; i++) {
         if (!available.length) break;
@@ -381,6 +454,9 @@ function bigMaff() {
     let selectedGnomeLineageKey = "";
     let selectedGnomeLineage = null;
     let selectedGnomeLineageAbility = "";
+    let selectedElvenLineageKey = "";
+    let selectedElvenLineage = null;
+    let selectedElvenLineageAbility = "";
     if (chosenRace.name === "Dragonborn" && chosenRace.dragonAncestries) {
       const ancestryKeys = Object.keys(chosenRace.dragonAncestries);
       const alignmentLower = alignmentValue.toLowerCase();
@@ -425,15 +501,44 @@ function bigMaff() {
         }
       }
     }
+    if (chosenRace.name === "Elf" && chosenRace.elvenLineages) {
+      const lineageKeys = Object.keys(chosenRace.elvenLineages);
+      if (lineageKeys.length) {
+        selectedElvenLineageKey = lineageKeys[Math.floor(Math.random() * lineageKeys.length)];
+        selectedElvenLineage = chosenRace.elvenLineages[selectedElvenLineageKey];
+        chosenRace.selectedAncestryKey = selectedElvenLineageKey;
+        chosenRace.selectedAncestry = selectedElvenLineage;
+        const abilityOptions = selectedElvenLineage?.spellcastingAbilities || [];
+        if (abilityOptions.length) {
+          selectedElvenLineageAbility = abilityOptions[Math.floor(Math.random() * abilityOptions.length)];
+          chosenRace.selectedLineageAbility = selectedElvenLineageAbility;
+        }
+      }
+    }
+    const raceWithSelections = attachSelectedAncestryToRace(chosenRace, {
+      dragonAncestryKey: selectedDragonAncestry ? selectedDragonAncestryKey : "",
+      dragonAncestry: selectedDragonAncestry,
+      giantAncestryKey: selectedGiantAncestry ? selectedGiantAncestryKey : "",
+      giantAncestry: selectedGiantAncestry,
+      gnomeLineageKey: selectedGnomeLineage ? selectedGnomeLineageKey : "",
+      gnomeLineage: selectedGnomeLineage,
+      gnomeLineageAbility: selectedGnomeLineageAbility,
+      elvenLineageKey: selectedElvenLineage ? selectedElvenLineageKey : "",
+      elvenLineage: selectedElvenLineage,
+      elvenLineageAbility: selectedElvenLineageAbility,
+    });
     setForm((prev) => {
       const updatedSkills = { ...(prev.skills || {}) };
-      if (chosenRace.skills) {
-        Object.assign(updatedSkills, chosenRace.skills);
+      if (raceWithSelections?.skills) {
+        Object.assign(updatedSkills, raceWithSelections.skills);
       }
       const nextForm = {
         ...prev,
-        race: chosenRace,
-        speed: chosenRace.speed,
+        race: raceWithSelections,
+        speed:
+          typeof raceWithSelections?.speed === "number"
+            ? raceWithSelections.speed
+            : prev.speed,
         size: selectedSize || prev.size || "",
         dragonAncestryKey: selectedDragonAncestry ? selectedDragonAncestryKey : "",
         dragonAncestry: selectedDragonAncestry || null,
@@ -442,6 +547,9 @@ function bigMaff() {
         gnomeLineageKey: selectedGnomeLineage ? selectedGnomeLineageKey : "",
         gnomeLineage: selectedGnomeLineage || null,
         gnomeLineageAbility: selectedGnomeLineageAbility || "",
+        elvenLineageKey: selectedElvenLineage ? selectedElvenLineageKey : "",
+        elvenLineage: selectedElvenLineage || null,
+        elvenLineageAbility: selectedElvenLineageAbility || "",
       };
       if (Object.keys(updatedSkills).length) {
         nextForm.skills = updatedSkills;
@@ -566,10 +674,15 @@ useEffect(() => {
         gnomeLineageKey: baseCharacter.gnomeLineageKey,
         gnomeLineage: baseCharacter.gnomeLineage,
         gnomeLineageAbility: baseCharacter.gnomeLineageAbility,
+        elvenLineageKey: baseCharacter.elvenLineageKey,
+        elvenLineage: baseCharacter.elvenLineage,
+        elvenLineageAbility: baseCharacter.elvenLineageAbility,
       }
     );
     if (raceWithAncestry) {
       newCharacter.race = raceWithAncestry;
+      delete newCharacter.race.__baseSpeed;
+      delete newCharacter.race.__baseDarkvisionRange;
     } else {
       delete newCharacter.race;
     }
@@ -636,6 +749,9 @@ const handleRaceChange = (e) => {
         gnomeLineageKey: "",
         gnomeLineage: null,
         gnomeLineageAbility: "",
+        elvenLineageKey: "",
+        elvenLineage: null,
+        elvenLineageAbility: "",
       };
     }
 
@@ -658,6 +774,9 @@ const handleRaceChange = (e) => {
     let gnomeLineageKey = "";
     let gnomeLineage = null;
     let gnomeLineageAbility = "";
+    let elvenLineageKey = "";
+    let elvenLineage = null;
+    let elvenLineageAbility = "";
     if (raceObj.dragonAncestries) {
       const prevKey =
         prev.race?.name === raceObj.name && prev.dragonAncestryKey
@@ -701,6 +820,29 @@ const handleRaceChange = (e) => {
       }
     }
 
+    if (raceObj.elvenLineages) {
+      const prevKey =
+        prev.race?.name === raceObj.name && prev.elvenLineageKey
+          ? prev.elvenLineageKey
+          : "";
+      if (prevKey && raceObj.elvenLineages[prevKey]) {
+        elvenLineageKey = prevKey;
+        elvenLineage = raceObj.elvenLineages[prevKey];
+        const prevAbility =
+          prev.race?.name === raceObj.name && prev.elvenLineageAbility
+            ? prev.elvenLineageAbility
+            : "";
+        if (
+          prevAbility &&
+          elvenLineage?.spellcastingAbilities?.includes(prevAbility)
+        ) {
+          elvenLineageAbility = prevAbility;
+        } else if ((elvenLineage?.spellcastingAbilities || []).length === 1) {
+          elvenLineageAbility = elvenLineage.spellcastingAbilities[0];
+        }
+      }
+    }
+
     const updatedRace = attachSelectedAncestryToRace(raceObj, {
       dragonAncestryKey,
       dragonAncestry,
@@ -709,12 +851,18 @@ const handleRaceChange = (e) => {
       gnomeLineageKey,
       gnomeLineage,
       gnomeLineageAbility,
+      elvenLineageKey,
+      elvenLineage,
+      elvenLineageAbility,
     });
 
     const updatedForm = {
       ...prev,
       race: updatedRace,
-      speed: raceObj.speed,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
       size,
       dragonAncestryKey,
       dragonAncestry,
@@ -723,6 +871,9 @@ const handleRaceChange = (e) => {
       gnomeLineageKey,
       gnomeLineage,
       gnomeLineageAbility,
+      elvenLineageKey,
+      elvenLineage,
+      elvenLineageAbility,
     };
 
     if (Object.keys(updatedSkills).length) {
@@ -745,6 +896,9 @@ const handleDragonAncestryChange = (e) => {
         gnomeLineageKey: prev.gnomeLineageKey,
         gnomeLineage: prev.gnomeLineage,
         gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
       });
       return {
         ...prev,
@@ -756,6 +910,13 @@ const handleDragonAncestryChange = (e) => {
         gnomeLineageKey: prev.gnomeLineageKey,
         gnomeLineage: prev.gnomeLineage,
         gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
       };
     }
 
@@ -768,6 +929,9 @@ const handleDragonAncestryChange = (e) => {
       gnomeLineageKey: "",
       gnomeLineage: null,
       gnomeLineageAbility: "",
+      elvenLineageKey: "",
+      elvenLineage: null,
+      elvenLineageAbility: "",
     });
 
     return {
@@ -780,6 +944,13 @@ const handleDragonAncestryChange = (e) => {
       gnomeLineageKey: "",
       gnomeLineage: null,
       gnomeLineageAbility: "",
+      elvenLineageKey: "",
+      elvenLineage: null,
+      elvenLineageAbility: "",
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
     };
   });
 };
@@ -796,6 +967,9 @@ const handleGiantAncestryChange = (e) => {
         gnomeLineageKey: prev.gnomeLineageKey,
         gnomeLineage: prev.gnomeLineage,
         gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
       });
       return {
         ...prev,
@@ -807,6 +981,13 @@ const handleGiantAncestryChange = (e) => {
         gnomeLineageKey: prev.gnomeLineageKey,
         gnomeLineage: prev.gnomeLineage,
         gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
       };
     }
 
@@ -819,6 +1000,9 @@ const handleGiantAncestryChange = (e) => {
       gnomeLineageKey: "",
       gnomeLineage: null,
       gnomeLineageAbility: "",
+      elvenLineageKey: "",
+      elvenLineage: null,
+      elvenLineageAbility: "",
     });
 
     return {
@@ -831,6 +1015,13 @@ const handleGiantAncestryChange = (e) => {
       gnomeLineageKey: "",
       gnomeLineage: null,
       gnomeLineageAbility: "",
+      elvenLineageKey: "",
+      elvenLineage: null,
+      elvenLineageAbility: "",
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
     };
   });
 };
@@ -847,6 +1038,9 @@ const handleGnomeLineageChange = (e) => {
         gnomeLineageKey: "",
         gnomeLineage: null,
         gnomeLineageAbility: "",
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
       });
       return {
         ...prev,
@@ -854,6 +1048,10 @@ const handleGnomeLineageChange = (e) => {
         gnomeLineageKey: "",
         gnomeLineage: null,
         gnomeLineageAbility: "",
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
       };
     }
 
@@ -876,6 +1074,9 @@ const handleGnomeLineageChange = (e) => {
       gnomeLineageKey: lineage ? key : "",
       gnomeLineage: lineage || null,
       gnomeLineageAbility: nextAbility,
+      elvenLineageKey: prev.elvenLineageKey,
+      elvenLineage: prev.elvenLineage,
+      elvenLineageAbility: prev.elvenLineageAbility,
     });
 
     return {
@@ -884,6 +1085,10 @@ const handleGnomeLineageChange = (e) => {
       gnomeLineageKey: lineage ? key : "",
       gnomeLineage: lineage || null,
       gnomeLineageAbility: nextAbility,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
     };
   });
 };
@@ -900,11 +1105,18 @@ const handleGnomeLineageAbilityChange = (e) => {
         gnomeLineageKey: "",
         gnomeLineage: null,
         gnomeLineageAbility: "",
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
       });
       return {
         ...prev,
         race: updatedRace,
         gnomeLineageAbility: "",
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
       };
     }
 
@@ -920,12 +1132,142 @@ const handleGnomeLineageAbilityChange = (e) => {
       gnomeLineageKey: lineage ? prev.gnomeLineageKey : "",
       gnomeLineage: lineage || null,
       gnomeLineageAbility: validAbility,
+      elvenLineageKey: prev.elvenLineageKey,
+      elvenLineage: prev.elvenLineage,
+      elvenLineageAbility: prev.elvenLineageAbility,
     });
 
     return {
       ...prev,
       race: updatedRace,
       gnomeLineageAbility: validAbility,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
+    };
+  });
+};
+
+const handleElvenLineageChange = (e) => {
+  const key = e.target.value;
+  setForm((prev) => {
+    if (!prev.race?.elvenLineages) {
+      const updatedRace = attachSelectedAncestryToRace(prev.race, {
+        dragonAncestryKey: prev.dragonAncestryKey,
+        dragonAncestry: prev.dragonAncestry,
+        giantAncestryKey: prev.giantAncestryKey,
+        giantAncestry: prev.giantAncestry,
+        gnomeLineageKey: prev.gnomeLineageKey,
+        gnomeLineage: prev.gnomeLineage,
+        gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: "",
+        elvenLineage: null,
+        elvenLineageAbility: "",
+      });
+      return {
+        ...prev,
+        race: updatedRace,
+        elvenLineageKey: "",
+        elvenLineage: null,
+        elvenLineageAbility: "",
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
+      };
+    }
+
+    const lineage = prev.race.elvenLineages[key];
+    const abilityOptions = lineage?.spellcastingAbilities || [];
+    let nextAbility = "";
+    if (lineage) {
+      if (abilityOptions.includes(prev.elvenLineageAbility)) {
+        nextAbility = prev.elvenLineageAbility;
+      } else if (abilityOptions.length === 1) {
+        nextAbility = abilityOptions[0];
+      }
+    }
+
+    const updatedRace = attachSelectedAncestryToRace(prev.race, {
+      dragonAncestryKey: prev.dragonAncestryKey,
+      dragonAncestry: prev.dragonAncestry,
+      giantAncestryKey: prev.giantAncestryKey,
+      giantAncestry: prev.giantAncestry,
+      gnomeLineageKey: prev.gnomeLineageKey,
+      gnomeLineage: prev.gnomeLineage,
+      gnomeLineageAbility: prev.gnomeLineageAbility,
+      elvenLineageKey: lineage ? key : "",
+      elvenLineage: lineage || null,
+      elvenLineageAbility: nextAbility,
+    });
+
+    return {
+      ...prev,
+      race: updatedRace,
+      elvenLineageKey: lineage ? key : "",
+      elvenLineage: lineage || null,
+      elvenLineageAbility: nextAbility,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
+    };
+  });
+};
+
+const handleElvenLineageAbilityChange = (e) => {
+  const ability = e.target.value;
+  setForm((prev) => {
+    if (!prev.race?.elvenLineages || !prev.elvenLineageKey) {
+      const updatedRace = attachSelectedAncestryToRace(prev.race, {
+        dragonAncestryKey: prev.dragonAncestryKey,
+        dragonAncestry: prev.dragonAncestry,
+        giantAncestryKey: prev.giantAncestryKey,
+        giantAncestry: prev.giantAncestry,
+        gnomeLineageKey: prev.gnomeLineageKey,
+        gnomeLineage: prev.gnomeLineage,
+        gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: "",
+        elvenLineage: null,
+        elvenLineageAbility: "",
+      });
+      return {
+        ...prev,
+        race: updatedRace,
+        elvenLineageAbility: "",
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
+      };
+    }
+
+    const lineage = prev.race.elvenLineages[prev.elvenLineageKey];
+    const validAbility =
+      lineage?.spellcastingAbilities?.includes(ability) ? ability : "";
+
+    const updatedRace = attachSelectedAncestryToRace(prev.race, {
+      dragonAncestryKey: prev.dragonAncestryKey,
+      dragonAncestry: prev.dragonAncestry,
+      giantAncestryKey: prev.giantAncestryKey,
+      giantAncestry: prev.giantAncestry,
+      gnomeLineageKey: prev.gnomeLineageKey,
+      gnomeLineage: prev.gnomeLineage,
+      gnomeLineageAbility: prev.gnomeLineageAbility,
+      elvenLineageKey: lineage ? prev.elvenLineageKey : "",
+      elvenLineage: lineage || null,
+      elvenLineageAbility: validAbility,
+    });
+
+    return {
+      ...prev,
+      race: updatedRace,
+      elvenLineageAbility: validAbility,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
     };
   });
 };
@@ -1050,10 +1392,15 @@ const sendManualToDb = useCallback(async (characterData) => {
       gnomeLineageKey: baseCharacter.gnomeLineageKey,
       gnomeLineage: baseCharacter.gnomeLineage,
       gnomeLineageAbility: baseCharacter.gnomeLineageAbility,
+      elvenLineageKey: baseCharacter.elvenLineageKey,
+      elvenLineage: baseCharacter.elvenLineage,
+      elvenLineageAbility: baseCharacter.elvenLineageAbility,
     }
   );
   if (raceWithAncestry) {
     newCharacter.race = raceWithAncestry;
+    delete newCharacter.race.__baseSpeed;
+    delete newCharacter.race.__baseDarkvisionRange;
   } else {
     delete newCharacter.race;
   }
@@ -1137,9 +1484,17 @@ const handleAbilitySkillConfirm = () => {
       gnomeLineageKey: form.gnomeLineageKey,
       gnomeLineage: form.gnomeLineage,
       gnomeLineageAbility: form.gnomeLineageAbility,
+      elvenLineageKey: form.elvenLineageKey,
+      elvenLineage: form.elvenLineage,
+      elvenLineageAbility: form.elvenLineageAbility,
     }
   );
-  const updatedForm = { ...form, race: updatedRace };
+  const updatedForm = {
+    ...form,
+    race: updatedRace,
+    speed:
+      typeof updatedRace?.speed === "number" ? updatedRace.speed : form.speed,
+  };
   if (Object.keys(updatedSkills).length) {
     updatedForm.skills = updatedSkills;
   }
@@ -1162,7 +1517,11 @@ const getAvailableAbilityOptions = (index) => {
 
 const getAvailableSkillOptions = (index) => {
   const taken = skillSelections.filter((_, i) => i !== index);
-  const base = SKILLS.map((s) => s.key).filter((s) => !form.skills?.[s]?.proficient);
+  const raceOptions = form.race?.skillChoices?.options;
+  const allOptions = raceOptions?.length
+    ? raceOptions
+    : SKILLS.map((s) => s.key);
+  const base = allOptions.filter((s) => !form.skills?.[s]?.proficient);
   return base.filter((opt) => !taken.includes(opt));
 };
 
@@ -1319,6 +1678,38 @@ const getAvailableSkillOptions = (index) => {
                 </option>
               ))}
             </Form.Select>
+          </>
+        )}
+        {form.race?.name === "Elf" && (
+          <>
+            <Form.Label className="text-light">Elven Lineage</Form.Label>
+            <Form.Select
+              value={form.elvenLineageKey || ""}
+              onChange={handleElvenLineageChange}
+            >
+              <option value="" disabled>Select your elven lineage</option>
+              {Object.entries(form.race.elvenLineages || {}).map(([key, lineage]) => (
+                <option key={key} value={key}>
+                  {lineage.label || lineage.name || "Elven Lineage"}
+                </option>
+              ))}
+            </Form.Select>
+            {form.elvenLineage?.spellcastingAbilities?.length ? (
+              <>
+                <Form.Label className="text-light">Spellcasting Ability</Form.Label>
+                <Form.Select
+                  value={form.elvenLineageAbility || ""}
+                  onChange={handleElvenLineageAbilityChange}
+                >
+                  <option value="" disabled>Select your spellcasting ability</option>
+                  {(form.elvenLineage?.spellcastingAbilities || []).map((ability) => (
+                    <option key={ability} value={ability}>
+                      {ability}
+                    </option>
+                  ))}
+                </Form.Select>
+              </>
+            ) : null}
           </>
         )}
         {form.race?.name === "Gnome" && (

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -33,13 +33,59 @@ const races = {
     speed: 30,
     abilities: { dex: 2 },
     skills: { perception: { proficient: true } },
+    skillChoices: {
+      count: 1,
+      options: ["insight", "perception", "survival"],
+      description: "Choose one of Insight, Perception, or Survival to gain proficiency in.",
+    },
     languages: ["Common", "Elvish"],
+    darkvisionRange: 60,
     weaponProficiencies: [
       "longsword",
       "shortsword",
       "shortbow",
       "longbow",
     ],
+    elvenLineages: {
+      drow: {
+        label: "Drow",
+        description:
+          "You know the Dancing Lights cantrip. Starting at 3rd level, you can also cast Faerie Fire once per long rest, and starting at 5th level, you can cast Darkness once per long rest.",
+        spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        darkvisionRange: 120,
+        level1Feature:
+          "You know the Dancing Lights cantrip. You can cast it without expending a spell slot.",
+        level3Feature:
+          "At 3rd level, you can cast Faerie Fire with this trait once per long rest.",
+        level5Feature:
+          "At 5th level, you can cast Darkness with this trait once per long rest.",
+      },
+      high: {
+        label: "High Elf",
+        description:
+          "You know the Prestidigitation cantrip. Starting at 3rd level, you can also cast Detect Magic once per long rest, and starting at 5th level, you can cast Misty Step once per long rest.",
+        spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        level1Feature:
+          "You know the Prestidigitation cantrip. You can cast it without expending a spell slot.",
+        level3Feature:
+          "At 3rd level, you can cast Detect Magic with this trait once per long rest.",
+        level5Feature:
+          "At 5th level, you can cast Misty Step with this trait once per long rest.",
+      },
+      wood: {
+        label: "Wood Elf",
+        description:
+          "You know the Druidcraft cantrip. Starting at 3rd level, you can also cast Longstrider once per long rest, and starting at 5th level, you can cast Pass without Trace once per long rest.",
+        spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        speed: 35,
+        level1Feature:
+          "You know the Druidcraft cantrip. You can cast it without expending a spell slot.",
+        level3Feature:
+          "At 3rd level, you can cast Longstrider with this trait once per long rest.",
+        level5Feature:
+          "At 5th level, you can cast Pass without Trace with this trait once per long rest.",
+      },
+    },
   },
   halfling: {
     name: "Halfling",


### PR DESCRIPTION
## Summary
- add elven lineage metadata, skill choices, and updated darkvision data to elves
- allow zombie character creation to pick and randomize elven lineages and spellcasting abilities while adjusting speed/darkvision
- render elven lineage traits in the features panel and show the active lineage in character info, with new tests for these behaviors

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js client/src/components/Zombies/attributes/CharacterInfo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1584c68488323a9347431de8ae2ee