### PR TITLE
Restrict character token picker to race and class folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -514,6 +514,18 @@ const TokenPickerModal = ({
     return null;
   }, [filterLookup, selectedFilterKey]);
 
+  const activeFilterMatchesScope = useMemo(() => {
+    if (!(filterScopeSet instanceof Set) || filterScopeSet.size === 0) {
+      return true;
+    }
+
+    if (!activeFilter) {
+      return false;
+    }
+
+    return filterMatchesScope(activeFilter, filterScopeSet);
+  }, [activeFilter, filterScopeSet]);
+
   const manifestFilterKey = useMemo(() => {
     if (!activeFilter) {
       return 'none';
@@ -528,6 +540,14 @@ const TokenPickerModal = ({
 
     return `${activeFilter.key || 'unknown'}::${folders}`;
   }, [activeFilter]);
+
+  const shouldDeferManifest = useMemo(() => {
+    if (!(filterScopeSet instanceof Set) || filterScopeSet.size === 0) {
+      return false;
+    }
+
+    return !activeFilterMatchesScope;
+  }, [activeFilterMatchesScope, filterScopeSet]);
 
   const fetchManifest = useCallback(
     async ({ cursor = null, append = false } = {}) => {
@@ -626,7 +646,7 @@ const TokenPickerModal = ({
       return;
     }
 
-    if (!campaignId || manifestFilterKey === 'none') {
+    if (!campaignId || manifestFilterKey === 'none' || shouldDeferManifest) {
       return;
     }
 
@@ -642,7 +662,14 @@ const TokenPickerModal = ({
     if (fetchManifestRef.current) {
       fetchManifestRef.current({ append: false, cursor: null });
     }
-  }, [show, manifestFilterKey, campaignId, isDm, resetState]);
+  }, [
+    show,
+    manifestFilterKey,
+    campaignId,
+    isDm,
+    resetState,
+    shouldDeferManifest,
+  ]);
 
   useEffect(() => {
     if (!isDm) {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -255,6 +255,133 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('player token picker scopes manifest requests when filterScope provided', async () => {
+    const user = setupUser();
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Dragonborn',
+              path: 'Tokens/Adventurers/Dragonborn',
+              relativePath: 'Adventurers/Dragonborn',
+              children: [],
+            },
+            {
+              name: 'Core_Class_Tokens',
+              path: 'Tokens/Adventurers/Core_Class_Tokens',
+              relativePath: 'Adventurers/Core_Class_Tokens',
+              children: [
+                {
+                  name: 'Fighter',
+                  path: 'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+                  relativePath: 'Adventurers/Core_Class_Tokens/Fighter',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Dragonborn',
+          path: 'Tokens/Adventurers/Dragonborn',
+          relativePath: 'Adventurers/Dragonborn',
+          depth: 1,
+          displayPath: 'Adventurers/Dragonborn',
+        },
+        {
+          name: 'Core_Class_Tokens',
+          path: 'Tokens/Adventurers/Core_Class_Tokens',
+          relativePath: 'Adventurers/Core_Class_Tokens',
+          depth: 1,
+          displayPath: 'Adventurers/Core_Class_Tokens',
+        },
+        {
+          name: 'Fighter',
+          path: 'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+          relativePath: 'Adventurers/Core_Class_Tokens/Fighter',
+          depth: 2,
+          displayPath: 'Adventurers/Core_Class_Tokens/Fighter',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={['Dragonborn', 'Core_Class_Tokens/Fighter']}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
+    });
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      expect(manifestCalls[0]).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn'
+      );
+    });
+
+    expect(
+      manifestCalls.includes('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers')
+    ).toBe(false);
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn');
+    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
+
+    await user.selectOptions(select, options[1]);
+
+    await waitFor(() => {
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FCore_Class_Tokens%2FFighter'
+      );
+    });
+  });
+
   test('player library dropdown stays disabled until folders finish loading', async () => {
     const folderTree = {
       rootFolder: 'Tokens',

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2729,6 +2729,77 @@ export default function ZombiesCharacterSheet() {
 
   const characterFigurine = useMemo(() => resolveFigurineImageData(form), [form]);
 
+  const tokenPickerFilterScope = useMemo(() => {
+    const scopeSet = new Set();
+
+    const addScopeVariants = (rawValue, prefixes = []) => {
+      if (typeof rawValue !== 'string') {
+        return;
+      }
+
+      const normalizedValue = rawValue.replace(/\s+/g, ' ').trim();
+      if (!normalizedValue) {
+        return;
+      }
+
+      const lowerValue = normalizedValue.toLowerCase();
+      const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
+
+      [normalizedValue, lowerValue, compactValue]
+        .filter(Boolean)
+        .forEach((entry) => scopeSet.add(entry));
+
+      prefixes
+        .map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
+        .filter(Boolean)
+        .forEach((prefix) => {
+          scopeSet.add(`${prefix}/${normalizedValue}`);
+          scopeSet.add(`${prefix}/${lowerValue}`);
+          if (compactValue) {
+            scopeSet.add(`${prefix}/${compactValue}`);
+          }
+        });
+    };
+
+    const raceName = typeof form?.race?.name === 'string' ? form.race.name : '';
+    if (raceName) {
+      addScopeVariants(raceName, [
+        'Adventurers',
+        'Tokens/Adventurers',
+        'Adventurers/Races',
+        'Tokens/Adventurers/Races',
+      ]);
+    }
+
+    const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
+    const seenClasses = new Set();
+    occupations.forEach((occupation) => {
+      if (!occupation || typeof occupation !== 'object') {
+        return;
+      }
+
+      const rawClassName =
+        typeof occupation.Occupation === 'string' ? occupation.Occupation.trim() : '';
+      if (!rawClassName) {
+        return;
+      }
+
+      const classKey = rawClassName.toLowerCase();
+      if (seenClasses.has(classKey)) {
+        return;
+      }
+      seenClasses.add(classKey);
+
+      addScopeVariants(rawClassName, [
+        'Core_Class_Tokens',
+        'Adventurers/Core_Class_Tokens',
+        'Tokens/Adventurers/Core_Class_Tokens',
+      ]);
+    });
+
+    return Array.from(scopeSet);
+  }, [form?.occupation, form?.race?.name]);
+
   const updateLocalDiceColor = useCallback(
     (incomingCharacterId, nextColor) => {
       const normalizedCharacterId =
@@ -4730,6 +4801,7 @@ export default function ZombiesCharacterSheet() {
       onClear={() => handleTokenSelection(null)}
       isBusy={tokenPickerSaving}
       errorMessage={tokenPickerError}
+      filterScope={tokenPickerFilterScope}
     />
     <MapModal
       show={shouldShowMapModal}


### PR DESCRIPTION
## Summary
- scope the character sheet token picker to only load assets from the selected race and class folders
- defer manifest fetches until a scoped folder is available to avoid loading the full Adventurers library
- add coverage ensuring the scoped folders trigger the expected Cloudinary manifest requests

## Testing
- npm --prefix client test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68ebeb7ceb4c832ea491153744cd3487