### PR TITLE
Fix TokenPickerModal manifest fetch effect

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, Spinner, Row, Col, Alert, Form } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
@@ -415,11 +415,32 @@ const TokenPickerModal = ({
     }
   }, []);
 
-  const activeFilter = selectedFilterKey && filterLookup.has(selectedFilterKey)
-    ? filterLookup.get(selectedFilterKey)
-    : filterLookup.size > 0
-      ? filterLookup.values().next().value
-      : null;
+  const activeFilter = useMemo(() => {
+    if (selectedFilterKey && filterLookup.has(selectedFilterKey)) {
+      return filterLookup.get(selectedFilterKey);
+    }
+
+    if (filterLookup.size > 0) {
+      return filterLookup.values().next().value;
+    }
+
+    return null;
+  }, [filterLookup, selectedFilterKey]);
+
+  const manifestFilterKey = useMemo(() => {
+    if (!activeFilter) {
+      return 'none';
+    }
+
+    const folders = Array.isArray(activeFilter.folders)
+      ? activeFilter.folders
+          .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
+          .filter(Boolean)
+          .join(',')
+      : '';
+
+    return `${activeFilter.key || 'unknown'}::${folders}`;
+  }, [activeFilter]);
 
   const fetchManifest = useCallback(
     async ({ cursor = null, append = false } = {}) => {
@@ -499,8 +520,16 @@ const TokenPickerModal = ({
     [campaignId, activeFilter, isDm]
   );
 
+  const fetchManifestRef = useRef(fetchManifest);
+  const lastFetchKeyRef = useRef(null);
+
+  useEffect(() => {
+    fetchManifestRef.current = fetchManifest;
+  }, [fetchManifest]);
+
   useEffect(() => {
     if (!show) {
+      lastFetchKeyRef.current = null;
       resetState();
       if (isDm) {
         setDmFolderOptions(null);
@@ -510,9 +539,23 @@ const TokenPickerModal = ({
       return;
     }
 
+    if (!campaignId || manifestFilterKey === 'none') {
+      return;
+    }
+
+    const fetchKey = `${campaignId}::${manifestFilterKey}`;
+
+    if (lastFetchKeyRef.current === fetchKey) {
+      return;
+    }
+
+    lastFetchKeyRef.current = fetchKey;
+
     resetState({ resetFolderLoading: false });
-    fetchManifest({ append: false, cursor: null });
-  }, [show, fetchManifest, activeFilter, resetState, isDm]);
+    if (fetchManifestRef.current) {
+      fetchManifestRef.current({ append: false, cursor: null });
+    }
+  }, [show, manifestFilterKey, campaignId, isDm, resetState]);
 
   useEffect(() => {
     if (!isDm) {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -366,4 +366,61 @@ describe('TokenPickerModal', () => {
 
     expect(await screen.findByText(errorMessage)).toBeInTheDocument();
   });
+
+  test('does not refetch repeatedly after a 503 manifest error', async () => {
+    const errorMessage = 'Service temporarily unavailable';
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      apiFetch.mockImplementation((url) => {
+        if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            statusText: 'Service Unavailable',
+            json: async () => ({ message: errorMessage }),
+          });
+        }
+
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      });
+
+      render(
+        <TokenPickerModal
+          show
+          campaignId="Camp1"
+          isDm={false}
+          onHide={jest.fn()}
+          onSelect={jest.fn()}
+        />
+      );
+
+      const manifestCallCount = () =>
+        apiFetch.mock.calls.filter(
+          ([url]) => typeof url === 'string' && url.includes('/token-manifest')
+        ).length;
+
+      await waitFor(() => {
+        expect(manifestCallCount()).toBe(1);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(errorMessage)).toBeInTheDocument();
+        expect(manifestCallCount()).toBe(1);
+      });
+
+      expect(manifestCallCount()).toBe(1);
+
+      const depthError = consoleErrorSpy.mock.calls.find((callArgs) =>
+        callArgs.some(
+          (arg) =>
+            typeof arg === 'string' && arg.toLowerCase().includes('maximum update depth exceeded')
+        )
+      );
+
+      expect(depthError).toBeUndefined();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- memoize the active filter and use refs to stabilize token manifest fetching in the modal
- guard the modal effect so opening or changing the selection triggers a single manifest request
- add a regression test that covers a 503 manifest failure without re-fetch loops

## Testing
- CI=true npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68e1cd622ee8832e82c4e8dc32ced3e5