### PR TITLE
Adjust enemy figurine scale on campaign map board

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -408,8 +408,12 @@ const CampaignMapBoard = ({
                     : null;
 
                 const sizeKey = resolveFigurineSizeKey(size);
-                const figurineScale =
-                  FIGURINE_SIZE_MULTIPLIERS[sizeKey] || FIGURINE_SIZE_MULTIPLIERS.medium;
+                const baseFigurineScale =
+                  FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? FIGURINE_SIZE_MULTIPLIERS.medium;
+                const scaleMultiplier = normalizedVariant === 'enemy' ? 0.75 : 1;
+                const figurineScale = Number.isFinite(baseFigurineScale)
+                  ? baseFigurineScale * scaleMultiplier
+                  : FIGURINE_SIZE_MULTIPLIERS.medium * scaleMultiplier;
 
                 const figurineColor =
                   normalizedVariant === 'enemy'

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -193,4 +193,36 @@ describe('CampaignMapBoard pointer interactions', () => {
     expect(figurineImage).toHaveAttribute('data-figurine-public-id', 'figurines/heroes/hero');
     expect(figurineImage?.getAttribute('alt')).toBe('');
   });
+
+  it('applies a reduced figurine scale for enemy variants', () => {
+    const { container } = renderBoard({
+      token: {
+        variant: 'enemy',
+        size: 'large',
+      },
+    });
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+    const scaleValue = Number.parseFloat(
+      tokenElement?.style.getPropertyValue('--figurine-size-scale') ?? ''
+    );
+    expect(scaleValue).toBeCloseTo(1.5, 5);
+  });
+
+  it('provides a finite figurine scale when no size is specified', () => {
+    const { container } = renderBoard({
+      token: {
+        size: undefined,
+      },
+    });
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+    const scaleValue = Number.parseFloat(
+      tokenElement?.style.getPropertyValue('--figurine-size-scale') ?? ''
+    );
+    expect(Number.isFinite(scaleValue)).toBe(true);
+    expect(scaleValue).toBeCloseTo(1, 5);
+  });
 });


### PR DESCRIPTION
## Summary
- apply a reduced scale multiplier to enemy tokens when resolving figurine sizes
- ensure figurine scale custom property always resolves to a finite number
- extend campaign map board tests to cover enemy scaling and missing size data

## Testing
- CI=true npm test -- CampaignMapBoard

------
https://chatgpt.com/codex/tasks/task_e_68e1925f497c832e8eec59e65f3d4459