### PR TITLE
Adjust tiefling legacy spell metadata

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -987,6 +987,14 @@ export default function Features({
         legacyMetaParts.push(`Spellcasting Ability: ${tieflingSpellAbilityLabel}`);
       }
       const legacyMeta = legacyMetaParts.join(' • ');
+      const legacySpellMeta = [
+        legacyLabel,
+        tieflingSpellAbilityLabel
+          ? `Spellcasting Ability: ${tieflingSpellAbilityLabel}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(' • ');
       const abilityText = tieflingSpellAbilityLabel
         ? ` This legacy uses ${tieflingSpellAbilityLabel} for its spells.`
         : '';
@@ -1065,7 +1073,7 @@ export default function Features({
         raceFeatures.push({
           id: spellId,
           name: `${spellName}${levelNote}`,
-          meta: legacyMeta,
+          meta: legacySpellMeta,
           description,
           desc: description,
           hideUseButton: !hasLimitedUses,

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1345,9 +1345,14 @@ test('tiefling fiendish legacy shows resistance and spells with ability details'
   if (!fireBoltCard) {
     throw new Error('Expected Fire Bolt card');
   }
+  const fireBoltWithin = within(fireBoltCard);
+  expect(fireBoltWithin.getByText(/Infernal Legacy/i)).toBeInTheDocument();
   expect(
-    within(fireBoltCard).getByText(/Spellcasting Ability: Charisma/i)
+    fireBoltWithin.getByText(/Spellcasting Ability: Charisma/i)
   ).toBeInTheDocument();
+  expect(
+    fireBoltWithin.queryByText(/Resistance:\s*Fire/i)
+  ).not.toBeInTheDocument();
 
   const hellishCard = screen
     .getByText('Hellish Rebuke (Level 3)')
@@ -1357,7 +1362,11 @@ test('tiefling fiendish legacy shows resistance and spells with ability details'
     throw new Error('Expected Hellish Rebuke card');
   }
   const hellishWithin = within(hellishCard);
+  expect(hellishWithin.getByText(/Infernal Legacy/i)).toBeInTheDocument();
   expect(hellishWithin.getByText(/Uses remaining/i)).toBeInTheDocument();
+  expect(
+    hellishWithin.queryByText(/Resistance:\s*Fire/i)
+  ).not.toBeInTheDocument();
   const viewHellish = hellishWithin.getByRole('button', { name: /view feature/i });
   await act(async () => {
     await userEvent.click(viewHellish);


### PR DESCRIPTION
## Summary
- create a separate fiendish legacy meta string for tiefling spells that omits resistance details
- continue to show resistance metadata on the resistance feature while using the new spell-specific meta
- expand the tiefling legacy test to confirm spell cards show the legacy label, spellcasting ability, and no resistance text

## Testing
- CI=true npm test -- Features.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e187068a088323a006c78be1d57941