### PR TITLE
Persist campaign map token rotation

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -155,6 +155,7 @@ const CampaignMapBoard = ({
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
   const [lastDraggedTokenId, setLastDraggedTokenId] = useState(null);
   const [rotationOverrides, setRotationOverrides] = useState({});
+  const rotationOverridesRef = useRef({});
   const tokenPositionsRef = useRef([]);
   const handleLayerRef = useCallback((node) => {
     layerRef.current = node;
@@ -184,6 +185,10 @@ const CampaignMapBoard = ({
   useEffect(() => {
     tokenPositionsRef.current = tokenPositions;
   }, [tokenPositions]);
+
+  useEffect(() => {
+    rotationOverridesRef.current = rotationOverrides;
+  }, [rotationOverrides]);
 
   useEffect(() => {
     const activeIds = new Set(tokenPositions.map((token) => token?.characterId));
@@ -444,25 +449,26 @@ const CampaignMapBoard = ({
         return;
       }
 
+      const tokensList = tokenPositionsRef.current;
+      const overrides = rotationOverridesRef.current || {};
+      const currentOverride = overrides[tokenId];
+      let baseRotation = Number.isFinite(currentOverride)
+        ? currentOverride
+        : (() => {
+            if (!Array.isArray(tokensList)) {
+              return 0;
+            }
+            const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
+            const rawRotation = Number(foundToken?.rotation);
+            return Number.isFinite(rawRotation) ? rawRotation : 0;
+          })();
+
+      const nextRotation = normalizeDegrees(baseRotation + delta);
+      if (!Number.isFinite(nextRotation)) {
+        return;
+      }
+
       setRotationOverrides((prev) => {
-        const currentOverride = prev[tokenId];
-        let baseRotation = Number.isFinite(currentOverride)
-          ? currentOverride
-          : (() => {
-              const tokensList = tokenPositionsRef.current;
-              if (!Array.isArray(tokensList)) {
-                return 0;
-              }
-              const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
-              const rawRotation = Number(foundToken?.rotation);
-              return Number.isFinite(rawRotation) ? rawRotation : 0;
-            })();
-
-        const nextRotation = normalizeDegrees(baseRotation + delta);
-        if (!Number.isFinite(nextRotation)) {
-          return prev;
-        }
-
         if (prev[tokenId] === nextRotation) {
           return prev;
         }
@@ -474,8 +480,29 @@ const CampaignMapBoard = ({
       });
 
       setLastDraggedTokenId(tokenId);
+
+      if (typeof onTokenPositionChange === 'function' && Array.isArray(tokensList)) {
+        const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
+        if (foundToken) {
+          const candidatePosition =
+            foundToken.position && typeof foundToken.position === 'object'
+              ? foundToken.position
+              : null;
+          const normalizedX = clamp01(candidatePosition?.x ?? foundToken.x);
+          const normalizedY = clamp01(candidatePosition?.y ?? foundToken.y);
+
+          if (normalizedX !== null && normalizedY !== null) {
+            onTokenPositionChange({
+              characterId: tokenId,
+              x: normalizedX,
+              y: normalizedY,
+              rotation: nextRotation,
+            });
+          }
+        }
+      }
     },
-    []
+    [onTokenPositionChange]
   );
 
   const lockRotation = useCallback((tokenId) => {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -176,7 +176,8 @@ describe('CampaignMapBoard pointer interactions', () => {
   });
 
   it('marks the last dragged token and enables rotation controls', async () => {
-    const { container, findByRole, queryByRole } = renderBoard();
+    const onTokenPositionChange = jest.fn();
+    const { container, findByRole, queryByRole } = renderBoard({ onTokenPositionChange });
 
     const applyLayerRect = () => {
       const layer = container.querySelector('.campaign-map-board__tokens-layer');
@@ -241,10 +242,28 @@ describe('CampaignMapBoard pointer interactions', () => {
     const rotateClockwiseButton = await findByRole('button', { name: /rotate clockwise/i });
     fireEvent.click(rotateClockwiseButton);
 
+    expect(onTokenPositionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        characterId: 'char-1',
+        rotation: 15,
+        x: expect.any(Number),
+        y: expect.any(Number),
+      })
+    );
+
     tokenElement = container.querySelector('[data-token-id="char-1"]');
     expect(tokenElement?.getAttribute('data-rotation')).toBe('15');
 
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    expect(onTokenPositionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        characterId: 'char-1',
+        rotation: 0,
+        x: expect.any(Number),
+        y: expect.any(Number),
+      })
+    );
 
     tokenElement = container.querySelector('[data-token-id="char-1"]');
     expect(tokenElement?.getAttribute('data-rotation')).toBe('0');

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -493,7 +493,7 @@ const MapModal = ({
   }, [normalizedCurrentCharacterId, tokensDictionary]);
 
   const handleCommitMove = useCallback(
-    async ({ characterId, x, y }) => {
+    async ({ characterId, x, y, rotation }) => {
       if (!isInteractive || placementPending) {
         return;
       }
@@ -511,12 +511,18 @@ const MapModal = ({
       setPlacementError(null);
 
       try {
-        const result = await onTokenMove({
+        const payload = {
           mapId: previewMapId,
           characterId: normalizedCharacterId,
           x,
           y,
-        });
+        };
+
+        if (Number.isFinite(rotation)) {
+          payload.rotation = rotation;
+        }
+
+        const result = await onTokenMove(payload);
 
         if (result === false) {
           setPlacementError('Unable to update figurine position.');
@@ -541,12 +547,12 @@ const MapModal = ({
   );
 
   const handleTokenPositionChange = useCallback(
-    ({ characterId, x, y }) => {
+    ({ characterId, x, y, rotation }) => {
       if (!isInteractive) {
         return;
       }
 
-      handleCommitMove({ characterId, x, y });
+      handleCommitMove({ characterId, x, y, rotation });
     },
     [handleCommitMove, isInteractive]
   );

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -308,6 +308,21 @@ const clamp01 = (value) => {
   return parsed;
 };
 
+const normalizeRotation = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  const normalized = parsed % 360;
+  const resolved = normalized < 0 ? normalized + 360 : normalized;
+  return Math.round(resolved * 1000) / 1000;
+};
+
 const sanitizeToken = (tokenValue, fallbackId) => {
   if (!tokenValue || typeof tokenValue !== 'object') {
     return null;
@@ -2074,7 +2089,7 @@ export default function ZombiesDM() {
     }, [campaignId, applyMapPayload, syncEnemyTokenSelection]);
 
     const persistTokenPosition = useCallback(
-      async ({ mapId, characterId, x, y }) => {
+      async ({ mapId, characterId, x, y, rotation }) => {
         const normalizedMapId =
           typeof mapId === 'string' && mapId.trim() !== '' ? mapId.trim() : null;
         const normalizedCharacterId =
@@ -2084,6 +2099,7 @@ export default function ZombiesDM() {
 
         const clampedX = clamp01(x);
         const clampedY = clamp01(y);
+        const normalizedRotation = normalizeRotation(rotation);
 
         if (!normalizedMapId || !normalizedCharacterId || clampedX === null || clampedY === null) {
           return;
@@ -2103,6 +2119,7 @@ export default function ZombiesDM() {
           x: clampedX,
           y: clampedY,
           updatedAt: new Date().toISOString(),
+          ...(normalizedRotation !== null ? { rotation: normalizedRotation } : {}),
         };
 
         setMapTokens((prev) => {
@@ -2141,7 +2158,11 @@ export default function ZombiesDM() {
             {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ x: clampedX, y: clampedY }),
+              body: JSON.stringify(
+                normalizedRotation !== null
+                  ? { x: clampedX, y: clampedY, rotation: normalizedRotation }
+                  : { x: clampedX, y: clampedY }
+              ),
             }
           );
 
@@ -3143,7 +3164,7 @@ export default function ZombiesDM() {
     ]);
 
     const handleTokenPositionChange = useCallback(
-      ({ characterId, x, y }) => {
+      ({ characterId, x, y, rotation }) => {
         const normalizedDisplayedMapId =
           typeof displayedMap?.mapId === 'string' && displayedMap.mapId.trim() !== ''
             ? displayedMap.mapId.trim()
@@ -3167,6 +3188,7 @@ export default function ZombiesDM() {
           characterId,
           x,
           y,
+          rotation,
         });
       },
       [campaignMap, displayedMap, persistTokenPosition, shouldShowCampaignTokens]
@@ -3195,7 +3217,7 @@ export default function ZombiesDM() {
     }, []);
 
     const handleMapModalTokenMove = useCallback(
-      async ({ mapId, characterId, x, y }) => {
+      async ({ mapId, characterId, x, y, rotation }) => {
         const normalizedMapId =
           typeof mapId === 'string' && mapId.trim() !== '' ? mapId.trim() : null;
         const normalizedCharacterId =
@@ -3204,6 +3226,7 @@ export default function ZombiesDM() {
             : mapPlacementState.enemyId;
         const clampedX = clamp01(x);
         const clampedY = clamp01(y);
+        const normalizedRotation = normalizeRotation(rotation);
 
         if (!normalizedMapId || !normalizedCharacterId || clampedX === null || clampedY === null) {
           return false;
@@ -3214,6 +3237,7 @@ export default function ZombiesDM() {
           characterId: normalizedCharacterId,
           x: clampedX,
           y: clampedY,
+          rotation: normalizedRotation,
         });
 
         return true;

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -1020,6 +1020,64 @@ describe('Campaign routes', () => {
       );
     });
 
+    test('update map token persists rotation when provided', async () => {
+      const existingToken = {
+        characterId: 'hero-1',
+        x: 0.2,
+        y: 0.4,
+        rotation: 45,
+      };
+      const campaignDoc = buildCampaignWithMap({}, {
+        mapTokens: {
+          [storedMap.mapId]: {
+            'hero-1': existingToken,
+          },
+        },
+      });
+      const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+      dbo.mockResolvedValue({
+        collection: (name) => {
+          if (name === 'Campaigns') {
+            return {
+              findOne: async () => campaignDoc,
+              updateOne,
+            };
+          }
+          if (name === 'Characters') {
+            return { findOne: jest.fn() };
+          }
+          return {};
+        },
+      });
+
+      const res = await request(app)
+        .put(`/campaigns/Test/maps/${storedMap.mapId}/tokens/hero-1`)
+        .send({ x: 0.2, y: 0.4, rotation: -30 });
+
+      expect(res.status).toBe(200);
+      const updatedToken = res.body.tokensByMapId?.[storedMap.mapId]?.['hero-1'];
+      expect(updatedToken).toBeDefined();
+      expect(updatedToken).toEqual(
+        expect.objectContaining({
+          characterId: 'hero-1',
+          x: 0.2,
+          y: 0.4,
+          rotation: 330,
+        })
+      );
+      const emittedPayload = emitMapUpdate.mock.calls[emitMapUpdate.mock.calls.length - 1]?.[1];
+      expect(emittedPayload?.tokensByMapId?.[storedMap.mapId]?.['hero-1']).toEqual(
+        expect.objectContaining({ rotation: 330 })
+      );
+      const updateCall = updateOne.mock.calls[updateOne.mock.calls.length - 1];
+      expect(updateCall?.[1]?.$set?.mapTokens?.[storedMap.mapId]?.['hero-1']).toEqual(
+        expect.objectContaining({ rotation: 330 })
+      );
+      expect(updateCall?.[1]?.$set?.['map.tokens']?.['hero-1']).toEqual(
+        expect.objectContaining({ rotation: 330 })
+      );
+    });
+
     test('update map token requires numeric coordinates', async () => {
       const campaignDoc = buildCampaignWithMap();
       dbo.mockResolvedValue({

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -13,6 +13,7 @@ const {
   prepareStoredMap,
   buildCampaignMapPayload,
   normalizeMapTokens,
+  normalizeTokenRotation,
 } = require('../utils/campaignMaps');
 const {
   uploadMapImage,
@@ -1101,6 +1102,11 @@ module.exports = (router) => {
           .withMessage('characterId is required'),
         body('x').isFloat().withMessage('x must be a number').toFloat(),
         body('y').isFloat().withMessage('y must be a number').toFloat(),
+        body('rotation')
+          .optional()
+          .isFloat()
+          .withMessage('rotation must be a number')
+          .toFloat(),
       ],
       handleValidationErrors,
       async (req, res, next) => {
@@ -1174,6 +1180,15 @@ module.exports = (router) => {
             y: req.body.y,
             updatedAt: now,
           };
+
+          if (Object.prototype.hasOwnProperty.call(req.body, 'rotation')) {
+            const normalizedRotation = normalizeTokenRotation(req.body.rotation);
+            if (normalizedRotation === null) {
+              delete nextTokens[mapId][trimmedCharacterId].rotation;
+            } else {
+              nextTokens[mapId][trimmedCharacterId].rotation = normalizedRotation;
+            }
+          }
 
           const { tokensByMapId } = normalizeMapTokens({
             mapTokens: nextTokens,

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -64,6 +64,25 @@ const clampPercentage = (value) => {
 
 const FIGURINE_STRING_FIELDS = ['imageUrl', 'cloudinaryPublicId', 'folder'];
 
+const normalizeTokenRotation = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  const normalized = parsed % 360;
+  const resolved = normalized < 0 ? normalized + 360 : normalized;
+
+  // Preserve precision for fractional rotations while avoiding floating-point
+  // noise from repeated normalization. Three decimal places is more than
+  // enough granularity for visual rotations.
+  return Math.round(resolved * 1000) / 1000;
+};
+
 const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
   const normalizedTokens = {};
   let didMutate = false;
@@ -155,6 +174,18 @@ const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
         updatedAt: resolvedUpdatedAt,
       };
 
+      if ('rotation' in candidate) {
+        const normalizedRotation = normalizeTokenRotation(candidate.rotation);
+        if (normalizedRotation === null) {
+          didMutate = true;
+        } else {
+          sanitizedToken.rotation = normalizedRotation;
+          if (normalizedRotation !== candidate.rotation) {
+            didMutate = true;
+          }
+        }
+      }
+
       FIGURINE_STRING_FIELDS.forEach((field) => {
         if (!(field in candidate)) {
           return;
@@ -189,6 +220,9 @@ const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
           }
           return acc;
         }, {}),
+        ...(rawValue && Object.prototype.hasOwnProperty.call(rawValue, 'rotation')
+          ? { rotation: rawValue.rotation }
+          : {}),
       });
       const sanitizedComparable = JSON.stringify(sanitizedToken);
       if (originalComparable !== sanitizedComparable) {
@@ -516,4 +550,5 @@ module.exports = {
   normalizeCampaignMapState,
   getMapSchemas,
   normalizeMapTokens,
+  normalizeTokenRotation,
 };


### PR DESCRIPTION
## Summary
- persist figurine rotation updates on the campaign map by tracking overrides and sending rotation values with token updates
- update map management flows to include rotation when moving tokens and normalize rotation values client-side
- extend the campaigns API and normalization utilities to accept rotation, persisting it server-side with new test coverage

## Testing
- CI=true npm --prefix client test -- CampaignMapBoard
- npm --prefix server test -- campaign

------
https://chatgpt.com/codex/tasks/task_e_68e2e8e69ed48323b9577ecd6b22cd8c