### PR TITLE
Add campaign map folder support across API and UI

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -84,6 +84,11 @@ const normalizeMaps = (maps) =>
     ? maps.filter((map) => map && typeof map === 'object')
     : [];
 
+const normalizeFolderName = (value) =>
+  typeof value === 'string' ? value.trim() : '';
+
+const UNGROUPED_FOLDER_KEY = '__ungrouped__';
+
 const resolveMapTitle = (map, index) => {
   if (!map || typeof map !== 'object') {
     return `Map ${index + 1}`;
@@ -180,6 +185,44 @@ const MapModal = ({
     () => normalizeMapId(previewMap?.mapId),
     [previewMap]
   );
+
+  const groupedMaps = useMemo(() => {
+    if (normalizedMaps.length === 0) {
+      return [];
+    }
+
+    const groups = new Map();
+
+    normalizedMaps.forEach((mapItem) => {
+      const folderName = normalizeFolderName(mapItem?.folder);
+      const key = folderName || UNGROUPED_FOLDER_KEY;
+
+      if (!groups.has(key)) {
+        groups.set(key, {
+          key,
+          label: folderName || 'No Folder',
+          maps: [],
+        });
+      }
+
+      groups.get(key).maps.push(mapItem);
+    });
+
+    const sortedGroups = Array.from(groups.values()).sort((a, b) => {
+      if (a.key === UNGROUPED_FOLDER_KEY && b.key === UNGROUPED_FOLDER_KEY) {
+        return 0;
+      }
+      if (a.key === UNGROUPED_FOLDER_KEY) {
+        return -1;
+      }
+      if (b.key === UNGROUPED_FOLDER_KEY) {
+        return 1;
+      }
+      return a.label.localeCompare(b.label);
+    });
+
+    return sortedGroups;
+  }, [normalizedMaps]);
 
   const normalizedCurrentCharacterId = useMemo(
     () => normalizeMapId(currentCharacterId),
@@ -592,72 +635,116 @@ const MapModal = ({
       );
     }
 
+    const toFolderTestId = (groupKey, label) => {
+      if (groupKey === UNGROUPED_FOLDER_KEY) {
+        return 'map-modal-folder-no-folder';
+      }
+
+      const normalizedLabel = label
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      return `map-modal-folder-${normalizedLabel || 'no-folder'}`;
+    };
+
     return (
       <ListGroup
         variant="flush"
         className="bg-transparent map-modal__list"
         data-testid="map-modal-list"
       >
-        {normalizedMaps.map((mapItem, index) => {
-          const mapId = normalizeMapId(mapItem?.mapId);
-          const key = mapId || `map-${index}`;
-          const isActive = Boolean(normalizedActiveId && mapId && normalizedActiveId === mapId);
-          const isSelected = Boolean(resolvedSelectedId && mapId && resolvedSelectedId === mapId);
-          const isProcessing = Boolean(mapId && normalizedActionId && normalizedActionId === mapId);
-          const titleText = resolveMapTitle(mapItem, index);
-          const canSelect = typeof onSelectMap === 'function' && Boolean(mapId);
-          const canActivate = typeof onActivateMap === 'function';
-          const canDelete = typeof onDeleteMap === 'function';
-
+        {groupedMaps.map((group) => {
+          const headerTestId = toFolderTestId(group.key, group.label);
           return (
-            <ListGroup.Item
-              as="div"
-              key={key}
-              action={canSelect}
-              active={isSelected}
-              onClick={() => {
-                if (canSelect && mapId) {
-                  handleSelectMap(mapId);
-                }
-              }}
-              className="bg-dark text-light border-secondary"
-              data-testid={`map-modal-item-${key}`}
-            >
-              <div className="d-flex justify-content-between align-items-start">
-                <div className="fw-semibold">{titleText}</div>
-                {isActive && (
-                  <Badge bg="success" className="ms-2" data-testid={`map-modal-active-badge-${key}`}>
-                    Active
-                  </Badge>
-                )}
-              </div>
-              {(canActivate || canDelete) && (
-                <div className="d-flex flex-wrap gap-2 mt-3">
-                  {canActivate && (
-                    <Button
-                      variant="outline-light"
-                      size="sm"
-                      disabled={!mapId || isProcessing || isActive}
-                      onClick={(event) => handleActivateMap(event, mapId)}
-                      data-testid={`map-modal-activate-${key}`}
-                    >
-                      {isActive ? 'Active' : 'Set Active'}
-                    </Button>
-                  )}
-                  {canDelete && (
-                    <Button
-                      variant="outline-danger"
-                      size="sm"
-                      disabled={!mapId || isProcessing}
-                      onClick={(event) => handleDeleteMap(event, mapId)}
-                      data-testid={`map-modal-delete-${key}`}
-                    >
-                      Delete
-                    </Button>
-                  )}
-                </div>
-              )}
-            </ListGroup.Item>
+            <React.Fragment key={group.key}>
+              <ListGroup.Item
+                as="div"
+                className="bg-secondary bg-opacity-50 text-light border-secondary d-flex justify-content-between align-items-center"
+                data-testid={headerTestId}
+              >
+                <span className="fw-semibold text-uppercase small">{group.label}</span>
+                <Badge bg="dark" pill>
+                  {group.maps.length}
+                </Badge>
+              </ListGroup.Item>
+              {group.maps.map((mapItem, index) => {
+                const mapId = normalizeMapId(mapItem?.mapId);
+                const key = mapId || `map-${group.key}-${index}`;
+                const isActive = Boolean(
+                  normalizedActiveId &&
+                  mapId &&
+                  normalizedActiveId === mapId
+                );
+                const isSelected = Boolean(
+                  resolvedSelectedId && mapId && resolvedSelectedId === mapId
+                );
+                const isProcessing = Boolean(
+                  mapId && normalizedActionId && normalizedActionId === mapId
+                );
+                const titleText = resolveMapTitle(mapItem, index);
+                const canSelect = typeof onSelectMap === 'function' && Boolean(mapId);
+                const canActivate = typeof onActivateMap === 'function';
+                const canDelete = typeof onDeleteMap === 'function';
+
+                return (
+                  <ListGroup.Item
+                    as="div"
+                    key={key}
+                    action={canSelect}
+                    active={isSelected}
+                    onClick={() => {
+                      if (canSelect && mapId) {
+                        handleSelectMap(mapId);
+                      }
+                    }}
+                    className="bg-dark text-light border-secondary"
+                    data-testid={`map-modal-item-${key}`}
+                    data-folder={
+                      group.key === UNGROUPED_FOLDER_KEY ? undefined : group.label
+                    }
+                  >
+                    <div className="d-flex justify-content-between align-items-start">
+                      <div className="fw-semibold">{titleText}</div>
+                      {isActive && (
+                        <Badge
+                          bg="success"
+                          className="ms-2"
+                          data-testid={`map-modal-active-badge-${key}`}
+                        >
+                          Active
+                        </Badge>
+                      )}
+                    </div>
+                    {(canActivate || canDelete) && (
+                      <div className="d-flex flex-wrap gap-2 mt-3">
+                        {canActivate && (
+                          <Button
+                            variant="outline-light"
+                            size="sm"
+                            disabled={!mapId || isProcessing || isActive}
+                            onClick={(event) => handleActivateMap(event, mapId)}
+                            data-testid={`map-modal-activate-${key}`}
+                          >
+                            {isActive ? 'Active' : 'Set Active'}
+                          </Button>
+                        )}
+                        {canDelete && (
+                          <Button
+                            variant="outline-danger"
+                            size="sm"
+                            disabled={!mapId || isProcessing}
+                            onClick={(event) => handleDeleteMap(event, mapId)}
+                            data-testid={`map-modal-delete-${key}`}
+                          >
+                            Delete
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                  </ListGroup.Item>
+                );
+              })}
+            </React.Fragment>
           );
         })}
       </ListGroup>

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -661,6 +661,7 @@ export default function ZombiesDM() {
       mode: 'create',
       map: null,
       title: '',
+      folder: '',
       imageUrl: '',
       imageBase64: '',
       imageType: '',
@@ -670,6 +671,7 @@ export default function ZombiesDM() {
     });
     const [mapEditorErrors, setMapEditorErrors] = useState({});
     const [mapEditorSaving, setMapEditorSaving] = useState(false);
+    const [lastMapFolder, setLastMapFolder] = useState('');
     const [mapActionLoadingId, setMapActionLoadingId] = useState(null);
     const [mapPrompt, setMapPrompt] = useState('');
     const [generatedMap, setGeneratedMap] = useState(null);
@@ -697,6 +699,24 @@ export default function ZombiesDM() {
       () => (campaignId ? encodeURIComponent(campaignId) : ''),
       [campaignId]
     );
+
+    const availableMapFolders = useMemo(() => {
+      const folderSet = new Set();
+      if (Array.isArray(maps)) {
+        maps.forEach((map) => {
+          if (!map || typeof map !== 'object') {
+            return;
+          }
+          const folderValue =
+            typeof map.folder === 'string' ? map.folder.trim() : '';
+          if (folderValue) {
+            folderSet.add(folderValue);
+          }
+        });
+      }
+
+      return Array.from(folderSet).sort((a, b) => a.localeCompare(b));
+    }, [maps]);
 
     useEffect(() => {
       mapTokensRef.current = mapTokens;
@@ -777,6 +797,11 @@ export default function ZombiesDM() {
         });
       }
     }, [mapEditorErrors.altText, mapEditorState.altText, mapEditorState.mode]);
+
+    const folderDatalistId = useMemo(
+      () => (availableMapFolders.length > 0 ? 'map-editor-folder-options' : undefined),
+      [availableMapFolders.length]
+    );
 
     const imageSourceDescribedBy = useMemo(() => {
       const ids = ['map-editor-image-requirement'];
@@ -3230,6 +3255,7 @@ export default function ZombiesDM() {
 
             setGeneratedMap(null);
             setStatus({ type: 'success', message: 'Map saved.' });
+            setLastMapFolder(trimmedFolder);
           } else {
             const activeId =
               activeMapId ||
@@ -3338,12 +3364,19 @@ export default function ZombiesDM() {
         {};
 
       const safeMap = sourceMap && typeof sourceMap === 'object' ? sourceMap : {};
+      const defaultFolder =
+        typeof safeMap.folder === 'string' && safeMap.folder.trim() !== ''
+          ? safeMap.folder.trim()
+          : typeof lastMapFolder === 'string'
+          ? lastMapFolder
+          : '';
 
       setMapEditorState({
         show: true,
         mode: 'create',
         map: safeMap,
         title: '',
+        folder: defaultFolder || '',
         imageUrl: '',
         imageBase64: '',
         imageType: '',
@@ -3351,7 +3384,7 @@ export default function ZombiesDM() {
         activateOnSave: maps.length === 0,
         fileInputKey: Date.now(),
       });
-    }, [generatedMap, selectedMapId, maps, campaignMap]);
+    }, [generatedMap, selectedMapId, maps, campaignMap, lastMapFolder]);
 
     const openRenameMapModal = useCallback((map) => {
       if (!map || typeof map !== 'object') {
@@ -3367,6 +3400,10 @@ export default function ZombiesDM() {
         mode: 'rename',
         map: safeMap,
         title: typeof safeMap.title === 'string' ? safeMap.title : '',
+        folder:
+          typeof safeMap.folder === 'string' && safeMap.folder.trim() !== ''
+            ? safeMap.folder.trim()
+            : '',
         imageUrl: typeof safeMap.imageUrl === 'string' ? safeMap.imageUrl : '',
         imageBase64:
           typeof safeMap.imageBase64 === 'string' ? safeMap.imageBase64 : '',
@@ -3462,6 +3499,7 @@ export default function ZombiesDM() {
           mode,
           map: editorMap,
           title,
+          folder,
           imageUrl,
           imageBase64,
           imageType,
@@ -3481,6 +3519,7 @@ export default function ZombiesDM() {
         const trimmedImageType =
           typeof imageType === 'string' ? imageType.trim() : '';
         const trimmedAltText = typeof altText === 'string' ? altText.trim() : '';
+        const trimmedFolder = typeof folder === 'string' ? folder.trim() : '';
 
         const errors = {};
 
@@ -3512,11 +3551,16 @@ export default function ZombiesDM() {
         delete sanitizedBaseMap.imageUrl;
         delete sanitizedBaseMap.imageBase64;
         delete sanitizedBaseMap.imageType;
+        delete sanitizedBaseMap.folder;
 
         const payloadMap = {
           ...sanitizedBaseMap,
           title: normalizedTitle,
         };
+
+        if (trimmedFolder) {
+          payloadMap.folder = trimmedFolder;
+        }
 
         if (trimmedAltText) {
           payloadMap.altText = trimmedAltText;
@@ -3661,6 +3705,7 @@ export default function ZombiesDM() {
             }
 
             setStatus({ type: 'success', message: 'Map updated.' });
+            setLastMapFolder(trimmedFolder);
           }
 
           setGeneratedMap(null);
@@ -3684,6 +3729,7 @@ export default function ZombiesDM() {
         previewMap,
         applyMapPayload,
         parseErrorMessage,
+        setLastMapFolder,
       ]
     );
 
@@ -7152,6 +7198,28 @@ const resolveIcon = (category, iconMap, fallback) => {
                   {mapEditorErrors.title}
                 </Form.Control.Feedback>
               )}
+            </Form.Group>
+            <Form.Group className="mb-3" controlId="map-editor-folder">
+              <Form.Label>Folder</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="Optional folder name"
+                value={mapEditorState.folder}
+                onChange={handleMapEditorInputChange('folder')}
+                disabled={mapEditorSaving}
+                list={folderDatalistId}
+                data-testid="map-editor-folder-input"
+              />
+              {availableMapFolders.length > 0 ? (
+                <datalist id="map-editor-folder-options">
+                  {availableMapFolders.map((folderName) => (
+                    <option value={folderName} key={folderName} />
+                  ))}
+                </datalist>
+              ) : null}
+              <Form.Text className="text-muted">
+                Choose an existing folder or enter a new one.
+              </Form.Text>
             </Form.Group>
             <Form.Group className="mb-3" controlId="map-editor-image-url">
               <Form.Label>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -133,11 +133,16 @@ describe('ZombiesDM AI generation', () => {
     const mapTab = await screen.findByRole('tab', { name: 'Map' });
     await userEvent.click(mapTab);
 
+    await screen.findByTestId('map-list');
+
     const createButton = await screen.findByTestId('create-map-button');
     await userEvent.click(createButton);
 
     const modal = await screen.findByTestId('map-editor-modal');
     const modalQueries = within(modal);
+
+    const folderInput = modalQueries.getByLabelText(/^Folder/);
+    expect(folderInput).not.toBeRequired();
 
     const getRequiredLabel = (labelText) =>
       modalQueries.getByText((_, element) => {
@@ -230,6 +235,162 @@ describe('ZombiesDM AI generation', () => {
     await waitFor(() => {
       expect(getMapPostCalls()).toHaveLength(1);
     });
+  });
+
+  test('map folder selection persists and manager groups maps by folder', async () => {
+    const now = '2024-01-01T00:00:00.000Z';
+    const baseMaps = [
+      {
+        mapId: 'encounter-map',
+        title: 'Existing Encounter',
+        folder: 'Encounters',
+        imageUrl: 'https://example.com/encounter.png',
+        altText: 'Encounter map',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        mapId: 'no-folder-map',
+        title: 'Loose Map',
+        imageUrl: 'https://example.com/loose.png',
+        altText: 'Loose map',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+    let storedMaps = [...baseMaps];
+    let lastPostBody = null;
+
+    apiFetch.mockImplementation((url, options = {}) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ participants: [], activeTurn: null }),
+          });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/maps': {
+          if (options.method === 'POST') {
+            const parsedBody = JSON.parse(options.body || '{}');
+            lastPostBody = parsedBody;
+            const createdMap = {
+              mapId: 'forest-map',
+              title: parsedBody.map?.title || 'Forest Map',
+              folder: parsedBody.map?.folder,
+              imageUrl: parsedBody.map?.imageUrl || 'https://example.com/forest.png',
+              altText: parsedBody.map?.altText || 'Forest map',
+              createdAt: now,
+              updatedAt: now,
+            };
+            storedMaps = [...baseMaps, createdMap];
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({
+                maps: storedMaps,
+                activeMapId: createdMap.mapId,
+                map: { ...createdMap, tokens: {} },
+                tokensByMapId: {},
+                activeMapTokens: {},
+              }),
+            });
+          }
+
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              maps: storedMaps,
+              activeMapId: storedMaps[0].mapId,
+              map: { ...storedMaps[0], tokens: {} },
+              tokensByMapId: {},
+              activeMapTokens: {},
+            }),
+          });
+        }
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    render(<ZombiesDM />);
+
+    const mapTab = await screen.findByRole('tab', { name: 'Map' });
+    await userEvent.click(mapTab);
+
+    const createButton = await screen.findByTestId('create-map-button');
+    await userEvent.click(createButton);
+
+    const modal = await screen.findByTestId('map-editor-modal');
+    const modalQueries = within(modal);
+
+    await userEvent.type(modalQueries.getByLabelText(/^Title/), 'Forest Ambush');
+    const folderInput = modalQueries.getByLabelText(/^Folder/);
+    await userEvent.clear(folderInput);
+    await userEvent.type(folderInput, 'Forest Encounters');
+    await userEvent.type(
+      modalQueries.getByLabelText(/^Image URL/),
+      'https://example.com/forest.png'
+    );
+    await userEvent.type(modalQueries.getByLabelText(/^Alt Text/), 'Forest clearing');
+
+    await userEvent.click(modalQueries.getByTestId('map-editor-submit-button'));
+
+    await waitFor(() => {
+      expect(lastPostBody).not.toBeNull();
+    });
+
+    expect(lastPostBody.map.folder).toBe('Forest Encounters');
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('map-editor-modal')).not.toBeInTheDocument()
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Forest Ambush')).toBeInTheDocument();
+    });
+
+    await userEvent.click(createButton);
+    const modalAgain = await screen.findByTestId('map-editor-modal');
+    const modalAgainQueries = within(modalAgain);
+    const folderInputAgain = modalAgainQueries.getByLabelText(/^Folder/);
+    expect(folderInputAgain).toHaveValue('Forest Encounters');
+
+    await userEvent.click(modalAgainQueries.getByRole('button', { name: /cancel/i }));
+    await waitFor(() =>
+      expect(screen.queryByTestId('map-editor-modal')).not.toBeInTheDocument()
+    );
+
+    const manageButton = await screen.findByTestId('open-map-manager-button');
+    await userEvent.click(manageButton);
+
+    await waitFor(() => {
+      const modalInvocation = MapModal.mock.calls.find(([props]) => props.show);
+      expect(modalInvocation).toBeDefined();
+    });
+
+    const [mapModalProps] = MapModal.mock.calls.find(([props]) => props.show);
+    const actualMapModal = jest.requireActual('../attributes/MapModal').default;
+    const { getByTestId: getModalByTestId, unmount: unmountModal } = render(
+      React.createElement(actualMapModal, { ...mapModalProps, show: true })
+    );
+
+    expect(getModalByTestId('map-modal-folder-forest-encounters')).toBeInTheDocument();
+    expect(getModalByTestId('map-modal-folder-encounters')).toBeInTheDocument();
+    expect(getModalByTestId('map-modal-folder-no-folder')).toBeInTheDocument();
+
+    expect(getModalByTestId('map-modal-item-forest-map').dataset.folder).toBe(
+      'Forest Encounters'
+    );
+    expect(getModalByTestId('map-modal-item-encounter-map').dataset.folder).toBe('Encounters');
+    expect(getModalByTestId('map-modal-item-no-folder-map').dataset.folder).toBeUndefined();
+
+    unmountModal();
   });
 
   test.skip('generates armor via AI and populates form', async () => {

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -177,6 +177,7 @@ describe('Campaign routes', () => {
     const baseMap = {
       title: 'Dungeon',
       summary: 'An underground lair',
+      folder: 'Dungeons',
       imageUrl:
         'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/base/dungeon.png',
       altText: 'Dungeon entrance map',
@@ -216,7 +217,9 @@ describe('Campaign routes', () => {
 
     const res = await request(app).get('/campaigns/Test/map');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(expect.objectContaining({ mapId: storedMap.mapId }));
+    expect(res.body).toEqual(
+      expect.objectContaining({ mapId: storedMap.mapId, folder: storedMap.folder })
+    );
     expect(res.body.tokens).toEqual({});
   });
 
@@ -267,7 +270,9 @@ describe('Campaign routes', () => {
     expect(res.body.activeMapTokens).toEqual({});
     expect(res.body.tokensByMapId).toEqual({});
     expect(res.body.maps).toEqual(
-      expect.arrayContaining([expect.objectContaining({ mapId: storedMap.mapId })])
+      expect.arrayContaining([
+        expect.objectContaining({ mapId: storedMap.mapId, folder: storedMap.folder }),
+      ])
     );
   });
 
@@ -297,6 +302,7 @@ describe('Campaign routes', () => {
         summary: 'An underground lair',
         imageBase64: 'QUJD',
         imageType: 'image/png',
+        folder: 'Boss Lairs',
       };
 
       const res = await request(app)
@@ -310,6 +316,7 @@ describe('Campaign routes', () => {
           title: baseMap.title,
           originalPrompt: 'Create a dungeon map',
           mapId: res.body.activeMapId,
+          folder: 'Boss Lairs',
           imageUrl:
             'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/new-map.png',
           cloudinaryPublicId: 'maps/demo/new-map',
@@ -320,7 +327,11 @@ describe('Campaign routes', () => {
       expect(res.body.tokensByMapId).toEqual({});
       expect(res.body.maps).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+          expect.objectContaining({
+            mapId: res.body.activeMapId,
+            title: baseMap.title,
+            folder: 'Boss Lairs',
+          }),
         ])
       );
       expect(uploadMapImage).toHaveBeenCalledWith('data:image/png;base64,QUJD');
@@ -331,7 +342,11 @@ describe('Campaign routes', () => {
             activeMapId: res.body.activeMapId,
             map: expect.objectContaining({ mapId: res.body.activeMapId }),
             maps: expect.arrayContaining([
-              expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+              expect.objectContaining({
+                mapId: res.body.activeMapId,
+                title: baseMap.title,
+                folder: 'Boss Lairs',
+              }),
             ]),
             mapTokens: {},
           }),
@@ -343,7 +358,11 @@ describe('Campaign routes', () => {
           activeMapId: res.body.activeMapId,
           map: expect.objectContaining({ mapId: res.body.activeMapId }),
           maps: expect.arrayContaining([
-            expect.objectContaining({ mapId: res.body.activeMapId, title: baseMap.title }),
+            expect.objectContaining({
+              mapId: res.body.activeMapId,
+              title: baseMap.title,
+              folder: 'Boss Lairs',
+            }),
           ]),
           tokensByMapId: {},
           activeMapTokens: {},
@@ -374,6 +393,7 @@ describe('Campaign routes', () => {
           mapId: storedMap.mapId,
           updatedAt: expect.any(String),
           tokens: {},
+          folder: baseMap.folder,
         })
       );
       const lastUpdate = updateOne.mock.calls[updateOne.mock.calls.length - 1]?.[1];
@@ -384,9 +404,14 @@ describe('Campaign routes', () => {
             map: expect.objectContaining({
               mapId: storedMap.mapId,
               originalPrompt: 'Create a dungeon map',
+              folder: baseMap.folder,
             }),
             maps: expect.arrayContaining([
-              expect.objectContaining({ mapId: storedMap.mapId, title: baseMap.title }),
+              expect.objectContaining({
+                mapId: storedMap.mapId,
+                title: baseMap.title,
+                folder: baseMap.folder,
+              }),
             ]),
             mapTokens: {},
           }),
@@ -396,7 +421,7 @@ describe('Campaign routes', () => {
         'Test',
         expect.objectContaining({
           activeMapId: storedMap.mapId,
-          map: expect.objectContaining({ mapId: storedMap.mapId }),
+          map: expect.objectContaining({ mapId: storedMap.mapId, folder: baseMap.folder }),
           tokensByMapId: {},
           activeMapTokens: {},
         })
@@ -482,7 +507,11 @@ describe('Campaign routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.activeMapId).toBe(secondaryMap.mapId);
       expect(res.body.map).toEqual(
-        expect.objectContaining({ mapId: secondaryMap.mapId, title: secondaryMap.title })
+        expect.objectContaining({
+          mapId: secondaryMap.mapId,
+          title: secondaryMap.title,
+          folder: secondaryMap.folder,
+        })
       );
       expect(res.body.map.tokens).toEqual({});
       expect(res.body.activeMapTokens).toEqual({});
@@ -534,6 +563,7 @@ describe('Campaign routes', () => {
             imageUrl:
               'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/updated-map.png',
             cloudinaryPublicId: 'maps/demo/updated-map',
+            folder: storedMap.folder,
           }),
         ])
       );
@@ -543,6 +573,7 @@ describe('Campaign routes', () => {
           title: 'Updated Dungeon',
           originalPrompt: 'Updated map prompt',
           cloudinaryPublicId: 'maps/demo/updated-map',
+          folder: storedMap.folder,
         })
       );
     });
@@ -578,12 +609,16 @@ describe('Campaign routes', () => {
           mapId: storedMap.mapId,
           title: storedMap.title,
           cloudinaryPublicId: storedMap.cloudinaryPublicId,
+          folder: storedMap.folder,
         })
       );
       expect(res.body.map.tokens).toEqual({});
       expect(res.body.activeMapTokens).toEqual({});
       expect(res.body.tokensByMapId).toEqual({});
       expect(res.body.maps).toHaveLength(1);
+      expect(res.body.maps[0]).toEqual(
+        expect.objectContaining({ folder: storedMap.folder })
+      );
       expect(deleteMapImage).toHaveBeenCalledTimes(1);
       expect(deleteMapImage).toHaveBeenCalledWith('maps/forest/secondary-map');
       expect(emitMapUpdate).toHaveBeenCalledWith(
@@ -623,6 +658,9 @@ describe('Campaign routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.activeMapId).toBe(storedMap.mapId);
+      expect(res.body.map).toEqual(
+        expect.objectContaining({ folder: storedMap.folder })
+      );
       expect(deleteMapImage).toHaveBeenCalledWith('maps/cavern/secondary-map');
       expect(emitMapUpdate).toHaveBeenCalled();
     });
@@ -654,6 +692,7 @@ describe('Campaign routes', () => {
       const res = await request(app).delete(`/campaigns/Test/maps/${secondaryMap.mapId}`);
 
       expect(res.status).toBe(200);
+      expect(res.body.map).toEqual(expect.objectContaining({ folder: storedMap.folder }));
       expect(deleteMapImage).toHaveBeenCalledWith('maps/test-citadel');
       expect(emitMapUpdate).toHaveBeenCalled();
     });

--- a/server/schemas/map.js
+++ b/server/schemas/map.js
@@ -17,6 +17,7 @@ const createMapSchema = (z) => {
     caption: z.string().trim().min(1).optional(),
     altText: z.string().trim().min(1).optional(),
     prompt: z.string().trim().min(1).optional(),
+    folder: z.string().trim().min(1).optional(),
     imageUrl: z.string().trim().url().optional(),
     imageBase64: z
       .string()
@@ -85,6 +86,15 @@ const createMapSchema = (z) => {
           delete map.imageType;
         } else {
           map.imageType = trimmedType;
+        }
+      }
+
+      if (map.folder && typeof map.folder === 'string') {
+        const trimmedFolder = map.folder.trim();
+        if (trimmedFolder.length === 0) {
+          delete map.folder;
+        } else {
+          map.folder = trimmedFolder;
         }
       }
 

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -280,12 +280,29 @@ const prepareStoredMap = ({
     }
   }
 
+  if (typeof storedMap.folder === 'string') {
+    const trimmedFolder = storedMap.folder.trim();
+    if (trimmedFolder) {
+      storedMap.folder = trimmedFolder;
+    } else {
+      delete storedMap.folder;
+    }
+  }
+
   if (
     !storedMap.title &&
     typeof existing.title === 'string' &&
     existing.title.trim() !== ''
   ) {
     storedMap.title = existing.title.trim();
+  }
+
+  if (
+    storedMap.folder === undefined &&
+    typeof existing.folder === 'string' &&
+    existing.folder.trim() !== ''
+  ) {
+    storedMap.folder = existing.folder.trim();
   }
 
   if (typeof storedMap.cloudinaryPublicId === 'string') {


### PR DESCRIPTION
## Summary
- extend the campaign map schema and storage helpers to accept and normalize optional folder metadata
- update campaign routes and unit tests to ensure map folders persist through create, update, delete, and listing flows
- add folder selection in the DM map editor, remember the last folder, and group the map manager UI (with tests verifying persistence and grouping)

## Testing
- npm --prefix server test -- campaigns.test.js
- CI=true npm --prefix client test -- src/components/Zombies/pages/ZombiesDM.test.js -t "map folder selection" --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68e157cde200832e9a3d5974ec666c82