### PR TITLE
Add collapsible map folders in MapModal

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -107,6 +107,24 @@ const findMapById = (maps, id) => {
   return maps.find((map) => normalizeMapId(map?.mapId) === normalizedId) || null;
 };
 
+const areSetsEqual = (a, b) => {
+  if (a === b) {
+    return true;
+  }
+
+  if (!a || !b || a.size !== b.size) {
+    return false;
+  }
+
+  for (const value of a) {
+    if (!b.has(value)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 const MapModal = ({
   show,
   onHide,
@@ -186,6 +204,75 @@ const MapModal = ({
     () => groupMapsByFolder(normalizedMaps),
     [normalizedMaps]
   );
+
+  const autoExpandedFolderKeys = useMemo(() => {
+    const keys = new Set();
+
+    groupedMaps.forEach((group) => {
+      const shouldExpand = group.maps.some((mapItem) => {
+        const mapId = normalizeMapId(mapItem?.mapId);
+        if (!mapId) {
+          return false;
+        }
+
+        if (normalizedActiveId && normalizedActiveId === mapId) {
+          return true;
+        }
+
+        if (resolvedSelectedId && resolvedSelectedId === mapId) {
+          return true;
+        }
+
+        return false;
+      });
+
+      if (shouldExpand) {
+        keys.add(group.key);
+      }
+    });
+
+    return keys;
+  }, [groupedMaps, normalizedActiveId, resolvedSelectedId]);
+
+  const [expandedFolderKeys, setExpandedFolderKeys] = useState(
+    () => new Set(autoExpandedFolderKeys)
+  );
+
+  useEffect(() => {
+    setExpandedFolderKeys((previousKeys) => {
+      const validKeys = new Set(groupedMaps.map((group) => group.key));
+      const nextKeys = new Set();
+
+      previousKeys.forEach((key) => {
+        if (validKeys.has(key)) {
+          nextKeys.add(key);
+        }
+      });
+
+      autoExpandedFolderKeys.forEach((key) => {
+        nextKeys.add(key);
+      });
+
+      if (areSetsEqual(previousKeys, nextKeys)) {
+        return previousKeys;
+      }
+
+      return nextKeys;
+    });
+  }, [groupedMaps, autoExpandedFolderKeys]);
+
+  const handleToggleFolder = useCallback((folderKey) => {
+    setExpandedFolderKeys((previousKeys) => {
+      const nextKeys = new Set(previousKeys);
+      if (nextKeys.has(folderKey)) {
+        nextKeys.delete(folderKey);
+      } else {
+        nextKeys.add(folderKey);
+      }
+
+      return nextKeys;
+    });
+  }, []);
 
   const normalizedCurrentCharacterId = useMemo(
     () => normalizeMapId(currentCharacterId),
@@ -618,95 +705,120 @@ const MapModal = ({
       >
         {groupedMaps.map((group) => {
           const headerTestId = toFolderTestId(group.key, group.label);
+          const listBodyId = `${headerTestId}-body`;
+          const toggleTestId = `${headerTestId}-toggle`;
+          const isExpanded = expandedFolderKeys.has(group.key);
+
           return (
             <React.Fragment key={group.key}>
               <ListGroup.Item
                 as="div"
-                className="bg-secondary bg-opacity-50 text-light border-secondary d-flex justify-content-between align-items-center"
+                className="bg-secondary bg-opacity-50 text-light border-secondary"
                 data-testid={headerTestId}
               >
-                <span className="fw-semibold text-uppercase small">{group.label}</span>
-                <Badge bg="dark" pill>
-                  {group.maps.length}
-                </Badge>
-              </ListGroup.Item>
-              {group.maps.map((mapItem, index) => {
-                const mapId = normalizeMapId(mapItem?.mapId);
-                const key = mapId || `map-${group.key}-${index}`;
-                const isActive = Boolean(
-                  normalizedActiveId &&
-                  mapId &&
-                  normalizedActiveId === mapId
-                );
-                const isSelected = Boolean(
-                  resolvedSelectedId && mapId && resolvedSelectedId === mapId
-                );
-                const isProcessing = Boolean(
-                  mapId && normalizedActionId && normalizedActionId === mapId
-                );
-                const titleText = resolveMapTitle(mapItem, index);
-                const canSelect = typeof onSelectMap === 'function' && Boolean(mapId);
-                const canActivate = typeof onActivateMap === 'function';
-                const canDelete = typeof onDeleteMap === 'function';
-
-                return (
-                  <ListGroup.Item
-                    as="div"
-                    key={key}
-                    action={canSelect}
-                    active={isSelected}
-                    onClick={() => {
-                      if (canSelect && mapId) {
-                        handleSelectMap(mapId);
-                      }
-                    }}
-                    className="bg-dark text-light border-secondary"
-                    data-testid={`map-modal-item-${key}`}
-                    data-folder={
-                      group.key === UNGROUPED_FOLDER_KEY ? undefined : group.label
-                    }
+                <div className="d-flex justify-content-between align-items-center gap-2">
+                  <button
+                    type="button"
+                    className="btn btn-link btn-sm text-decoration-none text-light d-flex align-items-center gap-2 p-0 flex-grow-1"
+                    onClick={() => handleToggleFolder(group.key)}
+                    aria-expanded={isExpanded}
+                    aria-controls={listBodyId}
+                    data-testid={toggleTestId}
                   >
-                    <div className="d-flex justify-content-between align-items-start">
-                      <div className="fw-semibold">{titleText}</div>
-                      {isActive && (
-                        <Badge
-                          bg="success"
-                          className="ms-2"
-                          data-testid={`map-modal-active-badge-${key}`}
-                        >
-                          Active
-                        </Badge>
-                      )}
-                    </div>
-                    {(canActivate || canDelete) && (
-                      <div className="d-flex flex-wrap gap-2 mt-3">
-                        {canActivate && (
-                          <Button
-                            variant="outline-light"
-                            size="sm"
-                            disabled={!mapId || isProcessing || isActive}
-                            onClick={(event) => handleActivateMap(event, mapId)}
-                            data-testid={`map-modal-activate-${key}`}
-                          >
-                            {isActive ? 'Active' : 'Set Active'}
-                          </Button>
+                    <span aria-hidden="true">{isExpanded ? '▾' : '▸'}</span>
+                    <span className="fw-semibold text-uppercase small text-start">
+                      {group.label}
+                    </span>
+                  </button>
+                  <Badge bg="dark" pill>
+                    {group.maps.length}
+                  </Badge>
+                </div>
+              </ListGroup.Item>
+              {isExpanded && (
+                <div id={listBodyId}>
+                  {group.maps.map((mapItem, index) => {
+                    const mapId = normalizeMapId(mapItem?.mapId);
+                    const key = mapId || `map-${group.key}-${index}`;
+                    const isActive = Boolean(
+                      normalizedActiveId &&
+                      mapId &&
+                      normalizedActiveId === mapId
+                    );
+                    const isSelected = Boolean(
+                      resolvedSelectedId && mapId && resolvedSelectedId === mapId
+                    );
+                    const isProcessing = Boolean(
+                      mapId && normalizedActionId && normalizedActionId === mapId
+                    );
+                    const titleText = resolveMapTitle(mapItem, index);
+                    const canSelect =
+                      typeof onSelectMap === 'function' && Boolean(mapId);
+                    const canActivate = typeof onActivateMap === 'function';
+                    const canDelete = typeof onDeleteMap === 'function';
+
+                    return (
+                      <ListGroup.Item
+                        as="div"
+                        key={key}
+                        action={canSelect}
+                        active={isSelected}
+                        onClick={() => {
+                          if (canSelect && mapId) {
+                            handleSelectMap(mapId);
+                          }
+                        }}
+                        className="bg-dark text-light border-secondary"
+                        data-testid={`map-modal-item-${key}`}
+                        data-folder={
+                          group.key === UNGROUPED_FOLDER_KEY
+                            ? undefined
+                            : group.label
+                        }
+                      >
+                        <div className="d-flex justify-content-between align-items-start">
+                          <div className="fw-semibold">{titleText}</div>
+                          {isActive && (
+                            <Badge
+                              bg="success"
+                              className="ms-2"
+                              data-testid={`map-modal-active-badge-${key}`}
+                            >
+                              Active
+                            </Badge>
+                          )}
+                        </div>
+                        {(canActivate || canDelete) && (
+                          <div className="d-flex flex-wrap gap-2 mt-3">
+                            {canActivate && (
+                              <Button
+                                variant="outline-light"
+                                size="sm"
+                                disabled={!mapId || isProcessing || isActive}
+                                onClick={(event) => handleActivateMap(event, mapId)}
+                                data-testid={`map-modal-activate-${key}`}
+                              >
+                                {isActive ? 'Active' : 'Set Active'}
+                              </Button>
+                            )}
+                            {canDelete && (
+                              <Button
+                                variant="outline-danger"
+                                size="sm"
+                                disabled={!mapId || isProcessing}
+                                onClick={(event) => handleDeleteMap(event, mapId)}
+                                data-testid={`map-modal-delete-${key}`}
+                              >
+                                Delete
+                              </Button>
+                            )}
+                          </div>
                         )}
-                        {canDelete && (
-                          <Button
-                            variant="outline-danger"
-                            size="sm"
-                            disabled={!mapId || isProcessing}
-                            onClick={(event) => handleDeleteMap(event, mapId)}
-                            data-testid={`map-modal-delete-${key}`}
-                          >
-                            Delete
-                          </Button>
-                        )}
-                      </div>
-                    )}
-                  </ListGroup.Item>
-                );
-              })}
+                      </ListGroup.Item>
+                    );
+                  })}
+                </div>
+              )}
             </React.Fragment>
           );
         })}

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import MapModal from './MapModal';
 
 let capturedModalProps;
@@ -53,5 +54,70 @@ describe('MapModal docking props', () => {
     expect(capturedModalProps.centered).toBe(true);
     expect(capturedModalProps.backdrop).toBe(true);
     expect(capturedModalProps.enforceFocus).toBe(true);
+  });
+});
+
+describe('MapModal folder expansion', () => {
+  const renderMapModal = (overrideProps = {}) => {
+    const maps = [
+      { mapId: 'map-1', title: 'Forest Path', folder: 'Encounters' },
+      { mapId: 'map-2', title: 'Dungeon Depths', folder: 'Dungeons' },
+      { mapId: 'map-3', title: 'Lonely Road' },
+    ];
+
+    return render(
+      <MapModal
+        show
+        title="Test Map Modal"
+        maps={maps}
+        activeMapId="map-1"
+        onHide={jest.fn()}
+        onSelectMap={jest.fn()}
+        onActivateMap={jest.fn()}
+        onDeleteMap={jest.fn()}
+        {...overrideProps}
+      />
+    );
+  };
+
+  it('expands folders that contain the active map by default and toggles visibility', async () => {
+    renderMapModal();
+
+    const encountersToggle = screen.getByTestId('map-modal-folder-encounters-toggle');
+    expect(encountersToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(encountersToggle).toHaveAttribute('aria-controls', 'map-modal-folder-encounters-body');
+
+    const encountersItem = await screen.findByTestId('map-modal-item-map-1');
+    expect(encountersItem.dataset.folder).toBe('Encounters');
+
+    await userEvent.click(encountersToggle);
+    await waitFor(() =>
+      expect(screen.queryByTestId('map-modal-item-map-1')).not.toBeInTheDocument()
+    );
+
+    await userEvent.click(encountersToggle);
+    await waitFor(() =>
+      expect(screen.getByTestId('map-modal-item-map-1')).toBeInTheDocument()
+    );
+  });
+
+  it('allows collapsed folders to be expanded to reveal their maps', async () => {
+    renderMapModal();
+
+    const dungeonsToggle = screen.getByTestId('map-modal-folder-dungeons-toggle');
+    expect(dungeonsToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('map-modal-item-map-2')).not.toBeInTheDocument();
+
+    await userEvent.click(dungeonsToggle);
+    const dungeonItem = await screen.findByTestId('map-modal-item-map-2');
+    expect(dungeonItem.dataset.folder).toBe('Dungeons');
+
+    const noFolderToggle = screen.getByTestId('map-modal-folder-no-folder-toggle');
+    expect(noFolderToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('map-modal-item-map-3')).not.toBeInTheDocument();
+
+    await userEvent.click(noFolderToggle);
+    const noFolderItem = await screen.findByTestId('map-modal-item-map-3');
+    expect(noFolderItem.dataset.folder).toBeUndefined();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -376,7 +376,12 @@ describe('ZombiesDM AI generation', () => {
 
     const [mapModalProps] = MapModal.mock.calls.find(([props]) => props.show);
     const actualMapModal = jest.requireActual('../attributes/MapModal').default;
-    const { getByTestId: getModalByTestId, unmount: unmountModal } = render(
+    const {
+      getByTestId: getModalByTestId,
+      queryByTestId: queryModalByTestId,
+      findByTestId: findModalByTestId,
+      unmount: unmountModal,
+    } = render(
       React.createElement(actualMapModal, { ...mapModalProps, show: true })
     );
 
@@ -384,11 +389,43 @@ describe('ZombiesDM AI generation', () => {
     expect(getModalByTestId('map-modal-folder-encounters')).toBeInTheDocument();
     expect(getModalByTestId('map-modal-folder-no-folder')).toBeInTheDocument();
 
-    expect(getModalByTestId('map-modal-item-forest-map').dataset.folder).toBe(
-      'Forest Encounters'
+    const forestToggle = getModalByTestId('map-modal-folder-forest-encounters-toggle');
+    expect(forestToggle).toHaveAttribute('aria-expanded', 'true');
+
+    const forestMapItem = await findModalByTestId('map-modal-item-forest-map');
+    expect(forestMapItem.dataset.folder).toBe('Forest Encounters');
+
+    await userEvent.click(forestToggle);
+    await waitFor(() =>
+      expect(queryModalByTestId('map-modal-item-forest-map')).not.toBeInTheDocument()
     );
-    expect(getModalByTestId('map-modal-item-encounter-map').dataset.folder).toBe('Encounters');
-    expect(getModalByTestId('map-modal-item-no-folder-map').dataset.folder).toBeUndefined();
+
+    await userEvent.click(forestToggle);
+    await waitFor(() =>
+      expect(getModalByTestId('map-modal-item-forest-map').dataset.folder).toBe(
+        'Forest Encounters'
+      )
+    );
+
+    const encountersToggle = getModalByTestId('map-modal-folder-encounters-toggle');
+    expect(encountersToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(queryModalByTestId('map-modal-item-encounter-map')).not.toBeInTheDocument();
+
+    await userEvent.click(encountersToggle);
+    await waitFor(() =>
+      expect(getModalByTestId('map-modal-item-encounter-map').dataset.folder).toBe(
+        'Encounters'
+      )
+    );
+
+    const noFolderToggle = getModalByTestId('map-modal-folder-no-folder-toggle');
+    expect(noFolderToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(queryModalByTestId('map-modal-item-no-folder-map')).not.toBeInTheDocument();
+
+    await userEvent.click(noFolderToggle);
+    await waitFor(() =>
+      expect(getModalByTestId('map-modal-item-no-folder-map').dataset.folder).toBeUndefined()
+    );
 
     unmountModal();
   });


### PR DESCRIPTION
## Summary
- track expanded folder keys in MapModal and provide accessible toggle controls
- hide folder contents when collapsed while keeping existing map actions functional
- update DM flow assertions and add MapModal tests covering folder expansion behaviour

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/attributes/MapModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1621d1f34832eb3e1960b21bbb5a0