### PR TITLE
Refine token picker modal effect handling

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -51,6 +51,30 @@ const cloneFilters = (filters = []) => {
     }));
 };
 
+const filterKeysMatch = (current, target) => {
+  const extractKeys = (filters) =>
+    Array.isArray(filters)
+      ? filters
+          .map((filter) => (filter && typeof filter === 'object' ? filter.key : null))
+          .filter(Boolean)
+      : [];
+
+  const currentKeys = extractKeys(current);
+  const targetKeys = extractKeys(target);
+
+  if (currentKeys.length !== targetKeys.length) {
+    return false;
+  }
+
+  const currentKeySet = new Set(currentKeys);
+
+  if (currentKeySet.size !== targetKeys.length) {
+    return false;
+  }
+
+  return targetKeys.every((key) => currentKeySet.has(key));
+};
+
 const buildDynamicDmFilters = (folderTree, fallbackFilters = DEFAULT_DM_FILTERS) => {
   const fallback = cloneFilters(fallbackFilters);
 
@@ -475,7 +499,7 @@ const TokenPickerModal = ({
         setLoadingMore(false);
       }
     },
-    [campaignId, activeFilter, isDm]
+    [campaignId, activeFilter]
   );
 
   useEffect(() => {
@@ -484,14 +508,25 @@ const TokenPickerModal = ({
       if (isDm) {
         setDmFolderOptions(null);
       } else {
-        setPlayerFolderOptions(cloneFilters(DEFAULT_PLAYER_FILTERS));
+        setPlayerFolderOptions((prev) =>
+          filterKeysMatch(prev, DEFAULT_PLAYER_FILTERS)
+            ? prev
+            : cloneFilters(DEFAULT_PLAYER_FILTERS)
+        );
       }
       return;
     }
 
     resetState({ resetFolderLoading: false });
+  }, [show, resetState, isDm]);
+
+  useEffect(() => {
+    if (!show || !activeFilter) {
+      return;
+    }
+
     fetchManifest({ append: false, cursor: null });
-  }, [show, fetchManifest, activeFilter, resetState, isDm]);
+  }, [show, activeFilter, fetchManifest]);
 
   useEffect(() => {
     if (!isDm) {


### PR DESCRIPTION
## Summary
- decouple the modal close effect from manifest-loading dependencies
- trigger token manifest fetching from a dedicated effect when the modal is open
- avoid resetting player filters when they already match the default set

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e1bc726420832e9a92013678056373