### PR TITLE
Add figurine imagery overlays to campaign map board

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2729,12 +2729,37 @@ h1 {
     filter: drop-shadow(0 0.35rem 0.85rem rgba(6, 7, 10, 0.65))
       drop-shadow(0 0.05rem 0.25rem rgba(255, 255, 255, 0.12));
     transition: transform 0.2s ease, filter 0.2s ease;
+    position: relative;
   }
 
   &__figurine--active {
     transform: translateY(-3px) scale(1.02);
     filter: drop-shadow(0 0.55rem 1.25rem rgba(7, 8, 13, 0.75))
       drop-shadow(0 0.15rem 0.35rem rgba(255, 255, 255, 0.2));
+  }
+
+  &__figurine-image-wrapper {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  &__figurine-image {
+    width: var(--figurine-body-width);
+    max-width: 100%;
+    height: auto;
+    max-height: calc(var(--figurine-base-size) * 2.35);
+    object-fit: contain;
+    filter: drop-shadow(0 0.4rem 0.9rem rgba(0, 0, 0, 0.55));
+  }
+
+  &__figurine--has-image .campaign-map-board__figurine-figure {
+    opacity: 0;
   }
 
   &__figurine-figure {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useMemo, useCallback, useEffect } from 'react'
 import PropTypes from 'prop-types';
 import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
+import { resolveFigurineImageData } from '../utils/figurineAssets';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -461,6 +462,9 @@ const CampaignMapBoard = ({
                     ? ENEMY_FIGURINE_COLOR
                     : normalizeText(color) || undefined;
 
+                const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(token);
+                const hasFigurineImage = Boolean(figurineImageUrl);
+
                 const labelClassName = classNames(
                   'campaign-map-board__figurine-label',
                   normalizedVariant ? `campaign-map-board__figurine-label--${normalizedVariant}` : null
@@ -546,10 +550,22 @@ const CampaignMapBoard = ({
                       className={classNames(
                         'campaign-map-board__figurine',
                         draggable && 'campaign-map-board__figurine--active',
-                        isActiveTurn && 'campaign-map-board__figurine--active-turn'
+                        isActiveTurn && 'campaign-map-board__figurine--active-turn',
+                        hasFigurineImage && 'campaign-map-board__figurine--has-image'
                       )}
                       style={{ '--figurine-color': figurineColor }}
                     >
+                      {hasFigurineImage && (
+                        <span className="campaign-map-board__figurine-image-wrapper" aria-hidden="true">
+                          <img
+                            src={figurineImageUrl}
+                            alt=""
+                            className="campaign-map-board__figurine-image"
+                            data-figurine-public-id={figurineImagePublicId || undefined}
+                            loading="lazy"
+                          />
+                        </span>
+                      )}
                       <span className="campaign-map-board__figurine-figure" aria-hidden="true">
                         <span className="campaign-map-board__figurine-head" />
                         <span className="campaign-map-board__figurine-torso" />
@@ -594,6 +610,8 @@ CampaignMapBoard.propTypes = {
       maxHp: PropTypes.number,
       isActiveTurn: PropTypes.bool,
       size: PropTypes.string,
+      figurineImageUrl: PropTypes.string,
+      figurineImagePublicId: PropTypes.string,
     })
   ),
   onTokenDragStart: PropTypes.func,

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -174,4 +174,23 @@ describe('CampaignMapBoard pointer interactions', () => {
 
     expect(pointerUpEvent.defaultPrevented).toBe(true);
   });
+
+  it('renders a figurine image overlay when provided and preserves accessibility labels', () => {
+    const { container } = renderBoard({
+      token: {
+        figurineImageUrl: ' https://example.com/figurines/hero.png ',
+        figurineImagePublicId: ' figurines/heroes/hero ',
+      },
+    });
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+    expect(tokenElement).toHaveAttribute('aria-label', 'Test Token');
+
+    const figurineImage = tokenElement.querySelector('.campaign-map-board__figurine-image');
+    expect(figurineImage).not.toBeNull();
+    expect(figurineImage).toHaveAttribute('src', 'https://example.com/figurines/hero.png');
+    expect(figurineImage).toHaveAttribute('data-figurine-public-id', 'figurines/heroes/hero');
+    expect(figurineImage?.getAttribute('alt')).toBe('');
+  });
 });

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -4,6 +4,7 @@ import { Modal, Button, ListGroup, Badge, Spinner, Alert } from 'react-bootstrap
 import MapDisplay from './MapDisplay';
 import CampaignMapBoard from './CampaignMapBoard';
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from '../utils/mapGrouping';
+import { resolveFigurineImageData } from '../utils/figurineAssets';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -447,6 +448,8 @@ const MapModal = ({
         const normalizedColor =
           typeof baseColor === 'string' && baseColor.trim() !== '' ? baseColor.trim() : null;
 
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(lookup, token);
+
         return {
           ...token,
           label: typeof rawLabel === 'string' ? rawLabel : token.characterId,
@@ -460,6 +463,8 @@ const MapModal = ({
           ...(currentHp !== null ? { currentHp } : {}),
           ...(maxHp !== null ? { maxHp } : {}),
           ...(size ? { size } : {}),
+          ...(figurineImageUrl ? { figurineImageUrl } : {}),
+          ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
         };
       })
       .sort((a, b) => {
@@ -973,6 +978,12 @@ MapModal.propTypes = {
     PropTypes.shape({
       color: PropTypes.string,
       label: PropTypes.string,
+      entityType: PropTypes.string,
+      currentHp: PropTypes.number,
+      maxHp: PropTypes.number,
+      size: PropTypes.string,
+      figurineImageUrl: PropTypes.string,
+      figurineImagePublicId: PropTypes.string,
     })
   ),
   onTokenMove: PropTypes.func,

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -121,3 +121,56 @@ describe('MapModal folder expansion', () => {
     expect(noFolderItem.dataset.folder).toBeUndefined();
   });
 });
+
+describe('MapModal figurine imagery', () => {
+  it('renders figurine overlays for board tokens with imagery metadata', async () => {
+    const { container } = render(
+      <MapModal
+        show
+        onHide={jest.fn()}
+        maps={[
+          {
+            mapId: 'map-1',
+            title: 'Forest Path',
+            imageUrl: 'https://example.com/map.png',
+          },
+        ]}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            hero: {
+              characterId: 'hero',
+              x: 0.25,
+              y: 0.5,
+              imageUrl: ' https://example.com/figurines/hero.png ',
+              cloudinaryPublicId: ' figurines/heroes/hero ',
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        activeCharacterId="hero"
+        characterLookup={{
+          hero: {
+            label: 'Hero',
+            entityType: 'character',
+          },
+        }}
+        onTokenMove={jest.fn()}
+        onTokenRemove={jest.fn()}
+        readOnly={false}
+      />
+    );
+
+    const tokenElement = await screen.findByRole('button', { name: 'Hero' });
+    expect(tokenElement).toBeInTheDocument();
+    expect(tokenElement).toHaveAttribute('aria-label', 'Hero');
+
+    const figurineImage = container.querySelector(
+      '[data-token-id="hero"] .campaign-map-board__figurine-image'
+    );
+    expect(figurineImage).not.toBeNull();
+    expect(figurineImage).toHaveAttribute('src', 'https://example.com/figurines/hero.png');
+    expect(figurineImage).toHaveAttribute('data-figurine-public-id', 'figurines/heroes/hero');
+    expect(figurineImage?.getAttribute('alt')).toBe('');
+  });
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -38,6 +38,7 @@ import speakWithAnimalsIcon from "../../../images/speak-with-animal.png";
 import ShopModal from "../attributes/ShopModal";
 import InventoryModal from "../attributes/InventoryModal";
 import EquipmentModal from "../attributes/EquipmentModal";
+import { resolveFigurineImageData } from '../utils/figurineAssets';
 import {
   normalizeItems as normalizeInventoryItems,
   normalizeAccessories as normalizeInventoryAccessories,
@@ -3213,6 +3214,8 @@ export default function ZombiesCharacterSheet() {
             value?.displayType
         );
 
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(value);
+
         lookup[trimmed] = {
           color,
           label,
@@ -3220,6 +3223,8 @@ export default function ZombiesCharacterSheet() {
           currentHp: Number.isFinite(currentHp) ? currentHp : null,
           maxHp: Number.isFinite(maxHp) ? maxHp : null,
           ...(recordSize ? { size: recordSize } : {}),
+          ...(figurineImageUrl ? { figurineImageUrl } : {}),
+          ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
         };
       });
     }
@@ -3258,6 +3263,8 @@ export default function ZombiesCharacterSheet() {
           enemy.size ?? enemy.displayType ?? enemy.type ?? enemy.enemyType
         );
 
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(enemy);
+
         lookup[enemyId] = {
           color: ENEMY_FIGURINE_COLOR,
           label,
@@ -3265,6 +3272,8 @@ export default function ZombiesCharacterSheet() {
           currentHp: enemyCurrentHp !== null ? enemyCurrentHp : null,
           maxHp: enemyMaxHp !== null ? enemyMaxHp : null,
           ...(enemySize ? { size: enemySize } : {}),
+          ...(figurineImageUrl ? { figurineImageUrl } : {}),
+          ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
         };
       });
     }
@@ -3297,6 +3306,8 @@ export default function ZombiesCharacterSheet() {
             form?.displayType
         );
 
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(form);
+
         lookup[resolvedCharacterId] = {
           color,
           label,
@@ -3304,6 +3315,8 @@ export default function ZombiesCharacterSheet() {
           currentHp: Number.isFinite(currentHp) ? currentHp : null,
           maxHp: Number.isFinite(maxHp) ? maxHp : null,
           ...(fallbackSize ? { size: fallbackSize } : {}),
+          ...(figurineImageUrl ? { figurineImageUrl } : {}),
+          ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
         };
       } else {
         const fallbackSize = normalizeCreatureSize(
@@ -3320,6 +3333,8 @@ export default function ZombiesCharacterSheet() {
 
         const nextEntry = { ...lookup[resolvedCharacterId] };
 
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(form);
+
         if (
           typeof nextEntry.entityType !== 'string' ||
           nextEntry.entityType.trim() === ''
@@ -3329,6 +3344,14 @@ export default function ZombiesCharacterSheet() {
 
         if (fallbackSize) {
           nextEntry.size = fallbackSize;
+        }
+
+        if (figurineImageUrl && !nextEntry.figurineImageUrl) {
+          nextEntry.figurineImageUrl = figurineImageUrl;
+        }
+
+        if (figurineImagePublicId && !nextEntry.figurineImagePublicId) {
+          nextEntry.figurineImagePublicId = figurineImagePublicId;
         }
 
         lookup[resolvedCharacterId] = nextEntry;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -65,6 +65,7 @@ import {
 } from "react-icons/gi";
 import { FiChevronDown, FiChevronRight, FiList, FiPlus } from "react-icons/fi";
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from "../utils/mapGrouping";
+import { resolveFigurineImageData } from '../utils/figurineAssets';
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -2771,6 +2772,8 @@ export default function ZombiesDM() {
               record?.displayType
           );
 
+          const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(record);
+
           identifiers.forEach((identifier) => {
             const trimmed = identifier.trim();
             if (!trimmed) {
@@ -2784,6 +2787,8 @@ export default function ZombiesDM() {
               ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
               ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
               ...(recordSize ? { size: recordSize } : {}),
+              ...(figurineImageUrl ? { figurineImageUrl } : {}),
+              ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
             };
           });
         });
@@ -2813,20 +2818,24 @@ export default function ZombiesDM() {
           );
           const enemyMaxHp = toFiniteNumberOrNull(enemy.maxHp ?? enemy.hitPoints);
 
-          const enemySize = normalizeCreatureSize(
-            enemy.size ?? enemy.displayType ?? enemy.type ?? enemy.enemyType
-          );
+        const enemySize = normalizeCreatureSize(
+          enemy.size ?? enemy.displayType ?? enemy.type ?? enemy.enemyType
+        );
 
-          lookup[enemyId] = {
-            color: ENEMY_FIGURINE_COLOR,
-            label,
-            entityType: 'enemy',
-            ...(enemyCurrentHp !== null ? { currentHp: enemyCurrentHp } : {}),
-            ...(enemyMaxHp !== null ? { maxHp: enemyMaxHp } : {}),
-            ...(enemySize ? { size: enemySize } : {}),
-          };
-        });
-      }
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(enemy);
+
+        lookup[enemyId] = {
+          color: ENEMY_FIGURINE_COLOR,
+          label,
+          entityType: 'enemy',
+          ...(enemyCurrentHp !== null ? { currentHp: enemyCurrentHp } : {}),
+          ...(enemyMaxHp !== null ? { maxHp: enemyMaxHp } : {}),
+          ...(enemySize ? { size: enemySize } : {}),
+          ...(figurineImageUrl ? { figurineImageUrl } : {}),
+          ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
+        };
+      });
+    }
 
       return lookup;
     }, [records, enemies]);
@@ -3002,6 +3011,8 @@ export default function ZombiesDM() {
           const normalizedColor =
             typeof baseColor === 'string' && baseColor.trim() !== '' ? baseColor.trim() : null;
 
+          const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(meta, token);
+
           return {
             ...token,
             label,
@@ -3013,6 +3024,8 @@ export default function ZombiesDM() {
             ...(normalizedCurrentHp !== null ? { currentHp: normalizedCurrentHp } : {}),
             ...(normalizedMaxHp !== null ? { maxHp: normalizedMaxHp } : {}),
             ...(size ? { size } : {}),
+            ...(figurineImageUrl ? { figurineImageUrl } : {}),
+            ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
           };
         })
         .sort((a, b) => {

--- a/client/src/components/Zombies/utils/figurineAssets.js
+++ b/client/src/components/Zombies/utils/figurineAssets.js
@@ -1,0 +1,97 @@
+const normalizeFigurineValue = (value) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+
+const getNestedValue = (source, path) => {
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+
+  const segments = path.split('.');
+  let current = source;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined) {
+      return null;
+    }
+
+    if (typeof current !== 'object') {
+      return null;
+    }
+
+    if (!(segment in current)) {
+      return null;
+    }
+
+    current = current[segment];
+  }
+
+  return current;
+};
+
+const FIGURINE_IMAGE_URL_PATHS = [
+  'figurineImageUrl',
+  'figurineImage.url',
+  'figurineImage.imageUrl',
+  'figurine.url',
+  'figurine.imageUrl',
+  'tokenImageUrl',
+  'tokenImage.url',
+  'tokenImage.imageUrl',
+  'imageUrl',
+];
+
+const FIGURINE_IMAGE_PUBLIC_ID_PATHS = [
+  'figurineImagePublicId',
+  'figurineImage.publicId',
+  'figurineImage.cloudinaryPublicId',
+  'figurine.publicId',
+  'figurine.cloudinaryPublicId',
+  'tokenImagePublicId',
+  'tokenImage.cloudinaryPublicId',
+  'cloudinaryPublicId',
+];
+
+const extractFromSource = (source) => {
+  if (!source || typeof source !== 'object') {
+    return { figurineImageUrl: null, figurineImagePublicId: null };
+  }
+
+  const figurineImageUrl = FIGURINE_IMAGE_URL_PATHS.reduce((acc, path) => {
+    if (acc) {
+      return acc;
+    }
+
+    const value = getNestedValue(source, path);
+    return normalizeFigurineValue(value);
+  }, null);
+
+  const figurineImagePublicId = FIGURINE_IMAGE_PUBLIC_ID_PATHS.reduce((acc, path) => {
+    if (acc) {
+      return acc;
+    }
+
+    const value = getNestedValue(source, path);
+    return normalizeFigurineValue(value);
+  }, null);
+
+  return { figurineImageUrl, figurineImagePublicId };
+};
+
+export const resolveFigurineImageData = (...sources) =>
+  sources.reduce(
+    (result, source) => {
+      if (result.figurineImageUrl && result.figurineImagePublicId) {
+        return result;
+      }
+
+      const { figurineImageUrl, figurineImagePublicId } = extractFromSource(source);
+
+      return {
+        figurineImageUrl: result.figurineImageUrl || figurineImageUrl || null,
+        figurineImagePublicId: result.figurineImagePublicId || figurineImagePublicId || null,
+      };
+    },
+    { figurineImageUrl: null, figurineImagePublicId: null }
+  );
+
+export default resolveFigurineImageData;


### PR DESCRIPTION
## Summary
- add a shared figurine asset helper to normalize token imagery metadata
- render optional figurine image overlays on campaign map tokens and style them appropriately
- propagate figurine asset data through DM/player map token builders and extend related tests

## Testing
- CI=1 npm test -- CampaignMapBoard.test.js MapModal.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e172cf8620832e87e158588e7a062a