### PR TITLE
Remove campaign map figurine base markup and styles

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2870,51 +2870,6 @@ h1 {
     }
   }
 
-  &__figurine-base {
-    position: relative;
-    width: var(--figurine-base-size);
-    aspect-ratio: 1 / 0.3;
-    margin-top: calc(var(--figurine-base-size) * -0.18);
-    border-radius: 70% 70% 85% 85% / 65% 65% 100% 100%;
-    background:
-      linear-gradient(180deg, rgba(78, 82, 94, 0.95), rgba(21, 22, 26, 0.98) 75%),
-      radial-gradient(ellipse at center, rgba(255, 255, 255, 0.2), transparent 70%);
-    box-shadow: inset 0 0.28rem 0.45rem rgba(255, 255, 255, 0.08),
-      inset 0 -0.35rem 0.45rem rgba(0, 0, 0, 0.55);
-    overflow: hidden;
-  }
-
-  &__figurine-base-top {
-    position: absolute;
-    top: 18%;
-    left: 50%;
-    width: 74%;
-    aspect-ratio: 1 / 0.24;
-    transform: translateX(-50%);
-    border-radius: 50%;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
-    box-shadow: inset 0 0.12rem 0.2rem rgba(255, 255, 255, 0.35),
-      0 0.12rem 0.25rem rgba(0, 0, 0, 0.45);
-    opacity: 0.9;
-  }
-
-  &__figurine-base-texture {
-    position: absolute;
-    inset: 32% 18% 14%;
-    border-radius: 45% 45% 65% 65% / 55% 55% 65% 65%;
-    background:
-      linear-gradient(180deg, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 65%),
-      repeating-linear-gradient(
-        135deg,
-        rgba(255, 255, 255, 0.18) 0,
-        rgba(255, 255, 255, 0.18) 8%,
-        rgba(0, 0, 0, 0) 8%,
-        rgba(0, 0, 0, 0) 18%
-      );
-    mix-blend-mode: soft-light;
-    opacity: 0.75;
-  }
-
   &__token:focus-visible {
     outline: 3px solid rgba(255, 255, 255, 0.85);
     outline-offset: 4px;
@@ -2959,13 +2914,6 @@ h1 {
         drop-shadow(0 0 2.1rem rgba(255, 239, 153, 0.55));
     }
 
-    .campaign-map-board__figurine-base,
-    .campaign-map-board__figurine-base-top {
-      box-shadow:
-        0 0 0.55rem rgba(255, 214, 102, 0.75),
-        0 0 1.25rem rgba(255, 198, 0, 0.65),
-        inset 0 0.12rem 0.28rem rgba(255, 255, 255, 0.65);
-    }
   }
 
   &--disabled &__token--draggable {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -529,10 +529,6 @@ const CampaignMapBoard = ({
                         <span className="campaign-map-board__figurine-torso" />
                         <span className="campaign-map-board__figurine-cloak" />
                       </span>
-                      <span className="campaign-map-board__figurine-base">
-                        <span className="campaign-map-board__figurine-base-top" />
-                        <span className="campaign-map-board__figurine-base-texture" />
-                      </span>
                     </div>
                     {displayLabel && (
                       <span className={labelClassName} aria-hidden="true">


### PR DESCRIPTION
## Summary
- remove the figurine base markup from campaign map tokens
- delete the unused figurine base style blocks and active-turn overrides

## Testing
- `rg "campaign-map-board__figurine-base"`


------
https://chatgpt.com/codex/tasks/task_e_68e1954e94cc832ea766e5a4f00de0e6