### PR TITLE
Center combat tracker header

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -69,7 +69,7 @@
   flex-wrap: nowrap;
   overflow-x: auto;
   gap: 12px;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: stretch;
   margin-bottom: 12px;
   padding-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- center the combat tracker header so the bar is aligned in the middle of the screen when space allows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebeffd57a4832e8718f05b3ae9605d