### PR TITLE
Add automatic enemy figurine suggestions

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -720,6 +720,7 @@ export default function ZombiesDM() {
     const activeMapTokensRef = useRef(activeMapTokens);
     const campaignMapRef = useRef(campaignMap);
     const activeMapIdRef = useRef(activeMapId);
+    const enemyTokenSelectionRef = useRef(enemyTokenSelection);
 
     const campaignId = params.campaign ?? '';
     const encodedCampaign = useMemo(
@@ -799,6 +800,10 @@ export default function ZombiesDM() {
     useEffect(() => {
       activeMapIdRef.current = activeMapId;
     }, [activeMapId]);
+
+    useEffect(() => {
+      enemyTokenSelectionRef.current = enemyTokenSelection;
+    }, [enemyTokenSelection]);
 
     useEffect(() => {
       if (!mapEditorErrors.title) {
@@ -985,6 +990,42 @@ export default function ZombiesDM() {
       return message;
     }, []);
 
+    const syncEnemyTokenSelection = useCallback(
+      (roster) => {
+        if (!Array.isArray(roster) || roster.length === 0) {
+          return;
+        }
+
+        const currentSelection = enemyTokenSelectionRef.current || {};
+        const hasUrl =
+          typeof currentSelection.figurineImageUrl === 'string' &&
+          currentSelection.figurineImageUrl.trim() !== '';
+        const hasPublicId =
+          typeof currentSelection.figurineImagePublicId === 'string' &&
+          currentSelection.figurineImagePublicId.trim() !== '';
+
+        if (hasUrl || hasPublicId) {
+          return;
+        }
+
+        const latestEnemy = roster[roster.length - 1];
+        if (!latestEnemy || typeof latestEnemy !== 'object') {
+          return;
+        }
+
+        const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(latestEnemy);
+        if (!figurineImageUrl && !figurineImagePublicId) {
+          return;
+        }
+
+        setEnemyTokenSelection({
+          figurineImageUrl: figurineImageUrl || null,
+          figurineImagePublicId: figurineImagePublicId || null,
+        });
+      },
+      [setEnemyTokenSelection]
+    );
+
     const fetchRecords = useCallback(async () => {
       if (!campaignId || !encodedCampaign) {
         setRecords([]);
@@ -1023,7 +1064,9 @@ export default function ZombiesDM() {
 
         if (enemiesResponse.ok) {
           const enemiesData = await enemiesResponse.json();
-          setEnemies(Array.isArray(enemiesData) ? enemiesData : []);
+          const normalizedEnemies = Array.isArray(enemiesData) ? enemiesData : [];
+          setEnemies(normalizedEnemies);
+          syncEnemyTokenSelection(normalizedEnemies);
         } else if (enemiesResponse.status === 404) {
           setEnemies([]);
         } else {
@@ -1118,7 +1161,7 @@ export default function ZombiesDM() {
       } finally {
         setMapLoading(false);
       }
-    }, [campaignId, encodedCampaign, applyMapPayload]);
+    }, [campaignId, encodedCampaign, applyMapPayload, syncEnemyTokenSelection]);
 
     const fetchMonsterCatalog = useCallback(async () => {
       if (monsterCatalogLoading) {
@@ -1949,6 +1992,7 @@ export default function ZombiesDM() {
 
         const sanitized = roster.filter((entry) => entry && typeof entry === 'object');
         setEnemies(sanitized);
+        syncEnemyTokenSelection(sanitized);
       };
 
       const handleCharacterMetadataUpdate = (update) => {
@@ -2029,7 +2073,7 @@ export default function ZombiesDM() {
         socket.disconnect();
         socketRef.current = null;
       };
-    }, [campaignId, applyMapPayload]);
+    }, [campaignId, applyMapPayload, syncEnemyTokenSelection]);
 
     const persistTokenPosition = useCallback(
       async ({ mapId, characterId, x, y }) => {

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -29,6 +29,7 @@ jest.mock('../utils/cloudinary', () => ({
   listTokenAssets: jest.fn(),
   listTokenFolderTree: jest.fn(),
   getTokenRootFolder: jest.fn(() => 'Tokens'),
+  suggestEnemyFigurine: jest.fn(),
 }));
 const { emitCombatUpdate, emitEnemiesUpdate, emitMapUpdate } = require('../utils/socket');
 const { getMonsterByIndex } = require('../utils/dnd5eApi');
@@ -39,6 +40,7 @@ const {
   listTokenAssets,
   listTokenFolderTree,
   getTokenRootFolder,
+  suggestEnemyFigurine,
 } = require('../utils/cloudinary');
 const registerCampaignRoutes = require('../routes/campaigns');
 
@@ -72,6 +74,7 @@ describe('Campaign routes', () => {
     listTokenAssets.mockReset();
     listTokenFolderTree.mockReset();
     getTokenRootFolder.mockReset();
+    suggestEnemyFigurine.mockReset();
     uploadMapImage.mockResolvedValue({
       secure_url:
         'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/default.png',
@@ -79,6 +82,7 @@ describe('Campaign routes', () => {
     });
     deleteMapImage.mockResolvedValue({ result: 'ok' });
     getTokenRootFolder.mockReturnValue('Tokens');
+    suggestEnemyFigurine.mockResolvedValue(null);
     mockUser = { username: 'DM' };
   });
 
@@ -1224,9 +1228,18 @@ describe('Campaign routes', () => {
     expect(res.body).toEqual([{ enemyId: 'enemy-1', name: 'Goblin' }]);
   });
 
-  test('add enemy success', async () => {
-    getMonsterByIndex.mockResolvedValue({ index: 'goblin' });
-    buildEnemyRecord.mockImplementation((monster, enemyId, providedName) => ({ enemyId, name: 'Goblin', providedName }));
+  test('add enemy success with suggested figurine', async () => {
+    getMonsterByIndex.mockResolvedValue({ index: 'goblin', name: 'Goblin' });
+    buildEnemyRecord.mockImplementation((monster, enemyId, providedName, extras) => ({
+      enemyId,
+      name: 'Goblin',
+      providedName,
+      ...extras,
+    }));
+    suggestEnemyFigurine.mockResolvedValue({
+      figurineImageUrl: 'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/goblin.png',
+      figurineImagePublicId: 'Tokens/DM/goblin',
+    });
     const findOneAndUpdate = jest.fn().mockImplementation(async (query, update) => ({
       value: {
         campaignName: 'Test',
@@ -1247,16 +1260,61 @@ describe('Campaign routes', () => {
     expect(res.body.name).toBe('Goblin');
     expect(typeof res.body.enemyId).toBe('string');
     expect(getMonsterByIndex).toHaveBeenCalledWith('goblin');
+    expect(suggestEnemyFigurine).toHaveBeenCalledWith({ index: 'goblin', name: 'Goblin' });
     expect(buildEnemyRecord).toHaveBeenCalledWith(
-      { index: 'goblin' },
+      { index: 'goblin', name: 'Goblin' },
       res.body.enemyId,
       undefined,
-      expect.objectContaining({ figurineImagePublicId: null, figurineImageUrl: null })
+      expect.objectContaining({
+        figurineImagePublicId: 'Tokens/DM/goblin',
+        figurineImageUrl: 'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/goblin.png',
+      })
     );
+    expect(res.body.figurineImageUrl).toBe(
+      'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/goblin.png'
+    );
+    expect(res.body.figurineImagePublicId).toBe('Tokens/DM/goblin');
     expect(emitEnemiesUpdate).toHaveBeenCalledWith(
       'Test',
       [expect.objectContaining({ enemyId: res.body.enemyId, name: 'Goblin' })]
     );
+  });
+
+  test('add enemy success without suggested figurine fallback', async () => {
+    getMonsterByIndex.mockResolvedValue({ index: 'skeleton', name: 'Skeleton' });
+    suggestEnemyFigurine.mockResolvedValue(null);
+    buildEnemyRecord.mockImplementation((monster, enemyId, providedName, extras) => ({
+      enemyId,
+      name: monster.name,
+      providedName,
+      ...extras,
+    }));
+    const findOneAndUpdate = jest.fn().mockImplementation(async (query, update) => ({
+      value: {
+        campaignName: 'Test',
+        enemies: [update.$push.enemies],
+      },
+    }));
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOneAndUpdate,
+      }),
+    });
+
+    const res = await request(app)
+      .post('/campaigns/Test/enemies')
+      .send({ index: 'skeleton' });
+
+    expect(res.status).toBe(200);
+    expect(suggestEnemyFigurine).toHaveBeenCalledWith({ index: 'skeleton', name: 'Skeleton' });
+    expect(buildEnemyRecord).toHaveBeenCalledWith(
+      { index: 'skeleton', name: 'Skeleton' },
+      res.body.enemyId,
+      undefined,
+      expect.objectContaining({ figurineImagePublicId: null, figurineImageUrl: null })
+    );
+    expect(res.body.figurineImageUrl).toBeNull();
+    expect(res.body.figurineImagePublicId).toBeNull();
   });
 
   test('delete enemy success', async () => {

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -20,6 +20,7 @@ const {
   listTokenAssets,
   getTokenRootFolder,
   listTokenFolderTree,
+  suggestEnemyFigurine,
 } = require('../utils/cloudinary');
 
 const deriveCloudinaryPublicIdFromUrl = (url) => {
@@ -1448,9 +1449,23 @@ module.exports = (router) => {
               ? req.body.figurineImagePublicId.trim()
               : '';
 
+          let suggestedFigurine = null;
+          if (!rawFigurineUrl && !rawFigurinePublicId && typeof suggestEnemyFigurine === 'function') {
+            try {
+              suggestedFigurine = await suggestEnemyFigurine(monster);
+            } catch (suggestionError) {
+              logger.warn('Failed to suggest figurine for enemy', {
+                error: suggestionError.message,
+                monsterIndex: monster?.index,
+              });
+            }
+          }
+
           const enemyRecord = buildEnemyRecord(monster, enemyId, name, {
-            figurineImageUrl: rawFigurineUrl || null,
-            figurineImagePublicId: rawFigurinePublicId || null,
+            figurineImageUrl:
+              rawFigurineUrl || suggestedFigurine?.figurineImageUrl || null,
+            figurineImagePublicId:
+              rawFigurinePublicId || suggestedFigurine?.figurineImagePublicId || null,
           });
 
           if (!enemyRecord) {

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -164,6 +164,10 @@ const sanitizeTokenResource = (resource = {}, rootFolder = DEFAULT_TOKEN_ROOT_FO
     width: typeof resource.width === 'number' ? resource.width : null,
     height: typeof resource.height === 'number' ? resource.height : null,
     createdAt: resource.created_at || null,
+    metadata:
+      resource.metadata && typeof resource.metadata === 'object' ? resource.metadata : null,
+    context:
+      resource.context && typeof resource.context === 'object' ? resource.context : null,
   };
 };
 
@@ -408,6 +412,360 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
   };
 };
 
+const DM_FOLDER_HINTS = ['DM', 'DM Only', 'DM-Only', 'DMOnly', '_DM'];
+const DM_FOLDER_PATTERN = /(^|\/)dm([ -]?only)?(\/|$)/i;
+const CONFIDENT_SUGGESTION_SCORE = 8;
+
+const sanitizeMatchKey = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const stringValue = typeof value === 'string' ? value : String(value);
+  const trimmed = stringValue.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = trimmed
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return normalized || null;
+};
+
+const expandKeyVariants = (value) => {
+  const base = sanitizeMatchKey(value);
+  if (!base) {
+    return [];
+  }
+
+  const variants = new Set([base]);
+
+  if (base.includes('-')) {
+    variants.add(base.replace(/-/g, ''));
+  }
+
+  return Array.from(variants).filter(Boolean);
+};
+
+const collectMonsterKeys = (monsterDetail = {}) => {
+  if (!monsterDetail || typeof monsterDetail !== 'object') {
+    return [];
+  }
+
+  const { index, slug, name, type, subtype } = monsterDetail;
+
+  const candidateValues = [
+    index,
+    slug,
+    name,
+    subtype,
+    type,
+    monsterDetail.monster_index,
+    monsterDetail.monster_slug,
+    monsterDetail.monster_type,
+    monsterDetail.monster_subtype,
+    monsterDetail.creature_type,
+    monsterDetail.creature_subtype,
+  ];
+
+  if (typeof name === 'string') {
+    const words = name.split(/[^A-Za-z0-9]+/g).filter(Boolean);
+    candidateValues.push(...words);
+  }
+
+  const sanitized = new Set();
+  candidateValues.forEach((value) => {
+    expandKeyVariants(value).forEach((variant) => sanitized.add(variant));
+  });
+
+  return Array.from(sanitized).filter(Boolean);
+};
+
+const collectCandidateTokens = (resource) => {
+  const tokens = new Set();
+
+  const addValue = (value) => {
+    expandKeyVariants(value).forEach((variant) => tokens.add(variant));
+  };
+
+  const crawl = (value) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach(crawl);
+      return;
+    }
+
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(crawl);
+      return;
+    }
+
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      addValue(value);
+    }
+  };
+
+  if (resource.publicId) {
+    addValue(resource.publicId);
+    resource.publicId
+      .split('/')
+      .filter(Boolean)
+      .forEach((segment) => addValue(segment));
+  }
+
+  if (resource.filename) {
+    addValue(resource.filename);
+  }
+
+  if (resource.metadata) {
+    crawl(resource.metadata);
+  }
+
+  if (resource.context) {
+    crawl(resource.context);
+  }
+
+  return tokens;
+};
+
+const evaluateResourceMatch = (resource, keys) => {
+  if (!resource || !keys || keys.length === 0) {
+    return null;
+  }
+
+  const candidateTokens = collectCandidateTokens(resource);
+  if (candidateTokens.size === 0) {
+    return null;
+  }
+
+  let score = 0;
+  let matchedCount = 0;
+  let hasExact = false;
+
+  keys.forEach((key) => {
+    let bestForKey = 0;
+
+    candidateTokens.forEach((token) => {
+      if (!token || !key) {
+        return;
+      }
+
+      if (token === key) {
+        bestForKey = Math.max(bestForKey, 10);
+        hasExact = true;
+        return;
+      }
+
+      if (token.includes(key)) {
+        bestForKey = Math.max(bestForKey, 4);
+      } else if (key.includes(token) && token.length >= 3) {
+        bestForKey = Math.max(bestForKey, 2);
+      }
+    });
+
+    if (bestForKey > 0) {
+      matchedCount += 1;
+      score += bestForKey;
+    }
+  });
+
+  if (matchedCount === 0) {
+    return null;
+  }
+
+  const folder = typeof resource.folder === 'string' ? resource.folder : '';
+  const isDmFolder = DM_FOLDER_PATTERN.test(folder);
+  if (isDmFolder) {
+    score += 1;
+  }
+
+  return { score, matchedCount, hasExact, isDmFolder };
+};
+
+const selectBestSuggestion = (resources, keys, rootFolder) => {
+  if (!Array.isArray(resources) || resources.length === 0) {
+    return null;
+  }
+
+  let best = null;
+
+  resources.forEach((resource) => {
+    const sanitized = sanitizeTokenResource(resource, rootFolder);
+    if (!sanitized) {
+      return;
+    }
+
+    const evaluation = evaluateResourceMatch(sanitized, keys);
+    if (!evaluation) {
+      return;
+    }
+
+    if (!best) {
+      best = { resource: sanitized, ...evaluation };
+      return;
+    }
+
+    if (evaluation.score > best.score) {
+      best = { resource: sanitized, ...evaluation };
+      return;
+    }
+
+    if (evaluation.score === best.score) {
+      if (evaluation.matchedCount > best.matchedCount) {
+        best = { resource: sanitized, ...evaluation };
+        return;
+      }
+
+      if (evaluation.matchedCount === best.matchedCount) {
+        if (evaluation.isDmFolder && !best.isDmFolder) {
+          best = { resource: sanitized, ...evaluation };
+        }
+      }
+    }
+  });
+
+  if (!best) {
+    return null;
+  }
+
+  if (!best.hasExact && best.score < CONFIDENT_SUGGESTION_SCORE) {
+    return null;
+  }
+
+  if (!best.resource || !best.resource.publicId || !best.resource.secureUrl) {
+    return null;
+  }
+
+  return {
+    figurineImageUrl: best.resource.secureUrl,
+    figurineImagePublicId: best.resource.publicId,
+  };
+};
+
+const buildMatchExpressions = (keys) => {
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return [];
+  }
+
+  const metaKeys = [
+    'monsterIndex',
+    'monster_index',
+    'monsterSlug',
+    'monster_slug',
+    'slug',
+    'name',
+    'type',
+    'subtype',
+    'creatureType',
+    'creature_type',
+    'creatureSubtype',
+    'creature_subtype',
+  ];
+
+  const expressions = new Set();
+
+  keys.forEach((key) => {
+    const variants = expandKeyVariants(key);
+    variants.forEach((variant) => {
+      const escaped = escapeExpressionValue(variant);
+      expressions.add(`public_id="${escaped}"`);
+      expressions.add(`public_id="${escapeExpressionValue(`*${variant}*`)}"`);
+      expressions.add(`filename="${escaped}"`);
+      expressions.add(`filename="${escapeExpressionValue(`*${variant}*`)}"`);
+      metaKeys.forEach((metaKey) => {
+        expressions.add(`metadata.${metaKey}="${escaped}"`);
+      });
+    });
+  });
+
+  return Array.from(expressions);
+};
+
+const executeFigurineSearch = async (sdk, { rootFolder, keys, folderHints }) => {
+  if (!sdk?.search || typeof sdk.search.expression !== 'function') {
+    return null;
+  }
+
+  const matchExpressions = buildMatchExpressions(keys);
+  if (matchExpressions.length === 0) {
+    return null;
+  }
+
+  const expressionSegments = ['resource_type:image'];
+  const folderExpressions = buildFolderExpressions(rootFolder, folderHints || []);
+
+  if (folderExpressions.length > 0) {
+    expressionSegments.push(`(${folderExpressions.join(' OR ')})`);
+  }
+
+  expressionSegments.push(`(${matchExpressions.join(' OR ')})`);
+
+  const expression = expressionSegments.join(' AND ');
+
+  const maxResults = Math.min(Math.max(keys.length * 20, 50), TOKEN_FALLBACK_MAX_RESULTS);
+
+  try {
+    let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
+    search = search
+      .max_results(maxResults)
+      .with_field('context')
+      .with_field('metadata');
+
+    const result = await search.execute();
+    const resources = Array.isArray(result?.resources) ? result.resources : [];
+
+    return selectBestSuggestion(resources, keys, rootFolder);
+  } catch (error) {
+    return null;
+  }
+};
+
+const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true } = {}) => {
+  const keys = collectMonsterKeys(monsterDetail);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  try {
+    configure();
+  } catch (error) {
+    return null;
+  }
+
+  const sdk = resolveCloudinary();
+  const rootFolder = getTokenRootFolder();
+
+  const searchScenarios = [
+    { folderHints: DM_FOLDER_HINTS },
+  ];
+
+  if (includeGeneralSearch) {
+    searchScenarios.push({ folderHints: [] });
+  }
+
+  for (const scenario of searchScenarios) {
+    const suggestion = await executeFigurineSearch(sdk, {
+      rootFolder,
+      keys,
+      folderHints: scenario.folderHints,
+    });
+
+    if (suggestion) {
+      return suggestion;
+    }
+  }
+
+  return null;
+};
+
 module.exports = {
   uploadMapImage,
   deleteMapImage,
@@ -415,4 +773,5 @@ module.exports = {
   getTokenRootFolder,
   listTokenAssets,
   listTokenFolderTree,
+  suggestEnemyFigurine,
 };


### PR DESCRIPTION
## Summary
- add a Cloudinary search helper to suggest enemy figurines based on monster metadata
- use the helper when creating enemies so the stored record includes figurine defaults and extend the unit tests
- sync the DM enemy token preview with server updates so auto-selected figurines appear in the UI

## Testing
- npx jest server/__tests__/campaigns.test.js *(fails: npm 403 fetching jest package)*

------
https://chatgpt.com/codex/tasks/task_e_68e1acccdd14832eadae4f3d3ae4acf8