### PR TITLE
Limit enemy token picker to adversary folders

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -67,6 +67,7 @@ import { FiChevronDown, FiChevronRight, FiList, FiPlus } from "react-icons/fi";
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from "../utils/mapGrouping";
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import TokenPickerModal from '../components/TokenPickerModal';
+import { buildEnemyTokenFilterScopeValues } from '../utils/enemyTokenFilters';
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -735,39 +736,10 @@ export default function ZombiesDM() {
     const activeMapIdRef = useRef(activeMapId);
     const enemyTokenSelectionRef = useRef(enemyTokenSelection);
 
-    const enemyTokenFilterScope = useMemo(() => {
-      const scope = new Set();
-
-      const addMonsterScope = (value) => {
-        if (typeof value !== 'string') {
-          return;
-        }
-
-        const normalizedValue = value.trim().toLowerCase();
-
-        switch (normalizedValue) {
-          case 'cultist':
-            scope.add('cultist');
-            scope.add('cultists');
-            break;
-          case 'orc':
-            scope.add('orc');
-            scope.add('orcs');
-            break;
-          default:
-            break;
-        }
-      };
-
-      addMonsterScope(selectedMonsterIndex);
-      addMonsterScope(selectedMonster?.name);
-
-      if (scope.size === 0) {
-        return null;
-      }
-
-      return Array.from(scope);
-    }, [selectedMonsterIndex, selectedMonster]);
+    const enemyTokenFilterScope = useMemo(
+      () => buildEnemyTokenFilterScopeValues(selectedMonsterIndex, selectedMonster),
+      [selectedMonsterIndex, selectedMonster]
+    );
 
     const campaignId = params.campaign ?? '';
     const encodedCampaign = useMemo(

--- a/client/src/components/Zombies/utils/enemyTokenFilters.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.js
@@ -1,0 +1,190 @@
+const ENEMY_ADVERSARY_TOKEN_CONFIG = {
+  bandit: {
+    folders: ['DM/Adversaries/Bandits'],
+    aliases: ['Bandit', 'Bandits'],
+  },
+  bugbear: {
+    folders: ['DM/Adversaries/Bugbears'],
+    aliases: ['Bugbear', 'Bugbears'],
+  },
+  cultist: {
+    folders: ['DM/Adversaries/Cultists'],
+    aliases: ['Cultist', 'Cultists'],
+  },
+  ghoul: {
+    folders: ['DM/Adversaries/Ghouls'],
+    aliases: ['Ghoul', 'Ghouls'],
+  },
+  'giant-spider': {
+    folders: ['DM/Adversaries/Giant Spiders'],
+    aliases: ['Giant Spider', 'Giant Spiders'],
+  },
+  'giant-wolf-spider': {
+    folders: ['DM/Adversaries/Giant Wolf Spiders'],
+    aliases: ['Giant Wolf Spider', 'Giant Wolf Spiders'],
+  },
+  goblin: {
+    folders: ['DM/Adversaries/Goblins'],
+    aliases: ['Goblin', 'Goblins'],
+  },
+  hobgoblin: {
+    folders: ['DM/Adversaries/Hobgoblins'],
+    aliases: ['Hobgoblin', 'Hobgoblins'],
+  },
+  kobold: {
+    folders: ['DM/Adversaries/Kobolds'],
+    aliases: ['Kobold', 'Kobolds'],
+  },
+  ogre: {
+    folders: ['DM/Adversaries/Ogres'],
+    aliases: ['Ogre', 'Ogres'],
+  },
+  orc: {
+    folders: ['DM/Adversaries/Orcs'],
+    aliases: ['Orc', 'Orcs'],
+  },
+  skeleton: {
+    folders: ['DM/Adversaries/Skeletons'],
+    aliases: ['Skeleton', 'Skeletons'],
+  },
+  wolf: {
+    folders: ['DM/Adversaries/Wolves'],
+    aliases: ['Wolf', 'Wolves'],
+  },
+  worg: {
+    folders: ['DM/Adversaries/Worgs'],
+    aliases: ['Worg', 'Worgs'],
+  },
+  zombie: {
+    folders: ['DM/Adversaries/Zombies'],
+    aliases: ['Zombie', 'Zombies'],
+  },
+};
+
+const addEnemyScopeValue = (set, value) => {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  set.add(trimmed);
+};
+
+const addEnemyNameVariantsToScope = (set, name) => {
+  if (typeof name !== 'string') {
+    return;
+  }
+
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  const lower = trimmed.toLowerCase();
+  const hyphenated = trimmed.replace(/\s+/g, '-');
+  const spaced = trimmed.replace(/[-_/]+/g, ' ');
+
+  [trimmed, lower, hyphenated, hyphenated.toLowerCase(), spaced, spaced.toLowerCase()].forEach(
+    (variant) => addEnemyScopeValue(set, variant)
+  );
+
+  const compactBase = spaced.toLowerCase();
+
+  if (compactBase && !compactBase.endsWith('s')) {
+    addEnemyScopeValue(set, `${compactBase}s`);
+  }
+
+  if (compactBase.endsWith('y')) {
+    addEnemyScopeValue(set, `${compactBase.slice(0, -1)}ies`);
+  } else if (compactBase.endsWith('fe')) {
+    addEnemyScopeValue(set, `${compactBase.slice(0, -2)}ves`);
+  } else if (compactBase.endsWith('f')) {
+    addEnemyScopeValue(set, `${compactBase.slice(0, -1)}ves`);
+  } else if (compactBase.endsWith('man')) {
+    addEnemyScopeValue(set, `${compactBase.slice(0, -3)}men`);
+  } else if (compactBase.endsWith('lf')) {
+    addEnemyScopeValue(set, `${compactBase.slice(0, -1)}ves`);
+  }
+
+  if (
+    compactBase.endsWith('s') ||
+    compactBase.endsWith('x') ||
+    compactBase.endsWith('z') ||
+    compactBase.endsWith('ch') ||
+    compactBase.endsWith('sh')
+  ) {
+    addEnemyScopeValue(set, `${compactBase}es`);
+  }
+};
+
+const addEnemyFolderVariantsToScope = (set, folderPath) => {
+  if (typeof folderPath !== 'string') {
+    return;
+  }
+
+  const normalized = folderPath.replace(/\\+/g, '/').replace(/^\/+|\/+$/g, '');
+  if (!normalized) {
+    return;
+  }
+
+  const pathWithTokens = normalized.toLowerCase().startsWith('tokens/')
+    ? normalized
+    : `Tokens/${normalized}`;
+
+  const variants = new Set([
+    pathWithTokens,
+    pathWithTokens.replace(/^Tokens\//i, ''),
+    pathWithTokens.replace(/^Tokens\/DM\//i, 'DM/'),
+    pathWithTokens.replace(/^Tokens\/DM\/Adversaries\//i, 'Adversaries/'),
+  ]);
+
+  const segments = pathWithTokens.split('/');
+  const leaf = segments[segments.length - 1];
+  if (leaf) {
+    variants.add(leaf);
+  }
+
+  variants.forEach((variant) => {
+    addEnemyScopeValue(set, variant);
+    addEnemyScopeValue(set, variant.replace(/\//g, ' '));
+    addEnemyScopeValue(set, variant.replace(/\//g, '-'));
+  });
+
+  addEnemyScopeValue(set, `folder:${pathWithTokens}`);
+};
+
+export const buildEnemyTokenFilterScopeValues = (monsterIndex, monsterDetail) => {
+  const scopeSet = new Set();
+
+  if (monsterIndex) {
+    addEnemyNameVariantsToScope(scopeSet, monsterIndex);
+    addEnemyNameVariantsToScope(scopeSet, monsterIndex.replace(/[-_]+/g, ' '));
+  }
+
+  if (monsterDetail && typeof monsterDetail === 'object') {
+    addEnemyNameVariantsToScope(scopeSet, monsterDetail.name);
+  }
+
+  const config =
+    (monsterIndex && ENEMY_ADVERSARY_TOKEN_CONFIG[monsterIndex]) ||
+    (monsterDetail && ENEMY_ADVERSARY_TOKEN_CONFIG[monsterDetail?.index]);
+
+  if (config) {
+    if (Array.isArray(config.aliases)) {
+      config.aliases.forEach((alias) => addEnemyNameVariantsToScope(scopeSet, alias));
+    }
+
+    const folders = Array.isArray(config.folders) ? config.folders : config.folder ? [config.folder] : [];
+    folders.forEach((folder) => addEnemyFolderVariantsToScope(scopeSet, folder));
+  }
+
+  return scopeSet.size > 0 ? Array.from(scopeSet) : null;
+};
+
+export default buildEnemyTokenFilterScopeValues;
+
+export { ENEMY_ADVERSARY_TOKEN_CONFIG };

--- a/client/src/components/Zombies/utils/enemyTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.test.js
@@ -1,0 +1,48 @@
+import { buildEnemyTokenFilterScopeValues } from './enemyTokenFilters';
+
+describe('buildEnemyTokenFilterScopeValues', () => {
+  it('returns scope values targeting cultist adversary folders', () => {
+    const scope = buildEnemyTokenFilterScopeValues('cultist', { index: 'cultist', name: 'Cultist' });
+
+    expect(scope).toBeInstanceOf(Array);
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'folder:Tokens/DM/Adversaries/Cultists',
+        'Tokens/DM/Adversaries/Cultists',
+      ])
+    );
+    expect(scope.map((value) => value.toLowerCase())).toEqual(
+      expect.arrayContaining(['cultist', 'cultists'])
+    );
+  });
+
+  it('includes pluralized wolves scope for wolf adversaries', () => {
+    const scope = buildEnemyTokenFilterScopeValues('wolf', { index: 'wolf', name: 'Wolf' });
+
+    expect(scope.map((value) => value.toLowerCase())).toEqual(
+      expect.arrayContaining(['wolf', 'wolves', 'folder:tokens/dm/adversaries/wolves'])
+    );
+  });
+
+  it('captures multi-word adversary folders', () => {
+    const scope = buildEnemyTokenFilterScopeValues('giant-wolf-spider', {
+      index: 'giant-wolf-spider',
+      name: 'Giant Wolf Spider',
+    });
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'folder:Tokens/DM/Adversaries/Giant Wolf Spiders',
+        'Tokens/DM/Adversaries/Giant Wolf Spiders',
+      ])
+    );
+    expect(scope.map((value) => value.toLowerCase())).toEqual(
+      expect.arrayContaining(['giant wolf spider', 'giant wolf spiders'])
+    );
+  });
+
+  it('returns null when no identifying information is provided', () => {
+    expect(buildEnemyTokenFilterScopeValues(null, null)).toBeNull();
+    expect(buildEnemyTokenFilterScopeValues('', {})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable helper to map monsters to their adversary token folders
- use the helper in the DM enemy picker so tokens come from the matching adversary directory
- cover the new helper with unit tests for singular, plural, and multi-word enemies

## Testing
- CI=true npx react-scripts test --runTestsByPath src/components/Zombies/utils/enemyTokenFilters.test.js --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e34461dddc8323803997e5a9858550