### PR TITLE
Adjust campaign map token sizing fallback

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2622,7 +2622,10 @@ h1 {
 
   &__tokens-layer {
     --tokens-layer-square-size: calc(100% / 24);
-    --map-square-size: var(--campaign-map-square-size, var(--tokens-layer-square-size));
+    --map-square-size: var(
+      --campaign-map-square-size,
+      clamp(48px, 10vw, 80px)
+    );
 
     position: absolute;
     inset: 0;


### PR DESCRIPTION
## Summary
- align the tokens layer map square fallback with the campaign map board clamp default
- retain the tokens layer square size variable for board-relative grid calculations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18e429198832e8ed16a5e1e5817b8