### PR TITLE
Use opaque background for DnD modal content

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1934,9 +1934,9 @@ max-width: 300px;
 
 .dnd-modal .modal-content {
   background: none !important;
-  background-color: rgba(0, 0, 0, 0.5) !important;
-  box-shadow: none !important;
-  border: none !important;
+  background-color: rgba(17, 16, 19, 0.95) !important;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55) !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
 }
 
 .dnd-modal .modal-body {


### PR DESCRIPTION
## Summary
- update the shared dnd modal content styling to use an opaque dark backdrop with a soft border and shadow for contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a9840564832e9457e7f3ee4c758d