### PR TITLE
Allow players to browse Adventurers tokens

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -14,6 +14,15 @@ const DEFAULT_DM_FILTERS = [
   { key: 'dm', label: 'Dungeon Master', folders: ['DM'], aliases: ['DM', 'dm'] },
 ];
 
+const DEFAULT_PLAYER_FILTERS = [
+  {
+    key: 'adventurers',
+    label: 'Adventurers',
+    folders: ['Adventurers'],
+    aliases: ['Adventurers', 'adventurers'],
+  },
+];
+
 const buildFilterMap = (filters = []) => {
   if (!Array.isArray(filters)) {
     return new Map();
@@ -152,6 +161,158 @@ const buildDynamicDmFilters = (folderTree, fallbackFilters = DEFAULT_DM_FILTERS)
   return filters;
 };
 
+const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_FILTERS) => {
+  const fallback = cloneFilters(fallbackFilters);
+  const filters = [];
+  const seenKeys = new Set();
+
+  const addFilter = (filter) => {
+    if (!filter || typeof filter !== 'object' || !filter.key) {
+      return;
+    }
+
+    if (seenKeys.has(filter.key)) {
+      return;
+    }
+
+    const normalized = {
+      ...filter,
+      ...(Array.isArray(filter.folders) ? { folders: [...filter.folders] } : {}),
+      ...(Array.isArray(filter.aliases)
+        ? { aliases: Array.from(new Set(filter.aliases.filter(Boolean))) }
+        : {}),
+    };
+
+    filters.push(normalized);
+    seenKeys.add(normalized.key);
+  };
+
+  const fallbackRoot =
+    fallback.find((filter) => filter && filter.key === 'adventurers') ||
+    {
+      key: 'adventurers',
+      label: 'Adventurers',
+      folders: ['Adventurers'],
+      aliases: ['Adventurers', 'adventurers'],
+    };
+
+  const fallbackRootFolders = Array.isArray(fallbackRoot.folders)
+    ? fallbackRoot.folders
+        .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
+        .filter(Boolean)
+    : [];
+
+  const inferredRootPath =
+    typeof folderTree?.folders?.[0]?.path === 'string' &&
+    folderTree.folders[0].path.trim() !== ''
+      ? folderTree.folders[0].path.trim()
+      : null;
+
+  const resolvedRootFolders =
+    inferredRootPath && inferredRootPath.trim() !== ''
+      ? [inferredRootPath.trim()]
+      : fallbackRootFolders.length > 0
+        ? fallbackRootFolders
+        : ['Adventurers'];
+
+  addFilter({
+    ...fallbackRoot,
+    folders: resolvedRootFolders,
+    aliases: Array.isArray(fallbackRoot.aliases)
+      ? Array.from(
+          new Set(
+            fallbackRoot.aliases
+              .concat(['Adventurers', 'adventurers'])
+              .filter(Boolean)
+          )
+        )
+      : ['Adventurers', 'adventurers'],
+    depth: 0,
+  });
+
+  const playerRootPath = resolvedRootFolders[0] || null;
+  const rootLeaf = playerRootPath
+    ? playerRootPath
+        .split('/')
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+        .pop()
+    : null;
+
+  const flatFolders = Array.isArray(folderTree?.flatFolders)
+    ? folderTree.flatFolders
+    : [];
+
+  flatFolders.forEach((entry) => {
+    if (!entry || typeof entry.path !== 'string') {
+      return;
+    }
+
+    const normalizedPath = entry.path.trim();
+    if (!normalizedPath) {
+      return;
+    }
+
+    if (playerRootPath && normalizedPath === playerRootPath) {
+      return;
+    }
+
+    const depth = Number.isInteger(entry.depth) ? entry.depth : 0;
+    const indent = depth > 0 ? NBSP.repeat(depth * 2) : '';
+
+    const relativePath =
+      typeof entry.relativePath === 'string' && entry.relativePath.trim() !== ''
+        ? entry.relativePath.trim()
+        : '';
+
+    const relativeSegments = relativePath
+      ? relativePath.split('/').map((segment) => segment.trim()).filter(Boolean)
+      : [];
+
+    const trimmedSegments =
+      rootLeaf && relativeSegments.length > 0 && relativeSegments[0] === rootLeaf
+        ? relativeSegments.slice(1)
+        : relativeSegments;
+
+    const trimmedRelativePath = trimmedSegments.join('/');
+
+    const displayCandidate =
+      trimmedRelativePath ||
+      (typeof entry.displayPath === 'string' && entry.displayPath.trim() !== ''
+        ? entry.displayPath.trim()
+        : typeof entry.name === 'string' && entry.name.trim() !== ''
+          ? entry.name.trim()
+          : normalizedPath.split('/').pop());
+
+    const aliasSet = new Set();
+
+    if (trimmedRelativePath) {
+      aliasSet.add(trimmedRelativePath);
+      aliasSet.add(trimmedRelativePath.toLowerCase());
+    }
+
+    if (relativePath) {
+      aliasSet.add(relativePath);
+      aliasSet.add(relativePath.toLowerCase());
+    }
+
+    if (displayCandidate) {
+      aliasSet.add(displayCandidate);
+      aliasSet.add(displayCandidate.toLowerCase());
+    }
+
+    addFilter({
+      key: `folder:${normalizedPath}`,
+      label: `${indent}${displayCandidate}`,
+      folders: [normalizedPath],
+      aliases: Array.from(aliasSet).filter(Boolean),
+      depth,
+    });
+  });
+
+  return filters.length > 0 ? filters : fallback;
+};
+
 const TokenPickerModal = ({
   show,
   onHide,
@@ -167,25 +328,26 @@ const TokenPickerModal = ({
   errorMessage = null,
 }) => {
   const [dmFolderOptions, setDmFolderOptions] = useState(null);
+  const [playerFolderOptions, setPlayerFolderOptions] = useState(() =>
+    cloneFilters(DEFAULT_PLAYER_FILTERS)
+  );
   const [fetchingFolders, setFetchingFolders] = useState(false);
 
   const availableFilters = useMemo(() => {
-    if (!isDm) {
-      return [
-        {
-          key: 'adventurers',
-          label: 'Adventurers',
-          folders: null,
-        },
-      ];
+    if (isDm) {
+      if (Array.isArray(dmFolderOptions)) {
+        return cloneFilters(dmFolderOptions);
+      }
+
+      return [];
     }
 
-    if (Array.isArray(dmFolderOptions)) {
-      return cloneFilters(dmFolderOptions);
+    if (Array.isArray(playerFolderOptions) && playerFolderOptions.length > 0) {
+      return cloneFilters(playerFolderOptions);
     }
 
-    return [];
-  }, [isDm, dmFolderOptions]);
+    return cloneFilters(DEFAULT_PLAYER_FILTERS);
+  }, [isDm, dmFolderOptions, playerFolderOptions]);
 
   const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
 
@@ -269,15 +431,13 @@ const TokenPickerModal = ({
         params.set('nextCursor', cursor);
       }
 
-      if (isDm) {
-        const folders = activeFilter.folders;
-        if (Array.isArray(folders) && folders.length > 0) {
-          const sanitized = folders
-            .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
-            .filter(Boolean);
-          if (sanitized.length > 0) {
-            params.set('folders', sanitized.join(','));
-          }
+      const folders = Array.isArray(activeFilter.folders) ? activeFilter.folders : null;
+      if (folders && folders.length > 0) {
+        const sanitized = folders
+          .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
+          .filter(Boolean);
+        if (sanitized.length > 0) {
+          params.set('folders', sanitized.join(','));
         }
       }
 
@@ -320,6 +480,8 @@ const TokenPickerModal = ({
       resetState();
       if (isDm) {
         setDmFolderOptions(null);
+      } else {
+        setPlayerFolderOptions(cloneFilters(DEFAULT_PLAYER_FILTERS));
       }
       return;
     }
@@ -383,6 +545,60 @@ const TokenPickerModal = ({
       isCancelled = true;
     };
   }, [show, isDm, campaignId, dmFilters]);
+
+  useEffect(() => {
+    if (isDm) {
+      return;
+    }
+
+    if (!show) {
+      return;
+    }
+
+    const fallbackFilters = cloneFilters(DEFAULT_PLAYER_FILTERS);
+
+    if (!campaignId) {
+      setPlayerFolderOptions(fallbackFilters);
+      return;
+    }
+
+    let isCancelled = false;
+
+    const fetchFolders = async () => {
+      setFetchingFolders(true);
+      try {
+        const encodedCampaignId = encodeURIComponent(campaignId);
+        const response = await apiFetch(`/campaigns/${encodedCampaignId}/token-folders`);
+
+        if (!response?.ok) {
+          throw new Error(response?.statusText || 'Failed to load token folders.');
+        }
+
+        const data = await response.json();
+        if (isCancelled) {
+          return;
+        }
+
+        setPlayerFolderOptions(buildPlayerFolderFilters(data, fallbackFilters));
+      } catch (err) {
+        console.error(err);
+        if (!isCancelled) {
+          setPlayerFolderOptions(fallbackFilters);
+        }
+      } finally {
+        if (!isCancelled) {
+          setFetchingFolders(false);
+        }
+      }
+    };
+
+    setPlayerFolderOptions(fallbackFilters);
+    fetchFolders();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [show, isDm, campaignId]);
 
   const handleFilterChange = useCallback(
     (event) => {
@@ -542,7 +758,7 @@ const TokenPickerModal = ({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {isDm && availableFilters.length > 1 ? (
+        {availableFilters.length > 1 ? (
           <Form.Group className="mb-3" controlId="tokenPickerFilter">
             <Form.Label>Token Library</Form.Label>
             <Form.Select

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -6,13 +6,16 @@ import apiFetch from '../../../utils/apiFetch';
 
 jest.mock('../../../utils/apiFetch');
 
+const setupUser = () =>
+  typeof userEvent.setup === 'function' ? userEvent.setup() : userEvent;
+
 describe('TokenPickerModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test('builds DM folder filters from Cloudinary tree and scopes manifest requests', async () => {
-    const user = userEvent.setup();
+    const user = setupUser();
     const folderTree = {
       rootFolder: 'Tokens',
       folders: [
@@ -108,9 +111,8 @@ describe('TokenPickerModal', () => {
     expect(options[3]).toHaveTextContent('DM/Dragons');
 
     await waitFor(() => {
-      expect(manifestCalls[0]).toBe(
-        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers'
-      );
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers');
     });
 
     await user.selectOptions(select, options[3]);
@@ -118,6 +120,117 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];
       expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FDM%2FDragons');
+    });
+  });
+
+  test('players see Adventurers folders and scope manifest requests to selections', async () => {
+    const user = setupUser();
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Heroes',
+              path: 'Tokens/Adventurers/Heroes',
+              relativePath: 'Adventurers/Heroes',
+              children: [
+                {
+                  name: 'Rogues',
+                  path: 'Tokens/Adventurers/Heroes/Rogues',
+                  relativePath: 'Adventurers/Heroes/Rogues',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Heroes',
+          path: 'Tokens/Adventurers/Heroes',
+          relativePath: 'Adventurers/Heroes',
+          depth: 1,
+          displayPath: 'Adventurers/Heroes',
+        },
+        {
+          name: 'Rogues',
+          path: 'Tokens/Adventurers/Heroes/Rogues',
+          relativePath: 'Adventurers/Heroes/Rogues',
+          depth: 2,
+          displayPath: 'Adventurers/Heroes/Rogues',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
+    });
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent('Adventurers');
+    expect(options[1].textContent.startsWith('\u00A0\u00A0')).toBe(true);
+    expect(options[1]).toHaveTextContent('Heroes');
+    expect(options[2].textContent.startsWith('\u00A0\u00A0\u00A0\u00A0')).toBe(true);
+    expect(options[2]).toHaveTextContent('Heroes/Rogues');
+
+    await waitFor(() => {
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers');
+    });
+
+    await user.selectOptions(select, options[2]);
+
+    await waitFor(() => {
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FHeroes%2FRogues'
+      );
     });
   });
 });

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -26,11 +26,20 @@ jest.mock('../utils/monsters', () => ({
 jest.mock('../utils/cloudinary', () => ({
   uploadMapImage: jest.fn(),
   deleteMapImage: jest.fn(),
+  listTokenAssets: jest.fn(),
+  listTokenFolderTree: jest.fn(),
+  getTokenRootFolder: jest.fn(() => 'Tokens'),
 }));
 const { emitCombatUpdate, emitEnemiesUpdate, emitMapUpdate } = require('../utils/socket');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
 const { buildEnemyRecord } = require('../utils/monsters');
-const { uploadMapImage, deleteMapImage } = require('../utils/cloudinary');
+const {
+  uploadMapImage,
+  deleteMapImage,
+  listTokenAssets,
+  listTokenFolderTree,
+  getTokenRootFolder,
+} = require('../utils/cloudinary');
 const registerCampaignRoutes = require('../routes/campaigns');
 
 const app = express();
@@ -60,12 +69,16 @@ describe('Campaign routes', () => {
     buildEnemyRecord.mockReset();
     uploadMapImage.mockReset();
     deleteMapImage.mockReset();
+    listTokenAssets.mockReset();
+    listTokenFolderTree.mockReset();
+    getTokenRootFolder.mockReset();
     uploadMapImage.mockResolvedValue({
       secure_url:
         'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/default.png',
       public_id: 'maps/default/map',
     });
     deleteMapImage.mockResolvedValue({ result: 'ok' });
+    getTokenRootFolder.mockReturnValue('Tokens');
     mockUser = { username: 'DM' };
   });
 
@@ -1234,7 +1247,12 @@ describe('Campaign routes', () => {
     expect(res.body.name).toBe('Goblin');
     expect(typeof res.body.enemyId).toBe('string');
     expect(getMonsterByIndex).toHaveBeenCalledWith('goblin');
-    expect(buildEnemyRecord).toHaveBeenCalledWith({ index: 'goblin' }, res.body.enemyId, undefined);
+    expect(buildEnemyRecord).toHaveBeenCalledWith(
+      { index: 'goblin' },
+      res.body.enemyId,
+      undefined,
+      expect.objectContaining({ figurineImagePublicId: null, figurineImageUrl: null })
+    );
     expect(emitEnemiesUpdate).toHaveBeenCalledWith(
       'Test',
       [expect.objectContaining({ enemyId: res.body.enemyId, name: 'Goblin' })]
@@ -1384,4 +1402,91 @@ describe('Campaign routes', () => {
     expect(res.body.message).toBe('Enemy not found');
   });
 
+  test('player can list Adventurers token folders', async () => {
+    mockUser = { username: 'Player1' };
+
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [],
+      flatFolders: [],
+    };
+
+    const findOne = jest.fn().mockResolvedValue({ campaignName: 'Test', dm: 'DM' });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return { findOne };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    });
+
+    listTokenFolderTree.mockResolvedValue(folderTree);
+
+    const res = await request(app).get(
+      '/campaigns/Test/token-folders?folders=Tokens/Adventurers/Heroes,Tokens/DM'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(folderTree);
+    expect(listTokenFolderTree).toHaveBeenCalledWith({
+      folders: ['Tokens/Adventurers/Heroes'],
+    });
+  });
+
+  test('player token manifest is limited to Adventurers folders', async () => {
+    mockUser = { username: 'Player1' };
+
+    const findOne = jest.fn().mockResolvedValue({ campaignName: 'Test', dm: 'DM' });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return { findOne };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    });
+
+    listTokenAssets.mockResolvedValueOnce({
+      assets: [],
+      nextCursor: null,
+      totalCount: 0,
+      appliedFolders: ['Tokens/Adventurers'],
+      rootFolder: 'Tokens',
+    });
+
+    const res = await request(app).get('/campaigns/Test/token-manifest');
+
+    expect(res.status).toBe(200);
+    expect(listTokenAssets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folders: ['Tokens/Adventurers'],
+        nextCursor: null,
+      })
+    );
+    expect(res.body.isDm).toBe(false);
+    expect(res.body.defaultPlayerFolders).toEqual(['Adventurers']);
+
+    listTokenAssets.mockClear();
+    listTokenAssets.mockResolvedValueOnce({
+      assets: [],
+      nextCursor: null,
+      totalCount: 0,
+      appliedFolders: ['Tokens/Adventurers/Heroes'],
+      rootFolder: 'Tokens',
+    });
+
+    const resWithFilter = await request(app).get(
+      '/campaigns/Test/token-manifest?folders=Tokens/Adventurers/Heroes,Tokens/DM'
+    );
+
+    expect(resWithFilter.status).toBe(200);
+    expect(listTokenAssets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folders: ['Tokens/Adventurers/Heroes'],
+        nextCursor: null,
+      })
+    );
+    expect(resWithFilter.body.appliedFolders).toEqual(['Tokens/Adventurers/Heroes']);
+  });
 });

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -207,6 +207,65 @@ const parseFolderFilters = (input) => {
   return Array.from(new Set(sanitized));
 };
 
+const sanitizeSingleFolder = (folder) => {
+  const sanitized = parseFolderFilters(
+    Array.isArray(folder) ? folder : folder ? [folder] : []
+  );
+
+  return sanitized.length > 0 ? sanitized[0] : null;
+};
+
+const ensureAbsoluteTokenFolderPath = (folder, tokenRootFolder) => {
+  const sanitized = sanitizeSingleFolder(folder);
+
+  if (!sanitized) {
+    return null;
+  }
+
+  if (sanitized === tokenRootFolder) {
+    return sanitized;
+  }
+
+  const normalizedRootPrefix = `${tokenRootFolder}/`;
+
+  if (sanitized.startsWith(normalizedRootPrefix)) {
+    return sanitized;
+  }
+
+  return `${tokenRootFolder}/${sanitized}`;
+};
+
+const resolvePlayerRootFolder = (tokenRootFolder) => {
+  const candidates = parseFolderFilters(getDefaultPlayerTokenFolders());
+
+  for (const candidate of candidates) {
+    const absolute = ensureAbsoluteTokenFolderPath(candidate, tokenRootFolder);
+    if (absolute) {
+      return absolute;
+    }
+  }
+
+  return null;
+};
+
+const filterPlayerAccessibleFolders = (inputFolders, playerRootFolder, tokenRootFolder) => {
+  if (!playerRootFolder) {
+    return [];
+  }
+
+  const normalized = parseFolderFilters(inputFolders);
+
+  return normalized
+    .map((folder) => ensureAbsoluteTokenFolderPath(folder, tokenRootFolder))
+    .filter((absolute) => {
+      if (!absolute) {
+        return false;
+      }
+
+      return absolute === playerRootFolder || absolute.startsWith(`${playerRootFolder}/`);
+    });
+};
+
 const getDefaultPlayerTokenFolders = () => {
   const raw = process.env.CLOUDINARY_PLAYER_TOKEN_FOLDERS;
 
@@ -1730,14 +1789,43 @@ module.exports = (router) => {
           }
 
           const isDm = req.user && campaign.dm === req.user.username;
-          if (!isDm) {
+          const tokenRootFolder = getTokenRootFolder();
+
+          if (isDm) {
+            const requestedFolders = parseFolderFilters(req.query.folders);
+
+            try {
+              const folderTree = await listTokenFolderTree({ folders: requestedFolders });
+              return res.json(folderTree);
+            } catch (error) {
+              logger.warn('Failed to load token folder tree from Cloudinary', {
+                campaign: campaignName,
+                error: error.message,
+              });
+              return res.json({
+                rootFolder: tokenRootFolder,
+                folders: [],
+                flatFolders: [],
+              });
+            }
+          }
+
+          const playerRootFolder = resolvePlayerRootFolder(tokenRootFolder);
+          if (!playerRootFolder) {
             return res.status(403).json({ message: 'Forbidden' });
           }
 
-          const requestedFolders = parseFolderFilters(req.query.folders);
+          const allowedFolders = filterPlayerAccessibleFolders(
+            req.query.folders,
+            playerRootFolder,
+            tokenRootFolder
+          );
+
+          const folderTargets =
+            allowedFolders.length > 0 ? allowedFolders : [playerRootFolder];
 
           try {
-            const folderTree = await listTokenFolderTree({ folders: requestedFolders });
+            const folderTree = await listTokenFolderTree({ folders: folderTargets });
             return res.json(folderTree);
           } catch (error) {
             logger.warn('Failed to load token folder tree from Cloudinary', {
@@ -1745,7 +1833,7 @@ module.exports = (router) => {
               error: error.message,
             });
             return res.json({
-              rootFolder: getTokenRootFolder(),
+              rootFolder: playerRootFolder,
               folders: [],
               flatFolders: [],
             });
@@ -1779,10 +1867,29 @@ module.exports = (router) => {
 
           const isDm = req.user && campaign.dm === req.user.username;
           const playerFolders = getDefaultPlayerTokenFolders();
-          const requestedFolders = isDm ? parseFolderFilters(req.query.folders) : playerFolders;
+          const tokenRootFolder = getTokenRootFolder();
 
-          const folders =
-            isDm && requestedFolders.length === 0 ? null : requestedFolders.filter(Boolean);
+          let folders = null;
+          let playerRootFolder = null;
+
+          if (isDm) {
+            const requestedFolders = parseFolderFilters(req.query.folders);
+            folders = requestedFolders.length === 0 ? null : requestedFolders.filter(Boolean);
+          } else {
+            playerRootFolder = resolvePlayerRootFolder(tokenRootFolder);
+
+            if (!playerRootFolder) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+
+            const allowedFolders = filterPlayerAccessibleFolders(
+              req.query.folders,
+              playerRootFolder,
+              tokenRootFolder
+            );
+
+            folders = allowedFolders.length > 0 ? allowedFolders : [playerRootFolder];
+          }
 
           let manifest;
           try {
@@ -1803,7 +1910,7 @@ module.exports = (router) => {
               nextCursor: null,
               totalCount: null,
               appliedFolders: Array.isArray(folders) ? folders : [],
-              rootFolder: getTokenRootFolder(),
+              rootFolder: tokenRootFolder,
             };
           }
 


### PR DESCRIPTION
## Summary
- gate server token folder tree and manifest routes so players may only access the Adventurers subtree while keeping DM access unchanged
- update the token picker modal to build Adventurers filter options from the folder tree for players and scope manifest requests based on the active filter
- extend server and client tests to cover the new player-only folder access and manifest filtering behaviour

## Testing
- npm test -- TokenPickerModal
- (cd server && npm test -- campaigns.test.js)

------
https://chatgpt.com/codex/tasks/task_e_68e19df4d400832e8777d73282f37b7a