### PR TITLE
Fix race token filtering for character token picker

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -49,6 +49,7 @@ import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
+import buildRaceTokenScopeData from '../utils/raceTokenFilters';
 
 const HEADER_PADDING = 16;
 const DOCKABLE_MODAL_DEFINITIONS = {
@@ -2861,11 +2862,8 @@ export default function ZombiesCharacterSheet() {
         });
     };
 
-    const raceName =
-      typeof form?.race?.name === 'string' ? form.race.name.replace(/\s+/g, ' ').trim() : '';
-    const racePrefixes = raceName
-      ? [raceName, `Adventurers/${raceName}`, `Tokens/Adventurers/${raceName}`]
-      : [];
+    const { nameVariants: raceNameVariants, prefixes: racePrefixList } =
+      buildRaceTokenScopeData(form?.race?.name);
 
     const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
     const seenClasses = new Set();
@@ -2892,16 +2890,19 @@ export default function ZombiesCharacterSheet() {
         'Tokens/Adventurers/Core_Class_Tokens',
       ]);
 
-      if (racePrefixes.length > 0) {
-        addScopeVariants(rawClassName, racePrefixes);
+      if (racePrefixList.length > 0) {
+        addScopeVariants(rawClassName, racePrefixList);
       }
     });
 
-    if (scopeSet.size === 0 && raceName) {
-      addScopeVariants(raceName, [
-        'Adventurers',
-        'Tokens/Adventurers',
-      ]);
+    if (scopeSet.size === 0 && raceNameVariants.length > 0) {
+      const fallbackRace = raceNameVariants.find((variant) => typeof variant === 'string' && variant.trim() !== '');
+      if (fallbackRace) {
+        addScopeVariants(fallbackRace, [
+          'Adventurers',
+          'Tokens/Adventurers',
+        ]);
+      }
     }
 
     return Array.from(scopeSet);

--- a/client/src/components/Zombies/utils/raceTokenFilters.js
+++ b/client/src/components/Zombies/utils/raceTokenFilters.js
@@ -1,0 +1,143 @@
+const capitalizeTokenWord = (word) => {
+  if (typeof word !== 'string' || word.length === 0) {
+    return '';
+  }
+
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+};
+
+const pluralizeTokenWord = (word) => {
+  if (typeof word !== 'string' || word.length === 0) {
+    return word;
+  }
+
+  const lower = word.toLowerCase();
+
+  if (lower.endsWith('person')) {
+    return `${lower.slice(0, -6)}people`;
+  }
+
+  if (lower === 'human') {
+    return 'humans';
+  }
+
+  if (lower.endsWith('man')) {
+    return `${lower.slice(0, -3)}men`;
+  }
+
+  if (lower.endsWith('child')) {
+    return `${lower.slice(0, -5)}children`;
+  }
+
+  if (lower.endsWith('tooth')) {
+    return `${lower.slice(0, -5)}teeth`;
+  }
+
+  if (lower.endsWith('foot')) {
+    return `${lower.slice(0, -4)}feet`;
+  }
+
+  if (lower.endsWith('mouse')) {
+    return `${lower.slice(0, -5)}mice`;
+  }
+
+  if (lower.endsWith('goose')) {
+    return `${lower.slice(0, -5)}geese`;
+  }
+
+  if (lower.endsWith('lf')) {
+    return `${lower.slice(0, -1)}ves`;
+  }
+
+  if (lower.endsWith('fe')) {
+    return `${lower.slice(0, -2)}ves`;
+  }
+
+  if (lower.endsWith('f')) {
+    return `${lower.slice(0, -1)}ves`;
+  }
+
+  if (lower.endsWith('y') && !/[aeiou]y$/.test(lower)) {
+    return `${lower.slice(0, -1)}ies`;
+  }
+
+  if (/([sxz]|ch|sh)$/.test(lower)) {
+    return `${lower}es`;
+  }
+
+  return `${lower}s`;
+};
+
+export const buildRaceTokenNameVariants = (raceName) => {
+  if (typeof raceName !== 'string') {
+    return [];
+  }
+
+  const normalized = raceName.replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return [];
+  }
+
+  const hyphenNormalized = normalized.replace(/\s*-\s*/g, '-');
+  const baseWords = hyphenNormalized
+    .split(/[-\s]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (baseWords.length === 0) {
+    return [];
+  }
+
+  const separators = [' ', '-', ''];
+  const variantSet = new Set();
+
+  const addVariantsForWords = (words) => {
+    separators.forEach((separator) => {
+      const variant = words.map(capitalizeTokenWord).join(separator).trim();
+      if (variant) {
+        variantSet.add(variant);
+      }
+    });
+  };
+
+  addVariantsForWords(baseWords);
+
+  const pluralWords = [...baseWords];
+  pluralWords[pluralWords.length - 1] = pluralizeTokenWord(pluralWords[pluralWords.length - 1]);
+  addVariantsForWords(pluralWords);
+
+  variantSet.add(hyphenNormalized);
+
+  return Array.from(variantSet).filter(Boolean);
+};
+
+export const buildRaceTokenScopeData = (raceName) => {
+  const nameVariants = buildRaceTokenNameVariants(raceName);
+
+  if (nameVariants.length === 0) {
+    return {
+      nameVariants: [],
+      prefixes: [],
+    };
+  }
+
+  const prefixSet = new Set();
+
+  nameVariants.forEach((variant) => {
+    const trimmed = typeof variant === 'string' ? variant.trim() : '';
+    if (!trimmed) {
+      return;
+    }
+
+    prefixSet.add(trimmed);
+    prefixSet.add(`Adventurers/${trimmed}`);
+    prefixSet.add(`Tokens/Adventurers/${trimmed}`);
+  });
+
+  return {
+    nameVariants,
+    prefixes: Array.from(prefixSet).filter(Boolean),
+  };
+};
+
+export default buildRaceTokenScopeData;

--- a/client/src/components/Zombies/utils/raceTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/raceTokenFilters.test.js
@@ -1,0 +1,32 @@
+import { buildRaceTokenNameVariants, buildRaceTokenScopeData } from './raceTokenFilters';
+
+describe('race token filter helpers', () => {
+  describe('buildRaceTokenNameVariants', () => {
+    it('includes pluralized variants for common races', () => {
+      const variants = buildRaceTokenNameVariants('Human');
+
+      expect(variants).toEqual(expect.arrayContaining(['Human', 'Humans']));
+    });
+
+    it('normalizes hyphenated race names', () => {
+      const variants = buildRaceTokenNameVariants('Half-elf');
+
+      expect(variants).toEqual(expect.arrayContaining(['Half-Elf', 'Half-Elves']));
+    });
+  });
+
+  describe('buildRaceTokenScopeData', () => {
+    it('generates race-specific prefixes for token scopes', () => {
+      const { prefixes } = buildRaceTokenScopeData('Human');
+
+      expect(prefixes).toEqual(
+        expect.arrayContaining([
+          'Human',
+          'Humans',
+          'Adventurers/Humans',
+          'Tokens/Adventurers/Humans',
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add helper functions to normalize and pluralize race token scope values
- update the character sheet token picker to use the normalized race scope data
- cover the new helpers with unit tests

## Testing
- CI=1 npm test -- raceTokenFilters

------
https://chatgpt.com/codex/tasks/task_e_68ec2feb848c83239907e80fa5d626b1