### PR TITLE
Fix touchAction styling on combat header

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -517,6 +517,11 @@ function CombatTurnHeader({ participants }) {
     return classes.join(' ');
   }, [isDragging, canScrollLeft, canScrollRight, participantsCount]);
 
+  const headerStyle = useMemo(
+    () => ({ touchAction: participantsCount ? 'pan-x' : 'auto' }),
+    [participantsCount]
+  );
+
   const finishDrag = useCallback((event) => {
     if (!isDraggingRef.current) {
       const container = headerRef.current;
@@ -666,9 +671,9 @@ function CombatTurnHeader({ participants }) {
     <div
       ref={headerRef}
       className={headerClassName}
+      style={headerStyle}
       role="group"
       aria-label="Combat turn order"
-      touchAction={participantsCount ? 'pan-x' : 'auto'}
       onPointerDown={participantsCount ? handlePointerDown : undefined}
       onPointerMove={participantsCount ? handlePointerMove : undefined}
       onPointerUp={participantsCount ? handlePointerUp : undefined}


### PR DESCRIPTION
## Summary
- set the combat turn header's touch-action using the style prop to avoid React warnings
- preserve existing pointer interactions for the turn order drag behavior

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1bd750778832e8a288424a1cf6fa3