### PR TITLE
Ensure modal outline buttons display white text

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1943,10 +1943,29 @@ max-width: 300px;
   color: #fff !important;
 }
 
-.dnd-modal .modal-body .btn,
 .dnd-modal .modal-body table,
 .dnd-modal .modal-body .dropdown-menu {
-  color: initial;
+  color: inherit;
+}
+
+.dnd-modal .modal-body .btn-outline-light {
+  color: #fff;
+  border-color: #fff;
+  background-color: transparent;
+}
+
+.dnd-modal .modal-body .btn-outline-light:hover,
+.dnd-modal .modal-body .btn-outline-light:focus {
+  color: #fff;
+  border-color: #fff;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.dnd-modal .modal-body .btn-outline-light:disabled,
+.dnd-modal .modal-body .btn-outline-light.disabled {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.65);
+  background-color: transparent;
 }
 
 .dnd-modal .modal-body .stat-card-view {


### PR DESCRIPTION
## Summary
- stop overriding modal button text color with `initial`
- explicitly style `.btn-outline-light` variants in modals to keep white text across states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a920a950832ebced496189f37702