### PR TITLE
Add Zombies token picker modal integration tests

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -1,0 +1,376 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button, Spinner, Row, Col, Alert, Form } from 'react-bootstrap';
+import apiFetch from '../../../utils/apiFetch';
+
+const DEFAULT_DM_FILTERS = [
+  { key: 'all', label: 'All Tokens', folders: null },
+  { key: 'adventurers', label: 'Adventurers', folders: ['Adventurers'] },
+  { key: 'dm', label: 'Dungeon Master', folders: ['DM'] },
+];
+
+const buildFilterMap = (filters = []) => {
+  if (!Array.isArray(filters)) {
+    return new Map();
+  }
+
+  return new Map(
+    filters
+      .filter((filter) => filter && typeof filter === 'object' && filter.key)
+      .map((filter) => [filter.key, filter])
+  );
+};
+
+const TokenPickerModal = ({
+  show,
+  onHide,
+  campaignId,
+  onSelect,
+  isDm = false,
+  defaultFilter = 'adventurers',
+  dmFilters = DEFAULT_DM_FILTERS,
+  title = 'Choose Figurine Token',
+  allowClear = false,
+  onClear,
+  isBusy = false,
+  errorMessage = null,
+}) => {
+  const availableFilters = useMemo(() => {
+    if (!isDm) {
+      return [
+        {
+          key: 'adventurers',
+          label: 'Adventurers',
+          folders: null,
+        },
+      ];
+    }
+
+    const filters = Array.isArray(dmFilters) && dmFilters.length > 0 ? dmFilters : DEFAULT_DM_FILTERS;
+    return filters.map((filter) => ({ ...filter }));
+  }, [isDm, dmFilters]);
+
+  const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
+
+  const [selectedFilterKey, setSelectedFilterKey] = useState(() => {
+    if (filterLookup.has(defaultFilter)) {
+      return defaultFilter;
+    }
+    const [firstKey] = filterLookup.keys();
+    return firstKey || null;
+  });
+
+  useEffect(() => {
+    if (!filterLookup.has(selectedFilterKey)) {
+      const [firstKey] = filterLookup.keys();
+      setSelectedFilterKey(firstKey || null);
+    }
+  }, [filterLookup, selectedFilterKey]);
+
+  const [assets, setAssets] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(null);
+  const [nextCursor, setNextCursor] = useState(null);
+  const [manifestMeta, setManifestMeta] = useState(null);
+
+  const resetState = useCallback(() => {
+    setAssets([]);
+    setLoading(false);
+    setLoadingMore(false);
+    setError(null);
+    setNextCursor(null);
+    setManifestMeta(null);
+  }, []);
+
+  const activeFilter = selectedFilterKey && filterLookup.has(selectedFilterKey)
+    ? filterLookup.get(selectedFilterKey)
+    : filterLookup.size > 0
+      ? filterLookup.values().next().value
+      : null;
+
+  const fetchManifest = useCallback(
+    async ({ cursor = null, append = false } = {}) => {
+      if (!campaignId || !activeFilter) {
+        return;
+      }
+
+      const encodedCampaignId = encodeURIComponent(campaignId);
+      const params = new URLSearchParams();
+
+      if (cursor) {
+        params.set('nextCursor', cursor);
+      }
+
+      if (isDm) {
+        const folders = activeFilter.folders;
+        if (Array.isArray(folders) && folders.length > 0) {
+          const sanitized = folders
+            .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
+            .filter(Boolean);
+          if (sanitized.length > 0) {
+            params.set('folders', sanitized.join(','));
+          }
+        }
+      }
+
+      const queryString = params.toString();
+      const endpoint = `/campaigns/${encodedCampaignId}/token-manifest${
+        queryString ? `?${queryString}` : ''
+      }`;
+
+      try {
+        if (append) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+          setError(null);
+        }
+
+        const response = await apiFetch(endpoint);
+        if (!response.ok) {
+          throw new Error(response.statusText || 'Failed to load token manifest.');
+        }
+
+        const data = await response.json();
+        const nextAssets = Array.isArray(data?.assets) ? data.assets.filter(Boolean) : [];
+        setAssets((prev) => (append ? [...prev, ...nextAssets] : nextAssets));
+        setNextCursor(typeof data?.nextCursor === 'string' && data.nextCursor ? data.nextCursor : null);
+        setManifestMeta(data || null);
+      } catch (err) {
+        console.error(err);
+        setError(err?.message || 'Failed to load token manifest.');
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [campaignId, activeFilter, isDm]
+  );
+
+  useEffect(() => {
+    if (!show) {
+      resetState();
+      return;
+    }
+
+    resetState();
+    fetchManifest({ append: false, cursor: null });
+  }, [show, fetchManifest, activeFilter, resetState]);
+
+  const handleFilterChange = useCallback(
+    (event) => {
+      const { value } = event.target;
+      setSelectedFilterKey(value);
+    },
+    []
+  );
+
+  const handleSelectAsset = useCallback(
+    (asset) => {
+      if (typeof onSelect === 'function') {
+        onSelect(asset);
+      }
+    },
+    [onSelect]
+  );
+
+  const handleClearSelection = useCallback(() => {
+    if (typeof onClear === 'function') {
+      onClear();
+    } else if (typeof onSelect === 'function') {
+      onSelect(null);
+    }
+  }, [onClear, onSelect]);
+
+  const renderBody = () => {
+    if (loading && assets.length === 0) {
+      return (
+        <div className="text-center py-4" role="status" aria-live="polite">
+          <Spinner animation="border" role="status" aria-hidden="true" />
+          <div className="mt-2">Loading tokens…</div>
+        </div>
+      );
+    }
+
+    if (error && assets.length === 0) {
+      return (
+        <Alert variant="danger" className="mb-0">
+          {error}
+        </Alert>
+      );
+    }
+
+    if (assets.length === 0) {
+      return <div className="text-center text-muted py-4">No tokens found.</div>;
+    }
+
+    return (
+      <>
+        <Row xs={2} sm={3} md={4} className="g-3">
+          {assets.map((asset) => {
+            if (!asset || !asset.publicId) {
+              return null;
+            }
+
+            const label = asset.filename || asset.publicId.split('/').pop();
+            const folderLabel = asset.relativeFolder || manifestMeta?.appliedFolders?.[0] || '';
+
+            return (
+              <Col key={asset.publicId}>
+                <Button
+                  variant="outline-light"
+                  className="w-100 h-100 text-start token-picker-option"
+                  onClick={() => handleSelectAsset(asset)}
+                  disabled={isBusy}
+                >
+                  <div className="ratio ratio-1x1 bg-dark-subtle rounded border border-secondary overflow-hidden">
+                    {asset.secureUrl ? (
+                      <img
+                        src={asset.secureUrl}
+                        alt={label || 'Token preview'}
+                        className="w-100 h-100"
+                        loading="lazy"
+                        style={{ objectFit: 'contain' }}
+                      />
+                    ) : (
+                      <div className="d-flex align-items-center justify-content-center h-100 text-muted">
+                        No preview
+                      </div>
+                    )}
+                  </div>
+                  <div className="mt-2 fw-semibold text-truncate" title={label}>
+                    {label || asset.publicId}
+                  </div>
+                  {folderLabel ? (
+                    <div className="text-muted small text-truncate" title={folderLabel}>
+                      {folderLabel}
+                    </div>
+                  ) : null}
+                </Button>
+              </Col>
+            );
+          })}
+        </Row>
+        {error ? (
+          <Alert variant="warning" className="mt-3">
+            {error}
+          </Alert>
+        ) : null}
+        {errorMessage ? (
+          <Alert variant="danger" className="mt-3">
+            {errorMessage}
+          </Alert>
+        ) : null}
+        {nextCursor ? (
+          <div className="text-center mt-3">
+            <Button
+              variant="outline-light"
+              onClick={() => fetchManifest({ append: true, cursor: nextCursor })}
+              disabled={loadingMore || isBusy}
+            >
+              {loadingMore ? (
+                <>
+                  <Spinner
+                    animation="border"
+                    size="sm"
+                    role="status"
+                    aria-hidden="true"
+                    className="me-2"
+                  />
+                  Loading…
+                </>
+              ) : (
+                'Load more'
+              )}
+            </Button>
+          </div>
+        ) : null}
+      </>
+    );
+  };
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      size="lg"
+      centered
+      scrollable
+      className="dnd-modal"
+      backdrop={isBusy ? 'static' : true}
+      keyboard={!isBusy}
+    >
+      <Modal.Header closeButton={!isBusy}>
+        <Modal.Title>
+          {title}
+          {isBusy ? (
+            <Spinner
+              animation="border"
+              size="sm"
+              role="status"
+              aria-hidden="true"
+              className="ms-2"
+            />
+          ) : null}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {isDm && availableFilters.length > 1 ? (
+          <Form.Group className="mb-3" controlId="tokenPickerFilter">
+            <Form.Label>Token Library</Form.Label>
+            <Form.Select
+              value={selectedFilterKey ?? ''}
+              onChange={handleFilterChange}
+              aria-label="Select token library"
+              disabled={isBusy}
+            >
+              {availableFilters.map((filter) => (
+                <option key={filter.key} value={filter.key}>
+                  {filter.label}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        ) : null}
+        {renderBody()}
+      </Modal.Body>
+      <Modal.Footer>
+        {allowClear ? (
+          <Button variant="outline-secondary" onClick={handleClearSelection} disabled={isBusy}>
+            Clear selection
+          </Button>
+        ) : null}
+        <Button variant="secondary" onClick={onHide} disabled={isBusy}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+TokenPickerModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onHide: PropTypes.func,
+  campaignId: PropTypes.string,
+  onSelect: PropTypes.func,
+  isDm: PropTypes.bool,
+  defaultFilter: PropTypes.string,
+  dmFilters: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      folders: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.oneOf([null]),
+      ]),
+    })
+  ),
+  title: PropTypes.string,
+  allowClear: PropTypes.bool,
+  onClear: PropTypes.func,
+  isBusy: PropTypes.bool,
+  errorMessage: PropTypes.string,
+};
+
+export default TokenPickerModal;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -48,6 +48,7 @@ import MapModal from "../attributes/MapModal";
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
+import TokenPickerModal from '../components/TokenPickerModal';
 
 const HEADER_PADDING = 16;
 const DOCKABLE_MODAL_DEFINITIONS = {
@@ -813,6 +814,9 @@ export default function ZombiesCharacterSheet() {
   const [spellPointsLeft, setSpellPointsLeft] = useState(0);
   const [longRestCount, setLongRestCount] = useState(0);
   const [shortRestCount, setShortRestCount] = useState(0);
+  const [showTokenPicker, setShowTokenPicker] = useState(false);
+  const [tokenPickerSaving, setTokenPickerSaving] = useState(false);
+  const [tokenPickerError, setTokenPickerError] = useState(null);
 
   const getStoredActiveEffects = useCallback((id) => {
     if (typeof window === 'undefined' || !id) {
@@ -2716,6 +2720,8 @@ export default function ZombiesCharacterSheet() {
     resolvedCharacterIdRef.current = resolvedCharacterId;
   }, [resolvedCharacterId]);
 
+  const characterFigurine = useMemo(() => resolveFigurineImageData(form), [form]);
+
   const updateLocalDiceColor = useCallback(
     (incomingCharacterId, nextColor) => {
       const normalizedCharacterId =
@@ -2799,6 +2805,133 @@ export default function ZombiesCharacterSheet() {
         }
 
         return { ...prev, diceColor: normalizedColor };
+      });
+    },
+    [setCampaignCharacters, setForm]
+  );
+
+  const updateLocalFigurineImage = useCallback(
+    (incomingCharacterId, nextUrl, nextPublicId) => {
+      const normalizedCharacterId =
+        typeof incomingCharacterId === 'string' && incomingCharacterId.trim() !== ''
+          ? incomingCharacterId.trim()
+          : null;
+      const normalizedUrl =
+        typeof nextUrl === 'string' && nextUrl.trim() !== '' ? nextUrl.trim() : null;
+      const normalizedPublicId =
+        typeof nextPublicId === 'string' && nextPublicId.trim() !== ''
+          ? nextPublicId.trim()
+          : null;
+
+      if (!normalizedCharacterId) {
+        return;
+      }
+
+      setCampaignCharacters((prev) => {
+        if (!prev || typeof prev !== 'object' || Object.keys(prev).length === 0) {
+          return prev;
+        }
+
+        let didUpdate = false;
+        const next = { ...prev };
+
+        Object.entries(prev).forEach(([key, value]) => {
+          if (!value || typeof value !== 'object') {
+            return;
+          }
+
+          const identifiers = new Set();
+          if (typeof key === 'string' && key.trim() !== '') {
+            identifiers.add(key.trim());
+          }
+          if (typeof value._id === 'string' && value._id.trim() !== '') {
+            identifiers.add(value._id.trim());
+          }
+          if (typeof value.characterId === 'string' && value.characterId.trim() !== '') {
+            identifiers.add(value.characterId.trim());
+          }
+
+          if (!identifiers.has(normalizedCharacterId)) {
+            return;
+          }
+
+          const nextValue = { ...value };
+          let changed = false;
+
+          if (normalizedUrl) {
+            if (nextValue.figurineImageUrl !== normalizedUrl) {
+              nextValue.figurineImageUrl = normalizedUrl;
+              changed = true;
+            }
+          } else if (nextValue.figurineImageUrl) {
+            delete nextValue.figurineImageUrl;
+            changed = true;
+          }
+
+          if (normalizedPublicId) {
+            if (nextValue.figurineImagePublicId !== normalizedPublicId) {
+              nextValue.figurineImagePublicId = normalizedPublicId;
+              changed = true;
+            }
+          } else if (nextValue.figurineImagePublicId) {
+            delete nextValue.figurineImagePublicId;
+            changed = true;
+          }
+
+          if (changed) {
+            next[key] = nextValue;
+            didUpdate = true;
+          }
+        });
+
+        return didUpdate ? next : prev;
+      });
+
+      setForm((prev) => {
+        if (!prev) {
+          return prev;
+        }
+
+        const identifiers = [];
+        if (typeof prev._id === 'string' && prev._id.trim() !== '') {
+          identifiers.push(prev._id.trim());
+        }
+        if (typeof prev.characterId === 'string' && prev.characterId.trim() !== '') {
+          identifiers.push(prev.characterId.trim());
+        }
+        const resolvedId = resolvedCharacterIdRef.current;
+        if (typeof resolvedId === 'string' && resolvedId.trim() !== '') {
+          identifiers.push(resolvedId.trim());
+        }
+
+        if (!identifiers.includes(normalizedCharacterId)) {
+          return prev;
+        }
+
+        const nextForm = { ...prev };
+        let changed = false;
+
+        if (normalizedUrl) {
+          if (nextForm.figurineImageUrl !== normalizedUrl) {
+            nextForm.figurineImageUrl = normalizedUrl;
+            changed = true;
+          }
+        } else if (nextForm.figurineImageUrl) {
+          delete nextForm.figurineImageUrl;
+          changed = true;
+        }
+
+        if (normalizedPublicId) {
+          if (nextForm.figurineImagePublicId !== normalizedPublicId) {
+            nextForm.figurineImagePublicId = normalizedPublicId;
+            changed = true;
+          }
+        } else if (nextForm.figurineImagePublicId) {
+          delete nextForm.figurineImagePublicId;
+          changed = true;
+        }
+
+        return changed ? nextForm : prev;
       });
     },
     [setCampaignCharacters, setForm]
@@ -3122,16 +3255,42 @@ export default function ZombiesCharacterSheet() {
         return;
       }
 
-      const normalizedDiceColor =
-        typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
-          ? update.diceColor.trim()
-          : null;
+      const hasDiceColorUpdate = Object.prototype.hasOwnProperty.call(update, 'diceColor');
+      const hasFigurineUrlUpdate = Object.prototype.hasOwnProperty.call(
+        update,
+        'figurineImageUrl'
+      );
+      const hasFigurineIdUpdate = Object.prototype.hasOwnProperty.call(
+        update,
+        'figurineImagePublicId'
+      );
 
-      if (!normalizedDiceColor) {
+      if (!hasDiceColorUpdate && !hasFigurineUrlUpdate && !hasFigurineIdUpdate) {
         return;
       }
 
-      updateLocalDiceColor(normalizedCharacterId, normalizedDiceColor);
+      if (hasDiceColorUpdate) {
+        const normalizedDiceColor =
+          typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
+            ? update.diceColor.trim()
+            : null;
+        if (normalizedDiceColor) {
+          updateLocalDiceColor(normalizedCharacterId, normalizedDiceColor);
+        }
+      }
+
+      if (hasFigurineUrlUpdate || hasFigurineIdUpdate) {
+        const normalizedUrl =
+          typeof update.figurineImageUrl === 'string' && update.figurineImageUrl.trim() !== ''
+            ? update.figurineImageUrl.trim()
+            : null;
+        const normalizedPublicId =
+          typeof update.figurineImagePublicId === 'string' &&
+          update.figurineImagePublicId.trim() !== ''
+            ? update.figurineImagePublicId.trim()
+            : null;
+        updateLocalFigurineImage(normalizedCharacterId, normalizedUrl, normalizedPublicId);
+      }
     };
 
     socket.on('combat:update', handleCombatUpdate);
@@ -3151,7 +3310,7 @@ export default function ZombiesCharacterSheet() {
       socket.disconnect();
       socketRef.current = null;
     };
-  }, [campaignId, applyMapPayload, updateLocalDiceColor]);
+  }, [campaignId, applyMapPayload, updateLocalDiceColor, updateLocalFigurineImage]);
 
   const handleDiceColorChange = useCallback(
     (nextColor) => {
@@ -3162,6 +3321,90 @@ export default function ZombiesCharacterSheet() {
       updateLocalDiceColor(currentId, nextColor);
     },
     [updateLocalDiceColor]
+  );
+
+  const handleOpenTokenPicker = useCallback(() => {
+    setTokenPickerError(null);
+    setShowTokenPicker(true);
+  }, []);
+
+  const handleCloseTokenPicker = useCallback(() => {
+    if (tokenPickerSaving) {
+      return;
+    }
+    setShowTokenPicker(false);
+    setTokenPickerError(null);
+  }, [tokenPickerSaving]);
+
+  const handleTokenSelection = useCallback(
+    async (asset) => {
+      if (!characterId) {
+        return;
+      }
+
+      const sanitizedUrl = asset
+        ? typeof asset.secureUrl === 'string' && asset.secureUrl.trim() !== ''
+          ? asset.secureUrl.trim()
+          : typeof asset.url === 'string' && asset.url.trim() !== ''
+            ? asset.url.trim()
+            : null
+        : '';
+
+      const sanitizedPublicId = asset
+        ? typeof asset.publicId === 'string' && asset.publicId.trim() !== ''
+          ? asset.publicId.trim()
+          : null
+        : '';
+
+      setTokenPickerSaving(true);
+      setTokenPickerError(null);
+
+      try {
+        const response = await apiFetch(`/characters/${characterId}/figurine`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            figurineImageUrl: sanitizedUrl,
+            figurineImagePublicId: sanitizedPublicId,
+          }),
+        });
+
+        if (!response.ok) {
+          let message = response.statusText || 'Failed to update figurine.';
+          try {
+            const errorData = await response.json();
+            if (errorData && typeof errorData.message === 'string' && errorData.message.trim() !== '') {
+              message = errorData.message.trim();
+            }
+          } catch (jsonError) {
+            // ignore parsing errors
+          }
+          throw new Error(message);
+        }
+
+        const result = await response.json();
+        const nextUrl =
+          typeof result?.figurineImageUrl === 'string' && result.figurineImageUrl.trim() !== ''
+            ? result.figurineImageUrl.trim()
+            : null;
+        const nextPublicId =
+          typeof result?.figurineImagePublicId === 'string' &&
+          result.figurineImagePublicId.trim() !== ''
+            ? result.figurineImagePublicId.trim()
+            : null;
+
+        const resolvedId =
+          (resolvedCharacterIdRef.current && resolvedCharacterIdRef.current.trim()) || characterId;
+        updateLocalFigurineImage(resolvedId, nextUrl, nextPublicId);
+        setShowTokenPicker(false);
+      } catch (error) {
+        console.error(error);
+        setTokenPickerError(error?.message || 'Failed to update figurine.');
+      } finally {
+        setTokenPickerSaving(false);
+      }
+    },
+    [characterId, updateLocalFigurineImage]
   );
 
   const tokenMetaById = useMemo(() => {
@@ -4137,6 +4380,27 @@ export default function ZombiesCharacterSheet() {
               {form?.characterName || 'Loading Character'}
             </h1>
 
+            <div className="d-flex justify-content-center mt-2">
+              <Button
+                variant="outline-light"
+                size="sm"
+                onClick={handleOpenTokenPicker}
+              >
+                {characterFigurine?.figurineImageUrl || characterFigurine?.figurineImagePublicId
+                  ? 'Change Figurine'
+                  : 'Choose Figurine'}
+              </Button>
+            </div>
+            {characterFigurine?.figurineImageUrl ? (
+              <div className="d-flex justify-content-center mt-2">
+                <img
+                  src={characterFigurine.figurineImageUrl}
+                  alt="Current figurine token"
+                  style={{ maxHeight: '96px', maxWidth: '96px', objectFit: 'contain' }}
+                />
+              </div>
+            ) : null}
+
             <HealthDefense
               form={form}
               totalLevel={totalLevel}
@@ -4466,6 +4730,18 @@ export default function ZombiesCharacterSheet() {
         />
       </>
     )}
+    <TokenPickerModal
+      show={showTokenPicker}
+      onHide={handleCloseTokenPicker}
+      campaignId={campaignId || undefined}
+      onSelect={handleTokenSelection}
+      allowClear={Boolean(
+        characterFigurine?.figurineImageUrl || characterFigurine?.figurineImagePublicId
+      )}
+      onClear={() => handleTokenSelection(null)}
+      isBusy={tokenPickerSaving}
+      errorMessage={tokenPickerError}
+    />
     <MapModal
       show={shouldShowMapModal}
       onHide={handleCloseMapModal}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -104,33 +104,40 @@ import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 const WIDE_SCREEN_QUERY = '(min-width: 1200px)';
 const matchMediaState = {};
 
+const defaultApiFetchImplementation = (url) => {
+  if (typeof url === 'string' && url.includes('/maps')) {
+    return Promise.resolve({ ok: false, status: 404 });
+  }
+
+  if (typeof url === 'string' && url.includes('/map')) {
+    return Promise.resolve({ ok: false, status: 404 });
+  }
+
+  if (typeof url === 'string' && url.includes('/classes/')) {
+    return Promise.resolve({ ok: true, json: async () => ({ spellsKnown: 0 }) });
+  }
+
+  if (typeof url === 'string' && url.includes('/combat')) {
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ participants: [], activeTurn: null }),
+    });
+  }
+
+  if (typeof url === 'string' && url.includes('/characters')) {
+    return Promise.resolve({ ok: true, json: async () => [] });
+  }
+
+  if (typeof url === 'string' && url.includes('/enemies')) {
+    return Promise.resolve({ ok: true, json: async () => [] });
+  }
+
+  return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
+};
+
 beforeEach(() => {
   apiFetch.mockReset();
-  apiFetch.mockImplementation((url) => {
-    if (typeof url === 'string' && url.includes('/maps')) {
-      return Promise.resolve({ ok: false, status: 404 });
-    }
-    if (typeof url === 'string' && url.includes('/map')) {
-      return Promise.resolve({ ok: false, status: 404 });
-    }
-    if (typeof url === 'string' && url.includes('/classes/')) {
-      return Promise.resolve({ ok: true, json: async () => ({ spellsKnown: 0 }) });
-    }
-    if (typeof url === 'string' && url.includes('/combat')) {
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ participants: [], activeTurn: null }),
-      });
-    }
-    if (typeof url === 'string' && url.includes('/characters')) {
-      return Promise.resolve({ ok: true, json: async () => [] });
-    }
-    if (typeof url === 'string' && url.includes('/enemies')) {
-      return Promise.resolve({ ok: true, json: async () => [] });
-    }
-
-    return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
-  });
+  apiFetch.mockImplementation(defaultApiFetchImplementation);
   mockSocketIo.mockReset();
   socketStub = {
     on: jest.fn(),
@@ -2348,5 +2355,232 @@ test('loads campaign map tokens and updates them after placement', async () => {
     const remainingToken =
       mockMapModalProps.current.tokensByMapId?.[mapId]?.['char-1'];
     expect(remainingToken).toBeUndefined();
+  });
+});
+
+test('allows selecting a figurine token through the token picker modal', async () => {
+  const campaignId = 'camp-figurines';
+  const manifestAsset = {
+    publicId: 'Tokens/Adventurers/Hero',
+    secureUrl: 'https://res.cloudinary.com/demo/image/upload/v123/Tokens/Adventurers/Hero.png',
+    filename: 'Hero Token',
+    relativeFolder: 'Adventurers',
+  };
+
+  const manifestResponse = {
+    assets: [manifestAsset],
+    nextCursor: null,
+    appliedFolders: ['Adventurers'],
+  };
+
+  const characterResponse = {
+    _id: '1',
+    characterId: '1',
+    campaign: campaignId,
+    characterName: 'Token Tester',
+    occupation: [{ Name: 'Wizard', Level: 1 }],
+    spells: [],
+    spellPoints: 0,
+    str: 10,
+    dex: 10,
+    con: 10,
+    int: 10,
+    wis: 10,
+    cha: 10,
+    startStatTotal: 60,
+    proficiencyPoints: 0,
+    skills: {},
+    item: [],
+    feat: [],
+    weapon: [],
+    armor: [],
+    accessories: [],
+    equipment: {},
+  };
+
+  apiFetch.mockImplementation((url, options = {}) => {
+    if (url === '/characters/1') {
+      return Promise.resolve({ ok: true, json: async () => characterResponse });
+    }
+
+    if (url === `/campaigns/${campaignId}/combat`) {
+      return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+    }
+
+    if (url === `/campaigns/${campaignId}/characters`) {
+      return Promise.resolve({ ok: true, json: async () => [characterResponse] });
+    }
+
+    if (url === `/campaigns/${campaignId}/maps`) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    if (url === `/campaigns/${campaignId}/map`) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    if (url === `/campaigns/${campaignId}/enemies`) {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+
+    if (url === `/campaigns/${campaignId}/token-manifest`) {
+      return Promise.resolve({ ok: true, json: async () => manifestResponse });
+    }
+
+    if (url === '/characters/1/figurine') {
+      expect(options.method).toBe('PUT');
+      const body = JSON.parse(options.body);
+      expect(body).toEqual({
+        figurineImageUrl: manifestAsset.secureUrl,
+        figurineImagePublicId: manifestAsset.publicId,
+      });
+      return Promise.resolve({ ok: true, json: async () => body });
+    }
+
+    if (typeof url === 'string' && url.includes('/classes/')) {
+      return Promise.resolve({ ok: true, json: async () => ({ spellsKnown: 0 }) });
+    }
+
+    return defaultApiFetchImplementation(url, options);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  const openPickerButton = await screen.findByRole('button', { name: /choose figurine/i });
+  await userEvent.click(openPickerButton);
+
+  await waitFor(() => {
+    expect(apiFetch).toHaveBeenCalledWith(`/campaigns/${campaignId}/token-manifest`);
+  });
+
+  const heroTokenButton = await screen.findByRole('button', { name: /hero token/i });
+  await userEvent.click(heroTokenButton);
+
+  await waitFor(() => {
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/characters/1/figurine',
+      expect.objectContaining({ method: 'PUT' })
+    );
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /change figurine/i })).toBeInTheDocument();
+  });
+
+  const previewImage = await screen.findByAltText('Current figurine token');
+  expect(previewImage).toHaveAttribute('src', manifestAsset.secureUrl);
+});
+
+test('allows clearing an existing figurine selection from the token picker modal', async () => {
+  const campaignId = 'camp-figurines';
+  const existingFigurineUrl = 'https://res.cloudinary.com/demo/image/upload/v123/Tokens/Adventurers/Existing.png';
+
+  const characterResponse = {
+    _id: '1',
+    characterId: '1',
+    campaign: campaignId,
+    characterName: 'Token Tester',
+    occupation: [{ Name: 'Wizard', Level: 1 }],
+    spells: [],
+    spellPoints: 0,
+    str: 10,
+    dex: 10,
+    con: 10,
+    int: 10,
+    wis: 10,
+    cha: 10,
+    startStatTotal: 60,
+    proficiencyPoints: 0,
+    skills: {},
+    item: [],
+    feat: [],
+    weapon: [],
+    armor: [],
+    accessories: [],
+    equipment: {},
+    figurineImageUrl: existingFigurineUrl,
+  };
+
+  const campaignCharacterResponse = {
+    ...characterResponse,
+    figurineImageUrl: existingFigurineUrl,
+  };
+
+  const manifestResponse = {
+    assets: [],
+    nextCursor: null,
+    appliedFolders: ['Adventurers'],
+  };
+
+  const figurineUpdateBodies = [];
+
+  apiFetch.mockImplementation((url, options = {}) => {
+    if (url === '/characters/1') {
+      return Promise.resolve({ ok: true, json: async () => characterResponse });
+    }
+
+    if (url === `/campaigns/${campaignId}/combat`) {
+      return Promise.resolve({ ok: true, json: async () => ({ participants: [], activeTurn: null }) });
+    }
+
+    if (url === `/campaigns/${campaignId}/characters`) {
+      return Promise.resolve({ ok: true, json: async () => [campaignCharacterResponse] });
+    }
+
+    if (url === `/campaigns/${campaignId}/maps`) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    if (url === `/campaigns/${campaignId}/map`) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    if (url === `/campaigns/${campaignId}/enemies`) {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+
+    if (url === `/campaigns/${campaignId}/token-manifest`) {
+      return Promise.resolve({ ok: true, json: async () => manifestResponse });
+    }
+
+    if (url === '/characters/1/figurine') {
+      expect(options.method).toBe('PUT');
+      const body = JSON.parse(options.body);
+      figurineUpdateBodies.push(body);
+      return Promise.resolve({ ok: true, json: async () => ({
+        figurineImageUrl: body.figurineImageUrl,
+        figurineImagePublicId: body.figurineImagePublicId,
+      }) });
+    }
+
+    if (typeof url === 'string' && url.includes('/classes/')) {
+      return Promise.resolve({ ok: true, json: async () => ({ spellsKnown: 0 }) });
+    }
+
+    return defaultApiFetchImplementation(url, options);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  await screen.findByRole('button', { name: /change figurine/i });
+  expect(screen.getByAltText('Current figurine token')).toHaveAttribute('src', existingFigurineUrl);
+
+  await userEvent.click(screen.getByRole('button', { name: /change figurine/i }));
+
+  const clearButton = await screen.findByRole('button', { name: /clear selection/i });
+  await userEvent.click(clearButton);
+
+  await waitFor(() => {
+    expect(figurineUpdateBodies.length).toBeGreaterThan(0);
+  });
+
+  expect(figurineUpdateBodies[0]).toEqual({ figurineImageUrl: '', figurineImagePublicId: '' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /choose figurine/i })).toBeInTheDocument();
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByAltText('Current figurine token')).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -66,6 +66,7 @@ import {
 import { FiChevronDown, FiChevronRight, FiList, FiPlus } from "react-icons/fi";
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from "../utils/mapGrouping";
 import { resolveFigurineImageData } from '../utils/figurineAssets';
+import TokenPickerModal from '../components/TokenPickerModal';
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -669,6 +670,11 @@ export default function ZombiesDM() {
     const [enemyHealthAdjustments, setEnemyHealthAdjustments] = useState({});
     const [enemyHealthSaving, setEnemyHealthSaving] = useState({});
     const [latestEnemyRoll, setLatestEnemyRoll] = useState(null);
+    const [showEnemyTokenPicker, setShowEnemyTokenPicker] = useState(false);
+    const [enemyTokenSelection, setEnemyTokenSelection] = useState({
+      figurineImageUrl: null,
+      figurineImagePublicId: null,
+    });
     const [status, setStatus] = useState(null);
     const [combatState, setCombatState] = useState(createEmptyCombatState());
     const [campaignMap, setCampaignMap] = useState(null);
@@ -1196,6 +1202,20 @@ export default function ZombiesDM() {
             payload.name = trimmedName;
           }
 
+          if (
+            enemyTokenSelection?.figurineImageUrl &&
+            enemyTokenSelection.figurineImageUrl.trim() !== ''
+          ) {
+            payload.figurineImageUrl = enemyTokenSelection.figurineImageUrl.trim();
+          }
+
+          if (
+            enemyTokenSelection?.figurineImagePublicId &&
+            enemyTokenSelection.figurineImagePublicId.trim() !== ''
+          ) {
+            payload.figurineImagePublicId = enemyTokenSelection.figurineImagePublicId.trim();
+          }
+
           const response = await apiFetch(`/campaigns/${encodedCampaign}/enemies`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -1216,6 +1236,7 @@ export default function ZombiesDM() {
           const addedEnemy = await response.json();
           setStatus({ type: 'success', message: `${addedEnemy?.name || 'Enemy'} added to campaign.` });
           setCustomEnemyName('');
+          setEnemyTokenSelection({ figurineImageUrl: null, figurineImagePublicId: null });
           await fetchRecords();
         } catch (error) {
           console.error(error);
@@ -1224,8 +1245,45 @@ export default function ZombiesDM() {
           setAddingEnemy(false);
         }
       },
-      [selectedMonsterIndex, encodedCampaign, customEnemyName, fetchRecords]
+      [
+        selectedMonsterIndex,
+        encodedCampaign,
+        customEnemyName,
+        fetchRecords,
+        enemyTokenSelection.figurineImagePublicId,
+        enemyTokenSelection.figurineImageUrl,
+      ]
     );
+
+    const handleOpenEnemyTokenPicker = useCallback(() => {
+      setShowEnemyTokenPicker(true);
+    }, []);
+
+    const handleCloseEnemyTokenPicker = useCallback(() => {
+      setShowEnemyTokenPicker(false);
+    }, []);
+
+    const handleEnemyTokenSelected = useCallback((asset) => {
+      if (!asset) {
+        setEnemyTokenSelection({ figurineImageUrl: null, figurineImagePublicId: null });
+        setShowEnemyTokenPicker(false);
+        return;
+      }
+
+      const nextUrl =
+        typeof asset.secureUrl === 'string' && asset.secureUrl.trim() !== ''
+          ? asset.secureUrl.trim()
+          : typeof asset.url === 'string' && asset.url.trim() !== ''
+            ? asset.url.trim()
+            : null;
+      const nextPublicId =
+        typeof asset.publicId === 'string' && asset.publicId.trim() !== ''
+          ? asset.publicId.trim()
+          : null;
+
+      setEnemyTokenSelection({ figurineImageUrl: nextUrl, figurineImagePublicId: nextPublicId });
+      setShowEnemyTokenPicker(false);
+    }, []);
 
     const removeCharacterTokensFromMaps = useCallback(
       async (character) => {
@@ -5912,6 +5970,25 @@ const resolveIcon = (category, iconMap, fallback) => {
                           disabled={!selectedMonsterIndex}
                         />
                       </Form.Group>
+                      <div className="d-flex flex-column align-items-start mt-3 gap-2">
+                        <Button
+                          variant="outline-light"
+                          size="sm"
+                          onClick={handleOpenEnemyTokenPicker}
+                          disabled={!selectedMonsterIndex}
+                        >
+                          {enemyTokenSelection?.figurineImageUrl || enemyTokenSelection?.figurineImagePublicId
+                            ? 'Change Token'
+                            : 'Choose Token'}
+                        </Button>
+                        {enemyTokenSelection?.figurineImageUrl ? (
+                          <img
+                            src={enemyTokenSelection.figurineImageUrl}
+                            alt="Selected enemy token"
+                            style={{ maxHeight: '96px', maxWidth: '96px', objectFit: 'contain' }}
+                          />
+                        ) : null}
+                      </div>
                     </Col>
                     <Col md={6} className="d-flex justify-content-center justify-content-md-end">
                       <div className="d-flex flex-column flex-md-row gap-2 mt-3 mt-md-0">
@@ -7323,6 +7400,17 @@ const resolveIcon = (category, iconMap, fallback) => {
     </Tab.Pane>
   </Tab.Content>
         </Tab.Container>
+        <TokenPickerModal
+          show={showEnemyTokenPicker}
+          onHide={handleCloseEnemyTokenPicker}
+          campaignId={campaignId || undefined}
+          onSelect={handleEnemyTokenSelected}
+          allowClear={Boolean(
+            enemyTokenSelection?.figurineImageUrl || enemyTokenSelection?.figurineImagePublicId
+          )}
+          onClear={() => handleEnemyTokenSelected(null)}
+          isDm
+        />
         <D20RollerModal
           show={showDiceRoller}
           onHide={() => setShowDiceRoller(false)}

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1,4 +1,4 @@
-const { param, body } = require('express-validator');
+const { param, body, query } = require('express-validator');
 const express = require('express');
 const { randomUUID } = require('crypto');
 const { ObjectId } = require('mongodb');
@@ -14,7 +14,12 @@ const {
   buildCampaignMapPayload,
   normalizeMapTokens,
 } = require('../utils/campaignMaps');
-const { uploadMapImage, deleteMapImage } = require('../utils/cloudinary');
+const {
+  uploadMapImage,
+  deleteMapImage,
+  listTokenAssets,
+  getTokenRootFolder,
+} = require('../utils/cloudinary');
 
 const deriveCloudinaryPublicIdFromUrl = (url) => {
   if (typeof url !== 'string' || url.trim() === '') {
@@ -178,6 +183,37 @@ const prepareMapAssetsForStorage = async (mapInput) => {
   }
 
   return prepared;
+};
+
+const parseFolderFilters = (input) => {
+  if (!input) {
+    return [];
+  }
+
+  const values = Array.isArray(input) ? input : String(input).split(',');
+
+  const sanitized = values
+    .map((value) => {
+      if (typeof value !== 'string') {
+        return null;
+      }
+
+      const trimmed = value.trim();
+      return trimmed || null;
+    })
+    .filter(Boolean);
+
+  return Array.from(new Set(sanitized));
+};
+
+const getDefaultPlayerTokenFolders = () => {
+  const raw = process.env.CLOUDINARY_PLAYER_TOKEN_FOLDERS;
+
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    return parseFolderFilters(raw.split(','));
+  }
+
+  return ['Adventurers'];
 };
 
 module.exports = (router) => {
@@ -1324,6 +1360,16 @@ module.exports = (router) => {
         param('campaign').trim().notEmpty().withMessage('campaign is required'),
         body('index').trim().notEmpty().withMessage('index is required'),
         body('name').optional().isString().withMessage('name must be a string'),
+        body('figurineImageUrl')
+          .optional({ nullable: true })
+          .isString()
+          .withMessage('figurineImageUrl must be a string')
+          .trim(),
+        body('figurineImagePublicId')
+          .optional({ nullable: true })
+          .isString()
+          .withMessage('figurineImagePublicId must be a string')
+          .trim(),
       ],
       handleValidationErrors,
       async (req, res, next) => {
@@ -1333,7 +1379,19 @@ module.exports = (router) => {
         try {
           const monster = await getMonsterByIndex(index);
           const enemyId = generateEnemyId();
-          const enemyRecord = buildEnemyRecord(monster, enemyId, name);
+          const rawFigurineUrl =
+            typeof req.body.figurineImageUrl === 'string'
+              ? req.body.figurineImageUrl.trim()
+              : '';
+          const rawFigurinePublicId =
+            typeof req.body.figurineImagePublicId === 'string'
+              ? req.body.figurineImagePublicId.trim()
+              : '';
+
+          const enemyRecord = buildEnemyRecord(monster, enemyId, name, {
+            figurineImageUrl: rawFigurineUrl || null,
+            figurineImagePublicId: rawFigurinePublicId || null,
+          });
 
           if (!enemyRecord) {
             return res.status(500).json({ message: 'Failed to create enemy record' });
@@ -1644,6 +1702,73 @@ module.exports = (router) => {
           emitCombatUpdate(req.params.campaign, combatState);
 
           res.json(combatState);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/token-manifest')
+    .get(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        query('nextCursor').optional().isString().trim(),
+        query('folders').optional(),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const db_connect = req.db;
+          const campaign = await db_connect
+            .collection('Campaigns')
+            .findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const isDm = req.user && campaign.dm === req.user.username;
+          const playerFolders = getDefaultPlayerTokenFolders();
+          const requestedFolders = isDm ? parseFolderFilters(req.query.folders) : playerFolders;
+
+          const folders =
+            isDm && requestedFolders.length === 0 ? null : requestedFolders.filter(Boolean);
+
+          let manifest;
+          try {
+            manifest = await listTokenAssets({
+              folders,
+              nextCursor:
+                typeof req.query.nextCursor === 'string' && req.query.nextCursor.trim() !== ''
+                  ? req.query.nextCursor.trim()
+                  : null,
+            });
+          } catch (error) {
+            logger.warn('Failed to load token manifest from Cloudinary', {
+              campaign: campaignName,
+              error: error.message,
+            });
+            manifest = {
+              assets: [],
+              nextCursor: null,
+              totalCount: null,
+              appliedFolders: Array.isArray(folders) ? folders : [],
+              rootFolder: getTokenRootFolder(),
+            };
+          }
+
+          res.json({
+            ...manifest,
+            appliedFolders: Array.isArray(manifest?.appliedFolders)
+              ? manifest.appliedFolders
+              : Array.isArray(folders)
+                ? folders
+                : [],
+            isDm,
+            defaultPlayerFolders: playerFolders,
+          });
         } catch (err) {
           next(err);
         }

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -630,6 +630,115 @@ module.exports = (router) => {
     }
   );
 
+  characterRouter.route('/:id/figurine').put(
+    [
+      body('figurineImageUrl')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('figurineImageUrl must be a string')
+        .trim(),
+      body('figurineImagePublicId')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('figurineImagePublicId must be a string')
+        .trim(),
+    ],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid ID' });
+      }
+
+      const db_connect = req.db;
+      const { figurineImageUrl, figurineImagePublicId } = matchedData(req, {
+        locations: ['body'],
+        includeOptionals: true,
+      });
+
+      const updates = {};
+      const unset = {};
+
+      if (figurineImageUrl !== undefined) {
+        const trimmedUrl = typeof figurineImageUrl === 'string' ? figurineImageUrl.trim() : '';
+        if (trimmedUrl) {
+          updates.figurineImageUrl = trimmedUrl;
+        } else {
+          unset.figurineImageUrl = '';
+        }
+      }
+
+      if (figurineImagePublicId !== undefined) {
+        const trimmedId =
+          typeof figurineImagePublicId === 'string' ? figurineImagePublicId.trim() : '';
+        if (trimmedId) {
+          updates.figurineImagePublicId = trimmedId;
+        } else {
+          unset.figurineImagePublicId = '';
+        }
+      }
+
+      if (Object.keys(updates).length === 0 && Object.keys(unset).length === 0) {
+        return res.status(400).json({ message: 'No updates provided' });
+      }
+
+      const updateDoc = {};
+      if (Object.keys(updates).length > 0) {
+        updateDoc.$set = updates;
+      }
+      if (Object.keys(unset).length > 0) {
+        updateDoc.$unset = unset;
+      }
+
+      try {
+        const result = await db_connect.collection('Characters').findOneAndUpdate(
+          { _id: ObjectId(req.params.id) },
+          updateDoc,
+          { returnDocument: 'after' }
+        );
+
+        const updatedCharacter = result && result.value ? result.value : null;
+        if (!updatedCharacter) {
+          return res.status(404).json({ message: 'Character not found' });
+        }
+
+        const payload = {
+          figurineImageUrl:
+            typeof updatedCharacter.figurineImageUrl === 'string'
+              ? updatedCharacter.figurineImageUrl
+              : null,
+          figurineImagePublicId:
+            typeof updatedCharacter.figurineImagePublicId === 'string'
+              ? updatedCharacter.figurineImagePublicId
+              : null,
+        };
+
+        const rawCampaignId =
+          typeof updatedCharacter.campaign === 'string'
+            ? updatedCharacter.campaign
+            : typeof updatedCharacter.campaignId === 'string'
+              ? updatedCharacter.campaignId
+              : null;
+        const campaignId = rawCampaignId && rawCampaignId.trim() !== '' ? rawCampaignId.trim() : null;
+        const characterId =
+          updatedCharacter._id && typeof updatedCharacter._id.toString === 'function'
+            ? updatedCharacter._id.toString()
+            : typeof updatedCharacter.characterId === 'string'
+              ? updatedCharacter.characterId
+              : null;
+
+        if (campaignId && characterId) {
+          emitCharacterMetadataUpdate(campaignId, { ...payload, characterId });
+        }
+
+        logger.info('Figurine imagery updated for character');
+
+        res.json({ ...payload, campaignId, characterId });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
   // This section will update feats.
   characterRouter.route('/:id/feats').put(
     [body('feat').isArray().withMessage('feat must be an array')],

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -1,6 +1,9 @@
 let cloudinary;
 let isConfigured = false;
 
+const DEFAULT_TOKEN_ROOT_FOLDER = 'Tokens';
+const TOKEN_FALLBACK_MAX_RESULTS = 200;
+
 const resolveCloudinary = () => {
   if (!cloudinary) {
     try {
@@ -36,6 +39,134 @@ const configure = () => {
 
 const getMapFolder = () => process.env.CLOUDINARY_MAP_FOLDER || 'Realm Tracker Maps';
 
+const getTokenRootFolder = () =>
+  process.env.CLOUDINARY_TOKEN_ROOT_FOLDER || DEFAULT_TOKEN_ROOT_FOLDER;
+
+const escapeExpressionValue = (value) => value.replace(/(["\\])/g, '\\$1');
+
+const sanitizeFolderSegment = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const segments = trimmed
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  return segments.join('/');
+};
+
+const buildFolderExpressions = (rootFolder, folders = []) => {
+  const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
+  const expressions = [];
+
+  const normalizedFilters = Array.isArray(folders)
+    ? folders
+        .map((folder) => {
+          const sanitized = sanitizeFolderSegment(folder);
+          if (!sanitized) {
+            return null;
+          }
+
+          if (sanitized === normalizedRoot) {
+            return sanitized;
+          }
+
+          if (sanitized.startsWith(`${normalizedRoot}/`)) {
+            return sanitized;
+          }
+
+          return `${normalizedRoot}/${sanitized}`;
+        })
+        .filter(Boolean)
+    : [];
+
+  const targets = normalizedFilters.length > 0 ? normalizedFilters : [normalizedRoot];
+
+  targets.forEach((folderPath) => {
+    const escaped = escapeExpressionValue(folderPath);
+    expressions.push(`folder="${escaped}"`);
+    expressions.push(`folder="${escaped}/*"`);
+  });
+
+  return expressions;
+};
+
+const sanitizeTokenResource = (resource = {}, rootFolder = DEFAULT_TOKEN_ROOT_FOLDER) => {
+  if (!resource || typeof resource !== 'object') {
+    return null;
+  }
+
+  const publicId =
+    typeof resource.public_id === 'string' && resource.public_id.trim() !== ''
+      ? resource.public_id.trim()
+      : null;
+
+  if (!publicId) {
+    return null;
+  }
+
+  const secureUrl =
+    typeof resource.secure_url === 'string' && resource.secure_url.trim() !== ''
+      ? resource.secure_url.trim()
+      : typeof resource.url === 'string' && resource.url.trim() !== ''
+        ? resource.url.trim()
+        : null;
+
+  const folder =
+    typeof resource.folder === 'string' && resource.folder.trim() !== ''
+      ? resource.folder.trim()
+      : null;
+
+  const filename =
+    typeof resource.filename === 'string' && resource.filename.trim() !== ''
+      ? resource.filename.trim()
+      : publicId.split('/').pop();
+
+  const relativeFolder = (() => {
+    if (!folder) {
+      return '';
+    }
+
+    const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
+    const rootPrefix = `${normalizedRoot}/`;
+    if (folder === normalizedRoot) {
+      return '';
+    }
+    if (folder.startsWith(rootPrefix)) {
+      return folder.slice(rootPrefix.length);
+    }
+    return folder;
+  })();
+
+  return {
+    assetId:
+      typeof resource.asset_id === 'string' && resource.asset_id.trim() !== ''
+        ? resource.asset_id.trim()
+        : null,
+    publicId,
+    secureUrl,
+    folder,
+    relativeFolder,
+    filename,
+    format: resource.format || null,
+    bytes: typeof resource.bytes === 'number' ? resource.bytes : null,
+    width: typeof resource.width === 'number' ? resource.width : null,
+    height: typeof resource.height === 'number' ? resource.height : null,
+    createdAt: resource.created_at || null,
+  };
+};
+
 const uploadMapImage = async (image, options = {}) => {
   configure();
   const sdk = resolveCloudinary();
@@ -59,8 +190,58 @@ const deleteMapImage = async (publicId, options = {}) => {
   });
 };
 
+const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults } = {}) => {
+  configure();
+  const sdk = resolveCloudinary();
+
+  if (!sdk?.search || typeof sdk.search.expression !== 'function') {
+    throw new Error('Cloudinary search API is unavailable');
+  }
+
+  const rootFolder = getTokenRootFolder();
+  const expressionSegments = ['resource_type:image'];
+  const folderExpressions = buildFolderExpressions(rootFolder, folders || []);
+
+  if (folderExpressions.length > 0) {
+    expressionSegments.push(`(${folderExpressions.join(' OR ')})`);
+  }
+
+  const expression = expressionSegments.join(' AND ');
+  let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
+
+  const resolvedMaxResults = Number.isInteger(maxResults)
+    ? Math.max(1, Math.min(maxResults, 500))
+    : TOKEN_FALLBACK_MAX_RESULTS;
+
+  search = search.max_results(resolvedMaxResults).with_field('context').with_field('metadata');
+
+  if (typeof nextCursor === 'string' && nextCursor.trim() !== '') {
+    search = search.next_cursor(nextCursor.trim());
+  }
+
+  const result = await search.execute();
+  const resources = Array.isArray(result?.resources) ? result.resources : [];
+  const assets = resources
+    .map((resource) => sanitizeTokenResource(resource, rootFolder))
+    .filter(Boolean);
+
+  return {
+    assets,
+    nextCursor: typeof result?.next_cursor === 'string' ? result.next_cursor : null,
+    totalCount: typeof result?.total_count === 'number' ? result.total_count : null,
+    appliedFolders: Array.isArray(folders)
+      ? folders
+          .map((folder) => sanitizeFolderSegment(folder))
+          .filter(Boolean)
+      : [],
+    rootFolder,
+  };
+};
+
 module.exports = {
   uploadMapImage,
   deleteMapImage,
   getMapFolder,
+  getTokenRootFolder,
+  listTokenAssets,
 };

--- a/server/utils/monsters.js
+++ b/server/utils/monsters.js
@@ -135,7 +135,7 @@ const normalizeMonsterDetail = (monster) => {
   };
 };
 
-const buildEnemyRecord = (monsterDetail, enemyId, nameOverride) => {
+const buildEnemyRecord = (monsterDetail, enemyId, nameOverride, extras = {}) => {
   if (!monsterDetail) {
     return null;
   }
@@ -147,13 +147,33 @@ const buildEnemyRecord = (monsterDetail, enemyId, nameOverride) => {
 
   const trimmedName = typeof nameOverride === 'string' ? nameOverride.trim() : '';
 
-  return {
+  const record = {
     ...normalized,
     enemyId,
     name: trimmedName || normalized.name,
     currentHp: normalized.hitPoints,
     addedAt: new Date().toISOString(),
   };
+
+  if (extras && typeof extras === 'object') {
+    const { figurineImageUrl, figurineImagePublicId } = extras;
+
+    if (typeof figurineImageUrl === 'string') {
+      const trimmedUrl = figurineImageUrl.trim();
+      if (trimmedUrl) {
+        record.figurineImageUrl = trimmedUrl;
+      }
+    }
+
+    if (typeof figurineImagePublicId === 'string') {
+      const trimmedId = figurineImagePublicId.trim();
+      if (trimmedId) {
+        record.figurineImagePublicId = trimmedId;
+      }
+    }
+  }
+
+  return record;
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary
- factor default apiFetch stub used by ZombiesCharacterSheet tests into a reusable helper
- add integration coverage for player token picker flows, including selecting and clearing figurine tokens

## Testing
- npm test -- ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e181d4a45c832eaa3e9d47cccbc9a7