### PR TITLE
Add Cloudinary token folder tree endpoint and dynamic DM token picker

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -4,9 +4,14 @@ import { Modal, Button, Spinner, Row, Col, Alert, Form } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 
 const DEFAULT_DM_FILTERS = [
-  { key: 'all', label: 'All Tokens', folders: null },
-  { key: 'adventurers', label: 'Adventurers', folders: ['Adventurers'] },
-  { key: 'dm', label: 'Dungeon Master', folders: ['DM'] },
+  { key: 'all', label: 'All Tokens', folders: null, aliases: ['all'] },
+  {
+    key: 'adventurers',
+    label: 'Adventurers',
+    folders: ['Adventurers'],
+    aliases: ['Adventurers', 'adventurers'],
+  },
+  { key: 'dm', label: 'Dungeon Master', folders: ['DM'], aliases: ['DM', 'dm'] },
 ];
 
 const buildFilterMap = (filters = []) => {
@@ -19,6 +24,132 @@ const buildFilterMap = (filters = []) => {
       .filter((filter) => filter && typeof filter === 'object' && filter.key)
       .map((filter) => [filter.key, filter])
   );
+};
+
+const NBSP = '\u00A0';
+
+const cloneFilters = (filters = []) => {
+  if (!Array.isArray(filters)) {
+    return [];
+  }
+
+  return filters
+    .filter((filter) => filter && typeof filter === 'object')
+    .map((filter) => ({
+      ...filter,
+      ...(Array.isArray(filter.folders) ? { folders: [...filter.folders] } : {}),
+      ...(Array.isArray(filter.aliases) ? { aliases: [...filter.aliases] } : {}),
+    }));
+};
+
+const buildDynamicDmFilters = (folderTree, fallbackFilters = DEFAULT_DM_FILTERS) => {
+  const fallback = cloneFilters(fallbackFilters);
+
+  if (!folderTree || typeof folderTree !== 'object') {
+    return fallback;
+  }
+
+  const flatFolders = Array.isArray(folderTree.flatFolders) ? folderTree.flatFolders : [];
+  const filters = [];
+
+  const addFilter = (filter) => {
+    if (!filter || typeof filter !== 'object' || !filter.key) {
+      return;
+    }
+
+    if (filters.some((existing) => existing.key === filter.key)) {
+      return;
+    }
+
+    const normalized = {
+      ...filter,
+      ...(Array.isArray(filter.folders) ? { folders: [...filter.folders] } : {}),
+      ...(Array.isArray(filter.aliases)
+        ? { aliases: Array.from(new Set(filter.aliases.filter(Boolean))) }
+        : {}),
+    };
+
+    filters.push(normalized);
+  };
+
+  addFilter({ key: 'all', label: 'All Tokens', folders: null, aliases: ['all'] });
+
+  flatFolders.forEach((entry) => {
+    if (!entry || typeof entry.path !== 'string') {
+      return;
+    }
+
+    const trimmedPath = entry.path.trim();
+    if (!trimmedPath) {
+      return;
+    }
+
+    const depth = Number.isInteger(entry.depth) ? entry.depth : 0;
+    const indent = depth > 0 ? NBSP.repeat(depth * 2) : '';
+    const displayPath =
+      typeof entry.displayPath === 'string' && entry.displayPath.trim() !== ''
+        ? entry.displayPath.trim()
+        : typeof entry.relativePath === 'string' && entry.relativePath.trim() !== ''
+          ? entry.relativePath.trim()
+          : typeof entry.name === 'string' && entry.name.trim() !== ''
+            ? entry.name.trim()
+            : trimmedPath.split('/').pop();
+
+    const aliases = [];
+    const relativePath =
+      typeof entry.relativePath === 'string' && entry.relativePath.trim() !== ''
+        ? entry.relativePath.trim()
+        : '';
+    if (relativePath) {
+      aliases.push(relativePath);
+      aliases.push(relativePath.toLowerCase());
+    }
+
+    const name = typeof entry.name === 'string' && entry.name.trim() !== '' ? entry.name.trim() : '';
+    if (name) {
+      aliases.push(name);
+      aliases.push(name.toLowerCase());
+    }
+
+    addFilter({
+      key: `folder:${trimmedPath}`,
+      label: `${indent}${displayPath}`,
+      folders: [trimmedPath],
+      aliases,
+      depth,
+    });
+  });
+
+  const hasAliasMatch = (filter, aliasSet) => {
+    if (!filter) {
+      return false;
+    }
+
+    if (aliasSet.has(filter.key)) {
+      return true;
+    }
+
+    if (!Array.isArray(filter.aliases)) {
+      return false;
+    }
+
+    return filter.aliases.some((alias) => aliasSet.has(alias));
+  };
+
+  fallback.forEach((fallbackFilter) => {
+    const aliasSet = new Set(
+      [fallbackFilter.key]
+        .concat(Array.isArray(fallbackFilter.aliases) ? fallbackFilter.aliases : [])
+        .filter(Boolean)
+    );
+
+    const alreadyPresent = filters.some((filter) => hasAliasMatch(filter, aliasSet));
+    if (!alreadyPresent) {
+      addFilter(fallbackFilter);
+    }
+  });
+
+  return filters;
 };
 
 const TokenPickerModal = ({
@@ -35,6 +166,9 @@ const TokenPickerModal = ({
   isBusy = false,
   errorMessage = null,
 }) => {
+  const [dmFolderOptions, setDmFolderOptions] = useState(null);
+  const [fetchingFolders, setFetchingFolders] = useState(false);
+
   const availableFilters = useMemo(() => {
     if (!isDm) {
       return [
@@ -46,26 +180,58 @@ const TokenPickerModal = ({
       ];
     }
 
-    const filters = Array.isArray(dmFilters) && dmFilters.length > 0 ? dmFilters : DEFAULT_DM_FILTERS;
-    return filters.map((filter) => ({ ...filter }));
-  }, [isDm, dmFilters]);
+    if (Array.isArray(dmFolderOptions)) {
+      return cloneFilters(dmFolderOptions);
+    }
+
+    return [];
+  }, [isDm, dmFolderOptions]);
 
   const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
 
-  const [selectedFilterKey, setSelectedFilterKey] = useState(() => {
-    if (filterLookup.has(defaultFilter)) {
-      return defaultFilter;
-    }
-    const [firstKey] = filterLookup.keys();
-    return firstKey || null;
-  });
+  const [selectedFilterKey, setSelectedFilterKey] = useState(null);
 
   useEffect(() => {
-    if (!filterLookup.has(selectedFilterKey)) {
-      const [firstKey] = filterLookup.keys();
-      setSelectedFilterKey(firstKey || null);
+    if (filterLookup.size === 0) {
+      if (selectedFilterKey !== null) {
+        setSelectedFilterKey(null);
+      }
+      return;
     }
-  }, [filterLookup, selectedFilterKey]);
+
+    if (selectedFilterKey && filterLookup.has(selectedFilterKey)) {
+      return;
+    }
+
+    let nextKey = null;
+
+    if (defaultFilter) {
+      if (filterLookup.has(defaultFilter)) {
+        nextKey = defaultFilter;
+      } else {
+        const aliasMatch = availableFilters.find(
+          (filter) =>
+            filter &&
+            typeof filter === 'object' &&
+            Array.isArray(filter.aliases) &&
+            filter.aliases.includes(defaultFilter)
+        );
+
+        if (aliasMatch) {
+          nextKey = aliasMatch.key;
+        }
+      }
+    }
+
+    if (!nextKey) {
+      const [firstKey] = filterLookup.keys();
+      nextKey = firstKey || null;
+    }
+
+    if (nextKey !== selectedFilterKey) {
+      setSelectedFilterKey(nextKey);
+    }
+  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey]);
 
   const [assets, setAssets] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -81,6 +247,7 @@ const TokenPickerModal = ({
     setError(null);
     setNextCursor(null);
     setManifestMeta(null);
+    setFetchingFolders(false);
   }, []);
 
   const activeFilter = selectedFilterKey && filterLookup.has(selectedFilterKey)
@@ -151,12 +318,71 @@ const TokenPickerModal = ({
   useEffect(() => {
     if (!show) {
       resetState();
+      if (isDm) {
+        setDmFolderOptions(null);
+      }
       return;
     }
 
     resetState();
     fetchManifest({ append: false, cursor: null });
-  }, [show, fetchManifest, activeFilter, resetState]);
+  }, [show, fetchManifest, activeFilter, resetState, isDm]);
+
+  useEffect(() => {
+    if (!isDm) {
+      return;
+    }
+
+    if (!show) {
+      return;
+    }
+
+    const fallbackFilters =
+      Array.isArray(dmFilters) && dmFilters.length > 0
+        ? cloneFilters(dmFilters)
+        : cloneFilters(DEFAULT_DM_FILTERS);
+
+    if (!campaignId) {
+      setDmFolderOptions(fallbackFilters);
+      return;
+    }
+
+    let isCancelled = false;
+
+    const fetchFolders = async () => {
+      setFetchingFolders(true);
+      try {
+        const encodedCampaignId = encodeURIComponent(campaignId);
+        const response = await apiFetch(`/campaigns/${encodedCampaignId}/token-folders`);
+
+        if (!response?.ok) {
+          throw new Error(response?.statusText || 'Failed to load token folders.');
+        }
+
+        const data = await response.json();
+        if (isCancelled) {
+          return;
+        }
+
+        setDmFolderOptions(buildDynamicDmFilters(data, fallbackFilters));
+      } catch (err) {
+        console.error(err);
+        if (!isCancelled) {
+          setDmFolderOptions(fallbackFilters);
+        }
+      } finally {
+        if (!isCancelled) {
+          setFetchingFolders(false);
+        }
+      }
+    };
+
+    fetchFolders();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [show, isDm, campaignId, dmFilters]);
 
   const handleFilterChange = useCallback(
     (event) => {
@@ -184,7 +410,7 @@ const TokenPickerModal = ({
   }, [onClear, onSelect]);
 
   const renderBody = () => {
-    if (loading && assets.length === 0) {
+    if ((loading || fetchingFolders) && assets.length === 0) {
       return (
         <div className="text-center py-4" role="status" aria-live="polite">
           <Spinner animation="border" role="status" aria-hidden="true" />

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TokenPickerModal from './TokenPickerModal';
+import apiFetch from '../../../utils/apiFetch';
+
+jest.mock('../../../utils/apiFetch');
+
+describe('TokenPickerModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('builds DM folder filters from Cloudinary tree and scopes manifest requests', async () => {
+    const user = userEvent.setup();
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [],
+        },
+        {
+          name: 'DM',
+          path: 'Tokens/DM',
+          relativePath: 'DM',
+          children: [
+            {
+              name: 'Dragons',
+              path: 'Tokens/DM/Dragons',
+              relativePath: 'DM/Dragons',
+              children: [],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'DM',
+          path: 'Tokens/DM',
+          relativePath: 'DM',
+          depth: 0,
+          displayPath: 'DM',
+        },
+        {
+          name: 'Dragons',
+          path: 'Tokens/DM/Dragons',
+          relativePath: 'DM/Dragons',
+          depth: 1,
+          displayPath: 'DM/Dragons',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        isDm
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
+    });
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+
+    expect(options).toHaveLength(4);
+    expect(options[0]).toHaveTextContent('All Tokens');
+    expect(options[1]).toHaveTextContent('Adventurers');
+    expect(options[2]).toHaveTextContent('DM');
+    expect(options[3].textContent.startsWith('\u00A0\u00A0')).toBe(true);
+    expect(options[3]).toHaveTextContent('DM/Dragons');
+
+    await waitFor(() => {
+      expect(manifestCalls[0]).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers'
+      );
+    });
+
+    await user.selectOptions(select, options[3]);
+
+    await waitFor(() => {
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FDM%2FDragons');
+    });
+  });
+});

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -19,6 +19,7 @@ const {
   deleteMapImage,
   listTokenAssets,
   getTokenRootFolder,
+  listTokenFolderTree,
 } = require('../utils/cloudinary');
 
 const deriveCloudinaryPublicIdFromUrl = (url) => {
@@ -1702,6 +1703,53 @@ module.exports = (router) => {
           emitCombatUpdate(req.params.campaign, combatState);
 
           res.json(combatState);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/token-folders')
+    .get(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        query('folders').optional(),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const db_connect = req.db;
+          const campaign = await db_connect
+            .collection('Campaigns')
+            .findOne({ campaignName });
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const isDm = req.user && campaign.dm === req.user.username;
+          if (!isDm) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const requestedFolders = parseFolderFilters(req.query.folders);
+
+          try {
+            const folderTree = await listTokenFolderTree({ folders: requestedFolders });
+            return res.json(folderTree);
+          } catch (error) {
+            logger.warn('Failed to load token folder tree from Cloudinary', {
+              campaign: campaignName,
+              error: error.message,
+            });
+            return res.json({
+              rootFolder: getTokenRootFolder(),
+              folders: [],
+              flatFolders: [],
+            });
+          }
         } catch (err) {
           next(err);
         }

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -190,6 +190,176 @@ const deleteMapImage = async (publicId, options = {}) => {
   });
 };
 
+const listTokenFolderTree = async ({ folders = null, rootFolder: inputRootFolder } = {}) => {
+  configure();
+  const sdk = resolveCloudinary();
+
+  if (!sdk?.api || typeof sdk.api.sub_folders !== 'function') {
+    throw new Error('Cloudinary folder API is unavailable');
+  }
+
+  const normalizedRoot = sanitizeFolderSegment(inputRootFolder) || getTokenRootFolder();
+  const rootPrefix = `${normalizedRoot}/`;
+
+  const normalizeFolderPath = (folderPath) => {
+    const sanitized = sanitizeFolderSegment(folderPath);
+    if (!sanitized) {
+      return null;
+    }
+
+    if (sanitized === normalizedRoot || sanitized.startsWith(rootPrefix)) {
+      return sanitized;
+    }
+
+    return `${normalizedRoot}/${sanitized}`;
+  };
+
+  const normalizedTargets = Array.isArray(folders) && folders.length > 0
+    ? Array.from(new Set(folders.map(normalizeFolderPath).filter(Boolean)))
+    : [normalizedRoot];
+
+  const visited = new Set();
+
+  const fetchSubfolders = async (folderPath) => {
+    const results = [];
+    let nextCursor = null;
+
+    do {
+      const response = await sdk.api.sub_folders(folderPath, {
+        max_results: 200,
+        ...(nextCursor ? { next_cursor: nextCursor } : {}),
+      });
+
+      const subFolders = Array.isArray(response?.folders) ? response.folders : [];
+      subFolders.forEach((folder) => {
+        if (!folder || typeof folder.path !== 'string') {
+          return;
+        }
+
+        const normalizedPath = normalizeFolderPath(folder.path);
+        if (!normalizedPath || normalizedPath === folderPath) {
+          return;
+        }
+
+        const name =
+          typeof folder.name === 'string' && folder.name.trim() !== ''
+            ? folder.name.trim()
+            : normalizedPath.split('/').pop();
+
+        results.push({
+          name,
+          path: normalizedPath,
+        });
+      });
+
+      nextCursor =
+        typeof response?.next_cursor === 'string' && response.next_cursor.trim() !== ''
+          ? response.next_cursor.trim()
+          : null;
+    } while (nextCursor);
+
+    results.sort((a, b) => a.name.localeCompare(b.name));
+    return results;
+  };
+
+  const buildNode = async (folderPath) => {
+    const normalizedPath = normalizeFolderPath(folderPath);
+    if (!normalizedPath) {
+      return null;
+    }
+
+    if (visited.has(normalizedPath)) {
+      return null;
+    }
+
+    visited.add(normalizedPath);
+
+    const relativePath = normalizedPath === normalizedRoot
+      ? ''
+      : normalizedPath.startsWith(rootPrefix)
+        ? normalizedPath.slice(rootPrefix.length)
+        : normalizedPath;
+
+    const name = relativePath ? relativePath.split('/').pop() : normalizedPath.split('/').pop();
+
+    const children = [];
+    const subFolders = await fetchSubfolders(normalizedPath);
+    for (const subFolder of subFolders) {
+      const childNode = await buildNode(subFolder.path);
+      if (childNode) {
+        children.push(childNode);
+      }
+    }
+
+    return {
+      name,
+      path: normalizedPath,
+      relativePath,
+      children,
+    };
+  };
+
+  const collectNodes = async () => {
+    const nodes = [];
+    for (const target of normalizedTargets) {
+      if (target === normalizedRoot) {
+        const rootChildren = await fetchSubfolders(normalizedRoot);
+        for (const child of rootChildren) {
+          const node = await buildNode(child.path);
+          if (node) {
+            nodes.push(node);
+          }
+        }
+      } else {
+        const node = await buildNode(target);
+        if (node) {
+          nodes.push(node);
+        }
+      }
+    }
+
+    const uniqueByPath = new Map();
+    nodes.forEach((node) => {
+      if (node && node.path && !uniqueByPath.has(node.path)) {
+        uniqueByPath.set(node.path, node);
+      }
+    });
+
+    return Array.from(uniqueByPath.values()).sort((a, b) => a.name.localeCompare(b.name));
+  };
+
+  const flattenNodes = (nodes, depth = 0, acc = []) => {
+    nodes.forEach((node) => {
+      if (!node) {
+        return;
+      }
+
+      acc.push({
+        name: node.name,
+        path: node.path,
+        relativePath: node.relativePath,
+        depth,
+        displayPath: node.relativePath || node.name,
+      });
+
+      if (Array.isArray(node.children) && node.children.length > 0) {
+        flattenNodes(node.children, depth + 1, acc);
+      }
+    });
+
+    return acc;
+  };
+
+  const foldersTree = await collectNodes();
+  const flatFolders = flattenNodes(foldersTree);
+
+  return {
+    rootFolder: normalizedRoot,
+    folders: foldersTree,
+    flatFolders,
+  };
+};
+
 const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults } = {}) => {
   configure();
   const sdk = resolveCloudinary();
@@ -244,4 +414,5 @@ module.exports = {
   getMapFolder,
   getTokenRootFolder,
   listTokenAssets,
+  listTokenFolderTree,
 };


### PR DESCRIPTION
## Summary
- add a Cloudinary helper to walk token folders and expose it through a DM-only campaign route
- update the token picker modal to load folder trees for DMs and drive manifest filters dynamically
- add unit coverage for the token picker to verify folder options and scoped manifest requests

## Testing
- npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68e19a0dacc4832e8d4261427c47a16f