### PR TITLE
Add tiefling legacy selection and display

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -65,9 +65,13 @@ export default function CharacterInfo({
   const isDragonborn = raceName === 'dragonborn';
   const isGoliath = raceName === 'goliath';
   const isElf = raceName === 'elf';
+  const isTiefling = raceName === 'tiefling';
   const dragonAncestries = isDragonborn ? form?.race?.dragonAncestries || {} : {};
   const giantAncestries = isGoliath ? form?.race?.giantAncestries || {} : {};
   const elvenLineages = isElf ? form?.race?.elvenLineages || {} : {};
+  const tieflingLegacies = isTiefling
+    ? form?.race?.fiendishLegacies || {}
+    : {};
   const goliathAncestry = isGoliath
     ? form?.race?.selectedAncestry ||
       (form?.race?.selectedAncestryKey && giantAncestries
@@ -115,6 +119,63 @@ export default function CharacterInfo({
   const elvenLineageName = elvenLineage
     ? elvenLineage.label || elvenLineage.name || 'Elven Lineage'
     : null;
+  const tieflingLegacy = isTiefling
+    ? form?.race?.selectedAncestry ||
+      (form?.race?.selectedAncestryKey && tieflingLegacies
+        ? tieflingLegacies[form.race.selectedAncestryKey]
+        : null) ||
+      form?.tieflingLegacy ||
+      (form?.tieflingLegacyKey && tieflingLegacies
+        ? tieflingLegacies[form.tieflingLegacyKey]
+        : null)
+    : null;
+  const tieflingLegacyName = tieflingLegacy
+    ? tieflingLegacy.label || tieflingLegacy.name || 'Fiendish Legacy'
+    : null;
+  const tieflingLegacyAbility = (() => {
+    const fromForm =
+      typeof form?.tieflingLegacyAbility === 'string'
+        ? form.tieflingLegacyAbility.trim()
+        : '';
+    if (fromForm) {
+      return fromForm;
+    }
+    const fromRace =
+      typeof form?.race?.selectedLineageAbility === 'string'
+        ? form.race.selectedLineageAbility.trim()
+        : '';
+    return fromRace;
+  })();
+  const tieflingLegacyResistance = (() => {
+    const fromRace =
+      typeof form?.race?.selectedFiendishLegacyResistance === 'string'
+        ? form.race.selectedFiendishLegacyResistance.trim()
+        : '';
+    if (fromRace) {
+      return fromRace;
+    }
+    const fromLegacy =
+      typeof tieflingLegacy?.resistance === 'string'
+        ? tieflingLegacy.resistance.trim()
+        : '';
+    return fromLegacy;
+  })();
+  const tieflingLegacySubtext = (() => {
+    if (!isTiefling) {
+      return null;
+    }
+    const parts = [];
+    if (tieflingLegacyName) {
+      parts.push(tieflingLegacyName);
+    }
+    if (tieflingLegacyResistance) {
+      parts.push(`Resistance: ${tieflingLegacyResistance}`);
+    }
+    if (tieflingLegacyAbility) {
+      parts.push(`Spellcasting Ability: ${tieflingLegacyAbility}`);
+    }
+    return parts.length ? parts.join(' • ') : null;
+  })();
   const displaySize =
     form?.temporarySize || form?.size || form?.height || "—";
 
@@ -165,6 +226,9 @@ export default function CharacterInfo({
                 )}
                 {isElf && elvenLineageName && (
                   <span className="character-info-subtext">{elvenLineageName}</span>
+                )}
+                {isTiefling && tieflingLegacySubtext && (
+                  <span className="character-info-subtext">{tieflingLegacySubtext}</span>
                 )}
               </div>
             </div>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -192,3 +192,46 @@ test('renders elven lineage within race card when lineage selected', () => {
   expect(getByText('Wood Elf')).toBeInTheDocument();
 });
 
+test('renders tiefling legacy details within race card when legacy selected', () => {
+  const infernalLegacy = {
+    label: 'Infernal Legacy',
+    resistance: 'Fire',
+    spellcastingAbilities: ['Intelligence', 'Wisdom', 'Charisma'],
+  };
+  const form = {
+    occupation: [],
+    race: {
+      name: 'Tiefling',
+      languages: [],
+      selectedAncestryKey: 'infernal',
+      selectedLineageAbility: 'Charisma',
+      selectedFiendishLegacyResistance: 'Fire',
+      fiendishLegacies: {
+        infernal: infernalLegacy,
+      },
+    },
+    tieflingLegacyKey: 'infernal',
+    tieflingLegacy: infernalLegacy,
+    tieflingLegacyAbility: 'Charisma',
+  };
+
+  render(
+    <CharacterInfo
+      form={form}
+      show={true}
+      handleClose={() => {}}
+      onShowBackground={() => {}}
+      onLongRest={() => {}}
+      onShortRest={() => {}}
+    />
+  );
+
+  const raceItem = screen.getByText('Race').closest('.character-info-item');
+  expect(raceItem).not.toBeNull();
+  const { getByText } = within(raceItem);
+  expect(getByText('Tiefling')).toBeInTheDocument();
+  expect(
+    getByText(/Infernal Legacy • Resistance: Fire • Spellcasting Ability: Charisma/i)
+  ).toBeInTheDocument();
+});
+

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -44,6 +44,30 @@ const LINEAGE_SPELLS = {
     spellName: 'Pass without Trace',
     maxUses: 1,
   },
+  'tiefling-abyssal-ray-of-sickness': {
+    spellName: 'Ray of Sickness',
+    maxUses: 1,
+  },
+  'tiefling-abyssal-hold-person': {
+    spellName: 'Hold Person',
+    maxUses: 1,
+  },
+  'tiefling-chthonic-darkness': {
+    spellName: 'Darkness',
+    maxUses: 1,
+  },
+  'tiefling-chthonic-bestow-curse': {
+    spellName: 'Bestow Curse',
+    maxUses: 1,
+  },
+  'tiefling-infernal-hellish-rebuke': {
+    spellName: 'Hellish Rebuke',
+    maxUses: 1,
+  },
+  'tiefling-infernal-fireball': {
+    spellName: 'Fireball',
+    maxUses: 1,
+  },
 };
 
 const LIMITED_USE_LINEAGE_SPELL_IDS = Object.entries(LINEAGE_SPELLS)
@@ -165,6 +189,73 @@ export default function Features({
     return gnomeLineageAbility.trim();
   }, [gnomeLineageAbility]);
 
+  const { tieflingLegacy, tieflingLegacyKey, tieflingLegacyAbility } = useMemo(() => {
+    const race = form?.race || {};
+    const legacyFromForm =
+      typeof form?.tieflingLegacy === 'object' ? form.tieflingLegacy : null;
+    const legacyKeyFromForm =
+      typeof form?.tieflingLegacyKey === 'string' ? form.tieflingLegacyKey : '';
+    const abilityFromForm =
+      typeof form?.tieflingLegacyAbility === 'string'
+        ? form.tieflingLegacyAbility
+        : '';
+
+    let legacy = legacyFromForm;
+    let legacyKey = legacyKeyFromForm;
+    if (!legacy) {
+      if (legacyKey && race?.fiendishLegacies?.[legacyKey]) {
+        legacy = race.fiendishLegacies[legacyKey];
+      } else if (race?.selectedAncestry && race?.fiendishLegacies) {
+        legacy = race.selectedAncestry;
+        legacyKey =
+          typeof race?.selectedAncestryKey === 'string'
+            ? race.selectedAncestryKey
+            : '';
+      } else if (
+        typeof race?.selectedAncestryKey === 'string' &&
+        race?.fiendishLegacies?.[race.selectedAncestryKey]
+      ) {
+        legacy = race.fiendishLegacies[race.selectedAncestryKey];
+        legacyKey = race.selectedAncestryKey;
+      }
+    }
+
+    let ability = abilityFromForm;
+    if (!ability) {
+      ability =
+        typeof race?.selectedLineageAbility === 'string'
+          ? race.selectedLineageAbility
+          : '';
+    }
+    if (!ability && legacy?.spellcastingAbilities?.length) {
+      ability = legacy.spellcastingAbilities[0];
+    }
+
+    return {
+      tieflingLegacy: legacy,
+      tieflingLegacyKey: legacyKey,
+      tieflingLegacyAbility: ability,
+    };
+  }, [
+    form?.race,
+    form?.tieflingLegacy,
+    form?.tieflingLegacyAbility,
+    form?.tieflingLegacyKey,
+  ]);
+
+  const tieflingSpellAbilityLabel = useMemo(() => {
+    if (typeof tieflingLegacyAbility !== 'string') return '';
+    return tieflingLegacyAbility.trim();
+  }, [tieflingLegacyAbility]);
+
+  const tieflingResistanceLabel = useMemo(() => {
+    const resistance = tieflingLegacy?.resistance;
+    if (typeof resistance !== 'string') {
+      return '';
+    }
+    return resistance.trim();
+  }, [tieflingLegacy]);
+
   const { elvenLineage, elvenLineageKey, elvenLineageAbility } = useMemo(() => {
     const race = form?.race || {};
     const lineageFromForm =
@@ -237,6 +328,23 @@ export default function Features({
     if (!gnomeLineageKey) return false;
     return gnomeLineageKey.toLowerCase() === 'rock';
   }, [gnomeLineageKey]);
+
+  const normalizedTieflingLegacyKey = useMemo(() => {
+    if (!tieflingLegacyKey) return '';
+    return tieflingLegacyKey.toLowerCase();
+  }, [tieflingLegacyKey]);
+
+  const isAbyssalTieflingLegacy = useMemo(() => {
+    return normalizedTieflingLegacyKey === 'abyssal';
+  }, [normalizedTieflingLegacyKey]);
+
+  const isChthonicTieflingLegacy = useMemo(() => {
+    return normalizedTieflingLegacyKey === 'chthonic';
+  }, [normalizedTieflingLegacyKey]);
+
+  const isInfernalTieflingLegacy = useMemo(() => {
+    return normalizedTieflingLegacyKey === 'infernal';
+  }, [normalizedTieflingLegacyKey]);
 
   const canUseSpeakWithAnimals = useMemo(() => {
     return isForestGnomeLineage;
@@ -319,11 +427,26 @@ export default function Features({
       'elf-wood-longstrider': isWoodElvenLineage && totalCharacterLevel >= 3,
       'elf-wood-pass-without-trace':
         isWoodElvenLineage && totalCharacterLevel >= 5,
+      'tiefling-abyssal-ray-of-sickness':
+        isAbyssalTieflingLegacy && totalCharacterLevel >= 3,
+      'tiefling-abyssal-hold-person':
+        isAbyssalTieflingLegacy && totalCharacterLevel >= 5,
+      'tiefling-chthonic-darkness':
+        isChthonicTieflingLegacy && totalCharacterLevel >= 3,
+      'tiefling-chthonic-bestow-curse':
+        isChthonicTieflingLegacy && totalCharacterLevel >= 5,
+      'tiefling-infernal-hellish-rebuke':
+        isInfernalTieflingLegacy && totalCharacterLevel >= 3,
+      'tiefling-infernal-fireball':
+        isInfernalTieflingLegacy && totalCharacterLevel >= 5,
     };
   }, [
     isDrowElvenLineage,
     isHighElvenLineage,
     isWoodElvenLineage,
+    isAbyssalTieflingLegacy,
+    isChthonicTieflingLegacy,
+    isInfernalTieflingLegacy,
     totalCharacterLevel,
   ]);
 
@@ -806,6 +929,87 @@ export default function Features({
           hideUseButton: true,
         });
       }
+    } else if (raceName === 'tiefling') {
+      const legacyLabel =
+        typeof tieflingLegacy?.label === 'string'
+          ? tieflingLegacy.label
+          : typeof tieflingLegacy?.name === 'string'
+          ? tieflingLegacy.name
+          : 'Fiendish Legacy';
+      const metaParts = [legacyLabel];
+      if (tieflingResistanceLabel) {
+        metaParts.push(`Resistance: ${tieflingResistanceLabel}`);
+      }
+      if (tieflingSpellAbilityLabel) {
+        metaParts.push(`Spellcasting Ability: ${tieflingSpellAbilityLabel}`);
+      }
+      const legacyMeta = metaParts.join(' • ');
+      const abilityText = tieflingSpellAbilityLabel
+        ? ` This legacy uses ${tieflingSpellAbilityLabel} for its spells.`
+        : '';
+
+      if (tieflingResistanceLabel) {
+        const resistanceDescription =
+          `You have resistance to ${tieflingResistanceLabel.toLowerCase()} damage.`;
+        raceFeatures.push({
+          id: `tiefling-${normalizedTieflingLegacyKey || 'legacy'}-resistance`,
+          name: `${tieflingResistanceLabel} Resistance`,
+          meta: legacyMeta,
+          description: resistanceDescription,
+          desc: resistanceDescription,
+          hideUseButton: true,
+        });
+      }
+
+      const spells = Array.isArray(tieflingLegacy?.spells)
+        ? tieflingLegacy.spells
+        : [];
+
+      const legacyKeyForId = normalizedTieflingLegacyKey || 'legacy';
+
+      spells.forEach((spell, index) => {
+        const requiredLevelRaw = Number(spell?.unlockedAtLevel);
+        const requiredLevel = Number.isFinite(requiredLevelRaw)
+          ? requiredLevelRaw
+          : 1;
+        if (totalCharacterLevel < Math.max(1, requiredLevel)) {
+          return;
+        }
+
+        const spellName = typeof spell?.name === 'string' ? spell.name : 'Legacy Spell';
+        const normalizedSpellName = spellName
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/(^-|-$)/g, '') || `spell-${index}`;
+        const spellId = `tiefling-${legacyKeyForId}-${normalizedSpellName}`;
+        const baseSpellConfig = LINEAGE_SPELLS[spellId];
+        const hasLimitedUses =
+          Number.isFinite(baseSpellConfig?.maxUses) && baseSpellConfig.maxUses > 0;
+
+        const descriptionParts = [];
+        if (typeof spell?.description === 'string' && spell.description.trim()) {
+          descriptionParts.push(spell.description.trim());
+        }
+        if (abilityText) {
+          descriptionParts.push(abilityText.trim());
+        }
+        if (typeof spell?.usage === 'string' && spell.usage.trim()) {
+          descriptionParts.push(`Uses: ${spell.usage.trim()}`);
+        }
+        const description = descriptionParts.join(' ');
+        const levelNote = requiredLevel > 1 ? ` (Level ${requiredLevel})` : '';
+
+        raceFeatures.push({
+          id: spellId,
+          name: `${spellName}${levelNote}`,
+          meta: legacyMeta,
+          description,
+          desc: description,
+          hideUseButton: !hasLimitedUses,
+          oncePerLongRestLineageSpell: hasLimitedUses,
+          lineageSpellName: baseSpellConfig?.spellName || spellName,
+        });
+      });
     }
 
     if (darkvisionRange && raceName !== 'dwarf' && raceName !== 'orc') {
@@ -975,6 +1179,18 @@ export default function Features({
     gnomeLineage,
     gnomeSpellAbilityLabel,
     isForestGnomeLineage,
+    isRockGnomeLineage,
+    elvenLineage,
+    elvenLineageKey,
+    elvenSpellAbilityLabel,
+    isDrowElvenLineage,
+    isHighElvenLineage,
+    isWoodElvenLineage,
+    tieflingLegacy,
+    tieflingLegacyKey,
+    tieflingSpellAbilityLabel,
+    tieflingResistanceLabel,
+    normalizedTieflingLegacyKey,
   ]);
 
   const displayFeatures = useMemo(() => {

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1239,6 +1239,114 @@ test('Speak with Animals wand button respects available uses and slots', async (
   await waitFor(() => expect(getWandButton()).toBeDisabled());
 });
 
+test('tiefling fiendish legacy shows resistance and spells with ability details', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const infernalLegacy = {
+    label: 'Infernal Legacy',
+    resistance: 'Fire',
+    spellcastingAbilities: ['Intelligence', 'Wisdom', 'Charisma'],
+    spells: [
+      {
+        name: 'Fire Bolt',
+        spellLevel: 'Cantrip',
+        unlockedAtLevel: 1,
+        description:
+          'Launch a mote of fire at a creature within range, dealing fire damage on a hit.',
+        usage: 'At will',
+      },
+      {
+        name: 'Hellish Rebuke',
+        spellLevel: '1st-level',
+        unlockedAtLevel: 3,
+        description:
+          'Surround an attacker in searing flame as a reaction, forcing a Dexterity save or dealing fire damage.',
+        usage: '1/long rest',
+      },
+      {
+        name: 'Fireball',
+        spellLevel: '3rd-level',
+        unlockedAtLevel: 5,
+        description:
+          'Detonate a roaring explosion of flame that engulfs creatures in a 20-foot-radius sphere.',
+        usage: '1/long rest',
+      },
+    ],
+  };
+
+  render(
+    <Features
+      form={{
+        race: {
+          name: 'Tiefling',
+          darkvisionRange: 60,
+          fiendishLegacies: { infernal: infernalLegacy },
+        },
+        tieflingLegacyKey: 'infernal',
+        tieflingLegacy: infernalLegacy,
+        tieflingLegacyAbility: 'Charisma',
+        occupation: [{ Name: 'Wizard', Level: 5 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      longRestCount={0}
+      shortRestCount={0}
+      availableSlots={{ regular: { 3: 1 } }}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const resistanceTitle = await screen.findByText('Fire Resistance');
+  const resistanceCard = resistanceTitle.closest('.feature-card');
+  expect(resistanceCard).not.toBeNull();
+  if (!resistanceCard) {
+    throw new Error('Expected Fire Resistance card');
+  }
+  const resistanceWithin = within(resistanceCard);
+  expect(resistanceWithin.getByText(/Resistance: Fire/i)).toBeInTheDocument();
+  expect(resistanceWithin.getByText(/Spellcasting Ability: Charisma/i)).toBeInTheDocument();
+
+  const fireBoltCard = screen.getByText('Fire Bolt').closest('.feature-card');
+  expect(fireBoltCard).not.toBeNull();
+  if (!fireBoltCard) {
+    throw new Error('Expected Fire Bolt card');
+  }
+  expect(
+    within(fireBoltCard).getByText(/Spellcasting Ability: Charisma/i)
+  ).toBeInTheDocument();
+
+  const hellishCard = screen
+    .getByText('Hellish Rebuke (Level 3)')
+    .closest('.feature-card');
+  expect(hellishCard).not.toBeNull();
+  if (!hellishCard) {
+    throw new Error('Expected Hellish Rebuke card');
+  }
+  const hellishWithin = within(hellishCard);
+  expect(hellishWithin.getByText(/Uses remaining/i)).toBeInTheDocument();
+  const viewHellish = hellishWithin.getByRole('button', { name: /view feature/i });
+  await act(async () => {
+    await userEvent.click(viewHellish);
+  });
+  expect(
+    await screen.findByText(/This legacy uses Charisma for its spells\./i)
+  ).toBeInTheDocument();
+  expect(screen.getByText(/Uses: 1\/long rest/i)).toBeInTheDocument();
+  const hellishModal = screen.getByText(/Uses: 1\/long rest/i).closest('.modal-content');
+  if (!hellishModal) {
+    throw new Error('Expected Hellish Rebuke modal');
+  }
+  const closeButton = within(hellishModal).getByRole('button', { name: /close/i });
+  await act(async () => {
+    await userEvent.click(closeButton);
+  });
+
+  expect(screen.getByText('Fireball (Level 5)')).toBeInTheDocument();
+});
+
 test('orc characters display racial traits and track Adrenaline Rush uses with rests', async () => {
   apiFetch.mockResolvedValue({
     ok: true,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -79,6 +79,9 @@ const createDefaultForm = useCallback((campaign) => {
     elvenLineageKey: "",
     elvenLineage: null,
     elvenLineageAbility: "",
+    tieflingLegacyKey: "",
+    tieflingLegacy: null,
+    tieflingLegacyAbility: "",
     background: null,
     feat: [],
     weapon: [],
@@ -229,6 +232,9 @@ const attachSelectedAncestryToRace = useCallback((race, {
   elvenLineageKey,
   elvenLineage,
   elvenLineageAbility,
+  tieflingLegacyKey,
+  tieflingLegacy,
+  tieflingLegacyAbility,
 }) => {
   if (!race) return race;
   const updatedRace = { ...race };
@@ -259,6 +265,7 @@ const attachSelectedAncestryToRace = useCallback((race, {
   delete updatedRace.selectedAncestryKey;
   delete updatedRace.selectedAncestry;
   delete updatedRace.selectedLineageAbility;
+  delete updatedRace.selectedFiendishLegacyResistance;
 
   if (race.dragonAncestries && dragonAncestryKey && dragonAncestry) {
     updatedRace.selectedAncestryKey = dragonAncestryKey;
@@ -277,6 +284,15 @@ const attachSelectedAncestryToRace = useCallback((race, {
     updatedRace.selectedAncestry = elvenLineage;
     if (elvenLineageAbility) {
       updatedRace.selectedLineageAbility = elvenLineageAbility;
+    }
+  } else if (race.fiendishLegacies && tieflingLegacyKey && tieflingLegacy) {
+    updatedRace.selectedAncestryKey = tieflingLegacyKey;
+    updatedRace.selectedAncestry = tieflingLegacy;
+    if (tieflingLegacyAbility) {
+      updatedRace.selectedLineageAbility = tieflingLegacyAbility;
+    }
+    if (tieflingLegacy?.resistance) {
+      updatedRace.selectedFiendishLegacyResistance = tieflingLegacy.resistance;
     }
   }
 
@@ -307,6 +323,20 @@ const attachSelectedAncestryToRace = useCallback((race, {
     if (lineageDarkvision != null) {
       updatedRace.darkvisionRange = lineageDarkvision;
     } else if (typeof baseDarkvision !== "undefined") {
+      if (baseDarkvision === null) {
+        delete updatedRace.darkvisionRange;
+      } else {
+        updatedRace.darkvisionRange = baseDarkvision;
+      }
+    }
+  }
+
+  if (race.fiendishLegacies) {
+    if (typeof baseSpeed === "number") {
+      updatedRace.speed = baseSpeed;
+    }
+
+    if (typeof baseDarkvision !== "undefined") {
       if (baseDarkvision === null) {
         delete updatedRace.darkvisionRange;
       } else {
@@ -457,6 +487,9 @@ function bigMaff() {
     let selectedElvenLineageKey = "";
     let selectedElvenLineage = null;
     let selectedElvenLineageAbility = "";
+    let selectedTieflingLegacyKey = "";
+    let selectedTieflingLegacy = null;
+    let selectedTieflingLegacyAbility = "";
     if (chosenRace.name === "Dragonborn" && chosenRace.dragonAncestries) {
       const ancestryKeys = Object.keys(chosenRace.dragonAncestries);
       const alignmentLower = alignmentValue.toLowerCase();
@@ -515,6 +548,23 @@ function bigMaff() {
         }
       }
     }
+    if (chosenRace.name === "Tiefling" && chosenRace.fiendishLegacies) {
+      const legacyKeys = Object.keys(chosenRace.fiendishLegacies);
+      if (legacyKeys.length) {
+        selectedTieflingLegacyKey = legacyKeys[Math.floor(Math.random() * legacyKeys.length)];
+        selectedTieflingLegacy = chosenRace.fiendishLegacies[selectedTieflingLegacyKey];
+        chosenRace.selectedAncestryKey = selectedTieflingLegacyKey;
+        chosenRace.selectedAncestry = selectedTieflingLegacy;
+        const abilityOptions = selectedTieflingLegacy?.spellcastingAbilities || [];
+        if (abilityOptions.length) {
+          selectedTieflingLegacyAbility = abilityOptions[Math.floor(Math.random() * abilityOptions.length)];
+          chosenRace.selectedLineageAbility = selectedTieflingLegacyAbility;
+        }
+        if (selectedTieflingLegacy?.resistance) {
+          chosenRace.selectedFiendishLegacyResistance = selectedTieflingLegacy.resistance;
+        }
+      }
+    }
     const raceWithSelections = attachSelectedAncestryToRace(chosenRace, {
       dragonAncestryKey: selectedDragonAncestry ? selectedDragonAncestryKey : "",
       dragonAncestry: selectedDragonAncestry,
@@ -526,6 +576,9 @@ function bigMaff() {
       elvenLineageKey: selectedElvenLineage ? selectedElvenLineageKey : "",
       elvenLineage: selectedElvenLineage,
       elvenLineageAbility: selectedElvenLineageAbility,
+      tieflingLegacyKey: selectedTieflingLegacy ? selectedTieflingLegacyKey : "",
+      tieflingLegacy: selectedTieflingLegacy,
+      tieflingLegacyAbility: selectedTieflingLegacyAbility,
     });
     setForm((prev) => {
       const updatedSkills = { ...(prev.skills || {}) };
@@ -550,6 +603,9 @@ function bigMaff() {
         elvenLineageKey: selectedElvenLineage ? selectedElvenLineageKey : "",
         elvenLineage: selectedElvenLineage || null,
         elvenLineageAbility: selectedElvenLineageAbility || "",
+        tieflingLegacyKey: selectedTieflingLegacy ? selectedTieflingLegacyKey : "",
+        tieflingLegacy: selectedTieflingLegacy || null,
+        tieflingLegacyAbility: selectedTieflingLegacyAbility || "",
       };
       if (Object.keys(updatedSkills).length) {
         nextForm.skills = updatedSkills;
@@ -677,6 +733,9 @@ useEffect(() => {
         elvenLineageKey: baseCharacter.elvenLineageKey,
         elvenLineage: baseCharacter.elvenLineage,
         elvenLineageAbility: baseCharacter.elvenLineageAbility,
+        tieflingLegacyKey: baseCharacter.tieflingLegacyKey,
+        tieflingLegacy: baseCharacter.tieflingLegacy,
+        tieflingLegacyAbility: baseCharacter.tieflingLegacyAbility,
       }
     );
     if (raceWithAncestry) {
@@ -752,6 +811,9 @@ const handleRaceChange = (e) => {
         elvenLineageKey: "",
         elvenLineage: null,
         elvenLineageAbility: "",
+        tieflingLegacyKey: "",
+        tieflingLegacy: null,
+        tieflingLegacyAbility: "",
       };
     }
 
@@ -777,6 +839,9 @@ const handleRaceChange = (e) => {
     let elvenLineageKey = "";
     let elvenLineage = null;
     let elvenLineageAbility = "";
+    let tieflingLegacyKey = "";
+    let tieflingLegacy = null;
+    let tieflingLegacyAbility = "";
     if (raceObj.dragonAncestries) {
       const prevKey =
         prev.race?.name === raceObj.name && prev.dragonAncestryKey
@@ -843,6 +908,29 @@ const handleRaceChange = (e) => {
       }
     }
 
+    if (raceObj.fiendishLegacies) {
+      const prevKey =
+        prev.race?.name === raceObj.name && prev.tieflingLegacyKey
+          ? prev.tieflingLegacyKey
+          : "";
+      if (prevKey && raceObj.fiendishLegacies[prevKey]) {
+        tieflingLegacyKey = prevKey;
+        tieflingLegacy = raceObj.fiendishLegacies[prevKey];
+        const prevAbility =
+          prev.race?.name === raceObj.name && prev.tieflingLegacyAbility
+            ? prev.tieflingLegacyAbility
+            : "";
+        if (
+          prevAbility &&
+          tieflingLegacy?.spellcastingAbilities?.includes(prevAbility)
+        ) {
+          tieflingLegacyAbility = prevAbility;
+        } else if ((tieflingLegacy?.spellcastingAbilities || []).length === 1) {
+          tieflingLegacyAbility = tieflingLegacy.spellcastingAbilities[0];
+        }
+      }
+    }
+
     const updatedRace = attachSelectedAncestryToRace(raceObj, {
       dragonAncestryKey,
       dragonAncestry,
@@ -854,6 +942,9 @@ const handleRaceChange = (e) => {
       elvenLineageKey,
       elvenLineage,
       elvenLineageAbility,
+      tieflingLegacyKey,
+      tieflingLegacy,
+      tieflingLegacyAbility,
     });
 
     const updatedForm = {
@@ -874,6 +965,9 @@ const handleRaceChange = (e) => {
       elvenLineageKey,
       elvenLineage,
       elvenLineageAbility,
+      tieflingLegacyKey,
+      tieflingLegacy,
+      tieflingLegacyAbility,
     };
 
     if (Object.keys(updatedSkills).length) {
@@ -899,6 +993,9 @@ const handleDragonAncestryChange = (e) => {
         elvenLineageKey: prev.elvenLineageKey,
         elvenLineage: prev.elvenLineage,
         elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
       });
       return {
         ...prev,
@@ -913,6 +1010,9 @@ const handleDragonAncestryChange = (e) => {
         elvenLineageKey: prev.elvenLineageKey,
         elvenLineage: prev.elvenLineage,
         elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
         speed:
           typeof updatedRace?.speed === "number"
             ? updatedRace.speed
@@ -932,6 +1032,9 @@ const handleDragonAncestryChange = (e) => {
       elvenLineageKey: "",
       elvenLineage: null,
       elvenLineageAbility: "",
+      tieflingLegacyKey: "",
+      tieflingLegacy: null,
+      tieflingLegacyAbility: "",
     });
 
     return {
@@ -947,6 +1050,9 @@ const handleDragonAncestryChange = (e) => {
       elvenLineageKey: "",
       elvenLineage: null,
       elvenLineageAbility: "",
+      tieflingLegacyKey: "",
+      tieflingLegacy: null,
+      tieflingLegacyAbility: "",
       speed:
         typeof updatedRace?.speed === "number"
           ? updatedRace.speed
@@ -970,6 +1076,9 @@ const handleGiantAncestryChange = (e) => {
         elvenLineageKey: prev.elvenLineageKey,
         elvenLineage: prev.elvenLineage,
         elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
       });
       return {
         ...prev,
@@ -984,6 +1093,9 @@ const handleGiantAncestryChange = (e) => {
         elvenLineageKey: prev.elvenLineageKey,
         elvenLineage: prev.elvenLineage,
         elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
         speed:
           typeof updatedRace?.speed === "number"
             ? updatedRace.speed
@@ -1003,6 +1115,9 @@ const handleGiantAncestryChange = (e) => {
       elvenLineageKey: "",
       elvenLineage: null,
       elvenLineageAbility: "",
+      tieflingLegacyKey: "",
+      tieflingLegacy: null,
+      tieflingLegacyAbility: "",
     });
 
     return {
@@ -1018,6 +1133,9 @@ const handleGiantAncestryChange = (e) => {
       elvenLineageKey: "",
       elvenLineage: null,
       elvenLineageAbility: "",
+      tieflingLegacyKey: "",
+      tieflingLegacy: null,
+      tieflingLegacyAbility: "",
       speed:
         typeof updatedRace?.speed === "number"
           ? updatedRace.speed
@@ -1041,6 +1159,9 @@ const handleGnomeLineageChange = (e) => {
         elvenLineageKey: prev.elvenLineageKey,
         elvenLineage: prev.elvenLineage,
         elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
       });
       return {
         ...prev,
@@ -1048,6 +1169,9 @@ const handleGnomeLineageChange = (e) => {
         gnomeLineageKey: "",
         gnomeLineage: null,
         gnomeLineageAbility: "",
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
         speed:
           typeof updatedRace?.speed === "number"
             ? updatedRace.speed
@@ -1077,6 +1201,9 @@ const handleGnomeLineageChange = (e) => {
       elvenLineageKey: prev.elvenLineageKey,
       elvenLineage: prev.elvenLineage,
       elvenLineageAbility: prev.elvenLineageAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
     });
 
     return {
@@ -1085,6 +1212,9 @@ const handleGnomeLineageChange = (e) => {
       gnomeLineageKey: lineage ? key : "",
       gnomeLineage: lineage || null,
       gnomeLineageAbility: nextAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
       speed:
         typeof updatedRace?.speed === "number"
           ? updatedRace.speed
@@ -1108,11 +1238,17 @@ const handleGnomeLineageAbilityChange = (e) => {
         elvenLineageKey: prev.elvenLineageKey,
         elvenLineage: prev.elvenLineage,
         elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
       });
       return {
         ...prev,
         race: updatedRace,
         gnomeLineageAbility: "",
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
         speed:
           typeof updatedRace?.speed === "number"
             ? updatedRace.speed
@@ -1135,12 +1271,18 @@ const handleGnomeLineageAbilityChange = (e) => {
       elvenLineageKey: prev.elvenLineageKey,
       elvenLineage: prev.elvenLineage,
       elvenLineageAbility: prev.elvenLineageAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
     });
 
     return {
       ...prev,
       race: updatedRace,
       gnomeLineageAbility: validAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
       speed:
         typeof updatedRace?.speed === "number"
           ? updatedRace.speed
@@ -1164,6 +1306,9 @@ const handleElvenLineageChange = (e) => {
         elvenLineageKey: "",
         elvenLineage: null,
         elvenLineageAbility: "",
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
       });
       return {
         ...prev,
@@ -1171,6 +1316,9 @@ const handleElvenLineageChange = (e) => {
         elvenLineageKey: "",
         elvenLineage: null,
         elvenLineageAbility: "",
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
         speed:
           typeof updatedRace?.speed === "number"
             ? updatedRace.speed
@@ -1200,6 +1348,9 @@ const handleElvenLineageChange = (e) => {
       elvenLineageKey: lineage ? key : "",
       elvenLineage: lineage || null,
       elvenLineageAbility: nextAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
     });
 
     return {
@@ -1208,6 +1359,9 @@ const handleElvenLineageChange = (e) => {
       elvenLineageKey: lineage ? key : "",
       elvenLineage: lineage || null,
       elvenLineageAbility: nextAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
       speed:
         typeof updatedRace?.speed === "number"
           ? updatedRace.speed
@@ -1231,11 +1385,17 @@ const handleElvenLineageAbilityChange = (e) => {
         elvenLineageKey: "",
         elvenLineage: null,
         elvenLineageAbility: "",
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
       });
       return {
         ...prev,
         race: updatedRace,
         elvenLineageAbility: "",
+        tieflingLegacyKey: prev.tieflingLegacyKey,
+        tieflingLegacy: prev.tieflingLegacy,
+        tieflingLegacyAbility: prev.tieflingLegacyAbility,
         speed:
           typeof updatedRace?.speed === "number"
             ? updatedRace.speed
@@ -1258,12 +1418,153 @@ const handleElvenLineageAbilityChange = (e) => {
       elvenLineageKey: lineage ? prev.elvenLineageKey : "",
       elvenLineage: lineage || null,
       elvenLineageAbility: validAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
     });
 
     return {
       ...prev,
       race: updatedRace,
       elvenLineageAbility: validAbility,
+      tieflingLegacyKey: prev.tieflingLegacyKey,
+      tieflingLegacy: prev.tieflingLegacy,
+      tieflingLegacyAbility: prev.tieflingLegacyAbility,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
+    };
+  });
+};
+
+const handleTieflingLegacyChange = (e) => {
+  const key = e.target.value;
+  setForm((prev) => {
+    if (!prev.race?.fiendishLegacies) {
+      const updatedRace = attachSelectedAncestryToRace(prev.race, {
+        dragonAncestryKey: prev.dragonAncestryKey,
+        dragonAncestry: prev.dragonAncestry,
+        giantAncestryKey: prev.giantAncestryKey,
+        giantAncestry: prev.giantAncestry,
+        gnomeLineageKey: prev.gnomeLineageKey,
+        gnomeLineage: prev.gnomeLineage,
+        gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: "",
+        tieflingLegacy: null,
+        tieflingLegacyAbility: "",
+      });
+      return {
+        ...prev,
+        race: updatedRace,
+        tieflingLegacyKey: "",
+        tieflingLegacy: null,
+        tieflingLegacyAbility: "",
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
+      };
+    }
+
+    const legacy = prev.race.fiendishLegacies[key];
+    const abilityOptions = legacy?.spellcastingAbilities || [];
+    let nextAbility = "";
+    if (legacy) {
+      if (abilityOptions.includes(prev.tieflingLegacyAbility)) {
+        nextAbility = prev.tieflingLegacyAbility;
+      } else if (abilityOptions.length === 1) {
+        nextAbility = abilityOptions[0];
+      }
+    }
+
+    const updatedRace = attachSelectedAncestryToRace(prev.race, {
+      dragonAncestryKey: prev.dragonAncestryKey,
+      dragonAncestry: prev.dragonAncestry,
+      giantAncestryKey: prev.giantAncestryKey,
+      giantAncestry: prev.giantAncestry,
+      gnomeLineageKey: prev.gnomeLineageKey,
+      gnomeLineage: prev.gnomeLineage,
+      gnomeLineageAbility: prev.gnomeLineageAbility,
+      elvenLineageKey: prev.elvenLineageKey,
+      elvenLineage: prev.elvenLineage,
+      elvenLineageAbility: prev.elvenLineageAbility,
+      tieflingLegacyKey: legacy ? key : "",
+      tieflingLegacy: legacy || null,
+      tieflingLegacyAbility: nextAbility,
+    });
+
+    return {
+      ...prev,
+      race: updatedRace,
+      tieflingLegacyKey: legacy ? key : "",
+      tieflingLegacy: legacy || null,
+      tieflingLegacyAbility: nextAbility,
+      speed:
+        typeof updatedRace?.speed === "number"
+          ? updatedRace.speed
+          : prev.speed,
+    };
+  });
+};
+
+const handleTieflingLegacyAbilityChange = (e) => {
+  const ability = e.target.value;
+  setForm((prev) => {
+    if (!prev.race?.fiendishLegacies || !prev.tieflingLegacyKey) {
+      const updatedRace = attachSelectedAncestryToRace(prev.race, {
+        dragonAncestryKey: prev.dragonAncestryKey,
+        dragonAncestry: prev.dragonAncestry,
+        giantAncestryKey: prev.giantAncestryKey,
+        giantAncestry: prev.giantAncestry,
+        gnomeLineageKey: prev.gnomeLineageKey,
+        gnomeLineage: prev.gnomeLineage,
+        gnomeLineageAbility: prev.gnomeLineageAbility,
+        elvenLineageKey: prev.elvenLineageKey,
+        elvenLineage: prev.elvenLineage,
+        elvenLineageAbility: prev.elvenLineageAbility,
+        tieflingLegacyKey: "",
+        tieflingLegacy: null,
+        tieflingLegacyAbility: "",
+      });
+      return {
+        ...prev,
+        race: updatedRace,
+        tieflingLegacyAbility: "",
+        speed:
+          typeof updatedRace?.speed === "number"
+            ? updatedRace.speed
+            : prev.speed,
+      };
+    }
+
+    const legacy = prev.race.fiendishLegacies[prev.tieflingLegacyKey];
+    const validAbility =
+      legacy?.spellcastingAbilities?.includes(ability) ? ability : "";
+
+    const updatedRace = attachSelectedAncestryToRace(prev.race, {
+      dragonAncestryKey: prev.dragonAncestryKey,
+      dragonAncestry: prev.dragonAncestry,
+      giantAncestryKey: prev.giantAncestryKey,
+      giantAncestry: prev.giantAncestry,
+      gnomeLineageKey: prev.gnomeLineageKey,
+      gnomeLineage: prev.gnomeLineage,
+      gnomeLineageAbility: prev.gnomeLineageAbility,
+      elvenLineageKey: prev.elvenLineageKey,
+      elvenLineage: prev.elvenLineage,
+      elvenLineageAbility: prev.elvenLineageAbility,
+      tieflingLegacyKey: legacy ? prev.tieflingLegacyKey : "",
+      tieflingLegacy: legacy || null,
+      tieflingLegacyAbility: validAbility,
+    });
+
+    return {
+      ...prev,
+      race: updatedRace,
+      tieflingLegacyAbility: validAbility,
       speed:
         typeof updatedRace?.speed === "number"
           ? updatedRace.speed
@@ -1395,6 +1696,9 @@ const sendManualToDb = useCallback(async (characterData) => {
       elvenLineageKey: baseCharacter.elvenLineageKey,
       elvenLineage: baseCharacter.elvenLineage,
       elvenLineageAbility: baseCharacter.elvenLineageAbility,
+      tieflingLegacyKey: baseCharacter.tieflingLegacyKey,
+      tieflingLegacy: baseCharacter.tieflingLegacy,
+      tieflingLegacyAbility: baseCharacter.tieflingLegacyAbility,
     }
   );
   if (raceWithAncestry) {
@@ -1487,6 +1791,9 @@ const handleAbilitySkillConfirm = () => {
       elvenLineageKey: form.elvenLineageKey,
       elvenLineage: form.elvenLineage,
       elvenLineageAbility: form.elvenLineageAbility,
+      tieflingLegacyKey: form.tieflingLegacyKey,
+      tieflingLegacy: form.tieflingLegacy,
+      tieflingLegacyAbility: form.tieflingLegacyAbility,
     }
   );
   const updatedForm = {
@@ -1735,6 +2042,38 @@ const getAvailableSkillOptions = (index) => {
                 >
                   <option value="" disabled>Select your spellcasting ability</option>
                   {(form.gnomeLineage?.spellcastingAbilities || []).map((ability) => (
+                    <option key={ability} value={ability}>
+                      {ability}
+                    </option>
+                  ))}
+                </Form.Select>
+              </>
+            ) : null}
+          </>
+        )}
+        {form.race?.name === "Tiefling" && (
+          <>
+            <Form.Label className="text-light">Fiendish Legacy</Form.Label>
+            <Form.Select
+              value={form.tieflingLegacyKey || ""}
+              onChange={handleTieflingLegacyChange}
+            >
+              <option value="" disabled>Select your fiendish legacy</option>
+              {Object.entries(form.race.fiendishLegacies || {}).map(([key, legacy]) => (
+                <option key={key} value={key}>
+                  {legacy.label || legacy.name || "Fiendish Legacy"}
+                </option>
+              ))}
+            </Form.Select>
+            {form.tieflingLegacy?.spellcastingAbilities?.length ? (
+              <>
+                <Form.Label className="text-light">Spellcasting Ability</Form.Label>
+                <Form.Select
+                  value={form.tieflingLegacyAbility || ""}
+                  onChange={handleTieflingLegacyAbilityChange}
+                >
+                  <option value="" disabled>Select your spellcasting ability</option>
+                  {(form.tieflingLegacy?.spellcastingAbilities || []).map((ability) => (
                     <option key={ability} value={ability}>
                       {ability}
                     </option>


### PR DESCRIPTION
## Summary
- add tiefling legacy selection state, handlers, and UI for character creation
- surface tiefling legacy details and spells in character info and features displays
- extend tests to cover tiefling legacy presentation

## Testing
- CI=true npm test -- CharacterInfo.test.js Features.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e17b2102608323b9419f1bc7659e98