### PR TITLE
Add dock controls to modal headers

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -238,42 +238,53 @@
   scrollbar-width: none;
 }
 
-.dock-selector {
-  position: fixed;
-  top: clamp(
-    1rem,
-    calc(var(--docked-modal-top-offset, 0) - 2.75rem),
-    calc(100vh - 4rem)
-  );
-  display: flex;
-  flex-direction: column;
+
+.modal-header {
+  position: relative;
+}
+
+.dock-control {
+  position: absolute;
+  top: 0.75rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  z-index: 1060;
-  pointer-events: none;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background-color: rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  z-index: 2;
+
+  &:hover,
+  &:focus {
+    color: #111;
+    background-color: rgba(255, 255, 255, 0.9);
+    border-color: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  }
 
   &--left {
-    left: 1.5rem;
+    left: 0.75rem;
   }
 
   &--right {
-    right: 1.5rem;
+    right: 0.75rem;
   }
 
-  &__label {
-    font-size: 0.875rem;
-    color: rgba(255, 255, 255, 0.85);
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-    background: rgba(0, 0, 0, 0.45);
-    padding: 0.25rem 0.75rem;
-    border-radius: 999px;
-    pointer-events: auto;
+  &--active {
+    background-color: rgba(13, 110, 253, 0.9);
+    border-color: rgba(255, 255, 255, 0.95);
+    color: #fff;
   }
 
-  &__control {
-    min-width: 11rem;
-    pointer-events: auto;
-    box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
+  &--docked-context {
+    top: 1rem;
   }
 }
 
@@ -332,10 +343,6 @@
 }
 
 @media (max-width: 1199.98px) {
-  .dock-selector {
-    display: none;
-  }
-
   .docked-modal.modal-dialog {
     position: static;
     top: auto;

--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useCallback } from "react";
 import { Card, Modal, Button } from "react-bootstrap";
+import DockControls from '../components/DockControls';
 import levelup from "../../../images/levelup.png";
 import LevelUp from "./LevelUp"; // Import LevelUp component
 
@@ -13,6 +14,7 @@ export default function CharacterInfo({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
   characterFigurine,
   handleOpenTokenPicker,
   tokenPickerSaving = false,
@@ -216,6 +218,11 @@ export default function CharacterInfo({
     >
       <Card className="modern-card text-center">
         <Card.Header className="modal-header">
+          <DockControls
+            dockedSide={dockedSide}
+            onDockChange={onDockChange}
+            isDocked={isDocked}
+          />
           <Card.Title className="modal-title">Character Info</Card.Title>
         </Card.Header>
         <Card.Body className="modal-body character-info-body" style={{ maxHeight: "60vh" }}>

--- a/client/src/components/Zombies/attributes/EquipmentModal.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.js
@@ -8,6 +8,7 @@ import {
   normalizeWeapons,
   normalizeAccessories,
 } from './inventoryNormalization';
+import DockControls from '../components/DockControls';
 
 export default function EquipmentModal({
   show,
@@ -18,6 +19,7 @@ export default function EquipmentModal({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const normalizedWeapons = useMemo(
     () => normalizeWeapons(form.weapon || []),
@@ -88,6 +90,11 @@ export default function EquipmentModal({
     >
       <Card className="modern-card">
         <Card.Header className="modal-header">
+          <DockControls
+            dockedSide={dockedSide}
+            onDockChange={onDockChange}
+            isDocked={isDocked}
+          />
           <Card.Title className="modal-title">Equipment</Card.Title>
         </Card.Header>
         <Card.Body

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -4,6 +4,7 @@ import { Modal, Card, Button, Form, Col, Row, Alert } from 'react-bootstrap';
 import { useNavigate, useParams } from "react-router-dom";
 import { SKILLS } from "../skillSchema";
 import { calculateFeatPointsLeft } from '../../../utils/featUtils';
+import DockControls from '../components/DockControls';
 
 // Tools and musical instruments that can be selected for proficiency.
 // This list is not exhaustive to every possible item in the game but
@@ -62,6 +63,7 @@ export default function Feats({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const params = useParams();
   const navigate = useNavigate();
@@ -346,9 +348,14 @@ export default function Feats({
       >
         <div className="text-center">
           <Card className="modern-card">
-            <Card.Header className="modal-header">
-              <Card.Title className="modal-title">Feats</Card.Title>
-            </Card.Header>
+        <Card.Header className="modal-header">
+          <DockControls
+            dockedSide={dockedSide}
+            onDockChange={onDockChange}
+            isDocked={isDocked}
+          />
+          <Card.Title className="modal-title">Feats</Card.Title>
+        </Card.Header>
             <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
               <div className="points-container" style={{ display: showFeatBtn }}>
                 <span className="points-label text-light">Points Left:</span>

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -9,6 +9,7 @@ import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
 import speakWithAnimalIcon from '../../../images/speak-with-animal.png';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
+import DockControls from '../components/DockControls';
 
 const LINEAGE_SPELLS = {
   'elf-drow-dancing-lights': {
@@ -123,6 +124,7 @@ export default function Features({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
   characterId,
 }) {
   const [features, setFeatures] = useState([]);
@@ -1477,6 +1479,11 @@ export default function Features({
         <div className="text-center">
           <Card className="modern-card">
             <Card.Header className="modal-header">
+              <DockControls
+                dockedSide={dockedSide}
+                onDockChange={onDockChange}
+                isDocked={isDocked}
+              />
               <Card.Title className="modal-title">Features</Card.Title>
             </Card.Header>
             <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -4,6 +4,7 @@ import { Modal, Card, Table, Button, Alert } from 'react-bootstrap'; // Adjust a
 import { useNavigate, useParams } from "react-router-dom";
 import CampaignModals from "../components/CampaignModals";
 import useCampaignActions from "../hooks/useCampaignActions";
+import DockControls from '../components/DockControls';
 
 const HEX_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
 const DEFAULT_DICE_COLOR = '#000000';
@@ -25,6 +26,7 @@ export default function Help({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const params = useParams();
   const navigate = useNavigate();
@@ -186,6 +188,11 @@ export default function Help({
       >
         <Card className="modern-card text-center">
           <Card.Header className="modal-header">
+            <DockControls
+              dockedSide={dockedSide}
+              onDockChange={onDockChange}
+              isDocked={isDocked}
+            />
             <Card.Title className="modal-title">Help</Card.Title>
           </Card.Header>
           <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -10,6 +10,7 @@ import {
   normalizeWeapons,
   normalizeAccessories,
 } from './inventoryNormalization';
+import DockControls from '../components/DockControls';
 
 const DEFAULT_TAB = 'weapons';
 
@@ -23,6 +24,7 @@ export default function InventoryModal({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -201,6 +203,11 @@ export default function InventoryModal({
     >
       <Card className="modern-card">
         <Card.Header className="modal-header">
+          <DockControls
+            dockedSide={dockedSide}
+            onDockChange={onDockChange}
+            isDocked={isDocked}
+          />
           <Card.Title className="modal-title">Inventory</Card.Title>
         </Card.Header>
         <Card.Body

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1,10 +1,11 @@
 import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Button, ListGroup, Badge, Spinner, Alert } from 'react-bootstrap';
+import { Modal, Button, ListGroup, Badge, Spinner, Alert, CloseButton } from 'react-bootstrap';
 import MapDisplay from './MapDisplay';
 import CampaignMapBoard from './CampaignMapBoard';
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from '../utils/mapGrouping';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
+import DockControls from '../components/DockControls';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -150,6 +151,7 @@ const MapModal = ({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) => {
   const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
   const normalizedActiveId = useMemo(() => normalizeMapId(activeMapId), [activeMapId]);
@@ -933,8 +935,18 @@ const MapModal = ({
       dialogClassName={dialogClassName}
       data-testid="map-modal-wrapper"
     >
-      <Modal.Header closeButton>
+      <Modal.Header className="modal-header">
+        <DockControls
+          dockedSide={dockedSide}
+          onDockChange={onDockChange}
+          isDocked={isDocked}
+        />
         <Modal.Title>{title}</Modal.Title>
+        <CloseButton
+          variant="white"
+          onClick={handleModalHide}
+          aria-label="Close map"
+        />
       </Modal.Header>
       <Modal.Body>
         {hasManagementFeatures ? (
@@ -1001,6 +1013,7 @@ MapModal.propTypes = {
   isDocked: PropTypes.bool,
   dockedSide: PropTypes.oneOf(['left', 'right']),
   onDockClose: PropTypes.func,
+  onDockChange: PropTypes.func,
 };
 
 MapModal.defaultProps = {
@@ -1027,6 +1040,7 @@ MapModal.defaultProps = {
   isDocked: false,
   dockedSide: null,
   onDockClose: null,
+  onDockChange: null,
 };
 
 export default MapModal;

--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -5,6 +5,7 @@ import WeaponList from '../../Weapons/WeaponList';
 import ArmorList from '../../Armor/ArmorList';
 import ItemList from '../../Items/ItemList';
 import AccessoryList from '../../Accessories/AccessoryList';
+import DockControls from '../components/DockControls';
 
 const DEFAULT_TAB = 'weapons';
 
@@ -419,6 +420,7 @@ export default function ShopModal({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const [cart, setCart] = useState([]);
   const [showCart, setShowCart] = useState(false);
@@ -692,6 +694,11 @@ export default function ShopModal({
       >
       <Card className="modern-card">
         <Card.Header className="modal-header">
+          <DockControls
+            dockedSide={dockedSide}
+            onDockChange={onDockChange}
+            isDocked={isDocked}
+          />
           <Card.Title className="modal-title">Shop</Card.Title>
         </Card.Header>
         <Card.Body

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -7,6 +7,7 @@ import { SKILLS } from '../skillSchema';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import SkillInfoModal from './SkillInfoModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
+import DockControls from '../components/DockControls';
 
 const EMPTY_OBJECT = Object.freeze({});
 
@@ -37,6 +38,7 @@ export default function Skills({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const params = useParams();
   const safeForm = form ?? {};
@@ -342,6 +344,11 @@ export default function Skills({
       >
         <Card className="modern-card text-center">
           <Card.Header className="modal-header">
+            <DockControls
+              dockedSide={dockedSide}
+              onDockChange={onDockChange}
+              isDocked={isDocked}
+            />
             <Card.Title className="modal-title">Skills</Card.Title>
           </Card.Header>
           <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import UpcastModal from './UpcastModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { isExplicitlyUnowned } from '../utils/derivedStats';
+import DockControls from '../components/DockControls';
 
 /**
  * Modal component allowing users to select spells for their character.
@@ -118,6 +119,7 @@ export default function SpellSelector({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const params = useParams();
 
@@ -585,6 +587,11 @@ export default function SpellSelector({
       >
         <Card className="modern-card">
           <Card.Header className="modal-header">
+            <DockControls
+              dockedSide={dockedSide}
+              onDockChange={onDockChange}
+              isDocked={isDocked}
+            />
             <Card.Title className="modal-title">Spells</Card.Title>
           </Card.Header>
           <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useCallback } from "react";
 import { Modal, Button } from "react-bootstrap";
+import DockControls from '../components/DockControls';
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
@@ -22,6 +23,7 @@ export default function Stats({
   isDocked = false,
   dockedSide = null,
   onDockClose,
+  onDockChange,
 }) {
   const [stats] = useState({
     str: form.str || 0,
@@ -181,6 +183,11 @@ export default function Stats({
         dialogClassName={dialogClassName}
       >
         <Modal.Header className="modal-header">
+          <DockControls
+            dockedSide={dockedSide}
+            onDockChange={onDockChange}
+            isDocked={isDocked}
+          />
           <Modal.Title className="modal-title">Stats</Modal.Title>
         </Modal.Header>
         <Modal.Body className="stats-modal-body">

--- a/client/src/components/Zombies/components/DockControls.js
+++ b/client/src/components/Zombies/components/DockControls.js
@@ -1,0 +1,74 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+
+const SIDE_LABELS = {
+  left: 'left',
+  right: 'right',
+};
+
+export default function DockControls({ dockedSide = null, onDockChange, isDocked = false }) {
+  const handleDock = useCallback(
+    (side) => {
+      if (typeof onDockChange !== 'function' || !SIDE_LABELS[side]) {
+        return;
+      }
+
+      if (dockedSide === side) {
+        onDockChange(null);
+      } else {
+        onDockChange(side);
+      }
+    },
+    [dockedSide, onDockChange]
+  );
+
+  if (typeof onDockChange !== 'function') {
+    return null;
+  }
+
+  const renderButton = (side) => {
+    const isActive = dockedSide === side;
+    const className = [
+      'dock-control',
+      `dock-control--${side}`,
+      isDocked ? 'dock-control--docked-context' : null,
+      isActive ? 'dock-control--active' : null,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const iconDirection = side === 'left' ? 'left' : 'right';
+    const title = isActive ? `Undock from the ${side} side` : `Dock to the ${side} side`;
+
+    return (
+      <Button
+        key={side}
+        type="button"
+        size="sm"
+        variant="outline-light"
+        className={className}
+        aria-pressed={isActive}
+        aria-label={`Dock to the ${side}`}
+        title={title}
+        onClick={() => handleDock(side)}
+      >
+        <i className={`fas fa-arrow-${iconDirection}`} aria-hidden="true" />
+      </Button>
+    );
+  };
+
+  return <>{renderButton('left')}{renderButton('right')}</>;
+}
+
+DockControls.propTypes = {
+  dockedSide: PropTypes.oneOf([null, 'left', 'right']),
+  onDockChange: PropTypes.func,
+  isDocked: PropTypes.bool,
+};
+
+DockControls.defaultProps = {
+  dockedSide: null,
+  onDockChange: null,
+  isDocked: false,
+};

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useRef, useCallback, useMemo } from "react"
 import { io } from "socket.io-client";
 import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
-import { Nav, Navbar, Container, Button, Form } from 'react-bootstrap';
+import { Nav, Navbar, Container, Button } from 'react-bootstrap';
 import '../../../App.scss';
 import loginbg from "../../../images/loginbg.png";
 import CharacterInfo from "../attributes/CharacterInfo";
@@ -64,14 +64,6 @@ const DOCKABLE_MODAL_DEFINITIONS = {
   map: { label: 'Campaign Map', component: MapModal },
   help: { label: 'Help', component: Help },
 };
-const DOCKABLE_MODAL_OPTIONS = [
-  { key: null, label: 'None' },
-  ...Object.entries(DOCKABLE_MODAL_DEFINITIONS).map(([key, { label }]) => ({
-    key,
-    label,
-  })),
-];
-const WIDE_SCREEN_QUERY = '(min-width: 1200px)';
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
 
 const toFiniteNumberOrNull = (value) => {
@@ -1011,12 +1003,6 @@ export default function ZombiesCharacterSheet() {
   const campaignMapsRef = useRef([]);
   const campaignActiveMapIdRef = useRef(null);
   const [dockedModals, setDockedModals] = useState({ left: null, right: null });
-  const [isWideScreen, setIsWideScreen] = useState(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return false;
-    }
-    return window.matchMedia(WIDE_SCREEN_QUERY).matches;
-  });
 
   useEffect(() => {
     setActiveEffects(getStoredActiveEffects(characterId));
@@ -1075,27 +1061,6 @@ export default function ZombiesCharacterSheet() {
       console.error('Failed to store used slots', error);
     }
   }, [characterId, usedSlots]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-      const mediaQueryList = window.matchMedia(WIDE_SCREEN_QUERY);
-      const listener = (event) => {
-        setIsWideScreen(event.matches);
-      };
-
-      if (typeof mediaQueryList.addEventListener === 'function') {
-        mediaQueryList.addEventListener('change', listener);
-        return () => mediaQueryList.removeEventListener('change', listener);
-      }
-
-      if (typeof mediaQueryList.addListener === 'function') {
-        mediaQueryList.addListener(listener);
-        return () => mediaQueryList.removeListener(listener);
-      }
-    }
-
-    return undefined;
-  }, []);
 
   useEffect(() => {
     campaignMapTokensRef.current = campaignMapTokens || {};
@@ -1931,7 +1896,7 @@ export default function ZombiesCharacterSheet() {
 
   useEffect(() => {
     updateDockedModalMetrics();
-  }, [updateDockedModalMetrics, headerHeight, isWideScreen]);
+  }, [updateDockedModalMetrics, headerHeight]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -2191,19 +2156,106 @@ export default function ZombiesCharacterSheet() {
     });
   }, []);
 
-  const handleDockSelectionChange = useCallback((side, value) => {
-    const normalizedValue = value || null;
-    setDockedModals((prev) => {
-      const next = { ...prev, [side]: normalizedValue };
-      if (normalizedValue) {
+  const handleDockChange = useCallback(
+    (modalKey, side) => {
+      if (!modalKey) {
+        return;
+      }
+
+      setDockedModals((prev) => {
+        let next = prev;
+        let detached = false;
+
+        ['left', 'right'].forEach((position) => {
+          if (prev[position] === modalKey) {
+            if (next === prev) {
+              next = { ...prev };
+            }
+            next[position] = null;
+            detached = true;
+          }
+        });
+
+        if (!side) {
+          return next === prev ? prev : next;
+        }
+
+        if (side !== 'left' && side !== 'right') {
+          return next === prev ? prev : next;
+        }
+
+        if (prev[side] === modalKey && detached) {
+          return next;
+        }
+
+        if (next === prev) {
+          next = { ...prev };
+        }
+
         const otherSide = side === 'left' ? 'right' : 'left';
-        if (prev[otherSide] === normalizedValue) {
+        next[side] = modalKey;
+
+        if (next[otherSide] === modalKey) {
           next[otherSide] = null;
         }
+
+        return next;
+      });
+
+      if (side) {
+        switch (modalKey) {
+          case 'characterInfo':
+            setShowCharacterInfo(false);
+            break;
+          case 'stats':
+            setShowStats(false);
+            break;
+          case 'skills':
+            setShowSkill(false);
+            break;
+          case 'feats':
+            setShowFeats(false);
+            break;
+          case 'features':
+            setShowFeatures(false);
+            break;
+          case 'spells':
+            setShowSpells(false);
+            break;
+          case 'equipment':
+            setShowEquipment(false);
+            break;
+          case 'inventory':
+            setShowInventory(false);
+            break;
+          case 'shop':
+            setShowShop(false);
+            break;
+          case 'help':
+            setShowHelpModal(false);
+            break;
+          case 'map':
+            setShowMapModal(false);
+            break;
+          default:
+            break;
+        }
       }
-      return next;
-    });
-  }, []);
+    },
+    [
+      setShowCharacterInfo,
+      setShowStats,
+      setShowSkill,
+      setShowFeats,
+      setShowFeatures,
+      setShowSpells,
+      setShowEquipment,
+      setShowInventory,
+      setShowShop,
+      setShowHelpModal,
+      setShowMapModal,
+    ]
+  );
 
   const handleShowSkill = useCallback(() => setShowSkill(true), []);
   const handleCloseSkill = useCallback(() => {
@@ -4150,6 +4202,7 @@ export default function ZombiesCharacterSheet() {
           onShowBackground: handleShowBackground,
           onLongRest: handleLongRest,
           onShortRest: handleShortRest,
+          onDockChange: (side) => handleDockChange('characterInfo', side),
         }),
       },
       stats: {
@@ -4159,6 +4212,7 @@ export default function ZombiesCharacterSheet() {
         getBaseProps: () => ({
           form,
           handleCloseStats,
+          onDockChange: (side) => handleDockChange('stats', side),
         }),
       },
       skills: {
@@ -4177,6 +4231,7 @@ export default function ZombiesCharacterSheet() {
           wisMod: statMods.wis,
           onSkillsChange: handleSkillsChange,
           onRollResult: handleRollResult,
+          onDockChange: (side) => handleDockChange('skills', side),
         }),
       },
       feats: {
@@ -4186,6 +4241,7 @@ export default function ZombiesCharacterSheet() {
         getBaseProps: () => ({
           form,
           handleCloseFeats,
+          onDockChange: (side) => handleDockChange('feats', side),
         }),
       },
       features: {
@@ -4199,6 +4255,7 @@ export default function ZombiesCharacterSheet() {
           onLargeForm: handleLargeForm,
           longRestCount,
           shortRestCount,
+          onDockChange: (side) => handleDockChange('features', side),
         }),
       },
       spells: {
@@ -4211,6 +4268,7 @@ export default function ZombiesCharacterSheet() {
           onSpellsChange: handleSpellsChange,
           onCastSpell: handleCastSpell,
           availableSlots,
+          onDockChange: (side) => handleDockChange('spells', side),
         }),
       },
       equipment: {
@@ -4221,6 +4279,7 @@ export default function ZombiesCharacterSheet() {
           form,
           onHide: handleCloseEquipment,
           onEquipmentChange: handleEquipmentChange,
+          onDockChange: (side) => handleDockChange('equipment', side),
         }),
       },
       inventory: {
@@ -4233,6 +4292,7 @@ export default function ZombiesCharacterSheet() {
           onHide: handleCloseInventory,
           onTabChange: setInventoryTab,
           characterId,
+          onDockChange: (side) => handleDockChange('inventory', side),
         }),
       },
       shop: {
@@ -4257,6 +4317,7 @@ export default function ZombiesCharacterSheet() {
             pp: form?.pp ?? 0,
           },
           onPurchase: handleShopPurchase,
+          onDockChange: (side) => handleDockChange('shop', side),
         }),
       },
       map: {
@@ -4273,6 +4334,7 @@ export default function ZombiesCharacterSheet() {
           characterLookup: tokenMetaById,
           onTokenMove: handleTokenMove,
           onHide: handleCloseMapModal,
+          onDockChange: (side) => handleDockChange('map', side),
         }),
       },
       help: {
@@ -4283,6 +4345,7 @@ export default function ZombiesCharacterSheet() {
           form,
           handleCloseHelpModal,
           onDiceColorChange: handleDiceColorChange,
+          onDockChange: (side) => handleDockChange('help', side),
         }),
       },
     }),
@@ -4311,6 +4374,7 @@ export default function ZombiesCharacterSheet() {
       handleCloseSpells,
       handleCloseStats,
       handleDiceColorChange,
+      handleDockChange,
       handleEquipmentChange,
       handleItemsChange,
       handleLongRest,
@@ -4383,11 +4447,12 @@ export default function ZombiesCharacterSheet() {
             isDocked
             dockedSide={dockedSide}
             onDockClose={() => handleDockClose(modalKey)}
+            onDockChange={(side) => handleDockChange(modalKey, side)}
           />
         );
       })
       .filter(Boolean);
-  }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockClose]);
+  }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
   return (
     <div
@@ -4415,72 +4480,6 @@ export default function ZombiesCharacterSheet() {
           minHeight: 0,
         }}
       >
-        {isWideScreen && (
-        <>
-          <div className="dock-selector dock-selector--left">
-            <label
-              className="dock-selector__label"
-              htmlFor="dock-selector-left"
-            >
-              Dock left modal
-            </label>
-            <Form.Select
-              id="dock-selector-left"
-              size="sm"
-              className="dock-selector__control"
-              value={dockedModals.left ?? ''}
-              onChange={(event) =>
-                handleDockSelectionChange('left', event.target.value)
-              }
-            >
-              {DOCKABLE_MODAL_OPTIONS.map(({ key, label }) => {
-                const config = key ? DOCKABLE_MODAL_CONFIG[key] : null;
-                const isDisabled = key ? config?.isEnabled === false : false;
-                return (
-                  <option
-                    key={key ?? 'none'}
-                    value={key ?? ''}
-                    disabled={isDisabled}
-                  >
-                    {label}
-                  </option>
-                );
-              })}
-            </Form.Select>
-          </div>
-          <div className="dock-selector dock-selector--right">
-            <label
-              className="dock-selector__label"
-              htmlFor="dock-selector-right"
-            >
-              Dock right modal
-            </label>
-            <Form.Select
-              id="dock-selector-right"
-              size="sm"
-              className="dock-selector__control"
-              value={dockedModals.right ?? ''}
-              onChange={(event) =>
-                handleDockSelectionChange('right', event.target.value)
-              }
-            >
-              {DOCKABLE_MODAL_OPTIONS.map(({ key, label }) => {
-                const config = key ? DOCKABLE_MODAL_CONFIG[key] : null;
-                const isDisabled = key ? config?.isEnabled === false : false;
-                return (
-                  <option
-                    key={key ?? 'none'}
-                    value={key ?? ''}
-                    disabled={isDisabled}
-                  >
-                    {label}
-                  </option>
-                );
-              })}
-            </Form.Select>
-          </div>
-        </>
-      )}
       {isFormReady ? (
         <>
           <div ref={headerRef}>
@@ -4741,6 +4740,8 @@ export default function ZombiesCharacterSheet() {
           characterFigurine={characterFigurine}
           handleOpenTokenPicker={handleOpenTokenPicker}
           tokenPickerSaving={tokenPickerSaving}
+          dockedSide={getDockedSide('characterInfo')}
+          onDockChange={(side) => handleDockChange('characterInfo', side)}
         />
         <Skills
           form={form}
@@ -4755,11 +4756,15 @@ export default function ZombiesCharacterSheet() {
           wisMod={statMods.wis}
           onSkillsChange={handleSkillsChange}
           onRollResult={handleRollResult}
+          dockedSide={getDockedSide('skills')}
+          onDockChange={(side) => handleDockChange('skills', side)}
         />
         <Stats
           form={form}
           showStats={showStats}
           handleCloseStats={handleCloseStats}
+          dockedSide={getDockedSide('stats')}
+          onDockChange={(side) => handleDockChange('stats', side)}
         />
         <BackgroundModal
           show={showBackground}
@@ -4770,6 +4775,8 @@ export default function ZombiesCharacterSheet() {
           form={form}
           showFeats={showFeats}
           handleCloseFeats={handleCloseFeats}
+          dockedSide={getDockedSide('feats')}
+          onDockChange={(side) => handleDockChange('feats', side)}
         />
         <Features
           form={form}
@@ -4785,6 +4792,8 @@ export default function ZombiesCharacterSheet() {
           availableSlots={availableSlots}
           actionCount={actionCount}
           characterId={characterId}
+          dockedSide={getDockedSide('features')}
+          onDockChange={(side) => handleDockChange('features', side)}
         />
         <InventoryModal
           show={showInventory}
@@ -4793,12 +4802,16 @@ export default function ZombiesCharacterSheet() {
           onTabChange={setInventoryTab}
           form={form}
           characterId={characterId}
+          dockedSide={getDockedSide('inventory')}
+          onDockChange={(side) => handleDockChange('inventory', side)}
         />
         <EquipmentModal
           show={showEquipment}
           onHide={handleCloseEquipment}
           form={form}
           onEquipmentChange={handleEquipmentChange}
+          dockedSide={getDockedSide('equipment')}
+          onDockChange={(side) => handleDockChange('equipment', side)}
         />
         <ShopModal
           show={showShop}
@@ -4819,6 +4832,8 @@ export default function ZombiesCharacterSheet() {
             pp: form?.pp ?? 0,
           }}
           onPurchase={handleShopPurchase}
+          dockedSide={getDockedSide('shop')}
+          onDockChange={(side) => handleDockChange('shop', side)}
         />
         {hasSpellcasting && (
           <SpellSelector
@@ -4828,6 +4843,8 @@ export default function ZombiesCharacterSheet() {
             onSpellsChange={handleSpellsChange}
             onCastSpell={handleCastSpell}
             availableSlots={availableSlots}
+            dockedSide={getDockedSide('spells')}
+            onDockChange={(side) => handleDockChange('spells', side)}
           />
         )}
         <Help
@@ -4835,6 +4852,8 @@ export default function ZombiesCharacterSheet() {
           showHelpModal={showHelpModal}
           handleCloseHelpModal={handleCloseHelpModal}
           onDiceColorChange={handleDiceColorChange}
+          dockedSide={getDockedSide('help')}
+          onDockChange={(side) => handleDockChange('help', side)}
         />
       </>
     )}
@@ -4863,6 +4882,8 @@ export default function ZombiesCharacterSheet() {
       characterLookup={tokenMetaById}
       onTokenMove={handleTokenMove}
       onTokenRemove={handleTokenRemove}
+      dockedSide={getDockedSide('map')}
+      onDockChange={(side) => handleDockChange('map', side)}
     />
     {dockedModalElements}
   </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -31,7 +31,7 @@ jest.mock('../attributes/Skills', () => (props) => {
   mockSkillsModalProps.current = props;
 
   if (props && typeof props.isDocked !== 'undefined') {
-    mockDockedSkillsModalProps.current = props;
+    mockDockedSkillsModalProps.current = props.isDocked ? props : null;
   }
 
   return props.showSkill ? <div data-testid="skills-modal" /> : null;
@@ -101,9 +101,6 @@ jest.mock('../attributes/Features', () => (props) => {
 
 import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
-const WIDE_SCREEN_QUERY = '(min-width: 1200px)';
-const matchMediaState = {};
-
 const defaultApiFetchImplementation = (url) => {
   if (typeof url === 'string' && url.includes('/maps')) {
     return Promise.resolve({ ok: false, status: 404 });
@@ -160,20 +157,16 @@ beforeEach(() => {
   mockCharacterInfoProps.current = null;
   mockHealthDefenseProps.current = null;
   window.localStorage.clear();
-  window.matchMedia = jest.fn().mockImplementation((query) => {
-    const matches = matchMediaState[query] ?? false;
-    return {
-      matches,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    };
-  });
-  matchMediaState[WIDE_SCREEN_QUERY] = false;
+  window.matchMedia = jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
 });
 
 test('uses character-derived hit points for synced combat participants', async () => {
@@ -589,8 +582,7 @@ test('warlock character renders spells button', async () => {
   expect(spellButton).toBeInTheDocument();
 });
 
-test('wide screens expose dock selectors and pass docking props', async () => {
-  matchMediaState[WIDE_SCREEN_QUERY] = true;
+test('modal docking controls update docking state', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,
     json: async () => ({
@@ -615,40 +607,36 @@ test('wide screens expose dock selectors and pass docking props', async () => {
 
   render(<ZombiesCharacterSheet />);
 
-  const leftSelector = await screen.findByLabelText(/Dock left modal/i);
-  expect(leftSelector).toBeInTheDocument();
-  expect(leftSelector).toHaveValue('');
-
   await waitFor(() => {
     expect(mockEquipmentModalProps.current).not.toBeNull();
   });
 
-  await userEvent.selectOptions(leftSelector, 'skills');
-  expect(leftSelector).toHaveValue('skills');
+  expect(mockSkillsModalProps.current).not.toBeNull();
+  expect(typeof mockSkillsModalProps.current.onDockChange).toBe('function');
 
-  await waitFor(() => {
-    const activeSkillsProps =
-      mockDockedSkillsModalProps.current ?? mockSkillsModalProps.current;
-
-    expect(activeSkillsProps).not.toBeNull();
-    expect(leftSelector).toHaveValue('skills');
-
-    if (activeSkillsProps && typeof activeSkillsProps.isDocked !== 'undefined') {
-      expect(activeSkillsProps.isDocked).toBe(true);
-      expect(activeSkillsProps.dockedSide).toBe('left');
-    }
+  act(() => {
+    mockSkillsModalProps.current.onDockChange?.('left');
   });
 
-  const rightSelector = screen.getByLabelText(/Dock right modal/i);
-  await userEvent.selectOptions(rightSelector, 'map');
+  await waitFor(() => {
+    expect(mockDockedSkillsModalProps.current).not.toBeNull();
+    if (mockDockedSkillsModalProps.current) {
+      expect(mockDockedSkillsModalProps.current.isDocked).toBe(true);
+      expect(mockDockedSkillsModalProps.current.dockedSide).toBe('left');
+    }
+    expect(mockSkillsModalProps.current.dockedSide).toBe('left');
+  });
+
+  act(() => {
+    mockDockedSkillsModalProps.current?.onDockChange?.('right');
+  });
 
   await waitFor(() => {
-    expect(mockMapModalProps.current).not.toBeNull();
-    if (typeof mockMapModalProps.current.isDocked !== 'undefined') {
-      expect(mockMapModalProps.current.isDocked).toBe(true);
-      expect(mockMapModalProps.current.dockedSide).toBe('right');
+    expect(mockDockedSkillsModalProps.current).not.toBeNull();
+    if (mockDockedSkillsModalProps.current) {
+      expect(mockDockedSkillsModalProps.current.dockedSide).toBe('right');
     }
-    expect(mockMapModalProps.current.show).toBe(true);
+    expect(mockSkillsModalProps.current.dockedSide).toBe('right');
   });
 
   act(() => {
@@ -656,16 +644,31 @@ test('wide screens expose dock selectors and pass docking props', async () => {
   });
 
   await waitFor(() => {
-    expect(leftSelector).toHaveValue('');
+    expect(mockSkillsModalProps.current.dockedSide).toBeNull();
   });
 
+  expect(typeof mockMapModalProps.current?.onDockChange).toBe('function');
+
   act(() => {
-    mockMapModalProps.current.onHide();
+    mockMapModalProps.current?.onDockChange?.('right');
   });
 
   await waitFor(() => {
-    expect(rightSelector).toHaveValue('');
-    if (typeof mockMapModalProps.current.isDocked !== 'undefined') {
+    expect(mockMapModalProps.current).not.toBeNull();
+    if (mockMapModalProps.current && typeof mockMapModalProps.current.isDocked !== 'undefined') {
+      expect(mockMapModalProps.current.isDocked).toBe(true);
+      expect(mockMapModalProps.current.dockedSide).toBe('right');
+    }
+    expect(mockMapModalProps.current?.show).toBe(true);
+  });
+
+  act(() => {
+    mockMapModalProps.current?.onDockClose?.();
+  });
+
+  await waitFor(() => {
+    expect(mockMapModalProps.current).not.toBeNull();
+    if (mockMapModalProps.current && typeof mockMapModalProps.current.isDocked !== 'undefined') {
       expect(mockMapModalProps.current.isDocked).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary
- remove the global docking selectors from the character sheet and manage docking via a new `handleDockChange` helper
- add a reusable `DockControls` component and wire it into each dockable modal with updated styling
- update the docking unit test to exercise the new per-modal controls

## Testing
- `npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` *(fails: suite emits existing act() warnings in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec114d95ac832eb8e6b8b304db625f