### PR TITLE
Fix docked modal resizing interaction

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -350,14 +350,16 @@
   top: var(--docked-modal-top-offset, 0);
   bottom: 1.5rem;
   margin: 0;
-  width: var(
+  --docked-modal-current-max-width: var(
     --docked-modal-max-width,
     clamp(520px, 40vw, 640px)
   );
-  max-width: var(
-    --docked-modal-max-width,
-    clamp(520px, 40vw, 640px)
+  --docked-modal-current-width: var(
+    --docked-modal-inline-width,
+    var(--docked-modal-current-max-width)
   );
+  width: var(--docked-modal-current-width);
+  max-width: var(--docked-modal-current-max-width);
   display: flex;
   align-items: stretch;
   transition: transform 0.2s ease;
@@ -366,11 +368,68 @@
 .docked-modal--left {
   left: 0;
   right: auto;
+  --docked-modal-current-max-width: var(
+    --docked-modal-max-width-left,
+    var(--docked-modal-max-width, clamp(520px, 40vw, 640px))
+  );
+  --docked-modal-current-width: var(
+    --docked-modal-inline-width,
+    var(
+      --docked-modal-width-left,
+      var(--docked-modal-current-max-width)
+    )
+  );
 }
 
 .docked-modal--right {
   left: auto;
   right: 0;
+  --docked-modal-current-max-width: var(
+    --docked-modal-max-width-right,
+    var(--docked-modal-max-width, clamp(520px, 40vw, 640px))
+  );
+  --docked-modal-current-width: var(
+    --docked-modal-inline-width,
+    var(
+      --docked-modal-width-right,
+      var(--docked-modal-current-max-width)
+    )
+  );
+}
+
+.docked-modal--left::after,
+.docked-modal--right::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  pointer-events: auto;
+  cursor: ew-resize;
+  z-index: 5;
+  opacity: 0.4;
+  transition: opacity 0.2s ease;
+  touch-action: none;
+}
+
+.docked-modal--left::after {
+  right: -6px;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+}
+
+.docked-modal--right::after {
+  left: -6px;
+  background: linear-gradient(to left, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+}
+
+body.docked-modal--resizing .docked-modal--left::after,
+body.docked-modal--resizing .docked-modal--right::after {
+  opacity: 0.75;
+}
+
+body.docked-modal--resizing {
+  user-select: none;
+  cursor: ew-resize;
 }
 
 .docked-modal.modal-dialog .modal-content {
@@ -402,6 +461,11 @@
     max-width: 100%;
     height: auto;
     margin: 1.5rem auto;
+  }
+
+  .docked-modal--left::after,
+  .docked-modal--right::after {
+    content: none;
   }
 
   .docked-modal.modal-dialog .modal-content {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -51,6 +51,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
 
 const HEADER_PADDING = 16;
+const MIN_DOCKED_MODAL_WIDTH = 320;
 const DOCKABLE_MODAL_DEFINITIONS = {
   characterInfo: { label: 'Character Info', component: CharacterInfo },
   stats: { label: 'Stats', component: Stats },
@@ -1126,6 +1127,42 @@ export default function ZombiesCharacterSheet() {
   const campaignMapsRef = useRef([]);
   const campaignActiveMapIdRef = useRef(null);
   const [dockedModals, setDockedModals] = useState({ left: null, right: null });
+  const [dockedModalWidths, setDockedModalWidths] = useState({ left: null, right: null });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+
+    const restoredWidths = {};
+    let hasRestoredWidth = false;
+
+    ['left', 'right'].forEach((side) => {
+      try {
+        const raw = window.localStorage.getItem(`zombiesDockedModalWidth:${side}`);
+        if (!raw) {
+          return;
+        }
+
+        const parsed = Number.parseFloat(raw);
+        if (!Number.isFinite(parsed)) {
+          return;
+        }
+
+        const normalized = Math.max(MIN_DOCKED_MODAL_WIDTH, Math.round(parsed));
+        restoredWidths[side] = normalized;
+        hasRestoredWidth = true;
+      } catch (storageError) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.error(storageError);
+        }
+      }
+    });
+
+    if (hasRestoredWidth) {
+      setDockedModalWidths((prev) => ({ ...prev, ...restoredWidths }));
+    }
+  }, [setDockedModalWidths]);
 
   useEffect(() => {
     setActiveEffects(getStoredActiveEffects(characterId));
@@ -1963,7 +2000,12 @@ export default function ZombiesCharacterSheet() {
     const rightGutter = Math.max(0, viewportWidth - contentRect.right);
     const largestGutter = Math.max(leftGutter, rightGutter);
     const BUFFER = 24;
-    const computedMaxWidth = largestGutter > BUFFER ? largestGutter - BUFFER : 0;
+    const computeMaxWidth = (gutter) => (gutter > BUFFER ? gutter - BUFFER : null);
+    const computedMaxWidths = {
+      left: computeMaxWidth(leftGutter),
+      right: computeMaxWidth(rightGutter),
+    };
+    const computedMaxWidth = computeMaxWidth(largestGutter) ?? 0;
 
     dockingScopeElement.style.setProperty('--docked-modal-top-offset', `${Math.round(topOffset)}px`);
 
@@ -1972,7 +2014,37 @@ export default function ZombiesCharacterSheet() {
     } else {
       dockingScopeElement.style.removeProperty('--docked-modal-max-width');
     }
-  }, []);
+
+    ['left', 'right'].forEach((side) => {
+      const value = computedMaxWidths[side];
+      const propertyName = `--docked-modal-max-width-${side}`;
+      if (typeof value === 'number' && value > 0) {
+        dockingScopeElement.style.setProperty(propertyName, `${Math.round(value)}px`);
+      } else {
+        dockingScopeElement.style.removeProperty(propertyName);
+      }
+    });
+
+    setDockedModalWidths((prev) => {
+      let next = prev;
+      ['left', 'right'].forEach((side) => {
+        const maxWidth = computedMaxWidths[side];
+        const currentWidth = prev[side];
+        if (
+          typeof maxWidth === 'number' &&
+          maxWidth > 0 &&
+          typeof currentWidth === 'number' &&
+          currentWidth > maxWidth + 0.5
+        ) {
+          if (next === prev) {
+            next = { ...prev };
+          }
+          next[side] = maxWidth;
+        }
+      });
+      return next;
+    });
+  }, [setDockedModalWidths]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -2013,6 +2085,9 @@ export default function ZombiesCharacterSheet() {
       const dockingScopeElement = document.documentElement || document.body;
       if (dockingScopeElement) {
         dockingScopeElement.style.removeProperty('--docked-modal-top-offset');
+        dockingScopeElement.style.removeProperty('--docked-modal-max-width');
+        dockingScopeElement.style.removeProperty('--docked-modal-max-width-left');
+        dockingScopeElement.style.removeProperty('--docked-modal-max-width-right');
       }
     };
   }, [updateDockedModalMetrics]);
@@ -2020,6 +2095,254 @@ export default function ZombiesCharacterSheet() {
   useEffect(() => {
     updateDockedModalMetrics();
   }, [updateDockedModalMetrics, headerHeight]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const dockingScopeElement = document.documentElement || document.body;
+    if (!dockingScopeElement) {
+      return undefined;
+    }
+
+    const applyInlineWidthToDialogs = (side, width) => {
+      const dialogs = document.querySelectorAll(
+        `.docked-modal.modal-dialog.docked-modal--${side}`
+      );
+
+      dialogs.forEach((dialog) => {
+        if (!(dialog instanceof HTMLElement)) {
+          return;
+        }
+
+        if (typeof width === 'number' && Number.isFinite(width)) {
+          const pixelValue = `${Math.round(width)}px`;
+          dialog.style.setProperty('--docked-modal-inline-width', pixelValue);
+        } else {
+          dialog.style.removeProperty('--docked-modal-inline-width');
+        }
+      });
+    };
+
+    ['left', 'right'].forEach((side) => {
+      const width = dockedModalWidths[side];
+      const propertyName = `--docked-modal-width-${side}`;
+      if (typeof width === 'number' && Number.isFinite(width)) {
+        const rounded = Math.round(width);
+        dockingScopeElement.style.setProperty(propertyName, `${rounded}px`);
+        applyInlineWidthToDialogs(side, rounded);
+
+        if (typeof window !== 'undefined' && window.localStorage) {
+          try {
+            window.localStorage.setItem(
+              `zombiesDockedModalWidth:${side}`,
+              String(rounded)
+            );
+          } catch (storageError) {
+            if (process.env.NODE_ENV !== 'production') {
+              console.error(storageError);
+            }
+          }
+        }
+      } else {
+        dockingScopeElement.style.removeProperty(propertyName);
+        applyInlineWidthToDialogs(side, null);
+
+        if (typeof window !== 'undefined' && window.localStorage) {
+          try {
+            window.localStorage.removeItem(`zombiesDockedModalWidth:${side}`);
+          } catch (storageError) {
+            if (process.env.NODE_ENV !== 'production') {
+              console.error(storageError);
+            }
+          }
+        }
+      }
+    });
+
+    return () => {
+      const scope = document.documentElement || document.body;
+      if (!scope) {
+        return;
+      }
+
+      ['left', 'right'].forEach((side) => {
+        scope.style.removeProperty(`--docked-modal-width-${side}`);
+        const dialogs = document.querySelectorAll(
+          `.docked-modal.modal-dialog.docked-modal--${side}`
+        );
+        dialogs.forEach((dialog) => {
+          if (dialog instanceof HTMLElement) {
+            dialog.style.removeProperty('--docked-modal-inline-width');
+          }
+        });
+      });
+    };
+  }, [dockedModalWidths]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const parseWidthValue = (value) => {
+      if (typeof value !== 'string') {
+        return null;
+      }
+
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      const numeric = Number.parseFloat(trimmed);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+
+    const EDGE_THRESHOLD_PX = 16;
+    const EDGE_HANDLE_BUFFER_PX = 12;
+
+    const handlePointerDown = (event) => {
+      if (event.button !== 0) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const dialog = target.closest('.docked-modal.modal-dialog');
+      if (!dialog) {
+        return;
+      }
+
+      const side = dialog.classList.contains('docked-modal--left')
+        ? 'left'
+        : dialog.classList.contains('docked-modal--right')
+        ? 'right'
+        : null;
+
+      if (!side) {
+        return;
+      }
+
+      const rect = dialog.getBoundingClientRect();
+      const distanceFromEdge =
+        side === 'left' ? rect.right - event.clientX : event.clientX - rect.left;
+      const isWithinEdgeZone =
+        Math.abs(distanceFromEdge) <= EDGE_THRESHOLD_PX + EDGE_HANDLE_BUFFER_PX;
+
+      if (!isWithinEdgeZone) {
+        return;
+      }
+
+      const root = document.documentElement || document.body;
+      const computedStyles = root ? window.getComputedStyle(root) : null;
+      const maxWidthFromSide =
+        parseWidthValue(computedStyles?.getPropertyValue(`--docked-modal-max-width-${side}`)) ?? null;
+      const fallbackMaxWidth =
+        parseWidthValue(computedStyles?.getPropertyValue('--docked-modal-max-width')) ?? null;
+      const startingWidth = rect.width;
+      const maxWidth = Math.max(
+        MIN_DOCKED_MODAL_WIDTH,
+        maxWidthFromSide ?? fallbackMaxWidth ?? startingWidth
+      );
+      const anchor = side === 'left' ? rect.left : rect.right;
+      const pointerId = event.pointerId;
+      let framePending = false;
+      let hasMoved = false;
+
+      const updateDialogInlineWidth = (value) => {
+        if (!(dialog instanceof HTMLElement)) {
+          return;
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          dialog.style.setProperty('--docked-modal-inline-width', `${Math.round(value)}px`);
+        } else {
+          dialog.style.removeProperty('--docked-modal-inline-width');
+        }
+      };
+
+      const applyWidth = (nextWidth) => {
+        const rounded = Math.round(nextWidth);
+        updateDialogInlineWidth(rounded);
+        setDockedModalWidths((prev) => {
+          const prevWidth = prev[side];
+          if (typeof prevWidth === 'number' && Math.abs(prevWidth - rounded) < 1) {
+            return prev;
+          }
+
+          return { ...prev, [side]: rounded };
+        });
+      };
+
+      const handlePointerMove = (moveEvent) => {
+        if (moveEvent.pointerId !== pointerId) {
+          return;
+        }
+
+        let proposedWidth =
+          side === 'left' ? moveEvent.clientX - anchor : anchor - moveEvent.clientX;
+
+        if (!Number.isFinite(proposedWidth)) {
+          return;
+        }
+
+        proposedWidth = Math.max(
+          MIN_DOCKED_MODAL_WIDTH,
+          Math.min(maxWidth, proposedWidth)
+        );
+
+        if (framePending) {
+          return;
+        }
+
+        framePending = true;
+        hasMoved = true;
+        window.requestAnimationFrame(() => {
+          framePending = false;
+          applyWidth(proposedWidth);
+        });
+      };
+
+      const stopResizing = () => {
+        dialog.releasePointerCapture?.(pointerId);
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', stopResizing);
+        document.removeEventListener('pointercancel', stopResizing);
+        document.body.classList.remove('docked-modal--resizing');
+        document.body.style.removeProperty('cursor');
+
+        if (!hasMoved) {
+          updateDialogInlineWidth(null);
+        }
+      };
+
+      updateDialogInlineWidth(startingWidth);
+
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', stopResizing);
+      document.addEventListener('pointercancel', stopResizing);
+
+      dialog.setPointerCapture?.(pointerId);
+      document.body.classList.add('docked-modal--resizing');
+      document.body.style.cursor = 'ew-resize';
+
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+      document.body.classList.remove('docked-modal--resizing');
+      document.body.style.removeProperty('cursor');
+    };
+  }, [setDockedModalWidths]);
 
   useEffect(() => {
     let isCancelled = false;


### PR DESCRIPTION
## Summary
- apply inline docked modal width variables so handle drags immediately resize the dialog and respect touch gestures
- persist per-side docked modal widths in localStorage and sync them to active dialogs for consistent sizing when reopened
- harden pointer resize handling by capturing the edge drag gesture, updating widths during the drag, and rolling back if no resize occurs

## Testing
- not run (existing figurine picker test failure unrelated to this change)

------
https://chatgpt.com/codex/tasks/task_e_68ec29ce4104832eb192838d32a3f793