### PR TITLE
Group ZombiesDM map list by folder

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Modal, Button, ListGroup, Badge, Spinner, Alert } from 'react-bootstrap';
 import MapDisplay from './MapDisplay';
 import CampaignMapBoard from './CampaignMapBoard';
+import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from '../utils/mapGrouping';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -83,11 +84,6 @@ const normalizeMaps = (maps) =>
   Array.isArray(maps)
     ? maps.filter((map) => map && typeof map === 'object')
     : [];
-
-const normalizeFolderName = (value) =>
-  typeof value === 'string' ? value.trim() : '';
-
-const UNGROUPED_FOLDER_KEY = '__ungrouped__';
 
 const resolveMapTitle = (map, index) => {
   if (!map || typeof map !== 'object') {
@@ -186,43 +182,10 @@ const MapModal = ({
     [previewMap]
   );
 
-  const groupedMaps = useMemo(() => {
-    if (normalizedMaps.length === 0) {
-      return [];
-    }
-
-    const groups = new Map();
-
-    normalizedMaps.forEach((mapItem) => {
-      const folderName = normalizeFolderName(mapItem?.folder);
-      const key = folderName || UNGROUPED_FOLDER_KEY;
-
-      if (!groups.has(key)) {
-        groups.set(key, {
-          key,
-          label: folderName || 'No Folder',
-          maps: [],
-        });
-      }
-
-      groups.get(key).maps.push(mapItem);
-    });
-
-    const sortedGroups = Array.from(groups.values()).sort((a, b) => {
-      if (a.key === UNGROUPED_FOLDER_KEY && b.key === UNGROUPED_FOLDER_KEY) {
-        return 0;
-      }
-      if (a.key === UNGROUPED_FOLDER_KEY) {
-        return -1;
-      }
-      if (b.key === UNGROUPED_FOLDER_KEY) {
-        return 1;
-      }
-      return a.label.localeCompare(b.label);
-    });
-
-    return sortedGroups;
-  }, [normalizedMaps]);
+  const groupedMaps = useMemo(
+    () => groupMapsByFolder(normalizedMaps),
+    [normalizedMaps]
+  );
 
   const normalizedCurrentCharacterId = useMemo(
     () => normalizeMapId(currentCharacterId),

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -63,7 +63,8 @@ import {
   GiPentagramRose,
   GiSpellBook,
 } from "react-icons/gi";
-import { FiList, FiPlus } from "react-icons/fi";
+import { FiChevronDown, FiChevronRight, FiList, FiPlus } from "react-icons/fi";
+import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from "../utils/mapGrouping";
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -129,6 +130,22 @@ const normalizeCreatureSize = (value) => {
   }
 
   return null;
+};
+
+const normalizeMapId = (value) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+
+const sanitizeTestIdValue = (value, fallback = 'item') => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  return trimmed.replace(/[^0-9A-Za-z_-]/g, '-').toLowerCase();
 };
 
 const sortParticipantsDescending = (participantsWithMeta) =>
@@ -682,6 +699,7 @@ export default function ZombiesDM() {
     const [showMapManager, setShowMapManager] = useState(false);
     const [mapTokens, setMapTokens] = useState({});
     const [activeMapTokens, setActiveMapTokens] = useState({});
+    const [mapFolderExpansion, setMapFolderExpansion] = useState({});
     const [mapPlacementState, setMapPlacementState] = useState({
       show: false,
       enemyId: null,
@@ -700,23 +718,74 @@ export default function ZombiesDM() {
       [campaignId]
     );
 
-    const availableMapFolders = useMemo(() => {
-      const folderSet = new Set();
-      if (Array.isArray(maps)) {
-        maps.forEach((map) => {
-          if (!map || typeof map !== 'object') {
-            return;
-          }
-          const folderValue =
-            typeof map.folder === 'string' ? map.folder.trim() : '';
-          if (folderValue) {
-            folderSet.add(folderValue);
-          }
+    const normalizedMaps = useMemo(
+      () => (Array.isArray(maps) ? maps.filter((map) => map && typeof map === 'object') : []),
+      [maps]
+    );
+
+    const groupedMaps = useMemo(
+      () => groupMapsByFolder(normalizedMaps),
+      [normalizedMaps]
+    );
+
+    const normalizedActiveMapId = useMemo(
+      () => normalizeMapId(activeMapId),
+      [activeMapId]
+    );
+
+    const normalizedSelectedMapId = useMemo(
+      () => normalizeMapId(selectedMapId),
+      [selectedMapId]
+    );
+
+    useEffect(() => {
+      setMapFolderExpansion((previous) => {
+        const next = {};
+
+        groupedMaps.forEach((group) => {
+          const hasImportantMap = group.maps.some((mapItem) => {
+            const mapIdValue = normalizeMapId(mapItem?.mapId);
+            return (
+              (normalizedActiveMapId && mapIdValue === normalizedActiveMapId) ||
+              (normalizedSelectedMapId && mapIdValue === normalizedSelectedMapId)
+            );
+          });
+
+          const hadValue = Object.prototype.hasOwnProperty.call(previous, group.key);
+          const defaultExpanded = group.key === UNGROUPED_FOLDER_KEY;
+          next[group.key] = hasImportantMap
+            ? true
+            : hadValue
+            ? previous[group.key]
+            : defaultExpanded;
         });
+
+        return next;
+      });
+    }, [groupedMaps, normalizedActiveMapId, normalizedSelectedMapId]);
+
+    const handleToggleMapFolder = useCallback((folderKey) => {
+      if (typeof folderKey !== 'string') {
+        return;
       }
 
+      setMapFolderExpansion((previous) => ({
+        ...previous,
+        [folderKey]: !previous[folderKey],
+      }));
+    }, []);
+
+    const availableMapFolders = useMemo(() => {
+      const folderSet = new Set();
+      normalizedMaps.forEach((map) => {
+        const folderValue = typeof map.folder === 'string' ? map.folder.trim() : '';
+        if (folderValue) {
+          folderSet.add(folderValue);
+        }
+      });
+
       return Array.from(folderSet).sort((a, b) => a.localeCompare(b));
-    }, [maps]);
+    }, [normalizedMaps]);
 
     useEffect(() => {
       mapTokensRef.current = mapTokens;
@@ -5471,94 +5540,149 @@ const resolveIcon = (category, iconMap, fallback) => {
                             </Button>
                           </div>
                         </div>
-                        {Array.isArray(maps) && maps.length > 0 ? (
+                        {groupedMaps.length > 0 ? (
                           <ListGroup
                             variant="flush"
                             className="bg-transparent map-list"
                             data-testid="map-list"
                           >
-                            {maps.map((mapItem, index) => {
-                              const mapIdValue =
-                                typeof mapItem?.mapId === 'string' && mapItem.mapId.trim() !== ''
-                                  ? mapItem.mapId.trim()
-                                  : null;
-                              const mapKey = mapIdValue || `map-${index}`;
-                              const isActive = Boolean(mapIdValue && mapIdValue === activeMapId);
-                              const isSelected = Boolean(
-                                mapIdValue && selectedMapId === mapIdValue
+                            {groupedMaps.map((group) => {
+                              const folderTestId = sanitizeTestIdValue(
+                                group.key === UNGROUPED_FOLDER_KEY ? 'ungrouped' : group.key,
+                                'folder'
                               );
-                              const isProcessing =
-                                Boolean(mapIdValue && mapActionLoadingId === mapIdValue);
-                              const title = getMapDisplayTitle(
-                                mapItem,
-                                DEFAULT_MAP_TITLE
-                              );
+                              const isExpanded =
+                                typeof mapFolderExpansion[group.key] === 'boolean'
+                                  ? mapFolderExpansion[group.key]
+                                  : group.key === UNGROUPED_FOLDER_KEY;
+
                               return (
-                                <ListGroup.Item
-                                  key={mapKey}
-                                  action={Boolean(mapIdValue)}
-                                  active={isSelected}
-                                  onClick={() => mapIdValue && handleSelectMap(mapIdValue)}
-                                  className="bg-dark text-light border-secondary"
-                                  data-testid={`map-list-item-${mapKey}`}
-                                >
-                                  <div className="d-flex justify-content-between align-items-start">
-                                    <div className="fw-semibold">{title}</div>
-                                    {isActive && (
-                                      <Badge
-                                        bg="success"
-                                        className="ms-2"
-                                        data-testid={`map-active-badge-${mapKey}`}
+                                <React.Fragment key={group.key}>
+                                  <ListGroup.Item
+                                    className="bg-dark text-light border-secondary"
+                                    data-testid={`map-folder-${folderTestId}-header`}
+                                  >
+                                    <div className="d-flex align-items-center justify-content-between gap-2">
+                                      <button
+                                        type="button"
+                                        className="btn btn-link text-light text-decoration-none p-0 d-flex align-items-center gap-2"
+                                        onClick={() => handleToggleMapFolder(group.key)}
+                                        aria-expanded={isExpanded}
+                                        data-testid={`map-folder-toggle-${folderTestId}`}
                                       >
-                                        Active
+                                        <span
+                                          className="d-inline-flex align-items-center justify-content-center"
+                                          aria-hidden="true"
+                                        >
+                                          {isExpanded ? (
+                                            <FiChevronDown aria-hidden="true" />
+                                          ) : (
+                                            <FiChevronRight aria-hidden="true" />
+                                          )}
+                                        </span>
+                                        <span className="fw-semibold text-start">
+                                          {group.label}
+                                        </span>
+                                      </button>
+                                      <Badge
+                                        bg="secondary"
+                                        pill
+                                        data-testid={`map-folder-count-${folderTestId}`}
+                                      >
+                                        {group.maps.length}
+                                        <span className="visually-hidden"> maps</span>
                                       </Badge>
-                                    )}
-                                  </div>
-                                  <div className="d-flex flex-wrap gap-2 mt-3">
-                                    <Button
-                                      variant="outline-light"
-                                      size="sm"
-                                      disabled={!mapIdValue || isProcessing}
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        if (mapIdValue) {
-                                          openRenameMapModal(mapItem);
-                                        }
-                                      }}
-                                      data-testid={`map-rename-button-${mapKey}`}
-                                    >
-                                      Rename
-                                    </Button>
-                                    <Button
-                                      variant="outline-light"
-                                      size="sm"
-                                      disabled={!mapIdValue || isActive || isProcessing}
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        if (mapIdValue) {
-                                          handleActivateMap(mapIdValue);
-                                        }
-                                      }}
-                                      data-testid={`map-activate-button-${mapKey}`}
-                                    >
-                                      {isActive ? 'Active' : 'Set Active'}
-                                    </Button>
-                                    <Button
-                                      variant="outline-danger"
-                                      size="sm"
-                                      disabled={!mapIdValue || isProcessing}
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        if (mapIdValue) {
-                                          handleDeleteMap(mapIdValue);
-                                        }
-                                      }}
-                                      data-testid={`map-delete-button-${mapKey}`}
-                                    >
-                                      Delete
-                                    </Button>
-                                  </div>
-                                </ListGroup.Item>
+                                    </div>
+                                  </ListGroup.Item>
+                                  {isExpanded &&
+                                    group.maps.map((mapItem, index) => {
+                                      const mapIdValue = normalizeMapId(mapItem?.mapId);
+                                      const mapKey = mapIdValue || `map-${group.key}-${index}`;
+                                      const isActive = Boolean(
+                                        mapIdValue && mapIdValue === normalizedActiveMapId
+                                      );
+                                      const isSelected = Boolean(
+                                        mapIdValue && normalizedSelectedMapId === mapIdValue
+                                      );
+                                      const isProcessing = Boolean(
+                                        mapIdValue && mapActionLoadingId === mapIdValue
+                                      );
+                                      const title = getMapDisplayTitle(
+                                        mapItem,
+                                        DEFAULT_MAP_TITLE
+                                      );
+                                      const mapTestId = `map-list-item-${mapKey}`;
+
+                                      return (
+                                        <ListGroup.Item
+                                          key={mapKey}
+                                          action={Boolean(mapIdValue)}
+                                          active={isSelected}
+                                          onClick={() => mapIdValue && handleSelectMap(mapIdValue)}
+                                          className="bg-dark text-light border-secondary ps-4"
+                                          data-testid={mapTestId}
+                                          data-folder-key={group.key}
+                                        >
+                                          <div className="d-flex justify-content-between align-items-start">
+                                            <div className="fw-semibold">{title}</div>
+                                            {isActive && (
+                                              <Badge
+                                                bg="success"
+                                                className="ms-2"
+                                                data-testid={`map-active-badge-${mapKey}`}
+                                              >
+                                                Active
+                                              </Badge>
+                                            )}
+                                          </div>
+                                          <div className="d-flex flex-wrap gap-2 mt-3">
+                                            <Button
+                                              variant="outline-light"
+                                              size="sm"
+                                              disabled={!mapIdValue || isProcessing}
+                                              onClick={(event) => {
+                                                event.stopPropagation();
+                                                if (mapIdValue) {
+                                                  openRenameMapModal(mapItem);
+                                                }
+                                              }}
+                                              data-testid={`map-rename-button-${mapKey}`}
+                                            >
+                                              Rename
+                                            </Button>
+                                            <Button
+                                              variant="outline-light"
+                                              size="sm"
+                                              disabled={!mapIdValue || isActive || isProcessing}
+                                              onClick={(event) => {
+                                                event.stopPropagation();
+                                                if (mapIdValue) {
+                                                  handleActivateMap(mapIdValue);
+                                                }
+                                              }}
+                                              data-testid={`map-activate-button-${mapKey}`}
+                                            >
+                                              {isActive ? 'Active' : 'Set Active'}
+                                            </Button>
+                                            <Button
+                                              variant="outline-danger"
+                                              size="sm"
+                                              disabled={!mapIdValue || isProcessing}
+                                              onClick={(event) => {
+                                                event.stopPropagation();
+                                                if (mapIdValue) {
+                                                  handleDeleteMap(mapIdValue);
+                                                }
+                                              }}
+                                              data-testid={`map-delete-button-${mapKey}`}
+                                            >
+                                              Delete
+                                            </Button>
+                                          </div>
+                                        </ListGroup.Item>
+                                      );
+                                    })}
+                                </React.Fragment>
                               );
                             })}
                           </ListGroup>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1055,6 +1055,65 @@ describe('ZombiesDM AI generation', () => {
     });
   });
 
+  test('renders map folders with accessible toggle controls', async () => {
+    const ungroupedMap = {
+      mapId: 'map-1',
+      title: 'Default Map',
+    };
+    const folderedMap = {
+      mapId: 'map-2',
+      title: 'Dungeon Map',
+      folder: 'Dungeon',
+    };
+
+    apiFetch.mockImplementation((url) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/maps':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              maps: [ungroupedMap, folderedMap],
+              activeMapId: ungroupedMap.mapId,
+              map: ungroupedMap,
+            }),
+          });
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    render(<ZombiesDM />);
+
+    const mapTab = await screen.findByRole('tab', { name: 'Map' });
+    await userEvent.click(mapTab);
+
+    const mapCard = await screen.findByTestId('resource-map-card');
+    const mapList = await within(mapCard).findByTestId('map-list');
+
+    const folderHeader = within(mapList).getByTestId('map-folder-dungeon-header');
+    const toggleButton = within(folderHeader).getByTestId('map-folder-toggle-dungeon');
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+    expect(within(mapList).queryByTestId('map-list-item-map-2')).not.toBeInTheDocument();
+
+    await userEvent.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+
+    const folderedMapItem = await within(mapList).findByTestId('map-list-item-map-2');
+    expect(within(folderedMapItem).getByText('Dungeon Map')).toBeInTheDocument();
+  });
+
   test('allows uploading a map image file when creating a campaign map', async () => {
     const mockBase64 = 'Zm9vYmFy';
     const originalFileReader = global.FileReader;

--- a/client/src/components/Zombies/utils/mapGrouping.js
+++ b/client/src/components/Zombies/utils/mapGrouping.js
@@ -1,0 +1,44 @@
+export const UNGROUPED_FOLDER_KEY = '__ungrouped__';
+
+export const normalizeFolderName = (value) =>
+  typeof value === 'string' ? value.trim() : '';
+
+export const groupMapsByFolder = (maps) => {
+  if (!Array.isArray(maps) || maps.length === 0) {
+    return [];
+  }
+
+  const groups = new Map();
+
+  maps.forEach((mapItem) => {
+    if (!mapItem || typeof mapItem !== 'object') {
+      return;
+    }
+
+    const folderName = normalizeFolderName(mapItem.folder);
+    const key = folderName || UNGROUPED_FOLDER_KEY;
+
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        label: folderName || 'No Folder',
+        maps: [],
+      });
+    }
+
+    groups.get(key).maps.push(mapItem);
+  });
+
+  return Array.from(groups.values()).sort((a, b) => {
+    if (a.key === UNGROUPED_FOLDER_KEY && b.key === UNGROUPED_FOLDER_KEY) {
+      return 0;
+    }
+    if (a.key === UNGROUPED_FOLDER_KEY) {
+      return -1;
+    }
+    if (b.key === UNGROUPED_FOLDER_KEY) {
+      return 1;
+    }
+    return a.label.localeCompare(b.label);
+  });
+};


### PR DESCRIPTION
## Summary
- extract a shared map folder grouping utility reused by MapModal and ZombiesDM
- render the DM map list grouped by folder with collapsible headers and maintain map actions
- cover the grouped rendering with a new unit test for the folder toggle state

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js *(fails: suite emits extensive act() warnings and timeouts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15f956ef8832e8b786ebf3fec6cd8