### PR TITLE
Add Tiefling fiendish legacy data and tests

### DIFF
--- a/server/__tests__/races.test.js
+++ b/server/__tests__/races.test.js
@@ -32,4 +32,55 @@ describe('Races API routes', () => {
       darkvisionRange: 120,
     });
   });
+
+  test('exposes tiefling fiendish legacy structure', async () => {
+    const res = await request(app).get('/races/tiefling');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      creatureType: 'Humanoid',
+      darkvisionRange: 60,
+    });
+
+    const { fiendishLegacies } = res.body;
+    expect(fiendishLegacies).toBeDefined();
+    expect(fiendishLegacies.abyssal).toBeDefined();
+    expect(fiendishLegacies.chthonic).toBeDefined();
+    expect(fiendishLegacies.infernal).toBeDefined();
+
+    Object.values(fiendishLegacies).forEach((legacy) => {
+      expect(legacy.resistance).toBeDefined();
+      expect(legacy.spellcastingAbilities).toEqual(
+        expect.arrayContaining(['Intelligence', 'Wisdom', 'Charisma'])
+      );
+      expect(legacy.spells).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ usage: 'At will' }),
+          expect.objectContaining({ usage: '1/long rest' }),
+        ])
+      );
+    });
+
+    expect(fiendishLegacies.abyssal.spells).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'Poison Spray', unlockedAtLevel: 1 }),
+        expect.objectContaining({ name: 'Ray of Sickness', unlockedAtLevel: 3 }),
+        expect.objectContaining({ name: 'Hold Person', unlockedAtLevel: 5 }),
+      ])
+    );
+    expect(fiendishLegacies.chthonic.spells).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'Chill Touch', unlockedAtLevel: 1 }),
+        expect.objectContaining({ name: 'Darkness', unlockedAtLevel: 3 }),
+        expect.objectContaining({ name: 'Bestow Curse', unlockedAtLevel: 5 }),
+      ])
+    );
+    expect(fiendishLegacies.infernal.spells).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'Fire Bolt', unlockedAtLevel: 1 }),
+        expect.objectContaining({ name: 'Hellish Rebuke', unlockedAtLevel: 3 }),
+        expect.objectContaining({ name: 'Fireball', unlockedAtLevel: 5 }),
+      ])
+    );
+  });
 });

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -240,6 +240,109 @@ const races = {
     abilities: { cha: 2, int: 1 },
     skills: {},
     languages: ["Common", "Infernal"],
+    creatureType: "Humanoid",
+    darkvisionRange: 60,
+    fiendishLegacies: {
+      abyssal: {
+        label: "Abyssal",
+        description:
+          "You channel the chaotic corruption of the Abyss, gaining resistances and magic steeped in poison.",
+        resistance: "Poison",
+        spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        spells: [
+          {
+            name: "Poison Spray",
+            spellLevel: "Cantrip",
+            unlockedAtLevel: 1,
+            description:
+              "Project a puff of noxious gas toward a creature you can see, forcing it to make a Constitution save or take poison damage.",
+            usage: "At will",
+          },
+          {
+            name: "Ray of Sickness",
+            spellLevel: "1st-level",
+            unlockedAtLevel: 3,
+            description:
+              "Hurl a ray of sickening energy that can poison a creature on a failed Constitution save.",
+            usage: "1/long rest",
+          },
+          {
+            name: "Hold Person",
+            spellLevel: "2nd-level",
+            unlockedAtLevel: 5,
+            description:
+              "Paralyze a humanoid you can see within range unless it succeeds on a Wisdom save.",
+            usage: "1/long rest",
+          },
+        ],
+      },
+      chthonic: {
+        label: "Chthonic",
+        description:
+          "Your legacy is tied to dark powers of the Lower Planes, cloaking you in necrotic energies and shadowed magic.",
+        resistance: "Necrotic",
+        spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        spells: [
+          {
+            name: "Chill Touch",
+            spellLevel: "Cantrip",
+            unlockedAtLevel: 1,
+            description:
+              "Create a ghostly skeletal hand that clings to a creature, dealing necrotic damage and hampering its healing.",
+            usage: "At will",
+          },
+          {
+            name: "Darkness",
+            spellLevel: "2nd-level",
+            unlockedAtLevel: 3,
+            description:
+              "Fill a 15-foot-radius sphere with magical darkness that blocks light and darkvision.",
+            usage: "1/long rest",
+          },
+          {
+            name: "Bestow Curse",
+            spellLevel: "3rd-level",
+            unlockedAtLevel: 5,
+            description:
+              "Inflict a potent magical curse on a creature, imposing debilitating effects of your choice.",
+            usage: "1/long rest",
+          },
+        ],
+      },
+      infernal: {
+        label: "Infernal",
+        description:
+          "You inherit the disciplined might of the Hells, wreathed in flame and armed with classic devilish magic.",
+        resistance: "Fire",
+        spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        spells: [
+          {
+            name: "Fire Bolt",
+            spellLevel: "Cantrip",
+            unlockedAtLevel: 1,
+            description:
+              "Launch a mote of fire at a creature within range, dealing fire damage on a hit.",
+            usage: "At will",
+          },
+          {
+            name: "Hellish Rebuke",
+            spellLevel: "1st-level",
+            unlockedAtLevel: 3,
+            description:
+              "Surround an attacker in searing flame as a reaction, forcing a Dexterity save or dealing fire damage.",
+            usage: "1/long rest",
+          },
+          {
+            name: "Fireball",
+            spellLevel: "3rd-level",
+            unlockedAtLevel: 5,
+            description:
+              "Detonate a roaring explosion of flame that engulfs creatures in a 20-foot-radius sphere.",
+            usage: "1/long rest",
+          },
+        ],
+      },
+    },
   },
   goliath: {
     name: "Goliath",


### PR DESCRIPTION
## Summary
- enrich the Tiefling race definition with core traits and detailed fiendish legacy spell data
- document Abyssal, Chthonic, and Infernal legacy spellcasting options including resistances and spell usage metadata
- add a server test that ensures the Tiefling endpoint exposes the new fiendish legacy structure

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68e1799e26cc83239fc23618b2156943