### PR TITLE
Carry figurine metadata through map modal lookup

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -322,6 +322,7 @@ const MapModal = ({
         typeof value?.size === 'string' && value.size.trim() !== ''
           ? value.size.trim().toLowerCase()
           : null;
+      const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(value);
 
       acc[trimmedKey] = {
         color,
@@ -331,6 +332,8 @@ const MapModal = ({
         ...(currentHp !== null ? { currentHp } : {}),
         ...(maxHp !== null ? { maxHp } : {}),
         ...(size ? { size } : {}),
+        ...(figurineImageUrl ? { figurineImageUrl } : {}),
+        ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
       };
       return acc;
     }, {});

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -173,4 +173,59 @@ describe('MapModal figurine imagery', () => {
     expect(figurineImage).toHaveAttribute('data-figurine-public-id', 'figurines/heroes/hero');
     expect(figurineImage?.getAttribute('alt')).toBe('');
   });
+
+  it('renders figurine overlays when imagery metadata is only available in character lookup', async () => {
+    const { container } = render(
+      <MapModal
+        show
+        onHide={jest.fn()}
+        maps={[
+          {
+            mapId: 'map-1',
+            title: 'Forest Path',
+            imageUrl: 'https://example.com/map.png',
+          },
+        ]}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            hero: {
+              characterId: 'hero',
+              x: 0.5,
+              y: 0.5,
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        activeCharacterId="hero"
+        characterLookup={{
+          hero: {
+            label: 'Hero',
+            entityType: 'character',
+            figurineImageUrl: ' https://example.com/figurines/lookup-hero.png ',
+            figurineImagePublicId: ' figurines/heroes/lookup-hero ',
+          },
+        }}
+        onTokenMove={jest.fn()}
+        onTokenRemove={jest.fn()}
+        readOnly={false}
+      />
+    );
+
+    const tokenElement = await screen.findByRole('button', { name: 'Hero' });
+    expect(tokenElement).toBeInTheDocument();
+
+    const figurineImage = container.querySelector(
+      '[data-token-id="hero"] .campaign-map-board__figurine-image'
+    );
+    expect(figurineImage).not.toBeNull();
+    expect(figurineImage).toHaveAttribute(
+      'src',
+      'https://example.com/figurines/lookup-hero.png'
+    );
+    expect(figurineImage).toHaveAttribute(
+      'data-figurine-public-id',
+      'figurines/heroes/lookup-hero'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- include figurine image metadata when normalizing the character lookup used by the map modal
- ensure board tokens can render figurine overlays even when imagery is only defined in the character lookup
- add unit coverage for figurine imagery sourced from character lookup entries

## Testing
- CI=true npm test -- MapModal

------
https://chatgpt.com/codex/tasks/task_e_68e189c4ac0c832e82ca54d4f6592133