### PR TITLE
Improve combat tracker mobile usability

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -65,12 +65,8 @@
 
 .combat-turn-header {
   --combat-turn-header-height: clamp(112px, 20vw, 148px);
-  display: flex;
-  flex-wrap: nowrap;
+  display: block;
   overflow-x: auto;
-  gap: 12px;
-  justify-content: flex-start;
-  align-items: stretch;
   margin-bottom: 12px;
   padding-bottom: 0.25rem;
   -webkit-overflow-scrolling: touch;
@@ -122,13 +118,30 @@
   &.combat-turn-header--empty {
     min-height: var(--combat-turn-header-height);
     cursor: default;
-    gap: 0;
 
     &::before,
     &::after {
       display: none;
     }
   }
+}
+
+.combat-turn-header--empty .combat-turn-header__track {
+  gap: 0;
+}
+
+.combat-turn-header__track {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 12px;
+  width: max-content;
+  min-width: 100%;
+  margin-inline: auto;
+}
+
+.combat-turn-header--scrollable .combat-turn-header__track {
+  margin-inline: 0;
 }
 
 .combat-turn-header__card {
@@ -159,6 +172,31 @@
     width: clamp(100px, 32vw, 33.333%);
     min-width: clamp(100px, 32vw, 33.333%);
   }
+}
+
+.combat-turn-header__active-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: #f9f3e0;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.5rem;
+}
+
+.combat-turn-header__active-indicator--inactive {
+  opacity: 0.75;
+}
+
+.combat-turn-header__active-label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.combat-turn-header__active-name {
+  font-size: 0.95rem;
 }
 
 .zombies-dm-container--spaced {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -466,6 +466,13 @@ function CombatTurnHeader({ participants }) {
 
     return participants.findIndex((participant) => participant?.isActive);
   }, [participants]);
+  const activeParticipant = useMemo(() => {
+    if (activeIndex < 0 || !Array.isArray(participants)) {
+      return null;
+    }
+
+    return participants[activeIndex] ?? null;
+  }, [activeIndex, participants]);
 
   const updateOverflowHints = useCallback(() => {
     const container = headerRef.current;
@@ -498,11 +505,16 @@ function CombatTurnHeader({ participants }) {
     };
   }, [updateOverflowHints, participantsCount]);
 
+  const isScrollable = canScrollLeft || canScrollRight;
+
   const headerClassName = useMemo(() => {
     const classes = ['combat-turn-header'];
 
     if (isDragging) {
       classes.push('combat-turn-header--dragging');
+    }
+    if (isScrollable) {
+      classes.push('combat-turn-header--scrollable');
     }
     if (canScrollLeft) {
       classes.push('combat-turn-header--fade-left');
@@ -515,7 +527,7 @@ function CombatTurnHeader({ participants }) {
     }
 
     return classes.join(' ');
-  }, [isDragging, canScrollLeft, canScrollRight, participantsCount]);
+  }, [isDragging, isScrollable, canScrollLeft, canScrollRight, participantsCount]);
 
   const finishDrag = useCallback((event) => {
     if (!isDraggingRef.current) {
@@ -619,7 +631,9 @@ function CombatTurnHeader({ participants }) {
       return;
     }
 
-    const card = container.children?.[activeIndex];
+    const card = container.querySelector(
+      `.combat-turn-header__card[data-participant-index="${activeIndex}"]`
+    );
     if (!card) {
       return;
     }
@@ -663,113 +677,131 @@ function CombatTurnHeader({ participants }) {
   }, [activeIndex, participants, isDragging, updateOverflowHints]);
 
   return (
-    <div
-      ref={headerRef}
-      className={headerClassName}
-      role="group"
-      aria-label="Combat turn order"
-      touchAction={participantsCount ? 'pan-x' : 'auto'}
-      onPointerDown={participantsCount ? handlePointerDown : undefined}
-      onPointerMove={participantsCount ? handlePointerMove : undefined}
-      onPointerUp={participantsCount ? handlePointerUp : undefined}
-      onPointerLeave={participantsCount ? handlePointerLeave : undefined}
-      onPointerCancel={participantsCount ? handlePointerCancel : undefined}
-      onScroll={participantsCount ? handleScroll : undefined}
-    >
-      {participantsCount ? (
-        participants.map((participant, index) => {
-          const { characterId, name, hpDisplay, hpCurrent, hpMax, isActive } = participant;
+    <>
+      <div
+        className={
+          activeParticipant
+            ? 'combat-turn-header__active-indicator'
+            : 'combat-turn-header__active-indicator combat-turn-header__active-indicator--inactive'
+        }
+        role="status"
+        aria-live="polite"
+      >
+        <span className="combat-turn-header__active-label">Current Turn:</span>
+        <span className="combat-turn-header__active-name">
+          {activeParticipant ? activeParticipant.name : 'No active combatant'}
+        </span>
+      </div>
+      <div
+        ref={headerRef}
+        className={headerClassName}
+        role="group"
+        aria-label="Combat turn order"
+        touchAction={participantsCount ? 'pan-x' : 'auto'}
+        onPointerDown={participantsCount ? handlePointerDown : undefined}
+        onPointerMove={participantsCount ? handlePointerMove : undefined}
+        onPointerUp={participantsCount ? handlePointerUp : undefined}
+        onPointerLeave={participantsCount ? handlePointerLeave : undefined}
+        onPointerCancel={participantsCount ? handlePointerCancel : undefined}
+        onScroll={participantsCount ? handleScroll : undefined}
+      >
+        <div className="combat-turn-header__track">
+          {participantsCount ? (
+            participants.map((participant, index) => {
+              const { characterId, name, hpDisplay, hpCurrent, hpMax, isActive } = participant;
 
-          const hasHpData = hpCurrent !== null || hpMax !== null;
-          const computedPercentage =
-            hpCurrent !== null && hpMax !== null && hpMax > 0
-              ? Math.max(0, Math.min(100, (hpCurrent / hpMax) * 100))
-              : null;
-          const hpPercentage = computedPercentage !== null ? computedPercentage : 0;
-          const hpColorHue = computedPercentage !== null ? (hpPercentage / 100) * 120 : 0;
-          const hpFillColor =
-            computedPercentage !== null
-              ? `hsl(${Math.round(hpColorHue)}, 70%, 45%)`
-              : "rgba(220, 220, 220, 0.35)";
+              const hasHpData = hpCurrent !== null || hpMax !== null;
+              const computedPercentage =
+                hpCurrent !== null && hpMax !== null && hpMax > 0
+                  ? Math.max(0, Math.min(100, (hpCurrent / hpMax) * 100))
+                  : null;
+              const hpPercentage = computedPercentage !== null ? computedPercentage : 0;
+              const hpColorHue = computedPercentage !== null ? (hpPercentage / 100) * 120 : 0;
+              const hpFillColor =
+                computedPercentage !== null
+                  ? `hsl(${Math.round(hpColorHue)}, 70%, 45%)`
+                  : "rgba(220, 220, 220, 0.35)";
 
-          return (
-            <div
-              key={characterId}
-              className="combat-turn-header__card"
-              data-participant-id={characterId}
-              data-participant-index={index}
-              style={{
-                background: isActive
-                  ? "linear-gradient(135deg, rgba(37, 31, 26, 0.96), rgba(18, 15, 12, 0.94))"
-                  : "rgba(28, 25, 22, 0.82)",
-                color: "#FFFFFF",
-                borderRadius: "12px",
-                padding: "10px 16px",
-                boxShadow: isActive
-                  ? "0 0 18px rgba(214, 178, 86, 0.7), 0 0 8px rgba(214, 178, 86, 0.4) inset"
-                  : "0 0 8px rgba(0, 0, 0, 0.45)",
-                border: isActive
-                  ? "1px solid rgba(214, 178, 86, 0.85)"
-                  : "1px solid rgba(255, 255, 255, 0.18)",
-                transition: "transform 0.2s ease, box-shadow 0.2s ease",
-                transform: isActive ? "scale(1.03)" : "scale(1)",
-              }}
-            >
-              <div
-                style={{
-                  fontWeight: 600,
-                  fontSize: "14px",
-                  letterSpacing: "0.5px",
-                }}
-              >
-                {name}
-              </div>
-              <div style={{ marginTop: "6px" }}>
+              return (
                 <div
+                  key={characterId ?? `combat-participant-${index}`}
+                  className="combat-turn-header__card"
+                  data-participant-id={characterId}
+                  data-participant-index={index}
                   style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    fontSize: "12px",
-                    opacity: 0.9,
-                    marginBottom: "4px",
-                  }}
-                >
-                  <span>HP</span>
-                  <span>{hasHpData ? hpDisplay : "—"}</span>
-                </div>
-                <div
-                  style={{
-                    position: "relative",
-                    width: "100%",
-                    height: "8px",
-                    borderRadius: "6px",
-                    background: "rgba(0, 0, 0, 0.45)",
-                    overflow: "hidden",
-                    border: "1px solid rgba(255, 255, 255, 0.12)",
+                    background: isActive
+                      ? "linear-gradient(135deg, rgba(37, 31, 26, 0.96), rgba(18, 15, 12, 0.94))"
+                      : "rgba(28, 25, 22, 0.82)",
+                    color: "#FFFFFF",
+                    borderRadius: "12px",
+                    padding: "10px 16px",
+                    boxShadow: isActive
+                      ? "0 0 18px rgba(214, 178, 86, 0.7), 0 0 8px rgba(214, 178, 86, 0.4) inset"
+                      : "0 0 8px rgba(0, 0, 0, 0.45)",
+                    border: isActive
+                      ? "1px solid rgba(214, 178, 86, 0.85)"
+                      : "1px solid rgba(255, 255, 255, 0.18)",
+                    transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                    transform: isActive ? "scale(1.03)" : "scale(1)",
                   }}
                 >
                   <div
                     style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      height: "100%",
-                      width: `${hpPercentage}%`,
-                      background: computedPercentage !== null
-                        ? `linear-gradient(90deg, ${hpFillColor} 0%, ${hpFillColor} 100%)`
-                        : "transparent",
-                      transition: "width 0.3s ease, background-color 0.3s ease",
+                      fontWeight: 600,
+                      fontSize: "14px",
+                      letterSpacing: "0.5px",
                     }}
-                  />
+                  >
+                    {name}
+                  </div>
+                  <div style={{ marginTop: "6px" }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        fontSize: "12px",
+                        opacity: 0.9,
+                        marginBottom: "4px",
+                      }}
+                    >
+                      <span>HP</span>
+                      <span>{hasHpData ? hpDisplay : "—"}</span>
+                    </div>
+                    <div
+                      style={{
+                        position: "relative",
+                        width: "100%",
+                        height: "8px",
+                        borderRadius: "6px",
+                        background: "rgba(0, 0, 0, 0.45)",
+                        overflow: "hidden",
+                        border: "1px solid rgba(255, 255, 255, 0.12)",
+                      }}
+                    >
+                      <div
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          height: "100%",
+                          width: `${hpPercentage}%`,
+                          background: computedPercentage !== null
+                            ? `linear-gradient(90deg, ${hpFillColor} 0%, ${hpFillColor} 100%)`
+                            : "transparent",
+                          transition: "width 0.3s ease, background-color 0.3s ease",
+                        }}
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          );
-        })
-      ) : (
-        <div className="combat-turn-header__placeholder" aria-hidden="true" />
-      )}
-    </div>
+              );
+            })
+          ) : (
+            <div className="combat-turn-header__placeholder" aria-hidden="true" />
+          )}
+        </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- rework the combat tracker header layout so it can center when there is room while still scrolling across all combatants on narrow screens, including reaching the first card on mobile
- add a persistent current turn indicator so the active combatant is always visible, even on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebeffd57a4832e8718f05b3ae9605d