### PR TITLE
Simplify map folder expansion defaults

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -745,26 +745,14 @@ export default function ZombiesDM() {
         const next = {};
 
         groupedMaps.forEach((group) => {
-          const hasImportantMap = group.maps.some((mapItem) => {
-            const mapIdValue = normalizeMapId(mapItem?.mapId);
-            return (
-              (normalizedActiveMapId && mapIdValue === normalizedActiveMapId) ||
-              (normalizedSelectedMapId && mapIdValue === normalizedSelectedMapId)
-            );
-          });
-
-          const hadValue = Object.prototype.hasOwnProperty.call(previous, group.key);
-          const defaultExpanded = group.key === UNGROUPED_FOLDER_KEY;
-          next[group.key] = hasImportantMap
-            ? true
-            : hadValue
+          next[group.key] = Object.prototype.hasOwnProperty.call(previous, group.key)
             ? previous[group.key]
-            : defaultExpanded;
+            : false;
         });
 
         return next;
       });
-    }, [groupedMaps, normalizedActiveMapId, normalizedSelectedMapId]);
+    }, [groupedMaps]);
 
     const handleToggleMapFolder = useCallback((folderKey) => {
       if (typeof folderKey !== 'string') {

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -415,17 +415,28 @@ describe('ZombiesDM AI generation', () => {
     expect(getModalByTestId('map-modal-folder-no-folder')).toBeInTheDocument();
 
     const forestToggle = getModalByTestId('map-modal-folder-forest-encounters-toggle');
-    expect(forestToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(forestToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(queryModalByTestId('map-modal-item-forest-map')).not.toBeInTheDocument();
+
+    await userEvent.click(forestToggle);
+    await waitFor(() => expect(forestToggle).toHaveAttribute('aria-expanded', 'true'));
+    await waitFor(() =>
+      expect(getModalByTestId('map-modal-item-forest-map').dataset.folder).toBe(
+        'Forest Encounters'
+      )
+    );
 
     const forestMapItem = await findModalByTestId('map-modal-item-forest-map');
     expect(forestMapItem.dataset.folder).toBe('Forest Encounters');
 
     await userEvent.click(forestToggle);
+    await waitFor(() => expect(forestToggle).toHaveAttribute('aria-expanded', 'false'));
     await waitFor(() =>
       expect(queryModalByTestId('map-modal-item-forest-map')).not.toBeInTheDocument()
     );
 
     await userEvent.click(forestToggle);
+    await waitFor(() => expect(forestToggle).toHaveAttribute('aria-expanded', 'true'));
     await waitFor(() =>
       expect(getModalByTestId('map-modal-item-forest-map').dataset.folder).toBe(
         'Forest Encounters'
@@ -437,6 +448,7 @@ describe('ZombiesDM AI generation', () => {
     expect(queryModalByTestId('map-modal-item-encounter-map')).not.toBeInTheDocument();
 
     await userEvent.click(encountersToggle);
+    await waitFor(() => expect(encountersToggle).toHaveAttribute('aria-expanded', 'true'));
     await waitFor(() =>
       expect(getModalByTestId('map-modal-item-encounter-map').dataset.folder).toBe(
         'Encounters'
@@ -448,6 +460,7 @@ describe('ZombiesDM AI generation', () => {
     expect(queryModalByTestId('map-modal-item-no-folder-map')).not.toBeInTheDocument();
 
     await userEvent.click(noFolderToggle);
+    await waitFor(() => expect(noFolderToggle).toHaveAttribute('aria-expanded', 'true'));
     await waitFor(() =>
       expect(getModalByTestId('map-modal-item-no-folder-map').dataset.folder).toBeUndefined()
     );


### PR DESCRIPTION
## Summary
- default all campaign map folders to a collapsed state unless the user has expanded them previously
- update the ZombiesDM map folder toggle tests to expect collapsed folders on initial render

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js *(fails: existing ZombiesDM tests timeout and assert failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e16ad52f98832e85b1ec99a412fc3a