### PR TITLE
Fix tiefling legacy canonical data refresh

### DIFF
--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -232,35 +232,64 @@ export default function Features({
         ? form.tieflingLegacyAbility
         : '';
 
-    let legacy = legacyFromForm;
-    let legacyKey = legacyKeyFromForm;
-    if (!legacy) {
-      if (legacyKey && race?.fiendishLegacies?.[legacyKey]) {
-        legacy = race.fiendishLegacies[legacyKey];
-      } else if (race?.selectedAncestry && race?.fiendishLegacies) {
-        legacy = race.selectedAncestry;
-        legacyKey =
-          typeof race?.selectedAncestryKey === 'string'
-            ? race.selectedAncestryKey
-            : '';
-      } else if (
-        typeof race?.selectedAncestryKey === 'string' &&
-        race?.fiendishLegacies?.[race.selectedAncestryKey]
-      ) {
-        legacy = race.fiendishLegacies[race.selectedAncestryKey];
-        legacyKey = race.selectedAncestryKey;
+    const fiendishLegacies = race?.fiendishLegacies || {};
+    const selectedAncestryKey =
+      typeof race?.selectedAncestryKey === 'string' ? race.selectedAncestryKey : '';
+
+    const legacyKeyCandidates = [legacyKeyFromForm, selectedAncestryKey].filter(
+      (candidateKey, index, arr) =>
+        typeof candidateKey === 'string' &&
+        candidateKey &&
+        arr.indexOf(candidateKey) === index,
+    );
+
+    let legacy = null;
+    let legacyKey = '';
+
+    for (const candidateKey of legacyKeyCandidates) {
+      if (fiendishLegacies?.[candidateKey]) {
+        legacy = fiendishLegacies[candidateKey];
+        legacyKey = candidateKey;
+        break;
       }
     }
 
-    let ability = abilityFromForm;
-    if (!ability) {
-      ability =
-        typeof race?.selectedLineageAbility === 'string'
-          ? race.selectedLineageAbility
-          : '';
+    if (!legacy && selectedAncestryKey && race?.selectedAncestry) {
+      legacy = race.selectedAncestry;
+      legacyKey = selectedAncestryKey;
     }
-    if (!ability && legacy?.spellcastingAbilities?.length) {
-      ability = legacy.spellcastingAbilities[0];
+
+    if (!legacy && legacyFromForm) {
+      legacy = legacyFromForm;
+      legacyKey = legacyKey || legacyKeyFromForm;
+    }
+
+    const legacyAbilities = Array.isArray(legacy?.spellcastingAbilities)
+      ? legacy.spellcastingAbilities.filter(
+          (option) => typeof option === 'string' && option.trim(),
+        )
+      : [];
+
+    const normalizedAbilityFromForm =
+      typeof abilityFromForm === 'string' ? abilityFromForm.trim() : '';
+
+    let ability = '';
+    if (legacyAbilities.length) {
+      const matchedAbility = legacyAbilities.find(
+        (option) =>
+          typeof option === 'string' &&
+          normalizedAbilityFromForm &&
+          option.toLowerCase() === normalizedAbilityFromForm.toLowerCase(),
+      );
+      ability = matchedAbility || legacyAbilities[0];
+    }
+
+    if (!ability && typeof race?.selectedLineageAbility === 'string') {
+      ability = race.selectedLineageAbility;
+    }
+
+    if (!ability) {
+      ability = normalizedAbilityFromForm;
     }
 
     return {

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1387,6 +1387,106 @@ test('tiefling fiendish legacy shows resistance and spells with ability details'
   expect(screen.getByText('Darkness (Level 5)')).toBeInTheDocument();
 });
 
+test('tiefling legacy spells refresh from race data when form legacy is stale', async () => {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  const canonicalChthonicLegacy = {
+    label: 'Chthonic Legacy',
+    resistance: 'Necrotic',
+    spellcastingAbilities: ['Wisdom', 'Charisma'],
+    spells: [
+      {
+        name: 'Chill Touch',
+        spellLevel: 'Cantrip',
+        unlockedAtLevel: 1,
+        description:
+          'Create a ghostly skeletal hand that clings to a creature, dealing necrotic damage and hampering its healing.',
+        usage: 'At will',
+      },
+      {
+        name: 'False Life',
+        spellLevel: '1st-level',
+        unlockedAtLevel: 3,
+        description:
+          'Bolster yourself with necromantic vitality, gaining temporary hit points for the duration.',
+        usage: '1/long rest',
+      },
+      {
+        name: 'Ray of Enfeeblement',
+        spellLevel: '2nd-level',
+        unlockedAtLevel: 5,
+        description:
+          "Sap a creature's strength with a weakening ray, halving its weapon damage on a failed Constitution save.",
+        usage: '1/long rest',
+      },
+    ],
+  };
+
+  const staleLegacy = {
+    label: 'Chthonic Legacy (Stale)',
+    resistance: 'Cold',
+    spellcastingAbilities: ['Intelligence'],
+    spells: [
+      {
+        name: 'Stale Spell',
+        spellLevel: '1st-level',
+        unlockedAtLevel: 3,
+        description: 'An outdated spell entry that should be replaced.',
+        usage: '1/long rest',
+      },
+      {
+        name: 'Ancient Misfire',
+        spellLevel: '2nd-level',
+        unlockedAtLevel: 5,
+        description: 'Another outdated spell entry.',
+        usage: '1/long rest',
+      },
+    ],
+  };
+
+  render(
+    <Features
+      form={{
+        race: {
+          name: 'Tiefling',
+          darkvisionRange: 60,
+          fiendishLegacies: { chthonic: canonicalChthonicLegacy },
+        },
+        tieflingLegacyKey: 'chthonic',
+        tieflingLegacy: staleLegacy,
+        tieflingLegacyAbility: 'Intelligence',
+        occupation: [{ Name: 'Wizard', Level: 5 }],
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      longRestCount={0}
+      shortRestCount={0}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const resistanceHeading = await screen.findByText('Necrotic Resistance');
+  const resistanceCard = resistanceHeading.closest('.feature-card');
+  expect(resistanceCard).not.toBeNull();
+  if (!resistanceCard) {
+    throw new Error('Expected Necrotic Resistance feature card');
+  }
+
+  const resistanceWithin = within(resistanceCard);
+  expect(resistanceWithin.getByText(/Resistance: Necrotic/i)).toBeInTheDocument();
+  expect(
+    resistanceWithin.getByText(/Spellcasting Ability: Wisdom/i)
+  ).toBeInTheDocument();
+
+  expect(await screen.findByText('False Life (Level 3)')).toBeInTheDocument();
+  expect(await screen.findByText('Ray of Enfeeblement (Level 5)')).toBeInTheDocument();
+  expect(screen.queryByText('Stale Spell (Level 3)')).not.toBeInTheDocument();
+  expect(screen.queryByText('Ancient Misfire (Level 5)')).not.toBeInTheDocument();
+});
+
 test('tiefling legacy spell uses upcast modal with C button and tracks usage', async () => {
   apiFetch.mockResolvedValue({
     ok: true,


### PR DESCRIPTION
## Summary
- prefer canonical fiendish legacy data for tiefling features and derive ability/resistance from that source
- add regression coverage to ensure stale legacy spell data is overwritten by canonical spells

## Testing
- `npm test -- --runTestsByPath client/src/components/Zombies/attributes/Features.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e1aaffe45083238aebbb9067fec3f6