### PR TITLE
Replace infernal legacy 5th-level spell with Darkness

### DIFF
--- a/server/data/races.js
+++ b/server/data/races.js
@@ -333,11 +333,11 @@ const races = {
             usage: "1/long rest",
           },
           {
-            name: "Fireball",
-            spellLevel: "3rd-level",
+            name: "Darkness",
+            spellLevel: "2nd-level",
             unlockedAtLevel: 5,
             description:
-              "Detonate a roaring explosion of flame that engulfs creatures in a 20-foot-radius sphere.",
+              "Create a 15-foot-radius sphere of magical darkness that even darkvision can't penetrate.",
             usage: "1/long rest",
           },
         ],


### PR DESCRIPTION
## Summary
- replace the infernal fiendish legacy's 5th-level spell data with Darkness to match the intended feature

## Testing
- CI=true npm --prefix client test *(fails: existing ZombiesDM tests timeout and cannot find expected map list items)*

------
https://chatgpt.com/codex/tasks/task_e_68e19e945e508323a629b0223b3689df