### PR TITLE
Refine token filter scoping for enemy selections

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -103,15 +103,36 @@ const filterMatchesScope = (filter, scopeSet) => {
     return false;
   }
 
+  const normalizedFilterVariants = new Set(
+    Array.from(filterVariantSet).filter((variant) => typeof variant === 'string')
+  );
+
+  if (normalizedFilterVariants.size === 0) {
+    return false;
+  }
+
   for (const scopeVariant of scopeSet) {
-    for (const filterVariant of filterVariantSet) {
-      if (
-        typeof scopeVariant === 'string' &&
-        typeof filterVariant === 'string' &&
-        (filterVariant.includes(scopeVariant) || scopeVariant.includes(filterVariant))
-      ) {
-        return true;
-      }
+    if (typeof scopeVariant !== 'string') {
+      continue;
+    }
+
+    const trimmedScope = scopeVariant.trim();
+    if (!trimmedScope) {
+      continue;
+    }
+
+    if (normalizedFilterVariants.has(trimmedScope)) {
+      return true;
+    }
+
+    const lowerScope = trimmedScope.toLowerCase();
+    if (normalizedFilterVariants.has(lowerScope)) {
+      return true;
+    }
+
+    const compactScope = lowerScope.replace(/[^a-z0-9]/g, '');
+    if (compactScope && normalizedFilterVariants.has(compactScope)) {
+      return true;
     }
   }
 

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -456,4 +456,43 @@ describe('TokenPickerModal', () => {
     expect(options).toHaveLength(1);
     expect(options[0]).toHaveTextContent('DM/Cultists');
   });
+
+  test('does not include parent folders when scope matches nested folder', async () => {
+    render(
+      <TokenPickerModal
+        show
+        isDm
+        dmFilters={[
+          {
+            key: 'folder:Tokens/DM/Adversaries',
+            label: 'Adversaries',
+            folders: ['Tokens/DM/Adversaries'],
+            aliases: ['Adversaries'],
+          },
+          {
+            key: 'folder:Tokens/DM/Adversaries/Goblinoids/Bugbears',
+            label: 'Adversaries/Goblinoids/Bugbears',
+            folders: ['Tokens/DM/Adversaries/Goblinoids/Bugbears'],
+            aliases: [
+              'Adversaries/Goblinoids/Bugbears',
+              'Bugbear',
+              'Bugbears',
+            ],
+          },
+        ]}
+        filterScope={[
+          'Adversaries/Goblinoids/Bugbears',
+          'folder:Tokens/DM/Adversaries/Goblinoids/Bugbears',
+        ]}
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Adversaries/Goblinoids/Bugbears');
+  });
 });


### PR DESCRIPTION
## Summary
- update token filter scope matching to rely on normalized equality instead of substring checks to prevent parent folder leakage
- add a regression test ensuring nested adversary folders are the only options when scoping enemy tokens

## Testing
- npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3487651dc83238ee2508c1a9c9b3f