### PR TITLE
Gate elven lineage features by character level thresholds

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -444,32 +444,36 @@ export default function Features({
             'Starting at 5th level, you can cast Darkness with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
             abilityText;
 
-          raceFeatures.push(
-            {
-              id: 'elf-drow-dancing-lights',
-              name: 'Dancing Lights',
-              meta: lineageMeta,
-              description: dancingLightsDescription,
-              desc: dancingLightsDescription,
-              hideUseButton: true,
-            },
-            {
+          raceFeatures.push({
+            id: 'elf-drow-dancing-lights',
+            name: 'Dancing Lights',
+            meta: lineageMeta,
+            description: dancingLightsDescription,
+            desc: dancingLightsDescription,
+            hideUseButton: true,
+          });
+
+          if (totalCharacterLevel >= 3) {
+            raceFeatures.push({
               id: 'elf-drow-faerie-fire',
               name: 'Faerie Fire (Level 3)',
               meta: lineageMeta,
               description: faerieFireDescription,
               desc: faerieFireDescription,
               hideUseButton: true,
-            },
-            {
+            });
+          }
+
+          if (totalCharacterLevel >= 5) {
+            raceFeatures.push({
               id: 'elf-drow-darkness',
               name: 'Darkness (Level 5)',
               meta: lineageMeta,
               description: darknessDescription,
               desc: darknessDescription,
               hideUseButton: true,
-            }
-          );
+            });
+          }
         } else if (isHighElvenLineage) {
           const prestidigitationDescription =
             'You know the Prestidigitation cantrip and can cast it without expending a spell slot.' +
@@ -481,32 +485,36 @@ export default function Features({
             'Starting at 5th level, you can cast Misty Step with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
             abilityText;
 
-          raceFeatures.push(
-            {
-              id: 'elf-high-prestidigitation',
-              name: 'Prestidigitation',
-              meta: lineageMeta,
-              description: prestidigitationDescription,
-              desc: prestidigitationDescription,
-              hideUseButton: true,
-            },
-            {
+          raceFeatures.push({
+            id: 'elf-high-prestidigitation',
+            name: 'Prestidigitation',
+            meta: lineageMeta,
+            description: prestidigitationDescription,
+            desc: prestidigitationDescription,
+            hideUseButton: true,
+          });
+
+          if (totalCharacterLevel >= 3) {
+            raceFeatures.push({
               id: 'elf-high-detect-magic',
               name: 'Detect Magic (Level 3)',
               meta: lineageMeta,
               description: detectMagicDescription,
               desc: detectMagicDescription,
               hideUseButton: true,
-            },
-            {
+            });
+          }
+
+          if (totalCharacterLevel >= 5) {
+            raceFeatures.push({
               id: 'elf-high-misty-step',
               name: 'Misty Step (Level 5)',
               meta: lineageMeta,
               description: mistyStepDescription,
               desc: mistyStepDescription,
               hideUseButton: true,
-            }
-          );
+            });
+          }
         } else if (isWoodElvenLineage) {
           const druidcraftDescription =
             'You know the Druidcraft cantrip and can cast it without expending a spell slot.' +
@@ -519,32 +527,36 @@ export default function Features({
             'Starting at 5th level, you can cast Pass without Trace with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
             abilityText;
 
-          raceFeatures.push(
-            {
-              id: 'elf-wood-druidcraft',
-              name: 'Druidcraft',
-              meta: lineageMeta,
-              description: druidcraftDescription,
-              desc: druidcraftDescription,
-              hideUseButton: true,
-            },
-            {
+          raceFeatures.push({
+            id: 'elf-wood-druidcraft',
+            name: 'Druidcraft',
+            meta: lineageMeta,
+            description: druidcraftDescription,
+            desc: druidcraftDescription,
+            hideUseButton: true,
+          });
+
+          if (totalCharacterLevel >= 3) {
+            raceFeatures.push({
               id: 'elf-wood-longstrider',
               name: 'Longstrider (Level 3)',
               meta: lineageMeta,
               description: longstriderDescription,
               desc: longstriderDescription,
               hideUseButton: true,
-            },
-            {
+            });
+          }
+
+          if (totalCharacterLevel >= 5) {
+            raceFeatures.push({
               id: 'elf-wood-pass-without-trace',
               name: 'Pass without Trace (Level 5)',
               meta: lineageMeta,
               description: passWithoutTraceDescription,
               desc: passWithoutTraceDescription,
               hideUseButton: true,
-            }
-          );
+            });
+          }
         }
       }
     } else if (raceName === 'gnome') {

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -377,7 +377,7 @@ test('elf characters display baseline traits and drow lineage magic', async () =
     occupation: [],
   };
 
-  render(
+  const { rerender } = render(
     <Features
       form={form}
       showFeatures={true}
@@ -397,8 +397,37 @@ test('elf characters display baseline traits and drow lineage magic', async () =
     within(dancingCard).getByText(/Spellcasting Ability: Charisma/i)
   ).toBeInTheDocument();
 
-  expect(screen.getByText('Faerie Fire (Level 3)')).toBeInTheDocument();
-  expect(screen.getByText('Darkness (Level 5)')).toBeInTheDocument();
+  expect(screen.queryByText('Faerie Fire (Level 3)')).not.toBeInTheDocument();
+  expect(screen.queryByText('Darkness (Level 5)')).not.toBeInTheDocument();
+
+  rerender(
+    <Features
+      form={{
+        ...form,
+        occupation: [{ Name: 'Wizard', Level: 3 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Faerie Fire (Level 3)')).toBeInTheDocument();
+  expect(screen.queryByText('Darkness (Level 5)')).not.toBeInTheDocument();
+
+  rerender(
+    <Features
+      form={{
+        ...form,
+        occupation: [{ Name: 'Wizard', Level: 5 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Darkness (Level 5)')).toBeInTheDocument();
 
   const darkvisionCard = screen.getByText('Darkvision').closest('.feature-card');
   expect(darkvisionCard).not.toBeNull();
@@ -451,7 +480,7 @@ test('wood elf lineage notes speed increase and lineage spells', async () => {
     occupation: [],
   };
 
-  render(
+  const { rerender } = render(
     <Features
       form={form}
       showFeatures={true}
@@ -474,8 +503,37 @@ test('wood elf lineage notes speed increase and lineage spells', async () => {
   expect(
     await screen.findByText(/Your walking speed increases to 35 feet/i)
   ).toBeInTheDocument();
-  expect(screen.getByText('Longstrider (Level 3)')).toBeInTheDocument();
-  expect(screen.getByText('Pass without Trace (Level 5)')).toBeInTheDocument();
+  expect(screen.queryByText('Longstrider (Level 3)')).not.toBeInTheDocument();
+  expect(screen.queryByText('Pass without Trace (Level 5)')).not.toBeInTheDocument();
+
+  rerender(
+    <Features
+      form={{
+        ...form,
+        occupation: [{ Name: 'Ranger', Level: 3 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Longstrider (Level 3)')).toBeInTheDocument();
+  expect(screen.queryByText('Pass without Trace (Level 5)')).not.toBeInTheDocument();
+
+  rerender(
+    <Features
+      form={{
+        ...form,
+        occupation: [{ Name: 'Ranger', Level: 5 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Pass without Trace (Level 5)')).toBeInTheDocument();
 });
 
 test('high elf lineage lists arcane cantrip and future spell hooks', async () => {
@@ -511,7 +569,7 @@ test('high elf lineage lists arcane cantrip and future spell hooks', async () =>
     occupation: [],
   };
 
-  render(
+  const { rerender } = render(
     <Features
       form={form}
       showFeatures={true}
@@ -526,8 +584,37 @@ test('high elf lineage lists arcane cantrip and future spell hooks', async () =>
   expect(
     within(prestidigitationCard).getByText(/Spellcasting Ability: Intelligence/i)
   ).toBeInTheDocument();
-  expect(screen.getByText('Detect Magic (Level 3)')).toBeInTheDocument();
-  expect(screen.getByText('Misty Step (Level 5)')).toBeInTheDocument();
+  expect(screen.queryByText('Detect Magic (Level 3)')).not.toBeInTheDocument();
+  expect(screen.queryByText('Misty Step (Level 5)')).not.toBeInTheDocument();
+
+  rerender(
+    <Features
+      form={{
+        ...form,
+        occupation: [{ Name: 'Wizard', Level: 3 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Detect Magic (Level 3)')).toBeInTheDocument();
+  expect(screen.queryByText('Misty Step (Level 5)')).not.toBeInTheDocument();
+
+  rerender(
+    <Features
+      form={{
+        ...form,
+        occupation: [{ Name: 'Wizard', Level: 5 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  expect(await screen.findByText('Misty Step (Level 5)')).toBeInTheDocument();
 });
 
 test('forest gnome lineage shows lineage spells with ability text and tracking', async () => {


### PR DESCRIPTION
## Summary
- gate elven lineage level 3 and level 5 feature cards behind the appropriate total character level checks while keeping cantrips visible
- update elf lineage unit tests to verify visibility at level 1, 3, and 5 scenarios

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e15f47baa08323ada9b00dd2524a56