### PR TITLE
Fix combat header HP to match character data

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1224,26 +1224,33 @@ export default function ZombiesCharacterSheet() {
 
         const { currentHp, maxHp } = calculateCharacterHitPoints(char);
 
-        let normalizedCurrentHp = participantCurrentHp !== null
-          ? participantCurrentHp
-          : Number.isFinite(currentHp)
-            ? currentHp
-            : null;
-        let normalizedMaxHp = participantMaxHp !== null
-          ? participantMaxHp
-          : Number.isFinite(maxHp)
-            ? maxHp
-            : null;
+        let normalizedCurrentHp = null;
+        let normalizedMaxHp = null;
 
-        if (normalizedMaxHp === null) {
-          const fallbackMax = toFiniteNumberOrNull(char?.hitPoints ?? char?.health);
-          if (fallbackMax !== null) {
-            normalizedMaxHp = fallbackMax;
+        if (char) {
+          normalizedCurrentHp = toFiniteNumberOrNull(currentHp);
+          normalizedMaxHp = toFiniteNumberOrNull(maxHp);
+
+          if (normalizedMaxHp === null) {
+            const fallbackMax = toFiniteNumberOrNull(
+              char?.hpMax ?? char?.hitPoints ?? char?.health
+            );
+            if (fallbackMax !== null) {
+              normalizedMaxHp = fallbackMax;
+            }
           }
-        }
 
-        if (normalizedCurrentHp === null && normalizedMaxHp !== null) {
-          normalizedCurrentHp = normalizedMaxHp;
+          if (normalizedCurrentHp === null && normalizedMaxHp !== null) {
+            normalizedCurrentHp = normalizedMaxHp;
+          }
+
+          if (normalizedCurrentHp === null && normalizedMaxHp === null) {
+            normalizedCurrentHp = participantCurrentHp;
+            normalizedMaxHp = participantMaxHp;
+          }
+        } else {
+          normalizedCurrentHp = participantCurrentHp;
+          normalizedMaxHp = participantMaxHp;
         }
 
         let hpDisplay = '—';

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -176,6 +176,84 @@ beforeEach(() => {
   matchMediaState[WIDE_SCREEN_QUERY] = false;
 });
 
+test('uses character-derived hit points for synced combat participants', async () => {
+  const characterResponse = {
+    _id: '1',
+    characterName: 'Hero',
+    campaign: 'test-campaign',
+    health: 30,
+    currentHp: 12,
+    occupation: [],
+    feat: [],
+    equipment: {},
+  };
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => characterResponse,
+      });
+    }
+
+    if (typeof url === 'string' && url.includes('/campaigns/test-campaign/combat')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          participants: [
+            {
+              characterId: '1',
+              initiative: 15,
+              currentHp: 5,
+              maxHp: 40,
+            },
+            {
+              characterId: 'npc-1',
+              displayName: 'Goblin',
+              currentHp: 4,
+              maxHp: 10,
+              initiative: 10,
+            },
+          ],
+          activeTurn: 0,
+        }),
+      });
+    }
+
+    if (typeof url === 'string' && url.includes('/campaigns/test-campaign/characters')) {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+
+    if (typeof url === 'string' && url.includes('/campaigns/test-campaign/enemies')) {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+
+    if (typeof url === 'string' && url.includes('/campaigns/test-campaign/maps')) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    if (typeof url === 'string' && url.includes('/campaigns/test-campaign/map')) {
+      return Promise.resolve({ ok: false, status: 404 });
+    }
+
+    return defaultApiFetchImplementation(url);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  await screen.findAllByText('Hero');
+  await screen.findByText('Goblin');
+
+  expect(screen.getByText('12/30')).toBeInTheDocument();
+  expect(screen.getByText('4/10')).toBeInTheDocument();
+  expect(screen.queryByText('5/40')).not.toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(mockHealthDefenseProps.current).not.toBeNull();
+  });
+  expect(mockHealthDefenseProps.current.form.health).toBe(30);
+});
+
 test('spells button includes points-glow when spell points available', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- prioritize character-derived hit points when building combat header participants
- preserve combat payload fallback for ad-hoc or NPC participants without character data
- add a regression test verifying synced participants display character hit points in the header

## Testing
- CI=true npm --prefix client test -- ZombiesCharacterSheet.test.js --testNamePattern="uses character-derived hit points"

------
https://chatgpt.com/codex/tasks/task_e_68e1e495c85c8323a302ae3516b96fae