### PR TITLE
Update chthonic tiefling lineage spells

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -74,16 +74,16 @@ const LINEAGE_SPELLS = {
     baseLevel: 2,
     castingTime: '1 action',
   },
-  'tiefling-chthonic-darkness': {
-    spellName: 'Darkness',
+  'tiefling-chthonic-false-life': {
+    spellName: 'False Life',
     maxUses: 1,
-    baseLevel: 2,
+    baseLevel: 1,
     castingTime: '1 action',
   },
-  'tiefling-chthonic-bestow-curse': {
-    spellName: 'Bestow Curse',
+  'tiefling-chthonic-ray-of-enfeeblement': {
+    spellName: 'Ray of Enfeeblement',
     maxUses: 1,
-    baseLevel: 3,
+    baseLevel: 2,
     castingTime: '1 action',
   },
   'tiefling-infernal-hellish-rebuke': {
@@ -463,9 +463,9 @@ export default function Features({
         isAbyssalTieflingLegacy && totalCharacterLevel >= 3,
       'tiefling-abyssal-hold-person':
         isAbyssalTieflingLegacy && totalCharacterLevel >= 5,
-      'tiefling-chthonic-darkness':
+      'tiefling-chthonic-false-life':
         isChthonicTieflingLegacy && totalCharacterLevel >= 3,
-      'tiefling-chthonic-bestow-curse':
+      'tiefling-chthonic-ray-of-enfeeblement':
         isChthonicTieflingLegacy && totalCharacterLevel >= 5,
       'tiefling-infernal-hellish-rebuke':
         isInfernalTieflingLegacy && totalCharacterLevel >= 3,

--- a/server/__tests__/races.test.js
+++ b/server/__tests__/races.test.js
@@ -71,8 +71,8 @@ describe('Races API routes', () => {
     expect(fiendishLegacies.chthonic.spells).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'Chill Touch', unlockedAtLevel: 1 }),
-        expect.objectContaining({ name: 'Darkness', unlockedAtLevel: 3 }),
-        expect.objectContaining({ name: 'Bestow Curse', unlockedAtLevel: 5 }),
+        expect.objectContaining({ name: 'False Life', unlockedAtLevel: 3 }),
+        expect.objectContaining({ name: 'Ray of Enfeeblement', unlockedAtLevel: 5 }),
       ])
     );
     expect(fiendishLegacies.infernal.spells).toEqual(

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -292,19 +292,19 @@ const races = {
             usage: "At will",
           },
           {
-            name: "Darkness",
-            spellLevel: "2nd-level",
+            name: "False Life",
+            spellLevel: "1st-level",
             unlockedAtLevel: 3,
             description:
-              "Fill a 15-foot-radius sphere with magical darkness that blocks light and darkvision.",
+              "Bolster yourself with necromantic vitality, gaining temporary hit points for the duration.",
             usage: "1/long rest",
           },
           {
-            name: "Bestow Curse",
-            spellLevel: "3rd-level",
+            name: "Ray of Enfeeblement",
+            spellLevel: "2nd-level",
             unlockedAtLevel: 5,
             description:
-              "Inflict a potent magical curse on a creature, imposing debilitating effects of your choice.",
+              "Sap a creature's strength with a weakening ray, halving its weapon damage on a failed Constitution save.",
             usage: "1/long rest",
           },
         ],


### PR DESCRIPTION
## Summary
- swap the chthonic tiefling lineage spell metadata to False Life and Ray of Enfeeblement
- align lineage spell eligibility checks and server-side spell lists/tests with the new spells

## Testing
- npm --prefix client test -- Features.test.js
- npm --prefix server test -- races.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1a5546aac8323b97f24d60f30558f