### PR TITLE
Handle token manifest retrieval failures gracefully

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -458,11 +458,32 @@ const TokenPickerModal = ({
         }
 
         const response = await apiFetch(endpoint);
-        if (!response.ok) {
-          throw new Error(response.statusText || 'Failed to load token manifest.');
+        let parsedBody = null;
+
+        if (typeof response?.json === 'function') {
+          try {
+            parsedBody = await response.json();
+          } catch (parseError) {
+            parsedBody = null;
+          }
         }
 
-        const data = await response.json();
+        if (!response.ok) {
+          const messageSource = [
+            parsedBody && typeof parsedBody.message === 'string' ? parsedBody.message.trim() : '',
+            parsedBody && typeof parsedBody.details === 'string' ? parsedBody.details.trim() : '',
+            parsedBody && typeof parsedBody.error === 'string' ? parsedBody.error.trim() : '',
+            typeof response.statusText === 'string' ? response.statusText.trim() : '',
+          ].find((value) => value);
+
+          throw new Error(messageSource || 'Failed to load token manifest.');
+        }
+
+        if (parsedBody === null) {
+          throw new Error('Failed to parse token manifest response.');
+        }
+
+        const data = parsedBody;
         const nextAssets = Array.isArray(data?.assets) ? data.assets.filter(Boolean) : [];
         setAssets((prev) => (append ? [...prev, ...nextAssets] : nextAssets));
         setNextCursor(typeof data?.nextCursor === 'string' && data.nextCursor ? data.nextCursor : null);

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -331,4 +331,39 @@ describe('TokenPickerModal', () => {
     const options = within(select).getAllByRole('option');
     expect(options.length).toBeGreaterThan(0);
   });
+
+  test('displays an error message when token manifest request fails', async () => {
+    const errorMessage = 'Cloudinary rate limit exceeded';
+
+    apiFetch.mockImplementation((url) => {
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          json: async () => ({ message: errorMessage }),
+        });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        isDm={false}
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/campaigns/Camp1/token-manifest')
+      );
+    });
+
+    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+  });
 });

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -1627,4 +1627,31 @@ describe('Campaign routes', () => {
     );
     expect(resWithFilter.body.appliedFolders).toEqual(['Tokens/Adventurers/Heroes']);
   });
+
+  test('returns an error when token manifest retrieval fails', async () => {
+    mockUser = { username: 'Player1' };
+
+    const findOne = jest.fn().mockResolvedValue({ campaignName: 'Test', dm: 'DM' });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return { findOne };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    });
+
+    const rateLimitError = new Error('Rate limit exceeded');
+    rateLimitError.http_code = 429;
+
+    listTokenAssets.mockRejectedValueOnce(rateLimitError);
+
+    const res = await request(app).get('/campaigns/Test/token-manifest');
+
+    expect(res.status).toBe(429);
+    expect(res.body).toEqual({
+      message: 'Failed to load token manifest.',
+      details: 'Rate limit exceeded',
+    });
+  });
 });

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1920,13 +1920,25 @@ module.exports = (router) => {
               campaign: campaignName,
               error: error.message,
             });
-            manifest = {
-              assets: [],
-              nextCursor: null,
-              totalCount: null,
-              appliedFolders: Array.isArray(folders) ? folders : [],
-              rootFolder: tokenRootFolder,
-            };
+
+            const candidateStatusCodes = [
+              error?.status,
+              error?.statusCode,
+              error?.status_code,
+              error?.http_code,
+              error?.response?.status,
+            ].filter((value) => Number.isInteger(value) && value >= 400 && value < 600);
+            const status = candidateStatusCodes.length > 0 ? candidateStatusCodes[0] : 503;
+
+            const detailMessage =
+              typeof error?.message === 'string' && error.message.trim() !== ''
+                ? error.message.trim()
+                : 'An unexpected error occurred while loading token assets.';
+
+            return res.status(status).json({
+              message: 'Failed to load token manifest.',
+              details: detailMessage,
+            });
           }
 
           res.json({


### PR DESCRIPTION
## Summary
- return a descriptive error response when Cloudinary token manifest retrieval fails
- surface token manifest API errors inside the token picker modal
- cover the new error handling with server and client tests

## Testing
- npm --prefix server test
- CI=true npm --prefix client test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1c8b3757c832eaf9b095df4f0c086