### PR TITLE
Ensure custom equipment entries default to unowned

### DIFF
--- a/server/__tests__/accessories.test.js
+++ b/server/__tests__/accessories.test.js
@@ -31,6 +31,7 @@ describe('Accessory routes', () => {
     expect(res.body).toBeDefined();
     expect(res.body['amulet-of-health']).toBeDefined();
     expect(res.body['amulet-of-health'].name).toBe('Amulet of Health');
+    expect(res.body['amulet-of-health'].owned).toBe(false);
     expect(Array.isArray(res.body['amulet-of-health'].targetSlots)).toBe(true);
     expect(res.body['amulet-of-health'].targetSlots).toContain('neck');
     expect(res.body['amulet-of-health'].weight).toBe(1);

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -403,6 +403,7 @@ describe('Character routes', () => {
     const res = await request(app).get('/equipment/items/Camp1');
     expect(res.status).toBe(200);
     expect(res.body[0].itemName).toBe('Potion');
+    expect(res.body[0].owned).toBe(false);
   });
 
   test('get items failure', async () => {

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -192,6 +192,8 @@ describe('Equipment routes', () => {
         notes: 'Shimmers with constellations',
         statBonuses: { dex: 2 },
       });
+      expect(insertedDoc.owned).toBe(false);
+      expect(res.body.owned).toBe(false);
     });
 
     test('create accessory rejects invalid slot', async () => {
@@ -470,8 +472,14 @@ describe('Equipment routes', () => {
     });
 
     test('insert success', async () => {
+      let insertedDoc;
       dbo.mockResolvedValue({
-        collection: () => ({ insertOne: async () => ({ insertedId: '507f1f77bcf86cd799439011' }) })
+        collection: () => ({
+          insertOne: async (doc) => {
+            insertedDoc = doc;
+            return { insertedId: '507f1f77bcf86cd799439011' };
+          }
+        })
       });
       const res = await request(app)
         .post('/equipment/items')
@@ -487,6 +495,8 @@ describe('Equipment routes', () => {
         });
       expect(res.status).toBe(200);
       expect(res.body._id).toBeDefined();
+      expect(insertedDoc.owned).toBe(false);
+      expect(res.body.owned).toBe(false);
       expect(res.body.statBonuses.str).toBe(1);
       expect(res.body.skillBonuses.acrobatics).toBe(2);
     });
@@ -524,6 +534,7 @@ describe('Equipment routes', () => {
       expect(res.body[0].name).toBe('Potion of healing');
       expect(res.body[0].statBonuses.str).toBe(1);
       expect(res.body[0].skillBonuses.acrobatics).toBe(2);
+      expect(res.body[0].owned).toBe(false);
     });
 
     test('get items failure', async () => {
@@ -533,6 +544,37 @@ describe('Equipment routes', () => {
         })
       });
       const res = await request(app).get('/equipment/items/Camp1');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('get accessories', () => {
+    test('get accessories success', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          find: () => ({
+            toArray: async () => [
+              {
+                name: 'Crown of Insight',
+                targetSlots: ['head'],
+              },
+            ],
+          }),
+        }),
+      });
+      const res = await request(app).get('/equipment/accessories/Camp1');
+      expect(res.status).toBe(200);
+      expect(res.body[0].name).toBe('Crown of Insight');
+      expect(res.body[0].owned).toBe(false);
+    });
+
+    test('get accessories failure', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({
+          find: () => ({ toArray: async () => { throw new Error('db error'); } }),
+        }),
+      });
+      const res = await request(app).get('/equipment/accessories/Camp1');
       expect(res.status).toBe(500);
     });
   });

--- a/server/data/accessories.js
+++ b/server/data/accessories.js
@@ -29,6 +29,7 @@ const slots = slotKeys.map((key) => slotMap.get(key) || { key, label: key });
  * @property {string} [attunement]
  * @property {string|number} [weight]
  * @property {string|number} [cost]
+ * @property {boolean} owned
  * @property {Record<string, number>} [statBonuses]
  * @property {Record<string, number>} [skillBonuses]
  * @property {string} [notes]
@@ -39,6 +40,7 @@ const accessories = {
   'amulet-of-health': {
     name: 'Amulet of Health',
     category: 'amulet',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['neck'],
@@ -50,6 +52,7 @@ const accessories = {
   'amulet-of-proof-against-detection-and-location': {
     name: 'Amulet of Proof against Detection and Location',
     category: 'amulet',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['neck'],
@@ -60,6 +63,7 @@ const accessories = {
   'amulet-of-the-planes': {
     name: 'Amulet of the Planes',
     category: 'amulet',
+    owned: false,
     rarity: 'very rare',
     attunement: 'requires attunement',
     targetSlots: ['neck'],
@@ -70,6 +74,7 @@ const accessories = {
   'periapt-of-proof-against-poison': {
     name: 'Periapt of Proof against Poison',
     category: 'amulet',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['neck'],
@@ -80,6 +85,7 @@ const accessories = {
   'periapt-of-wound-closure': {
     name: 'Periapt of Wound Closure',
     category: 'amulet',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['neck'],
@@ -90,6 +96,7 @@ const accessories = {
   'belt-of-dwarvenkind': {
     name: 'Belt of Dwarvenkind',
     category: 'belt',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['waist'],
@@ -101,6 +108,7 @@ const accessories = {
   'belt-of-hill-giant-strength': {
     name: 'Belt of Hill Giant Strength',
     category: 'belt',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['waist'],
@@ -112,6 +120,7 @@ const accessories = {
   'belt-of-stone-giant-strength': {
     name: 'Belt of Stone Giant Strength',
     category: 'belt',
+    owned: false,
     rarity: 'very rare',
     attunement: 'requires attunement',
     targetSlots: ['waist'],
@@ -123,6 +132,7 @@ const accessories = {
   'bracers-of-archery': {
     name: 'Bracers of Archery',
     category: 'bracelet',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['wrists'],
@@ -133,6 +143,7 @@ const accessories = {
   'bracers-of-defense': {
     name: 'Bracers of Defense',
     category: 'bracelet',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['wrists'],
@@ -143,6 +154,7 @@ const accessories = {
   'brooch-of-shielding': {
     name: 'Brooch of Shielding',
     category: 'brooch',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['neck'],
@@ -153,6 +165,7 @@ const accessories = {
   'cape-of-the-mountebank': {
     name: 'Cape of the Mountebank',
     category: 'cape',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['back'],
@@ -163,6 +176,7 @@ const accessories = {
   'cloak-of-elvenkind': {
     name: 'Cloak of Elvenkind',
     category: 'cloak',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['back'],
@@ -173,6 +187,7 @@ const accessories = {
   'cloak-of-protection': {
     name: 'Cloak of Protection',
     category: 'cloak',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['back'],
@@ -183,6 +198,7 @@ const accessories = {
   'cloak-of-the-bat': {
     name: 'Cloak of the Bat',
     category: 'cloak',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['back'],
@@ -193,6 +209,7 @@ const accessories = {
   'cloak-of-the-manta-ray': {
     name: 'Cloak of the Manta Ray',
     category: 'cloak',
+    owned: false,
     rarity: 'uncommon',
     targetSlots: ['back'],
     weight: 1,
@@ -202,6 +219,7 @@ const accessories = {
   'eyes-of-charming': {
     name: 'Eyes of Charming',
     category: 'goggles',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['eyes'],
@@ -212,6 +230,7 @@ const accessories = {
   'eyes-of-the-eagle': {
     name: 'Eyes of the Eagle',
     category: 'goggles',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['eyes'],
@@ -222,6 +241,7 @@ const accessories = {
   'goggles-of-night': {
     name: 'Goggles of Night',
     category: 'goggles',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['eyes'],
@@ -232,6 +252,7 @@ const accessories = {
   'ring-of-feather-falling': {
     name: 'Ring of Feather Falling',
     category: 'ring',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -242,6 +263,7 @@ const accessories = {
   'ring-of-free-action': {
     name: 'Ring of Free Action',
     category: 'ring',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -252,6 +274,7 @@ const accessories = {
   'ring-of-invisibility': {
     name: 'Ring of Invisibility',
     category: 'ring',
+    owned: false,
     rarity: 'legendary',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -262,6 +285,7 @@ const accessories = {
   'ring-of-protection': {
     name: 'Ring of Protection',
     category: 'ring',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -272,6 +296,7 @@ const accessories = {
   'ring-of-regeneration': {
     name: 'Ring of Regeneration',
     category: 'ring',
+    owned: false,
     rarity: 'very rare',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -282,6 +307,7 @@ const accessories = {
   'ring-of-spell-storing': {
     name: 'Ring of Spell Storing',
     category: 'ring',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -292,6 +318,7 @@ const accessories = {
   'ring-of-water-walking': {
     name: 'Ring of Water Walking',
     category: 'ring',
+    owned: false,
     rarity: 'uncommon',
     targetSlots: ['ringLeft', 'ringRight'],
     weight: 0,
@@ -301,6 +328,7 @@ const accessories = {
   'ring-of-warmth': {
     name: 'Ring of Warmth',
     category: 'ring',
+    owned: false,
     rarity: 'uncommon',
     attunement: 'requires attunement',
     targetSlots: ['ringLeft', 'ringRight'],
@@ -311,6 +339,7 @@ const accessories = {
   'robe-of-eyes': {
     name: 'Robe of Eyes',
     category: 'wrap',
+    owned: false,
     rarity: 'rare',
     attunement: 'requires attunement',
     targetSlots: ['back'],
@@ -321,6 +350,7 @@ const accessories = {
   'scarab-of-protection': {
     name: 'Scarab of Protection',
     category: 'brooch',
+    owned: false,
     rarity: 'legendary',
     attunement: 'requires attunement',
     targetSlots: ['neck'],

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -396,7 +396,11 @@ module.exports = (router) => {
         .collection('Items')
         .find({ campaign: req.params.campaign })
         .toArray();
-      res.json(result);
+      const normalized = result.map((item) => ({
+        ...item,
+        owned: item?.owned ?? false,
+      }));
+      res.json(normalized);
     } catch (err) {
       next(err);
     }
@@ -418,6 +422,9 @@ module.exports = (router) => {
     async (req, res, next) => {
       const db_connect = req.db;
       const myobj = matchedData(req, { locations: ['body'], includeOptionals: true });
+      if (myobj.owned === undefined) {
+        myobj.owned = false;
+      }
       try {
         const result = await db_connect.collection('Items').insertOne(myobj);
         const item = { _id: result.insertedId, ...myobj };
@@ -490,7 +497,11 @@ module.exports = (router) => {
         .collection('Accessories')
         .find({ campaign: req.params.campaign })
         .toArray();
-      res.json(result);
+      const normalized = result.map((accessory) => ({
+        ...accessory,
+        owned: accessory?.owned ?? false,
+      }));
+      res.json(normalized);
     } catch (err) {
       next(err);
     }
@@ -528,6 +539,9 @@ module.exports = (router) => {
     async (req, res, next) => {
       const db_connect = req.db;
       const myobj = matchedData(req, { locations: ['body'], includeOptionals: true });
+      if (myobj.owned === undefined) {
+        myobj.owned = false;
+      }
       myobj.targetSlots = normalizeAccessorySlots(myobj.targetSlots);
       try {
         const result = await db_connect.collection('Accessories').insertOne(myobj);


### PR DESCRIPTION
## Summary
- default custom campaign items and accessories to owned: false when inserting and fetching them
- expand equipment route tests to cover the owned defaults for custom items and accessories
- update character route tests to expect the owned property on custom item payloads

## Testing
- CI=true npm test -- equipment
- CI=true npm test -- characters

------
https://chatgpt.com/codex/tasks/task_e_68e2c43bfcc88323b97b38740dfeb627