### PR TITLE
Replace map active turn ring with exclamation indicator

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2735,6 +2735,24 @@ h1 {
     --figurine-size-scale: 4;
   }
 
+  &__turn-indicator {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    font-weight: 800;
+    font-size: clamp(0.9rem, calc(var(--figurine-base-size) * 0.6), 1.85rem);
+    line-height: 1;
+    color: #ff4d4f;
+    text-shadow:
+      0 0.35rem 0.8rem rgba(0, 0, 0, 0.6),
+      0 0 0.4rem rgba(255, 77, 79, 0.9),
+      0 0 1rem rgba(255, 125, 127, 0.75);
+    animation: campaignMapBoardTurnIndicatorPulse 1.4s ease-in-out infinite;
+    filter: drop-shadow(0 0.2rem 0.45rem rgba(0, 0, 0, 0.55));
+  }
+
   &__health {
     --campaign-map-board-health-color-resolved: var(
       --campaign-map-board-health-color,
@@ -2949,35 +2967,40 @@ h1 {
   }
 
   &__token--active-turn {
-    filter:
-      drop-shadow(0 0.45rem 1.2rem rgba(209, 143, 0, 0.55))
-      drop-shadow(0 0 1.85rem rgba(255, 214, 102, 0.45));
-
-    &::after {
-      content: '';
-      position: absolute;
-      inset: calc(var(--figurine-base-size) * -0.15);
-      border-radius: 999px;
-      pointer-events: none;
-      box-shadow:
-        0 0 0.65rem rgba(255, 214, 102, 0.45),
-        0 0 1.6rem rgba(255, 239, 153, 0.55),
-        inset 0 0 0.35rem rgba(255, 248, 220, 0.4);
-      opacity: 0.85;
-      z-index: -1;
+    .campaign-map-board__turn-indicator {
+      animation-play-state: running;
     }
-
-    .campaign-map-board__figurine {
-      filter:
-        drop-shadow(0 0.55rem 1.6rem rgba(255, 214, 102, 0.7))
-        drop-shadow(0 0.25rem 0.6rem rgba(255, 248, 220, 0.75))
-        drop-shadow(0 0 2.1rem rgba(255, 239, 153, 0.55));
-    }
-
   }
 
   &--disabled &__token--draggable {
     cursor: default;
+  }
+}
+
+@keyframes campaignMapBoardTurnIndicatorPulse {
+  0% {
+    transform: translateY(0) scale(0.92);
+    opacity: 0.85;
+    text-shadow:
+      0 0.25rem 0.65rem rgba(0, 0, 0, 0.55),
+      0 0 0.35rem rgba(255, 77, 79, 0.7),
+      0 0 0.85rem rgba(255, 140, 143, 0.6);
+  }
+  50% {
+    transform: translateY(calc(var(--figurine-base-size) * -0.04)) scale(1.05);
+    opacity: 1;
+    text-shadow:
+      0 0.45rem 1rem rgba(0, 0, 0, 0.65),
+      0 0 0.55rem rgba(255, 104, 107, 0.95),
+      0 0 1.4rem rgba(255, 168, 170, 0.85);
+  }
+  100% {
+    transform: translateY(0) scale(0.92);
+    opacity: 0.85;
+    text-shadow:
+      0 0.25rem 0.65rem rgba(0, 0, 0, 0.55),
+      0 0 0.35rem rgba(255, 77, 79, 0.7),
+      0 0 0.85rem rgba(255, 140, 143, 0.6);
   }
 }
 

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -488,6 +488,19 @@ const CampaignMapBoard = ({
                     }}
                     data-token-id={characterId}
                   >
+                    {displayLabel && (
+                      <span className={labelClassName} aria-hidden="true">
+                        {displayLabel}
+                      </span>
+                    )}
+                    {isActiveTurn && (
+                      <span className="campaign-map-board__turn-indicator">
+                        <span aria-hidden="true">!</span>
+                        <span className="visually-hidden">
+                          {`${displayLabel || 'This character'} is taking their turn`}
+                        </span>
+                      </span>
+                    )}
                     {hasHealth && safeCurrentHp !== null && safeMaxHp !== null && safeMaxHp > 0 && (
                       <div
                         className="campaign-map-board__health"
@@ -530,11 +543,6 @@ const CampaignMapBoard = ({
                         <span className="campaign-map-board__figurine-cloak" />
                       </span>
                     </div>
-                    {displayLabel && (
-                      <span className={labelClassName} aria-hidden="true">
-                        {displayLabel}
-                      </span>
-                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary
- replace the map token active-turn ring with a red exclamation indicator positioned between the name tag and health bar
- add supporting styles and animation plus accessibility text for the new indicator

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d3c60ca08323a3bb3da8c2bef40d