### PR TITLE
Filter enemy token picker for orcs

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -738,19 +738,29 @@ export default function ZombiesDM() {
     const enemyTokenFilterScope = useMemo(() => {
       const scope = new Set();
 
-      const normalizedIndex =
-        typeof selectedMonsterIndex === 'string' ? selectedMonsterIndex.trim().toLowerCase() : '';
-      if (normalizedIndex === 'cultist') {
-        scope.add('cultist');
-        scope.add('cultists');
-      }
+      const addMonsterScope = (value) => {
+        if (typeof value !== 'string') {
+          return;
+        }
 
-      const normalizedName =
-        typeof selectedMonster?.name === 'string' ? selectedMonster.name.trim().toLowerCase() : '';
-      if (normalizedName === 'cultist') {
-        scope.add('cultist');
-        scope.add('cultists');
-      }
+        const normalizedValue = value.trim().toLowerCase();
+
+        switch (normalizedValue) {
+          case 'cultist':
+            scope.add('cultist');
+            scope.add('cultists');
+            break;
+          case 'orc':
+            scope.add('orc');
+            scope.add('orcs');
+            break;
+          default:
+            break;
+        }
+      };
+
+      addMonsterScope(selectedMonsterIndex);
+      addMonsterScope(selectedMonster?.name);
 
       if (scope.size === 0) {
         return null;


### PR DESCRIPTION
## Summary
- scope the enemy token picker to orc-themed folders when selecting an orc enemy
- reuse the same helper to include both cultist and orc aliases when building the scope

## Testing
- npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e33d032a8883239e7f04e2865c85f9