### PR TITLE
Enable resizing of docked modals

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -350,14 +350,13 @@
   top: var(--docked-modal-top-offset, 0);
   bottom: 1.5rem;
   margin: 0;
-  width: var(
+  --docked-modal-current-max-width: var(
     --docked-modal-max-width,
     clamp(520px, 40vw, 640px)
   );
-  max-width: var(
-    --docked-modal-max-width,
-    clamp(520px, 40vw, 640px)
-  );
+  --docked-modal-current-width: var(--docked-modal-current-max-width);
+  width: var(--docked-modal-current-width);
+  max-width: var(--docked-modal-current-max-width);
   display: flex;
   align-items: stretch;
   transition: transform 0.2s ease;
@@ -366,11 +365,60 @@
 .docked-modal--left {
   left: 0;
   right: auto;
+  --docked-modal-current-max-width: var(
+    --docked-modal-max-width-left,
+    var(--docked-modal-max-width, clamp(520px, 40vw, 640px))
+  );
+  --docked-modal-current-width: var(
+    --docked-modal-width-left,
+    var(--docked-modal-current-max-width)
+  );
 }
 
 .docked-modal--right {
   left: auto;
   right: 0;
+  --docked-modal-current-max-width: var(
+    --docked-modal-max-width-right,
+    var(--docked-modal-max-width, clamp(520px, 40vw, 640px))
+  );
+  --docked-modal-current-width: var(
+    --docked-modal-width-right,
+    var(--docked-modal-current-max-width)
+  );
+}
+
+.docked-modal--left::after,
+.docked-modal--right::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  pointer-events: none;
+  z-index: 5;
+  opacity: 0.4;
+  transition: opacity 0.2s ease;
+}
+
+.docked-modal--left::after {
+  right: -6px;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+}
+
+.docked-modal--right::after {
+  left: -6px;
+  background: linear-gradient(to left, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+}
+
+body.docked-modal--resizing .docked-modal--left::after,
+body.docked-modal--resizing .docked-modal--right::after {
+  opacity: 0.75;
+}
+
+body.docked-modal--resizing {
+  user-select: none;
+  cursor: ew-resize;
 }
 
 .docked-modal.modal-dialog .modal-content {
@@ -402,6 +450,11 @@
     max-width: 100%;
     height: auto;
     margin: 1.5rem auto;
+  }
+
+  .docked-modal--left::after,
+  .docked-modal--right::after {
+    content: none;
   }
 
   .docked-modal.modal-dialog .modal-content {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -51,6 +51,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
 
 const HEADER_PADDING = 16;
+const MIN_DOCKED_MODAL_WIDTH = 320;
 const DOCKABLE_MODAL_DEFINITIONS = {
   characterInfo: { label: 'Character Info', component: CharacterInfo },
   stats: { label: 'Stats', component: Stats },
@@ -1126,6 +1127,7 @@ export default function ZombiesCharacterSheet() {
   const campaignMapsRef = useRef([]);
   const campaignActiveMapIdRef = useRef(null);
   const [dockedModals, setDockedModals] = useState({ left: null, right: null });
+  const [dockedModalWidths, setDockedModalWidths] = useState({ left: null, right: null });
 
   useEffect(() => {
     setActiveEffects(getStoredActiveEffects(characterId));
@@ -1963,7 +1965,12 @@ export default function ZombiesCharacterSheet() {
     const rightGutter = Math.max(0, viewportWidth - contentRect.right);
     const largestGutter = Math.max(leftGutter, rightGutter);
     const BUFFER = 24;
-    const computedMaxWidth = largestGutter > BUFFER ? largestGutter - BUFFER : 0;
+    const computeMaxWidth = (gutter) => (gutter > BUFFER ? gutter - BUFFER : null);
+    const computedMaxWidths = {
+      left: computeMaxWidth(leftGutter),
+      right: computeMaxWidth(rightGutter),
+    };
+    const computedMaxWidth = computeMaxWidth(largestGutter) ?? 0;
 
     dockingScopeElement.style.setProperty('--docked-modal-top-offset', `${Math.round(topOffset)}px`);
 
@@ -1972,7 +1979,37 @@ export default function ZombiesCharacterSheet() {
     } else {
       dockingScopeElement.style.removeProperty('--docked-modal-max-width');
     }
-  }, []);
+
+    ['left', 'right'].forEach((side) => {
+      const value = computedMaxWidths[side];
+      const propertyName = `--docked-modal-max-width-${side}`;
+      if (typeof value === 'number' && value > 0) {
+        dockingScopeElement.style.setProperty(propertyName, `${Math.round(value)}px`);
+      } else {
+        dockingScopeElement.style.removeProperty(propertyName);
+      }
+    });
+
+    setDockedModalWidths((prev) => {
+      let next = prev;
+      ['left', 'right'].forEach((side) => {
+        const maxWidth = computedMaxWidths[side];
+        const currentWidth = prev[side];
+        if (
+          typeof maxWidth === 'number' &&
+          maxWidth > 0 &&
+          typeof currentWidth === 'number' &&
+          currentWidth > maxWidth + 0.5
+        ) {
+          if (next === prev) {
+            next = { ...prev };
+          }
+          next[side] = maxWidth;
+        }
+      });
+      return next;
+    });
+  }, [setDockedModalWidths]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -2013,6 +2050,9 @@ export default function ZombiesCharacterSheet() {
       const dockingScopeElement = document.documentElement || document.body;
       if (dockingScopeElement) {
         dockingScopeElement.style.removeProperty('--docked-modal-top-offset');
+        dockingScopeElement.style.removeProperty('--docked-modal-max-width');
+        dockingScopeElement.style.removeProperty('--docked-modal-max-width-left');
+        dockingScopeElement.style.removeProperty('--docked-modal-max-width-right');
       }
     };
   }, [updateDockedModalMetrics]);
@@ -2020,6 +2060,176 @@ export default function ZombiesCharacterSheet() {
   useEffect(() => {
     updateDockedModalMetrics();
   }, [updateDockedModalMetrics, headerHeight]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const dockingScopeElement = document.documentElement || document.body;
+    if (!dockingScopeElement) {
+      return undefined;
+    }
+
+    ['left', 'right'].forEach((side) => {
+      const width = dockedModalWidths[side];
+      const propertyName = `--docked-modal-width-${side}`;
+      if (typeof width === 'number' && Number.isFinite(width)) {
+        dockingScopeElement.style.setProperty(propertyName, `${Math.round(width)}px`);
+      } else {
+        dockingScopeElement.style.removeProperty(propertyName);
+      }
+    });
+
+    return () => {
+      const scope = document.documentElement || document.body;
+      if (!scope) {
+        return;
+      }
+
+      ['left', 'right'].forEach((side) => {
+        scope.style.removeProperty(`--docked-modal-width-${side}`);
+      });
+    };
+  }, [dockedModalWidths]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const parseWidthValue = (value) => {
+      if (typeof value !== 'string') {
+        return null;
+      }
+
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      const numeric = Number.parseFloat(trimmed);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+
+    const EDGE_THRESHOLD_PX = 16;
+
+    const handlePointerDown = (event) => {
+      if (event.button !== 0) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const dialog = target.closest('.docked-modal.modal-dialog');
+      if (!dialog) {
+        return;
+      }
+
+      const side = dialog.classList.contains('docked-modal--left')
+        ? 'left'
+        : dialog.classList.contains('docked-modal--right')
+        ? 'right'
+        : null;
+
+      if (!side) {
+        return;
+      }
+
+      const rect = dialog.getBoundingClientRect();
+      const distanceFromEdge =
+        side === 'left' ? rect.right - event.clientX : event.clientX - rect.left;
+
+      if (distanceFromEdge < 0 || distanceFromEdge > EDGE_THRESHOLD_PX) {
+        return;
+      }
+
+      const root = document.documentElement || document.body;
+      const computedStyles = root ? window.getComputedStyle(root) : null;
+      const maxWidthFromSide =
+        parseWidthValue(computedStyles?.getPropertyValue(`--docked-modal-max-width-${side}`)) ?? null;
+      const fallbackMaxWidth =
+        parseWidthValue(computedStyles?.getPropertyValue('--docked-modal-max-width')) ?? null;
+      const startingWidth = rect.width;
+      const maxWidth = Math.max(
+        MIN_DOCKED_MODAL_WIDTH,
+        maxWidthFromSide ?? fallbackMaxWidth ?? startingWidth
+      );
+      const anchor = side === 'left' ? rect.left : rect.right;
+      const pointerId = event.pointerId;
+      let framePending = false;
+
+      const applyWidth = (nextWidth) => {
+        const rounded = Math.round(nextWidth);
+        setDockedModalWidths((prev) => {
+          const prevWidth = prev[side];
+          if (typeof prevWidth === 'number' && Math.abs(prevWidth - rounded) < 1) {
+            return prev;
+          }
+
+          return { ...prev, [side]: rounded };
+        });
+      };
+
+      const handlePointerMove = (moveEvent) => {
+        if (moveEvent.pointerId !== pointerId) {
+          return;
+        }
+
+        let proposedWidth =
+          side === 'left' ? moveEvent.clientX - anchor : anchor - moveEvent.clientX;
+
+        if (!Number.isFinite(proposedWidth)) {
+          return;
+        }
+
+        proposedWidth = Math.max(
+          MIN_DOCKED_MODAL_WIDTH,
+          Math.min(maxWidth, proposedWidth)
+        );
+
+        if (framePending) {
+          return;
+        }
+
+        framePending = true;
+        window.requestAnimationFrame(() => {
+          framePending = false;
+          applyWidth(proposedWidth);
+        });
+      };
+
+      const stopResizing = () => {
+        dialog.releasePointerCapture?.(pointerId);
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', stopResizing);
+        document.removeEventListener('pointercancel', stopResizing);
+        document.body.classList.remove('docked-modal--resizing');
+        document.body.style.removeProperty('cursor');
+      };
+
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', stopResizing);
+      document.addEventListener('pointercancel', stopResizing);
+
+      dialog.setPointerCapture?.(pointerId);
+      document.body.classList.add('docked-modal--resizing');
+      document.body.style.cursor = 'ew-resize';
+
+      event.preventDefault();
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.body.classList.remove('docked-modal--resizing');
+      document.body.style.removeProperty('cursor');
+    };
+  }, [setDockedModalWidths]);
 
   useEffect(() => {
     let isCancelled = false;


### PR DESCRIPTION
## Summary
- compute docked modal width variables per side and track user-resized widths
- add pointer-driven resizing behavior and visual indicators for docked modal edges
- expose width updates through CSS variables so docked dialogs respect custom sizing

## Testing
- `CI=true npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js` *(fails: unable to locate figurine buttons in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ec29ce4104832eb192838d32a3f793