### PR TITLE
Align combat row HP precedence with metadata helper

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -604,11 +604,12 @@ export const getCombatRowMeta = ({
   const rowCurrentHp = toFiniteNumberOrNull(
     character?.tempHealth ??
       participantInfo?.tempHealth ??
-      character?.currentHp ??
-      character?.hpCurrent ??
       participantInfo?.currentHp ??
       participantInfo?.hpCurrent ??
-      participantInfo?.health
+      character?.currentHp ??
+      character?.hpCurrent ??
+      participantInfo?.health ??
+      character?.health
   );
   const rowMaxHp = toFiniteNumberOrNull(
     character?.maxHp ??
@@ -5297,43 +5298,22 @@ const resolveIcon = (category, iconMap, fallback) => {
                                 participantInfo?.characterId ||
                                 'this character';
 
-                              const sanitizeIdentifier = (value, fallbackIndex) =>
-                                typeof value === 'string' && value.trim() !== ''
-                                  ? value.trim().replace(/[^0-9A-Za-z_-]/g, '-')
-                                  : `participant-${fallbackIndex}`;
-                              const rowTestId = `combat-row-${sanitizeIdentifier(
+                              const sanitizedRowIdentifier = sanitizeIdentifierForTestId(
                                 resolvedRowId,
-                                recordIndex
-                              )}`;
-                              const rowCurrentHp = toFiniteNumberOrNull(
-                                character?.tempHealth ??
-                                  participantInfo?.tempHealth ??
-                                  character?.currentHp ??
-                                  character?.hpCurrent ??
-                                  character?.health ??
-                                  participantInfo?.currentHp ??
-                                  participantInfo?.hpCurrent ??
-                                  participantInfo?.health
-                              );
-                              const rowMaxHp = toFiniteNumberOrNull(
-                                character?.maxHp ??
-                                  character?.hpMax ??
-                                  character?.health ??
-                                  participantInfo?.maxHp ??
-                                  participantInfo?.hpMax ??
-                                  participantInfo?.health
-                              );
-                              const rowTempHp = toFiniteNumberOrNull(
-                                character?.tempHealth ?? participantInfo?.tempHealth
+                                `participant-${recordIndex}`
                               );
 
+                              const { testId: rowTestId, dataAttributes: combatRowDataAttributes } =
+                                getCombatRowMeta({
+                                  character,
+                                  rowId: resolvedRowId,
+                                  participantInfo,
+                                  recordIndex,
+                                });
+
                               const rowDataAttributes = {
-                                'data-testid': rowTestId,
-                                ...(rowCurrentHp !== null
-                                  ? { 'data-current-hp': rowCurrentHp }
-                                  : {}),
-                                ...(rowMaxHp !== null ? { 'data-max-hp': rowMaxHp } : {}),
-                                ...(rowTempHp !== null ? { 'data-temp-hp': rowTempHp } : {}),
+                                ...(rowTestId ? { 'data-testid': rowTestId } : {}),
+                                ...combatRowDataAttributes,
                               };
 
                               return (
@@ -5347,7 +5327,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                                   <td className="text-center">
                                     <Form.Check
                                       type="checkbox"
-                                      id={`combat-toggle-${resolvedRowId}`}
+                                      id={`combat-toggle-${sanitizedRowIdentifier}`}
                                       checked={isParticipant}
                                       onChange={() =>
                                         resolvedRowId && handleToggleParticipant(resolvedRowId)

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -112,6 +112,30 @@ describe('ZombiesDM metadata helpers', () => {
     expect(combatMeta.dataAttributes['data-max-hp']).not.toBe(character.health);
   });
 
+  test('combat row metadata reflects temporary health updates before falling back to base health', () => {
+    const records = [
+      {
+        _id: 'temp-hero',
+        characterId: 'temp-hero',
+        health: 18,
+      },
+    ];
+
+    const updatedRecords = applyCharacterHealthUpdateToRecords({
+      records,
+      update: { _id: 'temp-hero', tempHealth: 9 },
+    });
+
+    const combatMeta = getCombatRowMeta({
+      character: updatedRecords[0],
+      rowId: 'temp-hero',
+      participantInfo: { characterId: 'temp-hero', health: 18 },
+      recordIndex: 0,
+    });
+
+    expect(combatMeta.dataAttributes['data-current-hp']).toBe(9);
+  });
+
   test('health updates keep current hp fields in sync with temp health', () => {
     const originalRecord = {
       _id: 'sync-1',


### PR DESCRIPTION
## Summary
- prioritize temporary and current hit points in `getCombatRowMeta` before falling back to base health
- reuse the combat row metadata helper when rendering the DM combat table to keep row attributes in sync
- add a unit test that ensures temporary health updates surface in combat row metadata

## Testing
- npm test -- ZombiesDM.test.js *(fails to complete in this environment because the CRA test runner expects interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_68e299312e6c8323a21d21cb4052f578