### PR TITLE
Add Cloudinary caching for token listings

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -78,6 +78,117 @@ describe('suggestEnemyFigurine helper', () => {
     });
   });
 });
+
+describe('Cloudinary caching helpers', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('cloudinary');
+    process.env = { ...originalEnv };
+  });
+
+  test('listTokenAssets reuses cached results when inputs repeat', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      CLOUDINARY_CLOUD_NAME: 'demo',
+      CLOUDINARY_API_KEY: 'key',
+      CLOUDINARY_API_SECRET: 'secret',
+      CLOUDINARY_TOKEN_CACHE_TTL_MS: '1000',
+    };
+
+    const mockExecute = jest.fn().mockResolvedValue({
+      resources: [
+        {
+          public_id: 'Tokens/DM/goblin_token',
+          secure_url: 'https://res.cloudinary.com/demo/image/upload/Tokens/DM/goblin_token.png',
+          folder: 'Tokens/DM',
+          filename: 'goblin_token',
+        },
+      ],
+      next_cursor: 'NEXT',
+      total_count: 1,
+    });
+
+    const searchInstance = {};
+    searchInstance.sort_by = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.max_results = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.with_field = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.next_cursor = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.execute = mockExecute;
+
+    const mockExpression = jest.fn().mockReturnValue(searchInstance);
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        search: {
+          expression: mockExpression,
+        },
+      },
+    }));
+
+    const { listTokenAssets: actualListTokenAssets } = jest.requireActual('../utils/cloudinary');
+
+    await actualListTokenAssets({ folders: ['DM'], nextCursor: null });
+    await actualListTokenAssets({ folders: ['DM'], nextCursor: null });
+
+    expect(mockExpression).toHaveBeenCalledTimes(1);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  test('listTokenFolderTree reuses cached results when inputs repeat', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      CLOUDINARY_CLOUD_NAME: 'demo',
+      CLOUDINARY_API_KEY: 'key',
+      CLOUDINARY_API_SECRET: 'secret',
+      CLOUDINARY_FOLDER_TREE_CACHE_TTL_MS: '1000',
+    };
+
+    const mockSubFolders = jest
+      .fn()
+      .mockImplementation(async (path) => {
+        if (path === 'Tokens') {
+          return {
+            folders: [
+              {
+                path: 'Tokens/Creatures',
+                name: 'Creatures',
+              },
+            ],
+            next_cursor: null,
+          };
+        }
+
+        if (path === 'Tokens/Creatures') {
+          return { folders: [], next_cursor: null };
+        }
+
+        throw new Error(`Unexpected folder path: ${path}`);
+      });
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        api: {
+          sub_folders: mockSubFolders,
+        },
+      },
+    }));
+
+    const { listTokenFolderTree: actualListTokenFolderTree } = jest.requireActual(
+      '../utils/cloudinary'
+    );
+
+    await actualListTokenFolderTree({});
+    await actualListTokenFolderTree({});
+
+    expect(mockSubFolders).toHaveBeenCalledTimes(2);
+  });
+});
 jest.mock('../utils/socket', () => ({
   emitCombatUpdate: jest.fn(),
   emitEnemiesUpdate: jest.fn(),

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -3,6 +3,76 @@ let isConfigured = false;
 
 const DEFAULT_TOKEN_ROOT_FOLDER = 'Tokens';
 const TOKEN_FALLBACK_MAX_RESULTS = 200;
+const DEFAULT_TOKEN_CACHE_TTL_MS = 60_000;
+const DEFAULT_FOLDER_TREE_CACHE_TTL_MS = 120_000;
+
+const tokenListCache = new Map();
+const folderTreeCache = new Map();
+
+const parseCacheTtl = (value, fallback) => {
+  const numericValue = Number(value);
+  if (Number.isFinite(numericValue) && numericValue >= 0) {
+    return numericValue;
+  }
+  return fallback;
+};
+
+const getTokenListCacheTtlMs = () =>
+  parseCacheTtl(process.env.CLOUDINARY_TOKEN_CACHE_TTL_MS, DEFAULT_TOKEN_CACHE_TTL_MS);
+
+const getFolderTreeCacheTtlMs = () =>
+  parseCacheTtl(
+    process.env.CLOUDINARY_FOLDER_TREE_CACHE_TTL_MS,
+    DEFAULT_FOLDER_TREE_CACHE_TTL_MS
+  );
+
+const getCacheEntry = (cache, key) => {
+  const entry = cache.get(key);
+  if (!entry) {
+    return null;
+  }
+
+  if (Date.now() >= entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCacheEntry = (cache, key, value, ttlMs) => {
+  if (ttlMs <= 0) {
+    return;
+  }
+
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + ttlMs,
+  });
+};
+
+const clearCacheWhenDisabled = (cache, ttlMs) => {
+  if (ttlMs <= 0 && cache.size > 0) {
+    cache.clear();
+  }
+};
+
+const buildTokenListCacheKey = ({ rootFolder, folders, nextCursor, maxResults }) => {
+  const normalizedFolders = Array.isArray(folders) ? folders.slice().sort() : [];
+  const serializedFolders = normalizedFolders.length > 0 ? normalizedFolders.join('|') : '__ALL__';
+  const normalizedCursor = typeof nextCursor === 'string' ? nextCursor : '';
+  const normalizedMaxResults = Number.isInteger(maxResults) ? maxResults : TOKEN_FALLBACK_MAX_RESULTS;
+
+  return [rootFolder || DEFAULT_TOKEN_ROOT_FOLDER, serializedFolders, normalizedCursor, normalizedMaxResults].join(
+    '::'
+  );
+};
+
+const buildFolderTreeCacheKey = ({ rootFolder, folders }) => {
+  const normalizedFolders = Array.isArray(folders) ? folders.slice().sort() : [];
+  const serializedFolders = normalizedFolders.length > 0 ? normalizedFolders.join('|') : '__ROOT__';
+  return [rootFolder || DEFAULT_TOKEN_ROOT_FOLDER, serializedFolders].join('::');
+};
 
 const resolveCloudinary = () => {
   if (!cloudinary) {
@@ -222,6 +292,21 @@ const listTokenFolderTree = async ({ folders = null, rootFolder: inputRootFolder
     ? Array.from(new Set(folders.map(normalizeFolderPath).filter(Boolean)))
     : [normalizedRoot];
 
+  const cacheTtlMs = getFolderTreeCacheTtlMs();
+  clearCacheWhenDisabled(folderTreeCache, cacheTtlMs);
+
+  const cacheKey = buildFolderTreeCacheKey({
+    rootFolder: normalizedRoot,
+    folders: normalizedTargets,
+  });
+
+  if (cacheTtlMs > 0) {
+    const cached = getCacheEntry(folderTreeCache, cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+
   const visited = new Set();
 
   const fetchSubfolders = async (folderPath) => {
@@ -357,11 +442,17 @@ const listTokenFolderTree = async ({ folders = null, rootFolder: inputRootFolder
   const foldersTree = await collectNodes();
   const flatFolders = flattenNodes(foldersTree);
 
-  return {
+  const result = {
     rootFolder: normalizedRoot,
     folders: foldersTree,
     flatFolders,
   };
+
+  if (cacheTtlMs > 0) {
+    setCacheEntry(folderTreeCache, cacheKey, result, cacheTtlMs);
+  }
+
+  return result;
 };
 
 const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults } = {}) => {
@@ -381,16 +472,43 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
   }
 
   const expression = expressionSegments.join(' AND ');
-  let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
 
   const resolvedMaxResults = Number.isInteger(maxResults)
     ? Math.max(1, Math.min(maxResults, 500))
     : TOKEN_FALLBACK_MAX_RESULTS;
 
+  const sanitizedFolders = Array.isArray(folders)
+    ? folders
+        .map((folder) => sanitizeFolderSegment(folder))
+        .filter(Boolean)
+    : [];
+
+  const sanitizedNextCursor =
+    typeof nextCursor === 'string' && nextCursor.trim() !== '' ? nextCursor.trim() : null;
+
+  const cacheTtlMs = getTokenListCacheTtlMs();
+  clearCacheWhenDisabled(tokenListCache, cacheTtlMs);
+
+  const cacheKey = buildTokenListCacheKey({
+    rootFolder,
+    folders: sanitizedFolders,
+    nextCursor: sanitizedNextCursor,
+    maxResults: resolvedMaxResults,
+  });
+
+  if (cacheTtlMs > 0) {
+    const cached = getCacheEntry(tokenListCache, cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+
+  let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
+
   search = search.max_results(resolvedMaxResults).with_field('context').with_field('metadata');
 
-  if (typeof nextCursor === 'string' && nextCursor.trim() !== '') {
-    search = search.next_cursor(nextCursor.trim());
+  if (sanitizedNextCursor) {
+    search = search.next_cursor(sanitizedNextCursor);
   }
 
   const result = await search.execute();
@@ -399,17 +517,19 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
     .map((resource) => sanitizeTokenResource(resource, rootFolder))
     .filter(Boolean);
 
-  return {
+  const response = {
     assets,
     nextCursor: typeof result?.next_cursor === 'string' ? result.next_cursor : null,
     totalCount: typeof result?.total_count === 'number' ? result.total_count : null,
-    appliedFolders: Array.isArray(folders)
-      ? folders
-          .map((folder) => sanitizeFolderSegment(folder))
-          .filter(Boolean)
-      : [],
+    appliedFolders: sanitizedFolders,
     rootFolder,
   };
+
+  if (cacheTtlMs > 0) {
+    setCacheEntry(tokenListCache, cacheKey, response, cacheTtlMs);
+  }
+
+  return response;
 };
 
 const DM_FOLDER_HINTS = ['DM', 'DM Only', 'DM-Only', 'DMOnly', '_DM'];


### PR DESCRIPTION
## Summary
- add short-lived in-memory caches for Cloudinary token manifest and folder tree requests with TTL controls
- ensure cached responses reuse sanitized folder metadata while respecting cache disabling via environment variables
- add unit tests covering repeated manifest and folder tree requests using the cache

## Testing
- npm --prefix server test -- campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ca2e0f40832ebbc4b1ef3996ee27