### PR TITLE
Tighten figurine health spacing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2644,7 +2644,7 @@ h1 {
     flex-direction: column;
     align-items: center;
     justify-content: flex-end;
-    gap: clamp(2px, calc(var(--figurine-base-size) * 0.08), 0.4rem);
+    gap: clamp(1px, calc(var(--figurine-base-size) * 0.05), 0.25rem);
     outline: none;
     touch-action: none;
     width: var(--figurine-base-size);


### PR DESCRIPTION
## Summary
- reduce the gap between campaign map figurines and their health indicators so the bar sits closer above the token

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e195c59a14832e88c1214a816e314e