### PR TITLE
Add remove controls for owned inventory items

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Card, Row, Col, Alert, Button, Modal, Badge } from 'react-bootstrap';
 import {
   GiAmmoBox,
@@ -93,10 +93,26 @@ const buildItemOwnershipMap = (initialItems) => {
   return map;
 };
 
+const getOwnedEntryName = (entry) => {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+
+  if (Array.isArray(entry)) {
+    return entry[0];
+  }
+
+  if (entry && typeof entry === 'object') {
+    return entry.name || entry.displayName || entry.itemName || '';
+  }
+
+  return '';
+};
+
 function ItemList({
   campaign,
   onChange,
-  initialItems = [],
+  initialItems: initialItemsProp,
   characterId,
   show = true,
   onClose,
@@ -105,15 +121,32 @@ function ItemList({
   ownedOnly = false,
   cartCounts = null,
 }) {
+  const localChangeRef = useRef(false);
+  const normalizedInitialItems = useMemo(
+    () => (Array.isArray(initialItemsProp) ? initialItemsProp : []),
+    [initialItemsProp]
+  );
+  const [ownedItems, setOwnedItems] = useState(() =>
+    normalizedInitialItems
+  );
   const [items, setItems] =
     useState/** @type {Record<string, Item & { owned?: boolean, ownedCount?: number, displayName?: string }> | null} */(null);
   const [error, setError] = useState(null);
   const [unknownItems, setUnknownItems] = useState([]);
   const [notesItem, setNotesItem] = useState(null);
 
+  useEffect(() => {
+    if (localChangeRef.current) {
+      localChangeRef.current = false;
+      return;
+    }
+
+    setOwnedItems(normalizedInitialItems);
+  }, [normalizedInitialItems]);
+
   const ownershipMap = useMemo(
-    () => buildItemOwnershipMap(initialItems),
-    [initialItems]
+    () => buildItemOwnershipMap(ownedItems),
+    [ownedItems]
   );
 
   useEffect(() => {
@@ -196,7 +229,7 @@ function ItemList({
     }
 
     fetchItems();
-  }, [campaign, initialItems, show]);
+  }, [campaign, normalizedInitialItems, show]);
 
   useEffect(() => {
     setItems((prev) => {
@@ -246,6 +279,7 @@ function ItemList({
   const handleShowNotes = (item) => () => setNotesItem(item);
 
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
+  const canModifyOwned = ownedOnly && typeof onChange === 'function';
   const filteredEntries = Object.entries(items).filter(([, item]) =>
     ownedOnly ? (item.ownedCount ?? 0) > 0 : true
   );
@@ -307,6 +341,61 @@ function ItemList({
                 ? item.category.toLowerCase()
                 : '';
             const Icon = categoryIcons[categoryKey] || GiTreasureMap;
+            const handleRemoveOwned = () => {
+              if (!canModifyOwned) return;
+
+              setOwnedItems((prev) => {
+                if (!Array.isArray(prev) || prev.length === 0) {
+                  return prev;
+                }
+
+                const normalizedKey = String(dataKey || '').trim().toLowerCase();
+                const displayKey = String(item.displayName || '')
+                  .trim()
+                  .toLowerCase();
+                const nameKey = String(item.name || '')
+                  .trim()
+                  .toLowerCase();
+                const validKeys = [normalizedKey, displayKey, nameKey].filter(
+                  Boolean
+                );
+
+                if (validKeys.length === 0) {
+                  return prev;
+                }
+
+                let seen = 0;
+                const indexToRemove = prev.findIndex((entry) => {
+                  const entryName = String(
+                    getOwnedEntryName(entry) || ''
+                  )
+                    .trim()
+                    .toLowerCase();
+                  if (!entryName || !validKeys.includes(entryName)) {
+                    return false;
+                  }
+
+                  if (seen === copyIndex) {
+                    return true;
+                  }
+
+                  seen += 1;
+                  return false;
+                });
+
+                if (indexToRemove === -1) {
+                  return prev;
+                }
+
+                const next = prev.slice();
+                next.splice(indexToRemove, 1);
+                localChangeRef.current = true;
+                if (typeof onChange === 'function') {
+                  onChange(next);
+                }
+                return next;
+              });
+            };
             return (
               <Col key={reactKey}>
                 <Card className="item-card h-100">
@@ -354,7 +443,7 @@ function ItemList({
                       </div>
                     )}
                   </Card.Body>
-                  {!ownedOnly && (
+                  {!ownedOnly ? (
                     <Card.Footer className="d-flex justify-content-center">
                       <div className="d-flex align-items-center gap-2">
                         <Button size="sm" onClick={handleAddToCart(item)}>
@@ -367,7 +456,17 @@ function ItemList({
                         ) : null}
                       </div>
                     </Card.Footer>
-                  )}
+                  ) : canModifyOwned ? (
+                    <Card.Footer className="d-flex justify-content-center">
+                      <Button
+                        size="sm"
+                        variant="outline-danger"
+                        onClick={handleRemoveOwned}
+                      >
+                        Remove
+                      </Button>
+                    </Card.Footer>
+                  ) : null}
                 </Card>
               </Col>
             );

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -160,3 +160,58 @@ test('renders duplicate item cards when multiple copies are owned', async () => 
   expect(screen.getByText('Copy 2 of 2')).toBeInTheDocument();
   expect(screen.getAllByText('Potion of healing')).toHaveLength(1);
 });
+
+test('allows removing owned items and triggers change callback', async () => {
+  apiFetch.mockResolvedValue({ ok: true, json: async () => itemsData });
+  const onChange = jest.fn();
+  const ownedItems = [
+    { name: 'Potion of healing', owned: true },
+    { name: 'Potion of healing', owned: true },
+    { name: 'Torch', owned: true },
+  ];
+
+  render(
+    <ItemList
+      ownedOnly
+      embedded
+      onChange={onChange}
+      initialItems={ownedItems}
+    />
+  );
+
+  const potionHeadings = await screen.findAllByText('Potion of healing');
+  expect(potionHeadings).toHaveLength(2);
+  const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+  expect(removeButtons).toHaveLength(3);
+  const potionRemoveButton = removeButtons.find((button) => {
+    const card = button.closest('.card');
+    return card
+      ? within(card).queryByText('Potion of healing') !== null
+      : false;
+  });
+  expect(potionRemoveButton).toBeDefined();
+
+  await act(async () => {
+    await userEvent.click(potionRemoveButton);
+  });
+
+  await waitFor(() =>
+    expect(screen.getAllByText('Potion of healing')).toHaveLength(1)
+  );
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  const updatedInventory = onChange.mock.calls[0][0];
+  expect(updatedInventory).toHaveLength(2);
+  const normalizeName = (entry) => {
+    if (typeof entry === 'string') return entry.toLowerCase();
+    if (Array.isArray(entry)) return String(entry[0] || '').toLowerCase();
+    if (entry && typeof entry === 'object') {
+      return String(entry.name || entry.displayName || entry.itemName || '').toLowerCase();
+    }
+    return '';
+  };
+  const potionCount = updatedInventory.filter(
+    (entry) => normalizeName(entry) === 'potion of healing'
+  ).length;
+  expect(potionCount).toBe(1);
+});


### PR DESCRIPTION
## Summary
- track owned inventory locally so embedded item lists can remove entries without breaking the shop cart view
- render a remove action for owned inventory copies when persistence callbacks are supplied
- add UI coverage to confirm the inventory list prunes duplicates and notifies the change handler

## Testing
- CI=true npm --prefix client test -- --runTestsByPath src/components/Items/ItemList.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e2a7227f788323a174661843ed2b4f