### PR TITLE
Update tiefling infernal legacy to Darkness

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -92,10 +92,10 @@ const LINEAGE_SPELLS = {
     baseLevel: 1,
     castingTime: 'Reaction',
   },
-  'tiefling-infernal-fireball': {
-    spellName: 'Fireball',
+  'tiefling-infernal-darkness': {
+    spellName: 'Darkness',
     maxUses: 1,
-    baseLevel: 3,
+    baseLevel: 2,
     castingTime: '1 action',
   },
 };
@@ -469,7 +469,7 @@ export default function Features({
         isChthonicTieflingLegacy && totalCharacterLevel >= 5,
       'tiefling-infernal-hellish-rebuke':
         isInfernalTieflingLegacy && totalCharacterLevel >= 3,
-      'tiefling-infernal-fireball':
+      'tiefling-infernal-darkness':
         isInfernalTieflingLegacy && totalCharacterLevel >= 5,
     };
   }, [

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1267,11 +1267,11 @@ test('tiefling fiendish legacy shows resistance and spells with ability details'
         usage: '1/long rest',
       },
       {
-        name: 'Fireball',
-        spellLevel: '3rd-level',
+        name: 'Darkness',
+        spellLevel: '2nd-level',
         unlockedAtLevel: 5,
         description:
-          'Detonate a roaring explosion of flame that engulfs creatures in a 20-foot-radius sphere.',
+          'Create a 15-foot-radius sphere of magical darkness that spreads around corners.',
         usage: '1/long rest',
       },
     ],
@@ -1384,7 +1384,7 @@ test('tiefling fiendish legacy shows resistance and spells with ability details'
     await userEvent.click(closeButton);
   });
 
-  expect(screen.getByText('Fireball (Level 5)')).toBeInTheDocument();
+  expect(screen.getByText('Darkness (Level 5)')).toBeInTheDocument();
 });
 
 test('tiefling legacy spell uses upcast modal with C button and tracks usage', async () => {
@@ -1413,10 +1413,10 @@ test('tiefling legacy spell uses upcast modal with C button and tracks usage', a
         usage: '1/long rest',
       },
       {
-        name: 'Fireball',
-        spellLevel: '3rd-level',
+        name: 'Darkness',
+        spellLevel: '2nd-level',
         unlockedAtLevel: 5,
-        description: 'A bright streak flashes to a point you choose.',
+        description: 'Magical darkness spreads from a point you choose.',
         usage: '1/long rest',
       },
     ],

--- a/server/__tests__/races.test.js
+++ b/server/__tests__/races.test.js
@@ -79,7 +79,7 @@ describe('Races API routes', () => {
       expect.arrayContaining([
         expect.objectContaining({ name: 'Fire Bolt', unlockedAtLevel: 1 }),
         expect.objectContaining({ name: 'Hellish Rebuke', unlockedAtLevel: 3 }),
-        expect.objectContaining({ name: 'Fireball', unlockedAtLevel: 5 }),
+        expect.objectContaining({ name: 'Darkness', unlockedAtLevel: 5 }),
       ])
     );
   });


### PR DESCRIPTION
## Summary
- swap the infernal lineage Fireball entry for Darkness with updated spell metadata and eligibility
- refresh client and server tests to expect Darkness as the 5th-level infernal legacy spell

## Testing
- CI=true npm --prefix client test -- Features.test.js
- npm --prefix server test -- races.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1a32298148323b45a7af2b9d913a3