### PR TITLE
Relocate figurine controls to character info modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -597,6 +597,47 @@
   overflow-y: auto;
 }
 
+.character-info-figurine {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.character-info-figurine__preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 160px;
+  min-height: 120px;
+  background: rgba(17, 16, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  color: var(--bs-light);
+}
+
+.character-info-figurine__image {
+  max-height: 96px;
+  max-width: 96px;
+  object-fit: contain;
+}
+
+.character-info-figurine__placeholder {
+  font-size: 2rem;
+  opacity: 0.65;
+}
+
+.character-info-figurine__details {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+}
+
 .character-info-grid {
   display: grid;
   grid-template-columns: 1fr;

--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -13,6 +13,9 @@ export default function CharacterInfo({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  characterFigurine,
+  handleOpenTokenPicker,
+  tokenPickerSaving = false,
 }) {
   const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
@@ -117,6 +120,25 @@ export default function CharacterInfo({
     : null;
   const displaySize =
     form?.temporarySize || form?.size || form?.height || "—";
+  const hasFigurineSelection = Boolean(
+    characterFigurine?.figurineImageUrl || characterFigurine?.figurineImagePublicId
+  );
+  const canOpenTokenPicker = typeof handleOpenTokenPicker === 'function';
+  const isFigurineButtonDisabled = tokenPickerSaving || !canOpenTokenPicker;
+
+  const figurineButtonLabel = tokenPickerSaving
+    ? 'Updating Figurine...'
+    : hasFigurineSelection
+    ? 'Change Figurine'
+    : 'Choose Figurine';
+
+  const handleFigurineButtonClick = useCallback(() => {
+    if (tokenPickerSaving || !canOpenTokenPicker) {
+      return;
+    }
+
+    handleOpenTokenPicker();
+  }, [canOpenTokenPicker, handleOpenTokenPicker, tokenPickerSaving]);
 
   return (
     <Modal
@@ -136,6 +158,35 @@ export default function CharacterInfo({
           <Card.Title className="modal-title">Character Info</Card.Title>
         </Card.Header>
         <Card.Body className="modal-body character-info-body" style={{ maxHeight: "60vh" }}>
+          <div className="character-info-figurine">
+            <div className="character-info-figurine__preview" aria-live="polite">
+              {characterFigurine?.figurineImageUrl ? (
+                <img
+                  src={characterFigurine.figurineImageUrl}
+                  alt="Selected figurine token"
+                  className="character-info-figurine__image"
+                />
+              ) : (
+                <div className="character-info-figurine__placeholder" aria-hidden="true">
+                  <i className="fas fa-chess-king"></i>
+                </div>
+              )}
+              {!characterFigurine?.figurineImageUrl && hasFigurineSelection && (
+                <div className="character-info-figurine__details">Figurine selected</div>
+              )}
+              {!hasFigurineSelection && (
+                <div className="character-info-figurine__details">No figurine selected</div>
+              )}
+            </div>
+            <Button
+              variant="outline-light"
+              size="sm"
+              onClick={handleFigurineButtonClick}
+              disabled={isFigurineButtonDisabled}
+            >
+              {figurineButtonLabel}
+            </Button>
+          </div>
           <div className="character-info-grid">
             <div className="character-info-item">
               <div className="character-info-label">Level</div>

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -4,17 +4,21 @@ import CharacterInfo from './CharacterInfo';
 
 jest.mock('./LevelUp', () => () => <div />);
 
-test('renders race languages', () => {
-  const form = {
-    occupation: [],
-    race: { name: 'Elf', languages: ['Common', 'Elvish', 'Choice'] },
-    age: 100,
-    sex: 'M',
-    size: 'Medium',
-    weight: 180,
-  };
+const baseForm = {
+  occupation: [],
+  race: { languages: [] },
+  background: null,
+  age: 100,
+  sex: 'M',
+  size: 'Medium',
+  weight: 180,
+};
 
-  render(
+const renderCharacterInfo = (overrides = {}) => {
+  const { form: formOverrides = {}, ...rest } = overrides;
+  const form = { ...baseForm, ...formOverrides };
+
+  return render(
     <CharacterInfo
       form={form}
       show={true}
@@ -22,8 +26,17 @@ test('renders race languages', () => {
       onShowBackground={() => {}}
       onLongRest={() => {}}
       onShortRest={() => {}}
+      {...rest}
     />
   );
+};
+
+test('renders race languages', () => {
+  renderCharacterInfo({
+    form: {
+      race: { name: 'Elf', languages: ['Common', 'Elvish', 'Choice'] },
+    },
+  });
 
   expect(screen.getByText('Common, Elvish')).toBeInTheDocument();
   const sizeItem = screen.getByText('Size').closest('.character-info-item');
@@ -35,26 +48,11 @@ test('renders race languages', () => {
 
 test('renders background name and calls onShowBackground', () => {
   const onShowBackground = jest.fn();
-  const form = {
-    occupation: [],
-    race: { languages: [] },
-    background: { name: 'Soldier' },
-    age: 100,
-    sex: 'M',
-    size: 'Medium',
-    weight: 180,
-  };
 
-  render(
-    <CharacterInfo
-      form={form}
-      show={true}
-      handleClose={() => {}}
-      onShowBackground={onShowBackground}
-      onLongRest={() => {}}
-      onShortRest={() => {}}
-    />
-  );
+  renderCharacterInfo({
+    form: { background: { name: 'Soldier' } },
+    onShowBackground,
+  });
 
   expect(screen.getByText('Soldier')).toBeInTheDocument();
   const button = screen.getByLabelText('Show Background');
@@ -63,27 +61,10 @@ test('renders background name and calls onShowBackground', () => {
 });
 
 test('calls rest handlers when buttons clicked', () => {
-  const form = {
-    occupation: [],
-    race: { languages: [] },
-    age: 100,
-    sex: 'M',
-    size: 'Medium',
-    weight: 180,
-  };
   const onLongRest = jest.fn();
   const onShortRest = jest.fn();
 
-  render(
-    <CharacterInfo
-      form={form}
-      show={true}
-      handleClose={() => {}}
-      onShowBackground={() => {}}
-      onLongRest={onLongRest}
-      onShortRest={onShortRest}
-    />
-  );
+  renderCharacterInfo({ onLongRest, onShortRest });
 
   fireEvent.click(screen.getByText('Long Rest'));
   fireEvent.click(screen.getByText('Short Rest'));
@@ -92,29 +73,18 @@ test('calls rest handlers when buttons clicked', () => {
 });
 
 test('renders goliath subrace within race card when ancestry selected', () => {
-  const form = {
-    occupation: [],
-    race: {
-      name: 'Goliath',
-      languages: [],
-      selectedAncestryKey: 'cloud',
-      giantAncestries: {
-        cloud: { label: "Cloud's Jaunt", ancestryName: 'Cloud Giant' },
+  renderCharacterInfo({
+    form: {
+      race: {
+        name: 'Goliath',
+        languages: [],
+        selectedAncestryKey: 'cloud',
+        giantAncestries: {
+          cloud: { label: "Cloud's Jaunt", ancestryName: 'Cloud Giant' },
+        },
       },
     },
-    size: 'Medium',
-  };
-
-  render(
-    <CharacterInfo
-      form={form}
-      show={true}
-      handleClose={() => {}}
-      onShowBackground={() => {}}
-      onLongRest={() => {}}
-      onShortRest={() => {}}
-    />
-  );
+  });
 
   const raceItem = screen.getByText('Race').closest('.character-info-item');
   expect(raceItem).not.toBeNull();
@@ -126,29 +96,18 @@ test('renders goliath subrace within race card when ancestry selected', () => {
 });
 
 test('renders dragonborn ancestry within race card when ancestry selected', () => {
-  const form = {
-    occupation: [],
-    race: {
-      name: 'Dragonborn',
-      languages: [],
-      selectedAncestryKey: 'bronze',
-      dragonAncestries: {
-        bronze: { label: 'Bronze Dragon', ancestryName: 'Bronze' },
+  renderCharacterInfo({
+    form: {
+      race: {
+        name: 'Dragonborn',
+        languages: [],
+        selectedAncestryKey: 'bronze',
+        dragonAncestries: {
+          bronze: { label: 'Bronze Dragon', ancestryName: 'Bronze' },
+        },
       },
     },
-    size: 'Medium',
-  };
-
-  render(
-    <CharacterInfo
-      form={form}
-      show={true}
-      handleClose={() => {}}
-      onShowBackground={() => {}}
-      onLongRest={() => {}}
-      onShortRest={() => {}}
-    />
-  );
+  });
 
   const raceItem = screen.getByText('Race').closest('.character-info-item');
   expect(raceItem).not.toBeNull();
@@ -160,30 +119,20 @@ test('renders dragonborn ancestry within race card when ancestry selected', () =
 });
 
 test('renders elven lineage within race card when lineage selected', () => {
-  const form = {
-    occupation: [],
-    race: {
-      name: 'Elf',
-      languages: [],
-      selectedAncestryKey: 'wood',
-      elvenLineages: {
-        wood: { label: 'Wood Elf' },
+  renderCharacterInfo({
+    form: {
+      race: {
+        name: 'Elf',
+        languages: [],
+        selectedAncestryKey: 'wood',
+        elvenLineages: {
+          wood: { label: 'Wood Elf' },
+        },
       },
+      elvenLineageKey: 'wood',
+      elvenLineage: { label: 'Wood Elf' },
     },
-    elvenLineageKey: 'wood',
-    elvenLineage: { label: 'Wood Elf' },
-  };
-
-  render(
-    <CharacterInfo
-      form={form}
-      show={true}
-      handleClose={() => {}}
-      onShowBackground={() => {}}
-      onLongRest={() => {}}
-      onShortRest={() => {}}
-    />
-  );
+  });
 
   const raceItem = screen.getByText('Race').closest('.character-info-item');
   expect(raceItem).not.toBeNull();
@@ -192,3 +141,32 @@ test('renders elven lineage within race card when lineage selected', () => {
   expect(getByText('Wood Elf')).toBeInTheDocument();
 });
 
+test('shows figurine placeholder and triggers picker when requested', () => {
+  const handleOpenTokenPicker = jest.fn();
+
+  renderCharacterInfo({ handleOpenTokenPicker });
+
+  expect(screen.getByText('No figurine selected')).toBeInTheDocument();
+  const figurineButton = screen.getByRole('button', { name: 'Choose Figurine' });
+  fireEvent.click(figurineButton);
+  expect(handleOpenTokenPicker).toHaveBeenCalled();
+});
+
+test('disables figurine button while saving and shows current figurine', () => {
+  const handleOpenTokenPicker = jest.fn();
+
+  renderCharacterInfo({
+    characterFigurine: { figurineImageUrl: 'https://example.com/token.png' },
+    handleOpenTokenPicker,
+    tokenPickerSaving: true,
+  });
+
+  expect(screen.getByAltText('Selected figurine token')).toHaveAttribute(
+    'src',
+    'https://example.com/token.png'
+  );
+  const figurineButton = screen.getByRole('button', { name: 'Updating Figurine...' });
+  expect(figurineButton).toBeDisabled();
+  fireEvent.click(figurineButton);
+  expect(handleOpenTokenPicker).not.toHaveBeenCalled();
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -4380,27 +4380,6 @@ export default function ZombiesCharacterSheet() {
               {form?.characterName || 'Loading Character'}
             </h1>
 
-            <div className="d-flex justify-content-center mt-2">
-              <Button
-                variant="outline-light"
-                size="sm"
-                onClick={handleOpenTokenPicker}
-              >
-                {characterFigurine?.figurineImageUrl || characterFigurine?.figurineImagePublicId
-                  ? 'Change Figurine'
-                  : 'Choose Figurine'}
-              </Button>
-            </div>
-            {characterFigurine?.figurineImageUrl ? (
-              <div className="d-flex justify-content-center mt-2">
-                <img
-                  src={characterFigurine.figurineImageUrl}
-                  alt="Current figurine token"
-                  style={{ maxHeight: '96px', maxWidth: '96px', objectFit: 'contain' }}
-                />
-              </div>
-            ) : null}
-
             <HealthDefense
               form={form}
               totalLevel={totalLevel}
@@ -4633,6 +4612,9 @@ export default function ZombiesCharacterSheet() {
           onShowBackground={handleShowBackground}
           onLongRest={handleLongRest}
           onShortRest={handleShortRest}
+          characterFigurine={characterFigurine}
+          handleOpenTokenPicker={handleOpenTokenPicker}
+          tokenPickerSaving={tokenPickerSaving}
         />
         <Skills
           form={form}


### PR DESCRIPTION
## Summary
- move the figurine selection controls from the character sheet header into the Character Info modal
- add dedicated styling for the figurine preview and change button in the modal body
- extend CharacterInfo tests to cover the new figurine picker interactions

## Testing
- CI=true npm --prefix client test -- CharacterInfo.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e1a58364a4832eb8b82f07c8fb201e