### PR TITLE
Scope token picker to race and class folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -380,6 +380,58 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
   return filters.length > 0 ? filters : fallback;
 };
 
+const sanitizeFolderTarget = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  let trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  trimmed = trimmed.replace(/^\/+/, '');
+
+  if (/^tokens\//i.test(trimmed)) {
+    return `Tokens/${trimmed.slice(trimmed.indexOf('/') + 1)}`;
+  }
+
+  if (/^adventurers\//i.test(trimmed)) {
+    return `Tokens/${trimmed}`;
+  }
+
+  if (/^core_class_tokens\//i.test(trimmed)) {
+    return `Tokens/Adventurers/${trimmed}`;
+  }
+
+  return `Tokens/${trimmed}`;
+};
+
+const buildFiltersFromTargets = (targets) => {
+  if (!Array.isArray(targets) || targets.length === 0) {
+    return null;
+  }
+
+  const uniqueTargets = Array.from(new Set(targets.map(sanitizeFolderTarget).filter(Boolean)));
+  if (uniqueTargets.length === 0) {
+    return null;
+  }
+
+  return uniqueTargets.map((target) => {
+    const displayPath = target.startsWith('Tokens/') ? target.slice('Tokens/'.length) : target;
+    const aliases = [target, displayPath, displayPath.toLowerCase(), target.toLowerCase()];
+    const depth = displayPath.split('/').filter(Boolean).length - 1;
+
+    return {
+      key: `target:${target}`,
+      label: displayPath,
+      folders: [target],
+      aliases,
+      depth: depth >= 0 ? depth : 0,
+    };
+  });
+};
+
 const TokenPickerModal = ({
   show,
   onHide,
@@ -394,12 +446,42 @@ const TokenPickerModal = ({
   isBusy = false,
   errorMessage = null,
   filterScope = null,
+  folderTargets = null,
 }) => {
   const [dmFolderOptions, setDmFolderOptions] = useState(null);
   const [playerFolderOptions, setPlayerFolderOptions] = useState(() =>
     cloneFilters(DEFAULT_PLAYER_FILTERS)
   );
   const [fetchingFolders, setFetchingFolders] = useState(false);
+
+  const normalizedFolderTargets = useMemo(() => {
+    if (!folderTargets) {
+      return [];
+    }
+
+    const values = Array.isArray(folderTargets) ? folderTargets : [folderTargets];
+    const variants = values
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean);
+
+    if (variants.length === 0) {
+      return [];
+    }
+
+    return Array.from(new Set(variants));
+  }, [folderTargets]);
+
+  const sanitizedFolderTargets = useMemo(() => {
+    const rawTargets = normalizedFolderTargets.length > 0
+      ? normalizedFolderTargets
+      : Array.isArray(folderTargets)
+        ? folderTargets
+        : typeof folderTargets === 'string'
+          ? [folderTargets]
+          : [];
+
+    return Array.from(new Set(rawTargets.map(sanitizeFolderTarget).filter(Boolean)));
+  }, [folderTargets, normalizedFolderTargets]);
 
   const baseFilters = useMemo(() => {
     if (isDm) {
@@ -738,6 +820,16 @@ const TokenPickerModal = ({
 
     const fallbackFilters = cloneFilters(DEFAULT_PLAYER_FILTERS);
 
+    const derivedFilters = sanitizedFolderTargets.length > 0
+      ? buildFiltersFromTargets(sanitizedFolderTargets)
+      : null;
+
+    if (derivedFilters) {
+      setPlayerFolderOptions(derivedFilters);
+      setFetchingFolders(false);
+      return;
+    }
+
     if (!campaignId) {
       setPlayerFolderOptions(fallbackFilters);
       return;
@@ -779,7 +871,12 @@ const TokenPickerModal = ({
     return () => {
       isCancelled = true;
     };
-  }, [show, isDm, campaignId]);
+  }, [
+    show,
+    isDm,
+    campaignId,
+    sanitizedFolderTargets,
+  ]);
 
   const handleFilterChange = useCallback(
     (event) => {
@@ -1000,6 +1097,10 @@ TokenPickerModal.propTypes = {
   isBusy: PropTypes.bool,
   errorMessage: PropTypes.string,
   filterScope: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+  folderTargets: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
   ]),

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -382,6 +382,125 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('player token picker limits folder request when folderTargets provided', async () => {
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Dragonborn',
+              path: 'Tokens/Adventurers/Dragonborn',
+              relativePath: 'Adventurers/Dragonborn',
+              children: [],
+            },
+            {
+              name: 'Core_Class_Tokens',
+              path: 'Tokens/Adventurers/Core_Class_Tokens',
+              relativePath: 'Adventurers/Core_Class_Tokens',
+              children: [
+                {
+                  name: 'Fighter',
+                  path: 'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+                  relativePath: 'Adventurers/Core_Class_Tokens/Fighter',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Dragonborn',
+          path: 'Tokens/Adventurers/Dragonborn',
+          relativePath: 'Adventurers/Dragonborn',
+          depth: 1,
+          displayPath: 'Adventurers/Dragonborn',
+        },
+        {
+          name: 'Core_Class_Tokens',
+          path: 'Tokens/Adventurers/Core_Class_Tokens',
+          relativePath: 'Adventurers/Core_Class_Tokens',
+          depth: 1,
+          displayPath: 'Adventurers/Core_Class_Tokens',
+        },
+        {
+          name: 'Fighter',
+          path: 'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+          relativePath: 'Adventurers/Core_Class_Tokens/Fighter',
+          depth: 2,
+          displayPath: 'Adventurers/Core_Class_Tokens/Fighter',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (
+        url ===
+        '/campaigns/Camp1/token-folders?folders=Tokens/Adventurers/Core_Class_Tokens/Fighter,Tokens/Adventurers/Dragonborn'
+      ) {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        folderTargets={[
+          'Tokens/Adventurers/Dragonborn',
+          'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+        ]}
+        filterScope={['Dragonborn', 'Core_Class_Tokens/Fighter']}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalled();
+    });
+
+    const folderCalls = apiFetch.mock.calls
+      .map(([url]) => url)
+      .filter((url) => url.startsWith('/campaigns/Camp1/token-folders'));
+    expect(folderCalls.length).toBe(0);
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      expect(manifestCalls[0]).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn'
+      );
+    });
+  });
+
   test('player library dropdown stays disabled until folders finish loading', async () => {
     const folderTree = {
       rootFolder: 'Tokens',

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2780,33 +2780,55 @@ export default function ZombiesCharacterSheet() {
   const tokenPickerFilterScope = useMemo(() => {
     const scopeSet = new Set();
 
-    const addScopeVariants = (rawValue, prefixes = []) => {
+    const buildValueVariants = (rawValue) => {
       if (typeof rawValue !== 'string') {
-        return;
+        return [];
       }
 
       const normalizedValue = rawValue.replace(/\s+/g, ' ').trim();
       if (!normalizedValue) {
-        return;
+        return [];
       }
 
       const lowerValue = normalizedValue.toLowerCase();
       const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
+      const underscoredValue = normalizedValue.replace(/\s+/g, '_');
+      const dashedValue = normalizedValue.replace(/\s+/g, '-');
 
-      [normalizedValue, lowerValue, compactValue]
-        .filter(Boolean)
-        .forEach((entry) => scopeSet.add(entry));
+      const variants = new Set([
+        normalizedValue,
+        lowerValue,
+        compactValue,
+        underscoredValue,
+        underscoredValue.toLowerCase(),
+        dashedValue,
+        dashedValue.toLowerCase(),
+      ]);
 
-      prefixes
+      return Array.from(variants).filter(Boolean);
+    };
+
+    const addScopeVariants = (rawValue, prefixes = []) => {
+      const variants = buildValueVariants(rawValue);
+      if (variants.length === 0) {
+        return;
+      }
+
+      variants.forEach((variant) => scopeSet.add(variant));
+
+      const normalizedPrefixes = prefixes
         .map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
-        .filter(Boolean)
-        .forEach((prefix) => {
-          scopeSet.add(`${prefix}/${normalizedValue}`);
-          scopeSet.add(`${prefix}/${lowerValue}`);
-          if (compactValue) {
-            scopeSet.add(`${prefix}/${compactValue}`);
-          }
+        .filter(Boolean);
+
+      if (normalizedPrefixes.length === 0) {
+        return;
+      }
+
+      normalizedPrefixes.forEach((prefix) => {
+        variants.forEach((variant) => {
+          scopeSet.add(`${prefix}/${variant}`);
         });
+      });
     };
 
     const raceName = typeof form?.race?.name === 'string' ? form.race.name : '';
@@ -2846,6 +2868,98 @@ export default function ZombiesCharacterSheet() {
     });
 
     return Array.from(scopeSet);
+  }, [form?.occupation, form?.race?.name]);
+
+  const tokenPickerFolderTargets = useMemo(() => {
+    const folderSet = new Set();
+
+    const buildValueVariants = (rawValue) => {
+      if (typeof rawValue !== 'string') {
+        return [];
+      }
+
+      const normalizedValue = rawValue.replace(/\s+/g, ' ').trim();
+      if (!normalizedValue) {
+        return [];
+      }
+
+      const lowerValue = normalizedValue.toLowerCase();
+      const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
+      const underscoredValue = normalizedValue.replace(/\s+/g, '_');
+      const dashedValue = normalizedValue.replace(/\s+/g, '-');
+
+      const variants = new Set([
+        normalizedValue,
+        lowerValue,
+        compactValue,
+        underscoredValue,
+        underscoredValue.toLowerCase(),
+        dashedValue,
+        dashedValue.toLowerCase(),
+      ]);
+
+      return Array.from(variants).filter(Boolean);
+    };
+
+    const addFolderTargets = (prefixes, rawValue) => {
+      const variants = buildValueVariants(rawValue);
+      if (variants.length === 0) {
+        return;
+      }
+
+      prefixes
+        .map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
+        .filter(Boolean)
+        .forEach((prefix) => {
+          variants.forEach((variant) => {
+            folderSet.add(`${prefix}/${variant}`);
+          });
+        });
+    };
+
+    const raceName = typeof form?.race?.name === 'string' ? form.race.name : '';
+    if (raceName) {
+      addFolderTargets(
+        [
+          'Tokens/Adventurers',
+          'Tokens/Adventurers/Races',
+          'Adventurers',
+          'Adventurers/Races',
+        ],
+        raceName
+      );
+    }
+
+    const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
+    const seenClasses = new Set();
+    occupations.forEach((occupation) => {
+      if (!occupation || typeof occupation !== 'object') {
+        return;
+      }
+
+      const rawClassName =
+        typeof occupation.Occupation === 'string' ? occupation.Occupation.trim() : '';
+      if (!rawClassName) {
+        return;
+      }
+
+      const classKey = rawClassName.toLowerCase();
+      if (seenClasses.has(classKey)) {
+        return;
+      }
+      seenClasses.add(classKey);
+
+      addFolderTargets(
+        [
+          'Tokens/Adventurers/Core_Class_Tokens',
+          'Adventurers/Core_Class_Tokens',
+          'Core_Class_Tokens',
+        ],
+        rawClassName
+      );
+    });
+
+    return Array.from(folderSet);
   }, [form?.occupation, form?.race?.name]);
 
   const updateLocalDiceColor = useCallback(
@@ -4850,6 +4964,7 @@ export default function ZombiesCharacterSheet() {
       isBusy={tokenPickerSaving}
       errorMessage={tokenPickerError}
       filterScope={tokenPickerFilterScope}
+      folderTargets={tokenPickerFolderTargets}
     />
     <MapModal
       show={shouldShowMapModal}


### PR DESCRIPTION
## Summary
- compute race- and class-based filter scopes and folder targets for the character token picker
- sanitize folder targets in the token picker modal, preserving ordering and scoping manifest requests to the provided folders
- expand the token picker tests to cover targeted manifest calls and remove temporary debugging output

## Testing
- CI=1 npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ec2103d6e08323aa01cb164f2b20d8