### PR TITLE
Prefer participant HP for Zombies DM combat row

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -573,9 +573,9 @@ export const getCombatRowMeta = ({
   const rowMaxHp = toFiniteNumberOrNull(
     character?.maxHp ??
       character?.hpMax ??
-      character?.health ??
       participantInfo?.maxHp ??
       participantInfo?.hpMax ??
+      character?.health ??
       participantInfo?.health
   );
   const rowTempHp = toFiniteNumberOrNull(

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -97,8 +97,8 @@ describe('ZombiesDM metadata helpers', () => {
     expect(combatMeta.dataAttributes['data-current-hp']).toBe(12);
   });
 
-  test('combat row metadata omits current hp when no explicit value is present', () => {
-    const character = { _id: 'def456', health: 30 };
+  test('combat row metadata prefers participant max hp over character health when no explicit current hp is present', () => {
+    const character = { _id: 'def456', health: 42 };
 
     const combatMeta = getCombatRowMeta({
       character,
@@ -109,6 +109,7 @@ describe('ZombiesDM metadata helpers', () => {
 
     expect(combatMeta.dataAttributes['data-current-hp']).toBeUndefined();
     expect(combatMeta.dataAttributes['data-max-hp']).toBe(30);
+    expect(combatMeta.dataAttributes['data-max-hp']).not.toBe(character.health);
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure combat row metadata prioritizes participant max HP values over character health when present
- update the ZombiesDM metadata helper unit test to cover differing participant and character HP values

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesDM.test.js *(fails: existing ZombiesDM tests exceed Jest timeouts and wrapper warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e42120e8832eb8feed14f9ef8e77