### PR TITLE
Fix token picker race scope filtering

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -75,6 +75,49 @@ const buildScopeVariantSet = (values) => {
   }, new Set());
 };
 
+const normalizeVariantData = (value, cache) => {
+  if (!cache.has(value)) {
+    if (typeof value !== 'string') {
+      cache.set(value, null);
+    } else {
+      const trimmed = value.replace(/\u00A0/g, ' ').trim();
+      if (!trimmed) {
+        cache.set(value, null);
+      } else {
+        const lower = trimmed.toLowerCase();
+        cache.set(value, {
+          lower,
+          compact: lower.replace(/[^a-z0-9]/g, ''),
+          segments: trimmed
+            .split('/')
+            .map((segment) => segment.replace(/\u00A0/g, ' ').trim())
+            .filter(Boolean)
+            .map((segment) => segment.toLowerCase().replace(/[^a-z0-9]+/g, '')),
+        });
+      }
+    }
+  }
+
+  return cache.get(value);
+};
+
+const segmentsContainSubsequence = (segments, target) => {
+  if (!Array.isArray(segments) || !Array.isArray(target) || target.length === 0) {
+    return false;
+  }
+
+  let searchIndex = 0;
+  return target.every((needle) => {
+    const foundIndex = segments.indexOf(needle, searchIndex);
+    if (foundIndex === -1) {
+      return false;
+    }
+
+    searchIndex = foundIndex + 1;
+    return true;
+  });
+};
+
 const filterMatchesScope = (filter, scopeSet) => {
   if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
     return true;
@@ -103,13 +146,26 @@ const filterMatchesScope = (filter, scopeSet) => {
     return false;
   }
 
+  const scopeCache = new Map();
+  const filterCache = new Map();
+
   for (const scopeVariant of scopeSet) {
+    const scopeData = normalizeVariantData(scopeVariant, scopeCache);
+    if (!scopeData) {
+      continue;
+    }
+
     for (const filterVariant of filterVariantSet) {
-      if (
-        typeof scopeVariant === 'string' &&
-        typeof filterVariant === 'string' &&
-        filterVariant.includes(scopeVariant)
-      ) {
+      const filterData = normalizeVariantData(filterVariant, filterCache);
+      if (!filterData) {
+        continue;
+      }
+
+      if (filterData.lower === scopeData.lower || filterData.compact === scopeData.compact) {
+        return true;
+      }
+
+      if (segmentsContainSubsequence(filterData.segments, scopeData.segments)) {
         return true;
       }
     }

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -396,6 +396,175 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('player token picker limits folders to scoped race and class combinations', async () => {
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Dragonborn',
+              path: 'Tokens/Adventurers/Dragonborn',
+              relativePath: 'Adventurers/Dragonborn',
+              children: [
+                {
+                  name: 'Druid',
+                  path: 'Tokens/Adventurers/Dragonborn/Druid',
+                  relativePath: 'Adventurers/Dragonborn/Druid',
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'Dwarves',
+              path: 'Tokens/Adventurers/Dwarves',
+              relativePath: 'Adventurers/Dwarves',
+              children: [
+                {
+                  name: 'Druid',
+                  path: 'Tokens/Adventurers/Dwarves/Druid',
+                  relativePath: 'Adventurers/Dwarves/Druid',
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'Core_Class_Tokens',
+              path: 'Tokens/Adventurers/Core_Class_Tokens',
+              relativePath: 'Adventurers/Core_Class_Tokens',
+              children: [
+                {
+                  name: 'Mediumfolk',
+                  path: 'Tokens/Adventurers/Core_Class_Tokens/Mediumfolk',
+                  relativePath: 'Adventurers/Core_Class_Tokens/Mediumfolk',
+                  children: [
+                    {
+                      name: 'Druid',
+                      path: 'Tokens/Adventurers/Core_Class_Tokens/Mediumfolk/Druid',
+                      relativePath: 'Adventurers/Core_Class_Tokens/Mediumfolk/Druid',
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Dragonborn',
+          path: 'Tokens/Adventurers/Dragonborn',
+          relativePath: 'Adventurers/Dragonborn',
+          depth: 1,
+          displayPath: 'Adventurers/Dragonborn',
+        },
+        {
+          name: 'Druid',
+          path: 'Tokens/Adventurers/Dragonborn/Druid',
+          relativePath: 'Adventurers/Dragonborn/Druid',
+          depth: 2,
+          displayPath: 'Adventurers/Dragonborn/Druid',
+        },
+        {
+          name: 'Dwarves',
+          path: 'Tokens/Adventurers/Dwarves',
+          relativePath: 'Adventurers/Dwarves',
+          depth: 1,
+          displayPath: 'Adventurers/Dwarves',
+        },
+        {
+          name: 'Druid',
+          path: 'Tokens/Adventurers/Dwarves/Druid',
+          relativePath: 'Adventurers/Dwarves/Druid',
+          depth: 2,
+          displayPath: 'Adventurers/Dwarves/Druid',
+        },
+        {
+          name: 'Core_Class_Tokens',
+          path: 'Tokens/Adventurers/Core_Class_Tokens',
+          relativePath: 'Adventurers/Core_Class_Tokens',
+          depth: 1,
+          displayPath: 'Adventurers/Core_Class_Tokens',
+        },
+        {
+          name: 'Mediumfolk',
+          path: 'Tokens/Adventurers/Core_Class_Tokens/Mediumfolk',
+          relativePath: 'Adventurers/Core_Class_Tokens/Mediumfolk',
+          depth: 2,
+          displayPath: 'Adventurers/Core_Class_Tokens/Mediumfolk',
+        },
+        {
+          name: 'Druid',
+          path: 'Tokens/Adventurers/Core_Class_Tokens/Mediumfolk/Druid',
+          relativePath: 'Adventurers/Core_Class_Tokens/Mediumfolk/Druid',
+          depth: 3,
+          displayPath: 'Adventurers/Core_Class_Tokens/Mediumfolk/Druid',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    const scope = [
+      'Core_Class_Tokens/Druid',
+      'Adventurers/Core_Class_Tokens/Druid',
+      'Tokens/Adventurers/Core_Class_Tokens/Druid',
+      'Dwarves/Druid',
+      'Adventurers/Dwarves/Druid',
+      'Tokens/Adventurers/Dwarves/Druid',
+    ];
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={scope}
+      />
+    );
+
+    const select = await screen.findByLabelText(/Token Library/i);
+
+    await waitFor(() => {
+      const options = within(select).getAllByRole('option');
+      const normalizedOptions = options.map((option) => option.textContent.replace(/\u00A0/g, ''));
+
+      expect(normalizedOptions).toEqual([
+        'Dwarves/Druid',
+        'Core_Class_Tokens/Mediumfolk/Druid',
+      ]);
+    });
+  });
+
   test('player library dropdown stays disabled until folders finish loading', async () => {
     const folderTree = {
       rootFolder: 'Tokens',

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2833,7 +2833,7 @@ export default function ZombiesCharacterSheet() {
   const tokenPickerFilterScope = useMemo(() => {
     const scopeSet = new Set();
 
-    const addScopeVariants = (rawValue, prefixes = []) => {
+    const addScopeVariants = (rawValue, prefixes = [], options = {}) => {
       if (typeof rawValue !== 'string') {
         return;
       }
@@ -2846,12 +2846,20 @@ export default function ZombiesCharacterSheet() {
       const lowerValue = normalizedValue.toLowerCase();
       const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
 
-      [normalizedValue, lowerValue, compactValue]
-        .filter(Boolean)
-        .forEach((entry) => scopeSet.add(entry));
+      const normalizedPrefixes = Array.isArray(prefixes)
+        ? prefixes.map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
+        : [];
 
-      prefixes
-        .map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
+      const includeStandalone =
+        options.includeStandalone ?? normalizedPrefixes.filter(Boolean).length === 0;
+
+      if (includeStandalone) {
+        [normalizedValue, lowerValue, compactValue]
+          .filter(Boolean)
+          .forEach((entry) => scopeSet.add(entry));
+      }
+
+      normalizedPrefixes
         .filter(Boolean)
         .forEach((prefix) => {
           scopeSet.add(`${prefix}/${normalizedValue}`);


### PR DESCRIPTION
## Summary
- tighten token picker scope matching so filters only match the intended race/class folders
- stop adding standalone class values to player scope generation when prefixes exist
- cover the scoped filtering behaviour with a focused unit test

## Testing
- npm test -- TokenPickerModal --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ec33a3bb0c83239339403eece54766