### PR TITLE
Restrict figurine picker to race/class token folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -269,7 +269,14 @@ describe('TokenPickerModal', () => {
               name: 'Dragonborn',
               path: 'Tokens/Adventurers/Dragonborn',
               relativePath: 'Adventurers/Dragonborn',
-              children: [],
+              children: [
+                {
+                  name: 'Fighter',
+                  path: 'Tokens/Adventurers/Dragonborn/Fighter',
+                  relativePath: 'Adventurers/Dragonborn/Fighter',
+                  children: [],
+                },
+              ],
             },
             {
               name: 'Core_Class_Tokens',
@@ -301,6 +308,13 @@ describe('TokenPickerModal', () => {
           relativePath: 'Adventurers/Dragonborn',
           depth: 1,
           displayPath: 'Adventurers/Dragonborn',
+        },
+        {
+          name: 'Fighter',
+          path: 'Tokens/Adventurers/Dragonborn/Fighter',
+          relativePath: 'Adventurers/Dragonborn/Fighter',
+          depth: 2,
+          displayPath: 'Adventurers/Dragonborn/Fighter',
         },
         {
           name: 'Core_Class_Tokens',
@@ -347,7 +361,7 @@ describe('TokenPickerModal', () => {
         campaignId="Camp1"
         onHide={jest.fn()}
         onSelect={jest.fn()}
-        filterScope={['Dragonborn', 'Core_Class_Tokens/Fighter']}
+        filterScope={['Dragonborn/Fighter', 'Core_Class_Tokens/Fighter']}
       />
     );
 
@@ -358,7 +372,7 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       expect(manifestCalls.length).toBeGreaterThan(0);
       expect(manifestCalls[0]).toBe(
-        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn'
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn%2FFighter'
       );
     });
 
@@ -369,7 +383,7 @@ describe('TokenPickerModal', () => {
     const select = await screen.findByLabelText(/Token Library/i);
     const options = within(select).getAllByRole('option');
     expect(options).toHaveLength(2);
-    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn');
+    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn/Fighter');
     expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
 
     await user.selectOptions(select, options[1]);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2861,15 +2861,11 @@ export default function ZombiesCharacterSheet() {
         });
     };
 
-    const raceName = typeof form?.race?.name === 'string' ? form.race.name : '';
-    if (raceName) {
-      addScopeVariants(raceName, [
-        'Adventurers',
-        'Tokens/Adventurers',
-        'Adventurers/Races',
-        'Tokens/Adventurers/Races',
-      ]);
-    }
+    const raceName =
+      typeof form?.race?.name === 'string' ? form.race.name.replace(/\s+/g, ' ').trim() : '';
+    const racePrefixes = raceName
+      ? [raceName, `Adventurers/${raceName}`, `Tokens/Adventurers/${raceName}`]
+      : [];
 
     const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
     const seenClasses = new Set();
@@ -2879,7 +2875,7 @@ export default function ZombiesCharacterSheet() {
       }
 
       const rawClassName =
-        typeof occupation.Occupation === 'string' ? occupation.Occupation.trim() : '';
+        typeof occupation.Occupation === 'string' ? occupation.Occupation.replace(/\s+/g, ' ').trim() : '';
       if (!rawClassName) {
         return;
       }
@@ -2895,7 +2891,18 @@ export default function ZombiesCharacterSheet() {
         'Adventurers/Core_Class_Tokens',
         'Tokens/Adventurers/Core_Class_Tokens',
       ]);
+
+      if (racePrefixes.length > 0) {
+        addScopeVariants(rawClassName, racePrefixes);
+      }
     });
+
+    if (scopeSet.size === 0 && raceName) {
+      addScopeVariants(raceName, [
+        'Adventurers',
+        'Tokens/Adventurers',
+      ]);
+    }
 
     return Array.from(scopeSet);
   }, [form?.occupation, form?.race?.name]);


### PR DESCRIPTION
## Summary
- scope the figurine token picker to race/class-specific Cloudinary folders and core class token folders
- normalize race/class names when generating the picker scope with a race-only fallback when no class is present
- update the token picker modal test fixtures and expectations for the new scoped folders

## Testing
- CI=true npm test -- TokenPickerModal.test

------
https://chatgpt.com/codex/tasks/task_e_68ec2dc94ec08323b7e947bcacf140ff