### PR TITLE
Remove tokens layer square size inline style

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useRef, useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
@@ -137,50 +137,9 @@ const CampaignMapBoard = ({
   const dragStateRef = useRef({ tokenId: null, pointerId: null });
   const [dragPositions, setDragPositions] = useState({});
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
-  const [squareSize, setSquareSize] = useState(null);
-  const [layerElement, setLayerElement] = useState(null);
-
   const handleLayerRef = useCallback((node) => {
     layerRef.current = node;
-    setLayerElement((prev) => (prev === node ? prev : node));
   }, []);
-
-  useEffect(() => {
-    const element = layerElement;
-    const ResizeObserverCtor =
-      typeof window !== 'undefined' && window.ResizeObserver
-        ? window.ResizeObserver
-        : typeof ResizeObserver !== 'undefined'
-        ? ResizeObserver
-        : null;
-
-    if (!element || !ResizeObserverCtor) {
-      setSquareSize((prev) => (prev === null ? prev : null));
-      return undefined;
-    }
-
-    const observer = new ResizeObserverCtor((entries) => {
-      entries.forEach((entry) => {
-        const width = entry?.contentRect?.width;
-        if (!Number.isFinite(width) || width <= 0) {
-          return;
-        }
-
-        const nextSquareSize = width / 24;
-        if (!Number.isFinite(nextSquareSize) || nextSquareSize <= 0) {
-          return;
-        }
-
-        setSquareSize((prev) => (prev === nextSquareSize ? prev : nextSquareSize));
-      });
-    });
-
-    observer.observe(element);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [layerElement]);
 
   const tokenPositions = useMemo(() => {
     if (!Array.isArray(tokens)) {
@@ -414,11 +373,6 @@ const CampaignMapBoard = ({
               className="campaign-map-board__tokens-layer"
               ref={handleLayerRef}
               onPointerDown={handleLayerPointerDown}
-              style={
-                Number.isFinite(squareSize) && squareSize > 0
-                  ? { '--campaign-map-square-size': `${squareSize}px` }
-                  : undefined
-              }
             >
               {tokenPositions.map((token) => {
                 const {


### PR DESCRIPTION
## Summary
- remove the resize observer plumbing for campaign map square sizing
- rely on the stylesheet clamp fallback by dropping the tokens layer inline square size style

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e19014b460832ebb420a499319c85a