### PR TITLE
Switch map editor folder field to select with create option

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -102,6 +102,7 @@ const toFiniteNumberOrNull = (value) => {
 };
 
 const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
+const NEW_FOLDER_OPTION_VALUE = '__create_new_folder__';
 
 const normalizeCreatureSize = (value) => {
   if (typeof value !== 'string') {
@@ -679,6 +680,7 @@ export default function ZombiesDM() {
       map: null,
       title: '',
       folder: '',
+      folderSelection: '',
       imageUrl: '',
       imageBase64: '',
       imageType: '',
@@ -866,11 +868,6 @@ export default function ZombiesDM() {
         });
       }
     }, [mapEditorErrors.altText, mapEditorState.altText, mapEditorState.mode]);
-
-    const folderDatalistId = useMemo(
-      () => (availableMapFolders.length > 0 ? 'map-editor-folder-options' : undefined),
-      [availableMapFolders.length]
-    );
 
     const imageSourceDescribedBy = useMemo(() => {
       const ids = ['map-editor-image-requirement'];
@@ -3453,12 +3450,20 @@ export default function ZombiesDM() {
           ? lastMapFolder
           : '';
 
+      const shouldUseExistingOption =
+        defaultFolder && availableMapFolders.includes(defaultFolder);
+
       setMapEditorState({
         show: true,
         mode: 'create',
         map: safeMap,
         title: '',
         folder: defaultFolder || '',
+        folderSelection: shouldUseExistingOption
+          ? defaultFolder
+          : defaultFolder
+          ? NEW_FOLDER_OPTION_VALUE
+          : '',
         imageUrl: '',
         imageBase64: '',
         imageType: '',
@@ -3466,7 +3471,14 @@ export default function ZombiesDM() {
         activateOnSave: maps.length === 0,
         fileInputKey: Date.now(),
       });
-    }, [generatedMap, selectedMapId, maps, campaignMap, lastMapFolder]);
+    }, [
+      generatedMap,
+      selectedMapId,
+      maps,
+      campaignMap,
+      lastMapFolder,
+      availableMapFolders,
+    ]);
 
     const openRenameMapModal = useCallback((map) => {
       if (!map || typeof map !== 'object') {
@@ -3486,6 +3498,12 @@ export default function ZombiesDM() {
           typeof safeMap.folder === 'string' && safeMap.folder.trim() !== ''
             ? safeMap.folder.trim()
             : '',
+        folderSelection:
+          typeof safeMap.folder === 'string' && safeMap.folder.trim() !== ''
+            ? availableMapFolders.includes(safeMap.folder.trim())
+              ? safeMap.folder.trim()
+              : NEW_FOLDER_OPTION_VALUE
+            : '',
         imageUrl: typeof safeMap.imageUrl === 'string' ? safeMap.imageUrl : '',
         imageBase64:
           typeof safeMap.imageBase64 === 'string' ? safeMap.imageBase64 : '',
@@ -3495,7 +3513,7 @@ export default function ZombiesDM() {
         activateOnSave: false,
         fileInputKey: Date.now(),
       });
-    }, []);
+    }, [availableMapFolders]);
 
     const handleCloseMapEditor = useCallback(() => {
       setMapEditorSaving(false);
@@ -3510,6 +3528,15 @@ export default function ZombiesDM() {
       },
       []
     );
+
+    const handleMapEditorFolderSelectionChange = useCallback((event) => {
+      const value = event?.target?.value ?? '';
+      setMapEditorState((prev) => ({
+        ...prev,
+        folderSelection: value,
+        folder: value && value !== NEW_FOLDER_OPTION_VALUE ? value : '',
+      }));
+    }, []);
 
     const handleMapEditorActivateChange = useCallback((event) => {
       const checked = Boolean(event?.target?.checked);
@@ -7336,26 +7363,41 @@ const resolveIcon = (category, iconMap, fallback) => {
                 </Form.Control.Feedback>
               )}
             </Form.Group>
-            <Form.Group className="mb-3" controlId="map-editor-folder">
-              <Form.Label>Folder</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="Optional folder name"
-                value={mapEditorState.folder}
-                onChange={handleMapEditorInputChange('folder')}
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="map-editor-folder-select">Folder</Form.Label>
+              <Form.Select
+                id="map-editor-folder-select"
+                value={mapEditorState.folderSelection}
+                onChange={handleMapEditorFolderSelectionChange}
                 disabled={mapEditorSaving}
-                list={folderDatalistId}
-                data-testid="map-editor-folder-input"
-              />
-              {availableMapFolders.length > 0 ? (
-                <datalist id="map-editor-folder-options">
-                  {availableMapFolders.map((folderName) => (
-                    <option value={folderName} key={folderName} />
-                  ))}
-                </datalist>
+                aria-describedby="map-editor-folder-help"
+                data-testid="map-editor-folder-select"
+              >
+                <option value="">No folder</option>
+                {availableMapFolders.map((folderName) => (
+                  <option value={folderName} key={folderName}>
+                    {folderName}
+                  </option>
+                ))}
+                <option value={NEW_FOLDER_OPTION_VALUE}>Create new folder…</option>
+              </Form.Select>
+              {mapEditorState.folderSelection === NEW_FOLDER_OPTION_VALUE ? (
+                <div className="mt-2">
+                  <Form.Label htmlFor="map-editor-folder-input">New folder name</Form.Label>
+                  <Form.Control
+                    id="map-editor-folder-input"
+                    type="text"
+                    placeholder="Enter folder name"
+                    value={mapEditorState.folder}
+                    onChange={handleMapEditorInputChange('folder')}
+                    disabled={mapEditorSaving}
+                    aria-describedby="map-editor-folder-help"
+                    data-testid="map-editor-folder-input"
+                  />
+                </div>
               ) : null}
-              <Form.Text className="text-muted">
-                Choose an existing folder or enter a new one.
+              <Form.Text id="map-editor-folder-help" className="text-muted">
+                Choose an existing folder or create a new one.
               </Form.Text>
             </Form.Group>
             <Form.Group className="mb-3" controlId="map-editor-image-url">

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -259,7 +259,7 @@ describe('ZombiesDM AI generation', () => {
       },
     ];
     let storedMaps = [...baseMaps];
-    let lastPostBody = null;
+    const mapPostBodies = [];
 
     apiFetch.mockImplementation((url, options = {}) => {
       switch (url) {
@@ -279,9 +279,11 @@ describe('ZombiesDM AI generation', () => {
         case '/campaigns/Camp1/maps': {
           if (options.method === 'POST') {
             const parsedBody = JSON.parse(options.body || '{}');
-            lastPostBody = parsedBody;
+            mapPostBodies.push(parsedBody);
+            const createdIndex = mapPostBodies.length;
+            const createdMapId = createdIndex === 1 ? 'forest-map' : `forest-map-${createdIndex}`;
             const createdMap = {
-              mapId: 'forest-map',
+              mapId: createdMapId,
               title: parsedBody.map?.title || 'Forest Map',
               folder: parsedBody.map?.folder,
               imageUrl: parsedBody.map?.imageUrl || 'https://example.com/forest.png',
@@ -289,7 +291,7 @@ describe('ZombiesDM AI generation', () => {
               createdAt: now,
               updatedAt: now,
             };
-            storedMaps = [...baseMaps, createdMap];
+            storedMaps = [...storedMaps, createdMap];
             return Promise.resolve({
               ok: true,
               json: async () => ({
@@ -330,9 +332,11 @@ describe('ZombiesDM AI generation', () => {
     const modalQueries = within(modal);
 
     await userEvent.type(modalQueries.getByLabelText(/^Title/), 'Forest Ambush');
-    const folderInput = modalQueries.getByLabelText(/^Folder/);
-    await userEvent.clear(folderInput);
-    await userEvent.type(folderInput, 'Forest Encounters');
+    const folderSelect = modalQueries.getByLabelText(/^Folder/);
+    expect(folderSelect.tagName).toBe('SELECT');
+    await userEvent.selectOptions(folderSelect, 'Create new folder…');
+    const newFolderInput = await modalQueries.findByLabelText('New folder name');
+    await userEvent.type(newFolderInput, 'Forest Encounters');
     await userEvent.type(
       modalQueries.getByLabelText(/^Image URL/),
       'https://example.com/forest.png'
@@ -342,10 +346,10 @@ describe('ZombiesDM AI generation', () => {
     await userEvent.click(modalQueries.getByTestId('map-editor-submit-button'));
 
     await waitFor(() => {
-      expect(lastPostBody).not.toBeNull();
+      expect(mapPostBodies).toHaveLength(1);
     });
 
-    expect(lastPostBody.map.folder).toBe('Forest Encounters');
+    expect(mapPostBodies[0].map.folder).toBe('Forest Encounters');
 
     await waitFor(() =>
       expect(screen.queryByTestId('map-editor-modal')).not.toBeInTheDocument()
@@ -358,13 +362,34 @@ describe('ZombiesDM AI generation', () => {
     await userEvent.click(createButton);
     const modalAgain = await screen.findByTestId('map-editor-modal');
     const modalAgainQueries = within(modalAgain);
-    const folderInputAgain = modalAgainQueries.getByLabelText(/^Folder/);
-    expect(folderInputAgain).toHaveValue('Forest Encounters');
+    const folderSelectAgain = modalAgainQueries.getByLabelText(/^Folder/);
+    expect(folderSelectAgain).toHaveValue('Forest Encounters');
 
-    await userEvent.click(modalAgainQueries.getByRole('button', { name: /cancel/i }));
+    await userEvent.selectOptions(folderSelectAgain, 'Encounters');
+    expect(folderSelectAgain).toHaveValue('Encounters');
+    expect(modalAgainQueries.queryByLabelText('New folder name')).not.toBeInTheDocument();
+
+    await userEvent.type(modalAgainQueries.getByLabelText(/^Title/), 'Encounters Redux');
+    await userEvent.type(
+      modalAgainQueries.getByLabelText(/^Image URL/),
+      'https://example.com/encounters-redux.png'
+    );
+    await userEvent.type(modalAgainQueries.getByLabelText(/^Alt Text/), 'Encounters redux map');
+
+    await userEvent.click(modalAgainQueries.getByTestId('map-editor-submit-button'));
+
+    await waitFor(() => {
+      expect(mapPostBodies).toHaveLength(2);
+    });
+    expect(mapPostBodies[1].map.folder).toBe('Encounters');
+
     await waitFor(() =>
       expect(screen.queryByTestId('map-editor-modal')).not.toBeInTheDocument()
     );
+
+    await waitFor(() => {
+      expect(screen.getByText('Encounters Redux')).toBeInTheDocument();
+    });
 
     const manageButton = await screen.findByTestId('open-map-manager-button');
     await userEvent.click(manageButton);


### PR DESCRIPTION
## Summary
- replace the map editor folder text field with a select element that lists existing folders and exposes a "Create new folder…" choice
- add state management for folder selection versus custom entry and surface a secondary input when creating a folder
- expand ZombiesDM map editor tests to cover selecting existing folders and entering new folders through the updated flow

## Testing
- CI=1 npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js *(fails: suite exceeds default Jest timeout in existing ZombiesDM tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e16535ff54832e83678d66f70daea9