### PR TITLE
Show darkvision range in feature metadata

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -475,7 +475,7 @@ export default function Features({
         {
           id: 'dwarf-darkvision',
           name: 'Darkvision',
-          meta: 'Dwarf',
+          meta: `${raceDisplayName} ${darkvisionRange ?? 60} ft`,
           description: darkvisionDescription,
           desc: darkvisionDescription,
           hideUseButton: true,
@@ -506,8 +506,12 @@ export default function Features({
         }
       );
     } else if (raceName === 'orc') {
+      const orcDarkvisionRange =
+        Number.isFinite(race?.darkvisionRange) && race.darkvisionRange > 0
+          ? race.darkvisionRange
+          : 120;
       const darkvisionDescription =
-        'Thanks to your orc heritage, you can see in dim light within 120 feet of you as if it were bright light, and in darkness as if it were dim light. You cannot discern color in darkness, only shades of gray.';
+        `Thanks to your orc heritage, you can see in dim light within ${orcDarkvisionRange} feet of you as if it were bright light, and in darkness as if it were dim light. You cannot discern color in darkness, only shades of gray.`;
       const adrenalineRushDescription =
         'As a bonus action, you can take the Dash action and gain temporary hit points equal to your proficiency bonus. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.';
       const relentlessEnduranceDescription =
@@ -524,7 +528,7 @@ export default function Features({
         {
           id: 'orc-darkvision',
           name: 'Darkvision',
-          meta: 'Orc',
+          meta: `${raceDisplayName} ${orcDarkvisionRange} ft`,
           description: darkvisionDescription,
           desc: darkvisionDescription,
           hideUseButton: true,
@@ -812,7 +816,7 @@ export default function Features({
       raceFeatures.push({
         id: raceName ? `${raceName}-darkvision` : 'darkvision',
         name: 'Darkvision',
-        meta: raceDisplayName,
+        meta: `${raceDisplayName} ${darkvisionRange ?? 60} ft`,
         description: darkvisionDescription,
         desc: darkvisionDescription,
         hideUseButton: true,

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -111,7 +111,9 @@ test('dragonborn always has damage resistance and gains draconic flight at level
   const darkvisionTitle = await screen.findByText('Darkvision');
   const darkvisionCard = darkvisionTitle.closest('.feature-card');
   expect(darkvisionCard).not.toBeNull();
-  expect(within(darkvisionCard).getByText('Dragonborn')).toBeInTheDocument();
+  expect(
+    within(darkvisionCard).getByText('Dragonborn 60 ft')
+  ).toBeInTheDocument();
 
   const darkvisionViewButton = within(darkvisionCard).getByRole('button', {
     name: /view feature/i,
@@ -851,7 +853,7 @@ test('forest gnome lineage shows lineage spells with ability text and tracking',
   const darkvisionTitle = await screen.findByText('Darkvision');
   const darkvisionCard = darkvisionTitle.closest('.feature-card');
   expect(darkvisionCard).not.toBeNull();
-  expect(within(darkvisionCard).getByText('Gnome')).toBeInTheDocument();
+  expect(within(darkvisionCard).getByText('Gnome 60 ft')).toBeInTheDocument();
 
   expect(await screen.findByText('Gnomish Cunning')).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- include the darkvision range in the feature metadata for dwarf, orc, and generic darkvision traits so the cards show both race and range
- update the component tests to expect the new metadata labels

## Testing
- CI=true npm --prefix client test *(fails: known ZombiesDM suite timeouts and act() warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e17594285c8323bb12ce75e07d7f1b