### PR TITLE
Add icons for elven lineage cantrip features

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -898,6 +898,16 @@
   flex-shrink: 0;
 }
 
+.feature-card-spell-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  font-size: 1.25rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .feature-card-actions .btn-outline-light {
   color: var(--bs-light);
   border-color: rgba(255, 255, 255, 0.4);

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -31,6 +31,12 @@ const ONCE_PER_LONG_REST_LINEAGE_SPELLS = {
   },
 };
 
+const ELVEN_LINEAGE_CANTRIP_FEATURE_IDS = new Set([
+  'elf-drow-dancing-lights',
+  'elf-high-prestidigitation',
+  'elf-wood-druidcraft',
+]);
+
 export default function Features({
   form,
   showFeatures,
@@ -1168,6 +1174,8 @@ export default function Features({
                     const isLineageOncePerLongRestSpell = Boolean(
                       lineageSpellConfig
                     );
+                    const isElvenLineageCantrip =
+                      ELVEN_LINEAGE_CANTRIP_FEATURE_IDS.has(feat.id);
                     const lineageSpellRemainingUses =
                       lineageSpellUses[feat.id] ?? 0;
                     return (
@@ -1189,6 +1197,12 @@ export default function Features({
                             </div>
                           </div>
                           <div className="feature-card-actions">
+                            {isElvenLineageCantrip && (
+                              <i
+                                className="fa-solid fa-wand-sparkles feature-card-spell-icon"
+                                aria-hidden="true"
+                              />
+                            )}
                             {isActionSurge ? (
                               <Button
                                 aria-label="use feature"

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -393,6 +393,9 @@ test('elf characters display baseline traits and drow lineage magic', async () =
   const dancingLightsTitle = await screen.findByText('Dancing Lights');
   const dancingCard = dancingLightsTitle.closest('.feature-card');
   expect(dancingCard).not.toBeNull();
+  const dancingIcon =
+    dancingCard && dancingCard.querySelector('.fa-wand-sparkles');
+  expect(dancingIcon).toBeInTheDocument();
   expect(
     within(dancingCard).getByText(/Spellcasting Ability: Charisma/i)
   ).toBeInTheDocument();
@@ -550,6 +553,9 @@ test('wood elf lineage notes speed increase and lineage spells', async () => {
   const druidcraftTitle = await screen.findByText('Druidcraft');
   const druidcraftCard = druidcraftTitle.closest('.feature-card');
   expect(druidcraftCard).not.toBeNull();
+  const druidcraftIcon =
+    druidcraftCard && druidcraftCard.querySelector('.fa-wand-sparkles');
+  expect(druidcraftIcon).toBeInTheDocument();
   const viewButton = within(druidcraftCard).getByRole('button', {
     name: /view feature/i,
   });
@@ -669,6 +675,10 @@ test('high elf lineage lists arcane cantrip and future spell hooks', async () =>
   const prestidigitationTitle = await screen.findByText('Prestidigitation');
   const prestidigitationCard = prestidigitationTitle.closest('.feature-card');
   expect(prestidigitationCard).not.toBeNull();
+  const prestidigitationIcon =
+    prestidigitationCard &&
+    prestidigitationCard.querySelector('.fa-wand-sparkles');
+  expect(prestidigitationIcon).toBeInTheDocument();
   expect(
     within(prestidigitationCard).getByText(/Spellcasting Ability: Intelligence/i)
   ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add an explicit list of elven lineage cantrip feature ids and show the wand icon when present
- style the static wand icon alongside existing feature card actions
- extend elven lineage feature tests to check for the wand icon on cantrip cards

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e170151da88323a883af8d7a86b89c