### PR TITLE
Fix Zombies tracker current HP fallback

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -522,8 +522,7 @@ export const getCharacterCardMeta = (character, itemIndex = 0) => {
   const fallbackCurrentHp = toFiniteNumberOrNull(
     character?.currentHp ??
       character?.hpCurrent ??
-      character?.tempHealth ??
-      character?.health
+      character?.tempHealth
   );
   const fallbackMaxHp = toFiniteNumberOrNull(
     character?.maxHp ?? character?.hpMax ?? character?.health
@@ -567,7 +566,6 @@ export const getCombatRowMeta = ({
     character?.currentHp ??
       character?.hpCurrent ??
       character?.tempHealth ??
-      character?.health ??
       participantInfo?.currentHp ??
       participantInfo?.hpCurrent ??
       participantInfo?.health

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -12,6 +12,7 @@ jest.mock('../attributes/CampaignMapBoard', () => {
     default: jest.fn(() => React.createElement('div', { 'data-testid': 'campaign-map-board' })),
   };
 });
+
 jest.mock('../attributes/MapModal', () => {
   const React = require('react');
   const actual = jest.requireActual('../attributes/MapModal');
@@ -64,6 +65,52 @@ const accessorySlotOptions = [
   { key: 'ringLeft', label: 'Ring I' },
   { key: 'ringRight', label: 'Ring II' },
 ];
+
+describe('ZombiesDM metadata helpers', () => {
+  test('character health updates propagate to record cards and combat rows', () => {
+    const originalRecord = { _id: 'abc123', health: 12 };
+    const records = [originalRecord];
+
+    const updatedRecords = applyCharacterHealthUpdateToRecords({
+      records,
+      update: { _id: 'abc123', characterId: 'hero-1', health: 7 },
+    });
+
+    expect(updatedRecords).not.toBe(records);
+    expect(updatedRecords[0]).not.toBe(originalRecord);
+    expect(updatedRecords[0].health).toBe(7);
+    expect(updatedRecords[0]._id).toBe('abc123');
+    expect(updatedRecords[0].characterId).toBe('hero-1');
+
+    const cardMeta = getCharacterCardMeta(updatedRecords[0], 0);
+    expect(cardMeta.testId).toBe('character-card-abc123');
+    expect(cardMeta.dataAttributes['data-character-id']).toBe('abc123');
+    expect(cardMeta.dataAttributes['data-current-hp']).toBeUndefined();
+
+    const combatMeta = getCombatRowMeta({
+      character: updatedRecords[0],
+      rowId: 'hero-1',
+      participantInfo: { characterId: 'hero-1', currentHp: 12, maxHp: 18 },
+      recordIndex: 0,
+    });
+    expect(combatMeta.testId).toBe('combat-row-hero-1');
+    expect(combatMeta.dataAttributes['data-current-hp']).toBe(12);
+  });
+
+  test('combat row metadata omits current hp when no explicit value is present', () => {
+    const character = { _id: 'def456', health: 30 };
+
+    const combatMeta = getCombatRowMeta({
+      character,
+      rowId: 'hero-2',
+      participantInfo: { characterId: 'hero-2', maxHp: 30 },
+      recordIndex: 1,
+    });
+
+    expect(combatMeta.dataAttributes['data-current-hp']).toBeUndefined();
+    expect(combatMeta.dataAttributes['data-max-hp']).toBe(30);
+  });
+});
 
 const openResourceCard = async (tabLabel, testId) => {
   const tab = await screen.findByRole('tab', { name: tabLabel });
@@ -631,35 +678,6 @@ describe('ZombiesDM AI generation', () => {
     ]);
   });
 
-  test('character health updates propagate to record cards and combat rows', () => {
-    const originalRecord = { _id: 'abc123', health: 12 };
-    const records = [originalRecord];
-
-    const updatedRecords = applyCharacterHealthUpdateToRecords({
-      records,
-      update: { _id: 'abc123', characterId: 'hero-1', health: 7 },
-    });
-
-    expect(updatedRecords).not.toBe(records);
-    expect(updatedRecords[0]).not.toBe(originalRecord);
-    expect(updatedRecords[0].health).toBe(7);
-    expect(updatedRecords[0]._id).toBe('abc123');
-    expect(updatedRecords[0].characterId).toBe('hero-1');
-
-    const cardMeta = getCharacterCardMeta(updatedRecords[0], 0);
-    expect(cardMeta.testId).toBe('character-card-abc123');
-    expect(cardMeta.dataAttributes['data-character-id']).toBe('abc123');
-    expect(cardMeta.dataAttributes['data-current-hp']).toBe(7);
-
-    const combatMeta = getCombatRowMeta({
-      character: updatedRecords[0],
-      rowId: 'hero-1',
-      participantInfo: { characterId: 'hero-1', currentHp: 12, maxHp: 18 },
-      recordIndex: 0,
-    });
-    expect(combatMeta.testId).toBe('combat-row-hero-1');
-    expect(combatMeta.dataAttributes['data-current-hp']).toBe(7);
-  });
 
   test('removes enemy tokens from maps before success status', async () => {
     const enemies = [{ enemyId: 'enemy-1', name: 'Goblin', type: 'humanoid' }];

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -204,7 +204,7 @@ export const calculateCharacterHitPoints = (character, overrides = {}) => {
           if (fallbackOverride !== null) {
             return fallbackOverride;
           }
-          return toFiniteNumberOrNull(character?.health);
+          return null;
         })();
 
   const maxHp =

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -68,6 +68,19 @@ describe('calculateCharacterHitPoints', () => {
     expect(result).toEqual({ currentHp: null, maxHp: null });
   });
 
+  it('does not default current hp to base health when no explicit value exists', () => {
+    const character = {
+      health: 30,
+      con: 10,
+      occupation: [{ Level: 3 }],
+    };
+
+    const result = calculateCharacterHitPoints(character);
+
+    expect(result.currentHp).toBeNull();
+    expect(result.maxHp).toBe(30);
+  });
+
   it('uses character.currentHp when provided', () => {
     const character = {
       health: 12,


### PR DESCRIPTION
## Summary
- stop defaulting current HP to max health in the hit point calculator and DM view metadata helpers
- update Zombies DM metadata tests to ensure missing current HP stays unset and combat row mirrors participant data
- extend character metrics tests to cover characters without explicit current HP values

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/utils/characterMetrics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1e0fcb994832eb8233ae36fb13a80