### PR TITLE
Scope cultist enemy token picker to cultist assets

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -51,6 +51,73 @@ const cloneFilters = (filters = []) => {
     }));
 };
 
+const buildScopeVariantSet = (values) => {
+  const rawValues = Array.isArray(values) ? values : [values];
+  return rawValues.reduce((set, value) => {
+    if (typeof value !== 'string') {
+      return set;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return set;
+    }
+
+    const lower = trimmed.toLowerCase();
+    const compact = lower.replace(/[^a-z0-9]/g, '');
+
+    set.add(lower);
+    if (compact && compact !== lower) {
+      set.add(compact);
+    }
+
+    return set;
+  }, new Set());
+};
+
+const filterMatchesScope = (filter, scopeSet) => {
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return true;
+  }
+
+  if (!filter || typeof filter !== 'object') {
+    return false;
+  }
+
+  const filterValues = [];
+  if (typeof filter.key === 'string') {
+    filterValues.push(filter.key);
+  }
+  if (typeof filter.label === 'string') {
+    filterValues.push(filter.label);
+  }
+  if (Array.isArray(filter.aliases)) {
+    filterValues.push(...filter.aliases);
+  }
+  if (Array.isArray(filter.folders)) {
+    filterValues.push(...filter.folders);
+  }
+
+  const filterVariantSet = buildScopeVariantSet(filterValues);
+  if (filterVariantSet.size === 0) {
+    return false;
+  }
+
+  for (const scopeVariant of scopeSet) {
+    for (const filterVariant of filterVariantSet) {
+      if (
+        typeof scopeVariant === 'string' &&
+        typeof filterVariant === 'string' &&
+        (filterVariant.includes(scopeVariant) || scopeVariant.includes(filterVariant))
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 const buildDynamicDmFilters = (folderTree, fallbackFilters = DEFAULT_DM_FILTERS) => {
   const fallback = cloneFilters(fallbackFilters);
 
@@ -326,6 +393,7 @@ const TokenPickerModal = ({
   onClear,
   isBusy = false,
   errorMessage = null,
+  filterScope = null,
 }) => {
   const [dmFolderOptions, setDmFolderOptions] = useState(null);
   const [playerFolderOptions, setPlayerFolderOptions] = useState(() =>
@@ -333,7 +401,7 @@ const TokenPickerModal = ({
   );
   const [fetchingFolders, setFetchingFolders] = useState(false);
 
-  const availableFilters = useMemo(() => {
+  const baseFilters = useMemo(() => {
     if (isDm) {
       if (Array.isArray(dmFolderOptions)) {
         return cloneFilters(dmFolderOptions);
@@ -348,6 +416,25 @@ const TokenPickerModal = ({
 
     return cloneFilters(DEFAULT_PLAYER_FILTERS);
   }, [isDm, dmFolderOptions, playerFolderOptions]);
+
+  const filterScopeSet = useMemo(() => buildScopeVariantSet(filterScope), [filterScope]);
+
+  const availableFilters = useMemo(() => {
+    if (!Array.isArray(baseFilters)) {
+      return [];
+    }
+
+    if (!(filterScopeSet instanceof Set) || filterScopeSet.size === 0) {
+      return baseFilters;
+    }
+
+    const scoped = baseFilters.filter((filter) => filterMatchesScope(filter, filterScopeSet));
+    if (scoped.length > 0) {
+      return scoped;
+    }
+
+    return baseFilters;
+  }, [baseFilters, filterScopeSet]);
 
   const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
 
@@ -885,6 +972,10 @@ TokenPickerModal.propTypes = {
   onClear: PropTypes.func,
   isBusy: PropTypes.bool,
   errorMessage: PropTypes.string,
+  filterScope: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
 };
 
 export default TokenPickerModal;

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -423,4 +423,37 @@ describe('TokenPickerModal', () => {
       consoleErrorSpy.mockRestore();
     }
   });
+
+  test('limits available filters when filterScope is provided', async () => {
+    render(
+      <TokenPickerModal
+        show
+        isDm
+        dmFilters={[
+          { key: 'all', label: 'All Tokens', folders: null, aliases: ['all'] },
+          {
+            key: 'folder:Tokens/DM/Cultists',
+            label: 'DM/Cultists',
+            folders: ['Tokens/DM/Cultists'],
+            aliases: ['cultist', 'cultists'],
+          },
+          {
+            key: 'folder:Tokens/DM/Dragons',
+            label: 'DM/Dragons',
+            folders: ['Tokens/DM/Dragons'],
+            aliases: ['dragon'],
+          },
+        ]}
+        filterScope={['cultist']}
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('DM/Cultists');
+  });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -735,6 +735,30 @@ export default function ZombiesDM() {
     const activeMapIdRef = useRef(activeMapId);
     const enemyTokenSelectionRef = useRef(enemyTokenSelection);
 
+    const enemyTokenFilterScope = useMemo(() => {
+      const scope = new Set();
+
+      const normalizedIndex =
+        typeof selectedMonsterIndex === 'string' ? selectedMonsterIndex.trim().toLowerCase() : '';
+      if (normalizedIndex === 'cultist') {
+        scope.add('cultist');
+        scope.add('cultists');
+      }
+
+      const normalizedName =
+        typeof selectedMonster?.name === 'string' ? selectedMonster.name.trim().toLowerCase() : '';
+      if (normalizedName === 'cultist') {
+        scope.add('cultist');
+        scope.add('cultists');
+      }
+
+      if (scope.size === 0) {
+        return null;
+      }
+
+      return Array.from(scope);
+    }, [selectedMonsterIndex, selectedMonster]);
+
     const campaignId = params.campaign ?? '';
     const encodedCampaign = useMemo(
       () => (campaignId ? encodeURIComponent(campaignId) : ''),
@@ -7471,6 +7495,7 @@ const resolveIcon = (category, iconMap, fallback) => {
           onHide={handleCloseEnemyTokenPicker}
           campaignId={campaignId || undefined}
           onSelect={handleEnemyTokenSelected}
+          filterScope={enemyTokenFilterScope}
           allowClear={Boolean(
             enemyTokenSelection?.figurineImageUrl || enemyTokenSelection?.figurineImagePublicId
           )}


### PR DESCRIPTION
## Summary
- add TokenPickerModal support for scoping available filters based on a provided scope hint
- restrict the DM enemy token picker to cultist folders when the cultist monster is selected
- cover the new scope behavior with a dedicated unit test

## Testing
- CI=1 npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68e335eddec88323b55751bd4db92fa4