### PR TITLE
Add per-long-rest controls for elven lineage spells

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -8,6 +8,70 @@ import largeFormIcon from '../../../images/large-form-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
 import speakWithAnimalIcon from '../../../images/speak-with-animal.png';
+import spellHasteIcon from '../../../images/spell-haste-icon.png';
+
+const ELVEN_LINEAGE_SPELLS = {
+  'elf-drow-faerie-fire': {
+    usageId: 'elf-drow-faerie-fire',
+    lineage: 'drow',
+    unlockLevel: 3,
+    spellName: 'Faerie Fire',
+    spellLevel: 1,
+    castingTime: '1 action',
+    actionType: 'action',
+    maxUses: 1,
+  },
+  'elf-drow-darkness': {
+    usageId: 'elf-drow-darkness',
+    lineage: 'drow',
+    unlockLevel: 5,
+    spellName: 'Darkness',
+    spellLevel: 2,
+    castingTime: '1 action',
+    actionType: 'action',
+    maxUses: 1,
+  },
+  'elf-high-detect-magic': {
+    usageId: 'elf-high-detect-magic',
+    lineage: 'high',
+    unlockLevel: 3,
+    spellName: 'Detect Magic',
+    spellLevel: 1,
+    castingTime: '1 action',
+    actionType: 'action',
+    maxUses: 1,
+  },
+  'elf-high-misty-step': {
+    usageId: 'elf-high-misty-step',
+    lineage: 'high',
+    unlockLevel: 5,
+    spellName: 'Misty Step',
+    spellLevel: 2,
+    castingTime: 'bonus action',
+    actionType: 'bonusAction',
+    maxUses: 1,
+  },
+  'elf-wood-longstrider': {
+    usageId: 'elf-wood-longstrider',
+    lineage: 'wood',
+    unlockLevel: 3,
+    spellName: 'Longstrider',
+    spellLevel: 1,
+    castingTime: '1 action',
+    actionType: 'action',
+    maxUses: 1,
+  },
+  'elf-wood-pass-without-trace': {
+    usageId: 'elf-wood-pass-without-trace',
+    lineage: 'wood',
+    unlockLevel: 5,
+    spellName: 'Pass without Trace',
+    spellLevel: 2,
+    castingTime: '1 action',
+    actionType: 'action',
+    maxUses: 1,
+  },
+};
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 
 export default function Features({
@@ -37,9 +101,13 @@ export default function Features({
   const [draconicFlightUsed, setDraconicFlightUsed] = useState(false);
   const [adrenalineRushUses, setAdrenalineRushUses] = useState(0);
   const [speakWithAnimalsUses, setSpeakWithAnimalsUses] = useState(0);
+  const [elvenLineageSpellUses, setElvenLineageSpellUses] = useState({});
   const [showUpcast, setShowUpcast] = useState(false);
   const [pendingSpell, setPendingSpell] = useState(null);
   const hasInitializedRestRef = useRef(false);
+  const longRestCounterRef = useRef(
+    Number.isFinite(longRestCount) ? longRestCount : 0
+  );
 
   const totalCharacterLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) return 0;
@@ -177,6 +245,37 @@ export default function Features({
     if (!elvenLineageKey) return false;
     return elvenLineageKey.toLowerCase() === 'wood';
   }, [elvenLineageKey]);
+
+  const availableElvenLineageSpells = useMemo(() => {
+    return Object.entries(ELVEN_LINEAGE_SPELLS).reduce(
+      (acc, [id, config]) => {
+        let matchesLineage = false;
+        if (config.lineage === 'drow') {
+          matchesLineage = isDrowElvenLineage;
+        } else if (config.lineage === 'high') {
+          matchesLineage = isHighElvenLineage;
+        } else if (config.lineage === 'wood') {
+          matchesLineage = isWoodElvenLineage;
+        }
+
+        if (!matchesLineage) {
+          return acc;
+        }
+
+        if (totalCharacterLevel >= config.unlockLevel) {
+          acc[id] = config;
+        }
+
+        return acc;
+      },
+      {}
+    );
+  }, [
+    isDrowElvenLineage,
+    isHighElvenLineage,
+    isWoodElvenLineage,
+    totalCharacterLevel,
+  ]);
 
   const isForestGnomeLineage = useMemo(() => {
     if (!gnomeLineageKey) return false;
@@ -438,10 +537,10 @@ export default function Features({
             'You know the Dancing Lights cantrip and can cast it without expending a spell slot.' +
             abilityText;
           const faerieFireDescription =
-            'Starting at 3rd level, you can cast Faerie Fire with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            'Starting at 3rd level, you can cast Faerie Fire with this trait once per long rest.' +
             abilityText;
           const darknessDescription =
-            'Starting at 5th level, you can cast Darkness with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            'Starting at 5th level, you can cast Darkness with this trait once per long rest.' +
             abilityText;
 
           raceFeatures.push({
@@ -454,24 +553,33 @@ export default function Features({
           });
 
           if (totalCharacterLevel >= 3) {
+            const faerieFireConfig =
+              ELVEN_LINEAGE_SPELLS['elf-drow-faerie-fire'];
             raceFeatures.push({
-              id: 'elf-drow-faerie-fire',
+              id: faerieFireConfig.usageId,
               name: 'Faerie Fire (Level 3)',
               meta: lineageMeta,
               description: faerieFireDescription,
               desc: faerieFireDescription,
-              hideUseButton: true,
+              usageId: faerieFireConfig.usageId,
+              spellName: faerieFireConfig.spellName,
+              spellLevel: faerieFireConfig.spellLevel,
+              castingTime: faerieFireConfig.castingTime,
             });
           }
 
           if (totalCharacterLevel >= 5) {
+            const darknessConfig = ELVEN_LINEAGE_SPELLS['elf-drow-darkness'];
             raceFeatures.push({
-              id: 'elf-drow-darkness',
+              id: darknessConfig.usageId,
               name: 'Darkness (Level 5)',
               meta: lineageMeta,
               description: darknessDescription,
               desc: darknessDescription,
-              hideUseButton: true,
+              usageId: darknessConfig.usageId,
+              spellName: darknessConfig.spellName,
+              spellLevel: darknessConfig.spellLevel,
+              castingTime: darknessConfig.castingTime,
             });
           }
         } else if (isHighElvenLineage) {
@@ -479,10 +587,10 @@ export default function Features({
             'You know the Prestidigitation cantrip and can cast it without expending a spell slot.' +
             abilityText;
           const detectMagicDescription =
-            'Starting at 3rd level, you can cast Detect Magic with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            'Starting at 3rd level, you can cast Detect Magic with this trait once per long rest.' +
             abilityText;
           const mistyStepDescription =
-            'Starting at 5th level, you can cast Misty Step with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            'Starting at 5th level, you can cast Misty Step with this trait once per long rest.' +
             abilityText;
 
           raceFeatures.push({
@@ -495,24 +603,34 @@ export default function Features({
           });
 
           if (totalCharacterLevel >= 3) {
+            const detectMagicConfig =
+              ELVEN_LINEAGE_SPELLS['elf-high-detect-magic'];
             raceFeatures.push({
-              id: 'elf-high-detect-magic',
+              id: detectMagicConfig.usageId,
               name: 'Detect Magic (Level 3)',
               meta: lineageMeta,
               description: detectMagicDescription,
               desc: detectMagicDescription,
-              hideUseButton: true,
+              usageId: detectMagicConfig.usageId,
+              spellName: detectMagicConfig.spellName,
+              spellLevel: detectMagicConfig.spellLevel,
+              castingTime: detectMagicConfig.castingTime,
             });
           }
 
           if (totalCharacterLevel >= 5) {
+            const mistyStepConfig =
+              ELVEN_LINEAGE_SPELLS['elf-high-misty-step'];
             raceFeatures.push({
-              id: 'elf-high-misty-step',
+              id: mistyStepConfig.usageId,
               name: 'Misty Step (Level 5)',
               meta: lineageMeta,
               description: mistyStepDescription,
               desc: mistyStepDescription,
-              hideUseButton: true,
+              usageId: mistyStepConfig.usageId,
+              spellName: mistyStepConfig.spellName,
+              spellLevel: mistyStepConfig.spellLevel,
+              castingTime: mistyStepConfig.castingTime,
             });
           }
         } else if (isWoodElvenLineage) {
@@ -521,10 +639,10 @@ export default function Features({
             abilityText +
             ' Your walking speed increases to 35 feet.';
           const longstriderDescription =
-            'Starting at 3rd level, you can cast Longstrider with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            'Starting at 3rd level, you can cast Longstrider with this trait once per long rest.' +
             abilityText;
           const passWithoutTraceDescription =
-            'Starting at 5th level, you can cast Pass without Trace with this trait once per long rest. Spellcasting integration for this trait will be added in a future update.' +
+            'Starting at 5th level, you can cast Pass without Trace with this trait once per long rest.' +
             abilityText;
 
           raceFeatures.push({
@@ -537,24 +655,34 @@ export default function Features({
           });
 
           if (totalCharacterLevel >= 3) {
+            const longstriderConfig =
+              ELVEN_LINEAGE_SPELLS['elf-wood-longstrider'];
             raceFeatures.push({
-              id: 'elf-wood-longstrider',
+              id: longstriderConfig.usageId,
               name: 'Longstrider (Level 3)',
               meta: lineageMeta,
               description: longstriderDescription,
               desc: longstriderDescription,
-              hideUseButton: true,
+              usageId: longstriderConfig.usageId,
+              spellName: longstriderConfig.spellName,
+              spellLevel: longstriderConfig.spellLevel,
+              castingTime: longstriderConfig.castingTime,
             });
           }
 
           if (totalCharacterLevel >= 5) {
+            const passWithoutTraceConfig =
+              ELVEN_LINEAGE_SPELLS['elf-wood-pass-without-trace'];
             raceFeatures.push({
-              id: 'elf-wood-pass-without-trace',
+              id: passWithoutTraceConfig.usageId,
               name: 'Pass without Trace (Level 5)',
               meta: lineageMeta,
               description: passWithoutTraceDescription,
               desc: passWithoutTraceDescription,
-              hideUseButton: true,
+              usageId: passWithoutTraceConfig.usageId,
+              spellName: passWithoutTraceConfig.spellName,
+              spellLevel: passWithoutTraceConfig.spellLevel,
+              castingTime: passWithoutTraceConfig.castingTime,
             });
           }
         }
@@ -872,6 +1000,56 @@ export default function Features({
   ]);
 
   useEffect(() => {
+    const normalizedLongRestCount = Number.isFinite(longRestCount)
+      ? longRestCount
+      : 0;
+    const previousLongRestCount = longRestCounterRef.current;
+    const longRestChanged = previousLongRestCount !== normalizedLongRestCount;
+    longRestCounterRef.current = normalizedLongRestCount;
+
+    setElvenLineageSpellUses((prev) => {
+      let changed = false;
+      const next = { ...prev };
+
+      Object.keys(next).forEach((usageId) => {
+        if (!availableElvenLineageSpells[usageId]) {
+          delete next[usageId];
+          changed = true;
+        }
+      });
+
+      Object.entries(availableElvenLineageSpells).forEach(
+        ([usageId, config]) => {
+          const maxUses = config.maxUses ?? 1;
+          const hasExistingEntry = Object.prototype.hasOwnProperty.call(
+            next,
+            usageId
+          );
+
+          if (!hasExistingEntry || longRestChanged) {
+            if (next[usageId] !== maxUses) {
+              next[usageId] = maxUses;
+              changed = true;
+            }
+            return;
+          }
+
+          if (next[usageId] > maxUses) {
+            next[usageId] = maxUses;
+            changed = true;
+          }
+        }
+      );
+
+      if (!changed) {
+        return prev;
+      }
+
+      return next;
+    });
+  }, [availableElvenLineageSpells, longRestCount]);
+
+  useEffect(() => {
     if (typeof window === 'undefined' || !speakWithAnimalsStorageKey) {
       return;
     }
@@ -890,6 +1068,46 @@ export default function Features({
     speakWithAnimalsStorageKey,
     speakWithAnimalsUses,
   ]);
+
+  const handleElvenLineageSpellCast = useCallback(
+    (spellConfig) => {
+      if (!spellConfig) return;
+
+      setElvenLineageSpellUses((prev) => {
+        const current = prev[spellConfig.usageId] ?? 0;
+        if (current <= 0) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [spellConfig.usageId]: Math.max(0, current - 1),
+        };
+      });
+
+      onCastSpell?.({
+        castingTime: spellConfig.castingTime,
+        level: spellConfig.spellLevel,
+        lineageUsageId: spellConfig.usageId,
+        name: spellConfig.spellName,
+      });
+
+      if (spellConfig.actionType) {
+        onCastSpell?.(spellConfig.actionType);
+      } else if (
+        typeof spellConfig.castingTime === 'string' &&
+        spellConfig.castingTime.toLowerCase().includes('bonus')
+      ) {
+        onCastSpell?.('bonusAction');
+      } else {
+        onCastSpell?.('action');
+      }
+
+      setShowUpcast(false);
+      setPendingSpell(null);
+    },
+    [onCastSpell]
+  );
 
   const handleSpeakWithAnimalsFreeCast = useCallback(() => {
     if (!canUseSpeakWithAnimals || speakWithAnimalsUses <= 0) return;
@@ -996,6 +1214,15 @@ export default function Features({
                     const isAdrenalineRush = feat.id === 'orc-adrenaline-rush';
                     const isSpeakWithAnimals =
                       feat.id === 'gnome-forest-speak-with-animals';
+                    const lineageSpellUsageId = feat.usageId || feat.id;
+                    const lineageSpell = lineageSpellUsageId
+                      ? availableElvenLineageSpells[lineageSpellUsageId]
+                      : undefined;
+                    const isElvenLineageSpell = Boolean(lineageSpell);
+                    const lineageSpellUsesRemaining = isElvenLineageSpell
+                      ? elvenLineageSpellUses[lineageSpell.usageId] ??
+                        lineageSpell.maxUses ?? 0
+                      : 0;
                     return (
                       <div className="feature-card" key={featKey}>
                         <div className="feature-card-header">
@@ -1101,6 +1328,29 @@ export default function Features({
                                   height={36}
                                 />
                               </Button>
+                            ) : isElvenLineageSpell ? (
+                              <Button
+                                aria-label={`Cast ${lineageSpell?.spellName ?? 'lineage spell'}`}
+                                variant="link"
+                                className={`p-0 border-0 ${
+                                  lineageSpellUsesRemaining <= 0 ? 'opacity-50' : ''
+                                }`}
+                                onClick={() => {
+                                  if (lineageSpell) {
+                                    handleElvenLineageSpellCast(lineageSpell);
+                                  }
+                                }}
+                                disabled={
+                                  lineageSpellUsesRemaining <= 0 || !lineageSpell
+                                }
+                              >
+                                <img
+                                  src={spellHasteIcon}
+                                  alt={`${lineageSpell?.spellName ?? 'Lineage Spell'} Icon`}
+                                  width={36}
+                                  height={36}
+                                />
+                              </Button>
                             ) : isSpeakWithAnimals ? (
                               <div className="d-flex align-items-center gap-1">
                                 <Button
@@ -1163,6 +1413,11 @@ export default function Features({
                         {isAdrenalineRush && (
                           <div className="feature-card-uses text-muted small mt-2">
                             Uses remaining: {adrenalineRushUses}
+                          </div>
+                        )}
+                        {isElvenLineageSpell && (
+                          <div className="feature-card-uses text-muted small mt-2">
+                            Uses remaining: {lineageSpellUsesRemaining}
                           </div>
                         )}
                         {isSpeakWithAnimals && (

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -8,6 +8,72 @@ import apiFetch from '../../../utils/apiFetch';
 
 const TEST_CHARACTER_ID = 'test-character-id';
 
+const ELVEN_LINEAGE_TEST_CASES = [
+  {
+    lineageKey: 'drow',
+    label: 'Drow',
+    ability: 'Charisma',
+    level3: {
+      displayName: 'Faerie Fire (Level 3)',
+      usageId: 'elf-drow-faerie-fire',
+      spellName: 'Faerie Fire',
+      spellLevel: 1,
+      castingTime: '1 action',
+      actionType: 'action',
+    },
+    level5: {
+      displayName: 'Darkness (Level 5)',
+      usageId: 'elf-drow-darkness',
+      spellName: 'Darkness',
+      spellLevel: 2,
+      castingTime: '1 action',
+      actionType: 'action',
+    },
+  },
+  {
+    lineageKey: 'high',
+    label: 'High Elf',
+    ability: 'Intelligence',
+    level3: {
+      displayName: 'Detect Magic (Level 3)',
+      usageId: 'elf-high-detect-magic',
+      spellName: 'Detect Magic',
+      spellLevel: 1,
+      castingTime: '1 action',
+      actionType: 'action',
+    },
+    level5: {
+      displayName: 'Misty Step (Level 5)',
+      usageId: 'elf-high-misty-step',
+      spellName: 'Misty Step',
+      spellLevel: 2,
+      castingTime: 'bonus action',
+      actionType: 'bonusAction',
+    },
+  },
+  {
+    lineageKey: 'wood',
+    label: 'Wood Elf',
+    ability: 'Wisdom',
+    level3: {
+      displayName: 'Longstrider (Level 3)',
+      usageId: 'elf-wood-longstrider',
+      spellName: 'Longstrider',
+      spellLevel: 1,
+      castingTime: '1 action',
+      actionType: 'action',
+    },
+    level5: {
+      displayName: 'Pass without Trace (Level 5)',
+      usageId: 'elf-wood-pass-without-trace',
+      spellName: 'Pass without Trace',
+      spellLevel: 2,
+      castingTime: '1 action',
+      actionType: 'action',
+    },
+  },
+];
+
 beforeEach(() => {
   apiFetch.mockReset();
   window.localStorage.clear();
@@ -1131,6 +1197,198 @@ test('orc characters display racial traits and track Adrenaline Rush uses with r
     refreshedWithin.getByText('Uses remaining: 3')
   ).toBeInTheDocument();
 });
+
+describe.each(ELVEN_LINEAGE_TEST_CASES)(
+  '$label lineage spells provide once-per-long-rest casts',
+  ({ lineageKey, label, ability, level3, level5 }) => {
+    test('renders lineage spell buttons with counters and resets on long rest', async () => {
+      apiFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ features: [] }),
+      });
+
+      const lineageDetails = {
+        label,
+        spellcastingAbilities: [ability],
+      };
+
+      const race = {
+        name: 'Elf',
+        elvenLineages: { [lineageKey]: lineageDetails },
+        selectedAncestryKey: lineageKey,
+        selectedAncestry: lineageDetails,
+      };
+
+      const createForm = (level) => ({
+        race,
+        elvenLineageKey: lineageKey,
+        elvenLineage: lineageDetails,
+        elvenLineageAbility: ability,
+        occupation: [{ Name: 'Wizard', Level: level }],
+      });
+
+      const onCastSpell = jest.fn();
+
+      const { rerender } = render(
+        <Features
+          form={createForm(3)}
+          showFeatures={true}
+          handleCloseFeatures={() => {}}
+          onCastSpell={onCastSpell}
+          longRestCount={0}
+          shortRestCount={0}
+          characterId={TEST_CHARACTER_ID}
+        />
+      );
+
+      const getFeatureCard = async (displayName) => {
+        const title = await screen.findByText(displayName);
+        const card = title.closest('.feature-card');
+        expect(card).not.toBeNull();
+        return card;
+      };
+
+      const level3Card = await getFeatureCard(level3.displayName);
+      const level3Within = within(level3Card);
+
+      await waitFor(() =>
+        expect(
+          level3Within.getByText('Uses remaining: 1')
+        ).toBeInTheDocument()
+      );
+
+      const level3Button = level3Within.getByRole('button', {
+        name: new RegExp(`Cast ${level3.spellName}`, 'i'),
+      });
+      expect(level3Button).toBeEnabled();
+
+      await act(async () => {
+        await userEvent.click(level3Button);
+      });
+
+      expect(onCastSpell).toHaveBeenNthCalledWith(1, {
+        castingTime: level3.castingTime,
+        level: level3.spellLevel,
+        lineageUsageId: level3.usageId,
+        name: level3.spellName,
+      });
+      expect(onCastSpell).toHaveBeenNthCalledWith(2, level3.actionType);
+      expect(level3Button).toBeDisabled();
+      expect(
+        level3Within.getByText('Uses remaining: 0')
+      ).toBeInTheDocument();
+
+      rerender(
+        <Features
+          form={createForm(3)}
+          showFeatures={true}
+          handleCloseFeatures={() => {}}
+          onCastSpell={onCastSpell}
+          longRestCount={1}
+          shortRestCount={0}
+          characterId={TEST_CHARACTER_ID}
+        />
+      );
+
+      const refreshedLevel3Card = await getFeatureCard(level3.displayName);
+      const refreshedLevel3Within = within(refreshedLevel3Card);
+      await waitFor(() =>
+        expect(
+          refreshedLevel3Within.getByText('Uses remaining: 1')
+        ).toBeInTheDocument()
+      );
+      const refreshedLevel3Button = refreshedLevel3Within.getByRole('button', {
+        name: new RegExp(`Cast ${level3.spellName}`, 'i'),
+      });
+      expect(refreshedLevel3Button).toBeEnabled();
+
+      rerender(
+        <Features
+          form={createForm(5)}
+          showFeatures={true}
+          handleCloseFeatures={() => {}}
+          onCastSpell={onCastSpell}
+          longRestCount={1}
+          shortRestCount={0}
+          characterId={TEST_CHARACTER_ID}
+        />
+      );
+
+      const level5Card = await getFeatureCard(level5.displayName);
+      const level5Within = within(level5Card);
+      await waitFor(() =>
+        expect(
+          level5Within.getByText('Uses remaining: 1')
+        ).toBeInTheDocument()
+      );
+
+      const level5Button = level5Within.getByRole('button', {
+        name: new RegExp(`Cast ${level5.spellName}`, 'i'),
+      });
+      expect(level5Button).toBeEnabled();
+
+      const level3CardAtFive = screen
+        .getByText(level3.displayName)
+        .closest('.feature-card');
+      expect(level3CardAtFive).not.toBeNull();
+      await waitFor(() =>
+        expect(
+          within(level3CardAtFive).getByText('Uses remaining: 1')
+        ).toBeInTheDocument()
+      );
+
+      await act(async () => {
+        await userEvent.click(level5Button);
+      });
+
+      expect(onCastSpell).toHaveBeenNthCalledWith(3, {
+        castingTime: level5.castingTime,
+        level: level5.spellLevel,
+        lineageUsageId: level5.usageId,
+        name: level5.spellName,
+      });
+      expect(onCastSpell).toHaveBeenNthCalledWith(4, level5.actionType);
+      expect(level5Button).toBeDisabled();
+      expect(
+        level5Within.getByText('Uses remaining: 0')
+      ).toBeInTheDocument();
+
+      rerender(
+        <Features
+          form={createForm(5)}
+          showFeatures={true}
+          handleCloseFeatures={() => {}}
+          onCastSpell={onCastSpell}
+          longRestCount={2}
+          shortRestCount={0}
+          characterId={TEST_CHARACTER_ID}
+        />
+      );
+
+      const resetLevel5Card = await getFeatureCard(level5.displayName);
+      const resetLevel5Within = within(resetLevel5Card);
+      await waitFor(() =>
+        expect(
+          resetLevel5Within.getByText('Uses remaining: 1')
+        ).toBeInTheDocument()
+      );
+
+      const resetLevel5Button = resetLevel5Within.getByRole('button', {
+        name: new RegExp(`Cast ${level5.spellName}`, 'i'),
+      });
+      expect(resetLevel5Button).toBeEnabled();
+      const resetLevel3Card = screen
+        .getByText(level3.displayName)
+        .closest('.feature-card');
+      expect(resetLevel3Card).not.toBeNull();
+      await waitFor(() =>
+        expect(
+          within(resetLevel3Card).getByText('Uses remaining: 1')
+        ).toBeInTheDocument()
+      );
+    });
+  }
+);
 
 test('rock gnome lineage surfaces cantrips and clockwork device guidance', async () => {
   apiFetch.mockResolvedValue({


### PR DESCRIPTION
## Summary
- track elven lineage spell usage for Drow, High, and Wood lineages with per-long-rest counters and casting buttons
- surface lineage spell metadata so the feature renderer can trigger onCastSpell with the right spell details
- extend feature tests to cover lineage spell buttons, counters, and long rest resets across the elven lineages

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e162995f34832384ae68aa45efc68d