### PR TITLE
Scope DM enemy token picker to adversary folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -433,15 +433,15 @@ describe('TokenPickerModal', () => {
         dmFilters={[
           { key: 'all', label: 'All Tokens', folders: null, aliases: ['all'] },
           {
-            key: 'folder:Tokens/DM/Cultists',
-            label: 'DM/Cultists',
-            folders: ['Tokens/DM/Cultists'],
+            key: 'folder:Tokens/Adversaries/Cultist',
+            label: 'Adversaries/Cultist',
+            folders: ['Tokens/Adversaries/Cultist'],
             aliases: ['cultist', 'cultists'],
           },
           {
-            key: 'folder:Tokens/DM/Dragons',
-            label: 'DM/Dragons',
-            folders: ['Tokens/DM/Dragons'],
+            key: 'folder:Tokens/Adversaries/Dragons',
+            label: 'Adversaries/Dragons',
+            folders: ['Tokens/Adversaries/Dragons'],
             aliases: ['dragon'],
           },
         ]}
@@ -455,7 +455,7 @@ describe('TokenPickerModal', () => {
     const options = within(select).getAllByRole('option');
 
     expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent('DM/Cultists');
+    expect(options[0]).toHaveTextContent('Adversaries/Cultist');
   });
 
   test('does not include parent adversary filters when scope targets specific adversary', async () => {
@@ -471,15 +471,15 @@ describe('TokenPickerModal', () => {
         dmFilters={[
           { key: 'all', label: 'All Tokens', folders: null, aliases: ['all'] },
           {
-            key: 'folder:Tokens/DM/Adversaries',
-            label: 'DM/Adversaries',
-            folders: ['Tokens/DM/Adversaries'],
+            key: 'folder:Tokens/Adversaries',
+            label: 'Adversaries',
+            folders: ['Tokens/Adversaries'],
             aliases: ['adversaries'],
           },
           {
-            key: 'folder:Tokens/DM/Adversaries/Cultists',
-            label: 'DM/Adversaries/Cultists',
-            folders: ['Tokens/DM/Adversaries/Cultists'],
+            key: 'folder:Tokens/Adversaries/Cultists',
+            label: 'Adversaries/Cultists',
+            folders: ['Tokens/Adversaries/Cultists'],
             aliases: ['cultist', 'cultists'],
           },
         ]}
@@ -493,6 +493,6 @@ describe('TokenPickerModal', () => {
     const options = within(select).getAllByRole('option');
 
     expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent('DM/Adversaries/Cultists');
+    expect(options[0]).toHaveTextContent('Adversaries/Cultists');
   });
 });

--- a/client/src/components/Zombies/utils/enemyTokenFilters.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.js
@@ -1,64 +1,150 @@
 const ENEMY_ADVERSARY_TOKEN_CONFIG = {
   bandit: {
-    folders: ['DM/Adversaries/Bandits'],
+    folders: ['Adversaries/Bandits'],
     aliases: ['Bandit', 'Bandits'],
   },
   bugbear: {
-    folders: ['DM/Adversaries/Bugbears'],
+    folders: ['Adversaries/Bugbears'],
     aliases: ['Bugbear', 'Bugbears'],
   },
   cultist: {
-    folders: ['DM/Adversaries/Cultists'],
+    folders: ['Adversaries/Cultists'],
     aliases: ['Cultist', 'Cultists'],
   },
   ghoul: {
-    folders: ['DM/Adversaries/Ghouls'],
+    folders: ['Adversaries/Ghouls'],
     aliases: ['Ghoul', 'Ghouls'],
   },
   'giant-spider': {
-    folders: ['DM/Adversaries/Giant Spiders'],
+    folders: ['Adversaries/Giant Spiders'],
     aliases: ['Giant Spider', 'Giant Spiders'],
   },
   'giant-wolf-spider': {
-    folders: ['DM/Adversaries/Giant Wolf Spiders'],
+    folders: ['Adversaries/Giant Wolf Spiders'],
     aliases: ['Giant Wolf Spider', 'Giant Wolf Spiders'],
   },
   goblin: {
-    folders: ['DM/Adversaries/Goblins'],
+    folders: ['Adversaries/Goblins'],
     aliases: ['Goblin', 'Goblins'],
   },
   hobgoblin: {
-    folders: ['DM/Adversaries/Hobgoblins'],
+    folders: ['Adversaries/Hobgoblins'],
     aliases: ['Hobgoblin', 'Hobgoblins'],
   },
   kobold: {
-    folders: ['DM/Adversaries/Kobolds'],
+    folders: ['Adversaries/Kobolds'],
     aliases: ['Kobold', 'Kobolds'],
   },
   ogre: {
-    folders: ['DM/Adversaries/Ogres'],
+    folders: ['Adversaries/Ogres'],
     aliases: ['Ogre', 'Ogres'],
   },
   orc: {
-    folders: ['DM/Adversaries/Orcs'],
+    folders: ['Adversaries/Orcs'],
     aliases: ['Orc', 'Orcs'],
   },
   skeleton: {
-    folders: ['DM/Adversaries/Skeletons'],
+    folders: ['Adversaries/Skeletons'],
     aliases: ['Skeleton', 'Skeletons'],
   },
   wolf: {
-    folders: ['DM/Adversaries/Wolves'],
+    folders: ['Adversaries/Wolves'],
     aliases: ['Wolf', 'Wolves'],
   },
   worg: {
-    folders: ['DM/Adversaries/Worgs'],
+    folders: ['Adversaries/Worgs'],
     aliases: ['Worg', 'Worgs'],
   },
   zombie: {
-    folders: ['DM/Adversaries/Zombies'],
+    folders: ['Adversaries/Zombies'],
     aliases: ['Zombie', 'Zombies'],
   },
+};
+
+const capitalizeWord = (word) => {
+  if (typeof word !== 'string' || word.length === 0) {
+    return '';
+  }
+
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+};
+
+const extractEnemyNameVariants = (name) => {
+  if (typeof name !== 'string') {
+    return new Set();
+  }
+
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return new Set();
+  }
+
+  const segments = trimmed
+    .split(/[-_\s]+/g)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return new Set([trimmed]);
+  }
+
+  const lowerSegments = segments.map((segment) => segment.toLowerCase());
+  const spaced = segments.join(' ');
+  const spacedLower = lowerSegments.join(' ');
+  const hyphenated = segments.join('-');
+  const hyphenatedLower = lowerSegments.join('-');
+  const underscored = segments.join('_');
+  const underscoredLower = lowerSegments.join('_');
+  const compact = segments.join('');
+  const compactLower = lowerSegments.join('');
+  const titleCase = segments.map(capitalizeWord).join(' ');
+  const pascalCase = segments.map(capitalizeWord).join('');
+
+  const variants = new Set([
+    trimmed,
+    spaced,
+    spacedLower,
+    hyphenated,
+    hyphenatedLower,
+    underscored,
+    underscoredLower,
+    compact,
+    compactLower,
+    titleCase,
+    pascalCase,
+  ]);
+
+  const compactBase = spacedLower;
+
+  if (compactBase) {
+    if (!compactBase.endsWith('s')) {
+      variants.add(`${compactBase}s`);
+    }
+
+    if (compactBase.endsWith('y')) {
+      variants.add(`${compactBase.slice(0, -1)}ies`);
+    } else if (compactBase.endsWith('fe')) {
+      variants.add(`${compactBase.slice(0, -2)}ves`);
+    } else if (compactBase.endsWith('f')) {
+      variants.add(`${compactBase.slice(0, -1)}ves`);
+    } else if (compactBase.endsWith('man')) {
+      variants.add(`${compactBase.slice(0, -3)}men`);
+    } else if (compactBase.endsWith('lf')) {
+      variants.add(`${compactBase.slice(0, -1)}ves`);
+    }
+
+    if (
+      compactBase.endsWith('s') ||
+      compactBase.endsWith('x') ||
+      compactBase.endsWith('z') ||
+      compactBase.endsWith('ch') ||
+      compactBase.endsWith('sh')
+    ) {
+      variants.add(`${compactBase}es`);
+    }
+  }
+
+  return new Set(Array.from(variants).filter(Boolean));
 };
 
 const addEnemyScopeValue = (set, value) => {
@@ -75,50 +161,8 @@ const addEnemyScopeValue = (set, value) => {
 };
 
 const addEnemyNameVariantsToScope = (set, name) => {
-  if (typeof name !== 'string') {
-    return;
-  }
-
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return;
-  }
-
-  const lower = trimmed.toLowerCase();
-  const hyphenated = trimmed.replace(/\s+/g, '-');
-  const spaced = trimmed.replace(/[-_/]+/g, ' ');
-
-  [trimmed, lower, hyphenated, hyphenated.toLowerCase(), spaced, spaced.toLowerCase()].forEach(
-    (variant) => addEnemyScopeValue(set, variant)
-  );
-
-  const compactBase = spaced.toLowerCase();
-
-  if (compactBase && !compactBase.endsWith('s')) {
-    addEnemyScopeValue(set, `${compactBase}s`);
-  }
-
-  if (compactBase.endsWith('y')) {
-    addEnemyScopeValue(set, `${compactBase.slice(0, -1)}ies`);
-  } else if (compactBase.endsWith('fe')) {
-    addEnemyScopeValue(set, `${compactBase.slice(0, -2)}ves`);
-  } else if (compactBase.endsWith('f')) {
-    addEnemyScopeValue(set, `${compactBase.slice(0, -1)}ves`);
-  } else if (compactBase.endsWith('man')) {
-    addEnemyScopeValue(set, `${compactBase.slice(0, -3)}men`);
-  } else if (compactBase.endsWith('lf')) {
-    addEnemyScopeValue(set, `${compactBase.slice(0, -1)}ves`);
-  }
-
-  if (
-    compactBase.endsWith('s') ||
-    compactBase.endsWith('x') ||
-    compactBase.endsWith('z') ||
-    compactBase.endsWith('ch') ||
-    compactBase.endsWith('sh')
-  ) {
-    addEnemyScopeValue(set, `${compactBase}es`);
-  }
+  const variants = extractEnemyNameVariants(name);
+  variants.forEach((variant) => addEnemyScopeValue(set, variant));
 };
 
 const addEnemyFolderVariantsToScope = (set, folderPath) => {
@@ -181,6 +225,66 @@ export const buildEnemyTokenFilterScopeValues = (monsterIndex, monsterDetail) =>
     const folders = Array.isArray(config.folders) ? config.folders : config.folder ? [config.folder] : [];
     folders.forEach((folder) => addEnemyFolderVariantsToScope(scopeSet, folder));
   }
+
+  const folderNameCandidates = new Set();
+  extractEnemyNameVariants(monsterIndex).forEach((variant) => folderNameCandidates.add(variant));
+  if (monsterDetail && typeof monsterDetail === 'object') {
+    extractEnemyNameVariants(monsterDetail.index).forEach((variant) =>
+      folderNameCandidates.add(variant)
+    );
+    extractEnemyNameVariants(monsterDetail.name).forEach((variant) =>
+      folderNameCandidates.add(variant)
+    );
+  }
+
+  folderNameCandidates.forEach((candidate) => {
+    if (typeof candidate !== 'string') {
+      return;
+    }
+
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const baseSegments = trimmed
+      .split(/[\\/]+/g)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    if (baseSegments.length === 0) {
+      return;
+    }
+
+    const normalizedWords = baseSegments
+      .join(' ')
+      .split(/\s+/g)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    if (normalizedWords.length === 0) {
+      return;
+    }
+
+    const titleCase = normalizedWords.map(capitalizeWord).join(' ');
+    const baseNameVariants = new Set([
+      normalizedWords.join(' '),
+      normalizedWords.join('-'),
+      normalizedWords.join('_'),
+      normalizedWords.join(''),
+      titleCase,
+      titleCase.replace(/\s+/g, '-'),
+      titleCase.replace(/\s+/g, ''),
+    ]);
+
+    baseNameVariants.forEach((variantName) => {
+      if (!variantName) {
+        return;
+      }
+
+      addEnemyFolderVariantsToScope(scopeSet, `Tokens/Adversaries/${variantName}`);
+    });
+  });
 
   return scopeSet.size > 0 ? Array.from(scopeSet) : null;
 };

--- a/client/src/components/Zombies/utils/enemyTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.test.js
@@ -7,8 +7,10 @@ describe('buildEnemyTokenFilterScopeValues', () => {
     expect(scope).toBeInstanceOf(Array);
     expect(scope).toEqual(
       expect.arrayContaining([
-        'folder:Tokens/DM/Adversaries/Cultists',
-        'Tokens/DM/Adversaries/Cultists',
+        'folder:Tokens/Adversaries/Cultist',
+        'Tokens/Adversaries/Cultist',
+        'folder:Tokens/Adversaries/Cultists',
+        'Tokens/Adversaries/Cultists',
       ])
     );
     expect(scope.map((value) => value.toLowerCase())).toEqual(
@@ -20,7 +22,12 @@ describe('buildEnemyTokenFilterScopeValues', () => {
     const scope = buildEnemyTokenFilterScopeValues('wolf', { index: 'wolf', name: 'Wolf' });
 
     expect(scope.map((value) => value.toLowerCase())).toEqual(
-      expect.arrayContaining(['wolf', 'wolves', 'folder:tokens/dm/adversaries/wolves'])
+      expect.arrayContaining([
+        'wolf',
+        'wolves',
+        'folder:tokens/adversaries/wolf',
+        'folder:tokens/adversaries/wolves',
+      ])
     );
   });
 
@@ -32,8 +39,10 @@ describe('buildEnemyTokenFilterScopeValues', () => {
 
     expect(scope).toEqual(
       expect.arrayContaining([
-        'folder:Tokens/DM/Adversaries/Giant Wolf Spiders',
-        'Tokens/DM/Adversaries/Giant Wolf Spiders',
+        'folder:Tokens/Adversaries/Giant Wolf Spider',
+        'Tokens/Adversaries/Giant Wolf Spider',
+        'folder:Tokens/Adversaries/Giant Wolf Spiders',
+        'Tokens/Adversaries/Giant Wolf Spiders',
       ])
     );
     expect(scope.map((value) => value.toLowerCase())).toEqual(


### PR DESCRIPTION
## Summary
- update the enemy token filter scope builder to target adversary folders that match the selected monster name
- refresh supporting unit tests to reflect the adversary-specific folder expectations

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/utils/enemyTokenFilters.test.js
- CI=true npm test -- --runTestsByPath src/components/Zombies/components/TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ebe13f2570832e9a08d85aa9fc590c