### PR TITLE
Increase default campaign map figurine scale

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2580,7 +2580,7 @@ h1 {
 }
 
 .campaign-map-board {
-  --map-square-size: var(--campaign-map-square-size, clamp(36px, 8vw, 64px));
+  --map-square-size: var(--campaign-map-square-size, clamp(48px, 10vw, 80px));
   --figurine-size-scale: 1;
 
   position: relative;


### PR DESCRIPTION
## Summary
- enlarge the default campaign map square size clamp so figurines appear larger by default
- retain the existing CSS variable fallback so external size modifiers remain effective

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e18c0aef9c832eac314c5746998a9d