### PR TITLE
Update lineage cast icons to wand sparkles

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1671,7 +1671,7 @@ export default function Features({
                                         icon: (
                                           <span className="d-flex align-items-center gap-1">
                                             <i
-                                              className="fa-solid fa-wand-sparkle"
+                                              className="fa-solid fa-wand-sparkles"
                                               aria-hidden="true"
                                             />
                                             <span>C</span>
@@ -1742,7 +1742,7 @@ export default function Features({
                                   (!isTieflingLineageSpell || !hasSlotsForLineageSpell)
                                 }
                               >
-                                <i className="fa-solid fa-wand-sparkle" />
+                                <i className="fa-solid fa-wand-sparkles" />
                               </Button>
                             ) : isSpeakWithAnimals ? (
                               <div className="d-flex align-items-center gap-1">

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1461,7 +1461,7 @@ test('tiefling legacy spell uses upcast modal with C button and tracks usage', a
   expect(
     within(hellishFeature).getByRole('button', {
       name: /cast hellish rebuke from lineage/i,
-    }).querySelector('.fa-wand-sparkle')
+    }).querySelector('.fa-wand-sparkles')
   ).not.toBeNull();
 
   await act(async () => {
@@ -1875,7 +1875,7 @@ test('elven lineage spells use wand icon and track uses with persistence and res
   });
   expect(lineageCastButton).toBeEnabled();
   expect(
-    lineageCastButton.querySelector('i.fa-solid.fa-wand-sparkle')
+    lineageCastButton.querySelector('i.fa-solid.fa-wand-sparkles')
   ).not.toBeNull();
   expect(
     longstriderWithin.getByText('Uses remaining: 1')


### PR DESCRIPTION
## Summary
- switch lineage cast button and free-cast modal icons to Font Awesome's wand sparkles variant
- align attribute feature tests with the new wand sparkles icon selector

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e188547518832385b5344cd2c43f0c