### PR TITLE
Enable figurine rotation after drag

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2696,6 +2696,7 @@ h1 {
   &__token {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
+    --figurine-rotation: 0deg;
     position: absolute;
     transform: translate(-50%, -50%);
     pointer-events: auto;
@@ -2709,6 +2710,10 @@ h1 {
     touch-action: none;
     width: var(--figurine-base-size);
     height: calc(var(--figurine-base-size) * 1.6);
+  }
+
+  &__token.lastDragged {
+    z-index: 6;
   }
 
   &__token--size-tiny {
@@ -2811,12 +2816,91 @@ h1 {
       drop-shadow(0 0.05rem 0.25rem rgba(255, 255, 255, 0.12));
     transition: transform 0.2s ease, filter 0.2s ease;
     position: relative;
+    transform: rotate(var(--figurine-rotation, 0deg));
   }
 
   &__figurine--active {
-    transform: translateY(-3px) scale(1.02);
+    transform: rotate(var(--figurine-rotation, 0deg)) translateY(-3px) scale(1.02);
     filter: drop-shadow(0 0.55rem 1.25rem rgba(7, 8, 13, 0.75))
       drop-shadow(0 0.15rem 0.35rem rgba(255, 255, 255, 0.2));
+  }
+
+  &__rotation-controls {
+    position: absolute;
+    top: calc(var(--figurine-base-size) * -0.45);
+    left: 50%;
+    transform: translate(-50%, -100%) scale(0.92);
+    display: inline-flex;
+    align-items: center;
+    gap: clamp(0.25rem, calc(var(--figurine-base-size) * 0.12), 0.45rem);
+    padding: clamp(0.25rem, calc(var(--figurine-base-size) * 0.18), 0.4rem)
+      clamp(0.45rem, calc(var(--figurine-base-size) * 0.22), 0.65rem);
+    background: rgba(18, 16, 14, 0.92);
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    box-shadow: 0 0.45rem 1.1rem rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 12;
+  }
+
+  &__token.lastDragged &__rotation-controls,
+  &__rotation-controls:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translate(-50%, -100%) scale(1);
+  }
+
+  &__rotation-button {
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    color: #f8f9fa;
+    border-radius: 50%;
+    width: clamp(1.75rem, calc(var(--figurine-base-size) * 0.6), 2.35rem);
+    height: clamp(1.75rem, calc(var(--figurine-base-size) * 0.6), 2.35rem);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: clamp(0.85rem, calc(var(--figurine-base-size) * 0.34), 1.05rem);
+    cursor: pointer;
+    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+
+  &__rotation-button:hover,
+  &__rotation-button:focus-visible {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.45);
+    transform: scale(1.05);
+  }
+
+  &__rotation-angle {
+    min-width: clamp(2.1rem, calc(var(--figurine-base-size) * 0.9), 2.75rem);
+    text-align: center;
+    font-weight: 600;
+    font-size: clamp(0.75rem, calc(var(--figurine-base-size) * 0.32), 0.95rem);
+    color: #f1f3f5;
+  }
+
+  &__rotation-lock {
+    background: rgba(51, 154, 240, 0.25);
+    border: 1px solid rgba(51, 154, 240, 0.55);
+    color: #f8f9fa;
+    border-radius: 999px;
+    padding: clamp(0.2rem, calc(var(--figurine-base-size) * 0.16), 0.35rem)
+      clamp(0.55rem, calc(var(--figurine-base-size) * 0.28), 0.8rem);
+    font-size: clamp(0.7rem, calc(var(--figurine-base-size) * 0.27), 0.9rem);
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+    white-space: nowrap;
+  }
+
+  &__rotation-lock:hover,
+  &__rotation-lock:focus-visible {
+    background: rgba(51, 154, 240, 0.38);
+    border-color: rgba(51, 154, 240, 0.7);
+    transform: translateY(-1px);
   }
 
   &__figurine-image-wrapper {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo, useCallback } from 'react';
+import React, { useRef, useState, useMemo, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
@@ -109,6 +109,22 @@ const resolveFigurineSizeKey = (value) => {
   return 'medium';
 };
 
+const ROTATION_STEP_DEGREES = 15;
+
+const normalizeDegrees = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return 0;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+
+  const normalized = parsed % 360;
+  return normalized < 0 ? normalized + 360 : normalized;
+};
+
 const CampaignMapBoard = ({
   map,
   tokens,
@@ -137,6 +153,9 @@ const CampaignMapBoard = ({
   const dragStateRef = useRef({ tokenId: null, pointerId: null });
   const [dragPositions, setDragPositions] = useState({});
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
+  const [lastDraggedTokenId, setLastDraggedTokenId] = useState(null);
+  const [rotationOverrides, setRotationOverrides] = useState({});
+  const tokenPositionsRef = useRef([]);
   const handleLayerRef = useCallback((node) => {
     layerRef.current = node;
   }, []);
@@ -161,6 +180,36 @@ const CampaignMapBoard = ({
         };
       });
   }, [tokens, dragPositions]);
+
+  useEffect(() => {
+    tokenPositionsRef.current = tokenPositions;
+  }, [tokenPositions]);
+
+  useEffect(() => {
+    const activeIds = new Set(tokenPositions.map((token) => token?.characterId));
+
+    setRotationOverrides((prev) => {
+      const next = {};
+      activeIds.forEach((id) => {
+        if (Object.prototype.hasOwnProperty.call(prev, id)) {
+          next[id] = prev[id];
+        }
+      });
+
+      const prevKeys = Object.keys(prev);
+      const nextKeys = Object.keys(next);
+      if (
+        prevKeys.length === nextKeys.length &&
+        prevKeys.every((key) => next[key] === prev[key])
+      ) {
+        return prev;
+      }
+
+      return next;
+    });
+
+    setLastDraggedTokenId((prev) => (prev && !activeIds.has(prev) ? null : prev));
+  }, [tokenPositions]);
 
   const resetDragState = useCallback(() => {
     dragStateRef.current = { tokenId: null, pointerId: null };
@@ -223,6 +272,8 @@ const CampaignMapBoard = ({
         },
       }));
 
+      setLastDraggedTokenId(null);
+
       if (typeof onTokenDragStart === 'function') {
         onTokenDragStart({ token, characterId });
       }
@@ -280,7 +331,11 @@ const CampaignMapBoard = ({
       }
 
       const { tokenId, pointerId } = dragState;
-      if (pointerId !== undefined && event.pointerId !== pointerId) {
+      if (
+        pointerId !== undefined &&
+        event.pointerId !== undefined &&
+        event.pointerId !== pointerId
+      ) {
         return;
       }
 
@@ -301,6 +356,7 @@ const CampaignMapBoard = ({
       }
 
       resetDragState();
+      setLastDraggedTokenId(cancelled ? null : tokenId);
     },
     [getNormalizedCoordinates, onTokenDragEnd, onTokenPositionChange, resetDragState, updateDragPosition]
   );
@@ -314,6 +370,9 @@ const CampaignMapBoard = ({
 
       event.preventDefault();
       event.stopPropagation();
+      if (dragState.tokenId) {
+        setLastDraggedTokenId(dragState.tokenId);
+      }
       finalizeDrag(event, false);
     },
     [finalizeDrag]
@@ -336,6 +395,7 @@ const CampaignMapBoard = ({
   const handleLayerPointerDown = useCallback(
     (event) => {
       setActiveLabelTokenId(null);
+      setLastDraggedTokenId(null);
       if (interactionDisabled || typeof onBackgroundClick !== 'function') {
         return;
       }
@@ -360,6 +420,121 @@ const CampaignMapBoard = ({
       setActiveLabelTokenId,
     ]
   );
+
+  const getResolvedRotationForToken = useCallback(
+    (token) => {
+      if (!token || !token.characterId) {
+        return 0;
+      }
+
+      const override = rotationOverrides[token.characterId];
+      if (Number.isFinite(override)) {
+        return normalizeDegrees(override);
+      }
+
+      const baseRotation = Number(token.rotation);
+      return Number.isFinite(baseRotation) ? normalizeDegrees(baseRotation) : 0;
+    },
+    [rotationOverrides]
+  );
+
+  const rotateTokenBy = useCallback(
+    (tokenId, delta) => {
+      if (!tokenId || !Number.isFinite(delta)) {
+        return;
+      }
+
+      setRotationOverrides((prev) => {
+        const currentOverride = prev[tokenId];
+        let baseRotation = Number.isFinite(currentOverride)
+          ? currentOverride
+          : (() => {
+              const tokensList = tokenPositionsRef.current;
+              if (!Array.isArray(tokensList)) {
+                return 0;
+              }
+              const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
+              const rawRotation = Number(foundToken?.rotation);
+              return Number.isFinite(rawRotation) ? rawRotation : 0;
+            })();
+
+        const nextRotation = normalizeDegrees(baseRotation + delta);
+        if (!Number.isFinite(nextRotation)) {
+          return prev;
+        }
+
+        if (prev[tokenId] === nextRotation) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [tokenId]: nextRotation,
+        };
+      });
+
+      setLastDraggedTokenId(tokenId);
+    },
+    []
+  );
+
+  const lockRotation = useCallback((tokenId) => {
+    if (!tokenId) {
+      setLastDraggedTokenId(null);
+      return;
+    }
+
+    setLastDraggedTokenId((prev) => (prev === tokenId ? null : prev));
+  }, []);
+
+  useEffect(() => {
+    if (!lastDraggedTokenId) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (!event || typeof event.key !== 'string') {
+        return;
+      }
+
+      const key = event.key;
+      const lowerKey = key.toLowerCase();
+
+      if (
+        key === 'ArrowLeft' ||
+        key === '[' ||
+        key === '{' ||
+        lowerKey === 'a' ||
+        lowerKey === 'q'
+      ) {
+        event.preventDefault();
+        rotateTokenBy(lastDraggedTokenId, -ROTATION_STEP_DEGREES);
+        return;
+      }
+
+      if (
+        key === 'ArrowRight' ||
+        key === ']' ||
+        key === '}' ||
+        lowerKey === 'd' ||
+        lowerKey === 'e'
+      ) {
+        event.preventDefault();
+        rotateTokenBy(lastDraggedTokenId, ROTATION_STEP_DEGREES);
+        return;
+      }
+
+      if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Escape') {
+        event.preventDefault();
+        lockRotation(lastDraggedTokenId);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [lastDraggedTokenId, lockRotation, rotateTokenBy]);
 
   return (
     <div className={classNames('campaign-map-board', className, interactionDisabled && 'campaign-map-board--disabled')}>
@@ -422,6 +597,13 @@ const CampaignMapBoard = ({
 
                 const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(token);
                 const hasFigurineImage = Boolean(figurineImageUrl);
+                const resolvedRotation = getResolvedRotationForToken(token);
+                const rotationValue = Number.isFinite(resolvedRotation)
+                  ? resolvedRotation
+                  : 0;
+                const rotationDisplay = Math.round(rotationValue * 10) / 10;
+                const rotationStyleValue = `${rotationValue}deg`;
+                const isRotationActive = lastDraggedTokenId === characterId;
 
                 const labelClassName = classNames(
                   'campaign-map-board__figurine-label',
@@ -439,12 +621,14 @@ const CampaignMapBoard = ({
                       draggable && 'campaign-map-board__token--draggable',
                       isLabelActive && 'campaign-map-board__token--label-active',
                       isActiveTurn && 'campaign-map-board__token--active-turn',
-                      `campaign-map-board__token--size-${sizeKey}`
+                      `campaign-map-board__token--size-${sizeKey}`,
+                      isRotationActive && 'lastDragged'
                     )}
                     style={{
                       left: `${(position?.x ?? 0) * 100}%`,
                       top: `${(position?.y ?? 0) * 100}%`,
                       '--figurine-size-scale': figurineScale,
+                      '--figurine-rotation': rotationStyleValue,
                     }}
                     title={displayLabel || undefined}
                     onPointerDown={(event) => {
@@ -487,6 +671,7 @@ const CampaignMapBoard = ({
                       });
                     }}
                     data-token-id={characterId}
+                    data-rotation={rotationValue}
                   >
                     {displayLabel && (
                       <span className={labelClassName} aria-hidden="true">
@@ -543,6 +728,53 @@ const CampaignMapBoard = ({
                         <span className="campaign-map-board__figurine-cloak" />
                       </span>
                     </div>
+                    {isRotationActive && (
+                      <div
+                        className="campaign-map-board__rotation-controls"
+                        role="group"
+                        aria-label="Figurine rotation controls"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onPointerUp={(event) => event.stopPropagation()}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <button
+                          type="button"
+                          className="campaign-map-board__rotation-button"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            rotateTokenBy(characterId, -ROTATION_STEP_DEGREES);
+                          }}
+                          aria-label="Rotate counterclockwise"
+                        >
+                          <span aria-hidden="true">⟲</span>
+                        </button>
+                        <div className="campaign-map-board__rotation-angle" aria-live="polite">
+                          {`${rotationDisplay}°`}
+                        </div>
+                        <button
+                          type="button"
+                          className="campaign-map-board__rotation-button"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            rotateTokenBy(characterId, ROTATION_STEP_DEGREES);
+                          }}
+                          aria-label="Rotate clockwise"
+                        >
+                          <span aria-hidden="true">⟳</span>
+                        </button>
+                        <button
+                          type="button"
+                          className="campaign-map-board__rotation-lock"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            lockRotation(characterId);
+                          }}
+                          aria-label="Lock rotation"
+                        >
+                          Lock
+                        </button>
+                      </div>
+                    )}
                   </div>
                 );
               })}
@@ -574,6 +806,7 @@ CampaignMapBoard.propTypes = {
       size: PropTypes.string,
       figurineImageUrl: PropTypes.string,
       figurineImagePublicId: PropTypes.string,
+      rotation: PropTypes.number,
     })
   ),
   onTokenDragStart: PropTypes.func,

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { createEvent } from '@testing-library/dom';
 import CampaignMapBoard from './CampaignMapBoard';
 
@@ -173,6 +173,89 @@ describe('CampaignMapBoard pointer interactions', () => {
     fireEvent(tokenElement, pointerUpEvent);
 
     expect(pointerUpEvent.defaultPrevented).toBe(true);
+  });
+
+  it('marks the last dragged token and enables rotation controls', async () => {
+    const { container, findByRole, queryByRole } = renderBoard();
+
+    const applyLayerRect = () => {
+      const layer = container.querySelector('.campaign-map-board__tokens-layer');
+      expect(layer).not.toBeNull();
+      if (layer) {
+        layer.getBoundingClientRect = () => ({
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 400,
+        });
+      }
+      return layer;
+    };
+
+    applyLayerRect();
+
+    let tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    const pointerDownEvent = createEvent.pointerDown(tokenElement, {
+      button: 0,
+      pointerId: 1,
+      clientX: 100,
+      clientY: 100,
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(tokenElement, pointerDownEvent);
+
+    applyLayerRect();
+
+    const pointerMoveEvent = createEvent.pointerMove(tokenElement, {
+      button: 0,
+      pointerId: 1,
+      clientX: 150,
+      clientY: 120,
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(tokenElement, pointerMoveEvent);
+
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    const pointerUpEvent = createEvent.pointerUp(tokenElement, {
+      button: 0,
+      pointerId: 1,
+      clientX: 150,
+      clientY: 120,
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(tokenElement, pointerUpEvent);
+
+    await waitFor(() => {
+      const latestToken = container.querySelector('[data-token-id="char-1"]');
+      expect(latestToken).not.toBeNull();
+      expect(latestToken).toHaveClass('lastDragged');
+    });
+
+    const rotateClockwiseButton = await findByRole('button', { name: /rotate clockwise/i });
+    fireEvent.click(rotateClockwiseButton);
+
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement?.getAttribute('data-rotation')).toBe('15');
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement?.getAttribute('data-rotation')).toBe('0');
+
+    const lockButton = await findByRole('button', { name: /lock rotation/i });
+    fireEvent.click(lockButton);
+
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+    expect(tokenElement).not.toHaveClass('lastDragged');
+    expect(queryByRole('button', { name: /lock rotation/i })).toBeNull();
   });
 
   it('renders a figurine image overlay when provided and preserves accessibility labels', () => {


### PR DESCRIPTION
## Summary
- apply last-drag tracking to campaign map tokens and expose keyboard/button rotation controls
- style rotation controls, highlight the last dragged figurine, and respect rotation transforms
- cover the rotation workflow with updated CampaignMapBoard tests

## Testing
- npm test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2df2cc83483239525a3c4c6f7fe70