### PR TITLE
Restrict small-sized characters to Smallfolk token folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -565,6 +565,163 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('player token picker targets smallfolk folders for small-sized races', async () => {
+    const user = setupUser();
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Smallfolk',
+              path: 'Tokens/Adventurers/Smallfolk',
+              relativePath: 'Adventurers/Smallfolk',
+              children: [
+                {
+                  name: 'Halflings',
+                  path: 'Tokens/Adventurers/Smallfolk/Halflings',
+                  relativePath: 'Adventurers/Smallfolk/Halflings',
+                  children: [
+                    {
+                      name: 'Rogue',
+                      path: 'Tokens/Adventurers/Smallfolk/Halflings/Rogue',
+                      relativePath: 'Adventurers/Smallfolk/Halflings/Rogue',
+                      children: [],
+                    },
+                  ],
+                },
+                {
+                  name: 'Core_Class_Tokens',
+                  path: 'Tokens/Adventurers/Smallfolk/Core_Class_Tokens',
+                  relativePath: 'Adventurers/Smallfolk/Core_Class_Tokens',
+                  children: [
+                    {
+                      name: 'Rogue',
+                      path: 'Tokens/Adventurers/Smallfolk/Core_Class_Tokens/Rogue',
+                      relativePath: 'Adventurers/Smallfolk/Core_Class_Tokens/Rogue',
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Smallfolk',
+          path: 'Tokens/Adventurers/Smallfolk',
+          relativePath: 'Adventurers/Smallfolk',
+          depth: 1,
+          displayPath: 'Adventurers/Smallfolk',
+        },
+        {
+          name: 'Halflings',
+          path: 'Tokens/Adventurers/Smallfolk/Halflings',
+          relativePath: 'Adventurers/Smallfolk/Halflings',
+          depth: 2,
+          displayPath: 'Adventurers/Smallfolk/Halflings',
+        },
+        {
+          name: 'Rogue',
+          path: 'Tokens/Adventurers/Smallfolk/Halflings/Rogue',
+          relativePath: 'Adventurers/Smallfolk/Halflings/Rogue',
+          depth: 3,
+          displayPath: 'Adventurers/Smallfolk/Halflings/Rogue',
+        },
+        {
+          name: 'Core_Class_Tokens',
+          path: 'Tokens/Adventurers/Smallfolk/Core_Class_Tokens',
+          relativePath: 'Adventurers/Smallfolk/Core_Class_Tokens',
+          depth: 2,
+          displayPath: 'Adventurers/Smallfolk/Core_Class_Tokens',
+        },
+        {
+          name: 'Rogue',
+          path: 'Tokens/Adventurers/Smallfolk/Core_Class_Tokens/Rogue',
+          relativePath: 'Adventurers/Smallfolk/Core_Class_Tokens/Rogue',
+          depth: 3,
+          displayPath: 'Adventurers/Smallfolk/Core_Class_Tokens/Rogue',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={['Smallfolk/Halflings/Rogue', 'Smallfolk/Core_Class_Tokens/Rogue']}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
+    });
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      expect(manifestCalls[0]).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FSmallfolk%2FHalflings%2FRogue'
+      );
+    });
+
+    expect(
+      manifestCalls.includes('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FHalflings%2FRogue')
+    ).toBe(false);
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Smallfolk/Halflings/Rogue');
+    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe(
+      'Smallfolk/Core_Class_Tokens/Rogue'
+    );
+
+    await user.selectOptions(select, options[1]);
+
+    await waitFor(() => {
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FSmallfolk%2FCore_Class_Tokens%2FRogue'
+      );
+    });
+  });
+
   test('player library dropdown stays disabled until folders finish loading', async () => {
     const folderTree = {
       rootFolder: 'Tokens',

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2870,8 +2870,23 @@ export default function ZombiesCharacterSheet() {
         });
     };
 
-    const { nameVariants: raceNameVariants, prefixes: racePrefixList } =
-      buildRaceTokenScopeData(form?.race?.name);
+    const raceSize = normalizeCreatureSize(
+      form?.temporarySize ??
+        form?.size ??
+        form?.characterSize ??
+        form?.character?.size ??
+        form?.creature?.size ??
+        form?.profile?.size ??
+        form?.race?.size ??
+        form?.attributes?.size ??
+        form?.displayType
+    );
+
+    const {
+      nameVariants: raceNameVariants,
+      prefixes: racePrefixList,
+      isSmallfolk: isSmallfolkRace,
+    } = buildRaceTokenScopeData(form?.race?.name, { size: raceSize });
 
     const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
     const seenClasses = new Set();
@@ -2892,11 +2907,19 @@ export default function ZombiesCharacterSheet() {
       }
       seenClasses.add(classKey);
 
-      addScopeVariants(rawClassName, [
-        'Core_Class_Tokens',
-        'Adventurers/Core_Class_Tokens',
-        'Tokens/Adventurers/Core_Class_Tokens',
-      ]);
+      const coreClassPrefixes = isSmallfolkRace
+        ? [
+            'Smallfolk/Core_Class_Tokens',
+            'Adventurers/Smallfolk/Core_Class_Tokens',
+            'Tokens/Adventurers/Smallfolk/Core_Class_Tokens',
+          ]
+        : [
+            'Core_Class_Tokens',
+            'Adventurers/Core_Class_Tokens',
+            'Tokens/Adventurers/Core_Class_Tokens',
+          ];
+
+      addScopeVariants(rawClassName, coreClassPrefixes);
 
       if (racePrefixList.length > 0) {
         addScopeVariants(rawClassName, racePrefixList);
@@ -2906,15 +2929,28 @@ export default function ZombiesCharacterSheet() {
     if (scopeSet.size === 0 && raceNameVariants.length > 0) {
       const fallbackRace = raceNameVariants.find((variant) => typeof variant === 'string' && variant.trim() !== '');
       if (fallbackRace) {
-        addScopeVariants(fallbackRace, [
-          'Adventurers',
-          'Tokens/Adventurers',
-        ]);
+        const fallbackPrefixes = isSmallfolkRace
+          ? ['Smallfolk', 'Adventurers/Smallfolk', 'Tokens/Adventurers/Smallfolk']
+          : ['Adventurers', 'Tokens/Adventurers'];
+
+        addScopeVariants(fallbackRace, fallbackPrefixes);
       }
     }
 
     return Array.from(scopeSet);
-  }, [form?.occupation, form?.race?.name]);
+  }, [
+    form?.occupation,
+    form?.race?.name,
+    form?.temporarySize,
+    form?.size,
+    form?.characterSize,
+    form?.character?.size,
+    form?.creature?.size,
+    form?.profile?.size,
+    form?.race?.size,
+    form?.attributes?.size,
+    form?.displayType,
+  ]);
 
   const updateLocalDiceColor = useCallback(
     (incomingCharacterId, nextColor) => {

--- a/client/src/components/Zombies/utils/raceTokenFilters.js
+++ b/client/src/components/Zombies/utils/raceTokenFilters.js
@@ -111,8 +111,33 @@ export const buildRaceTokenNameVariants = (raceName) => {
   return Array.from(variantSet).filter(Boolean);
 };
 
-export const buildRaceTokenScopeData = (raceName) => {
+const normalizeSize = (size) => {
+  if (typeof size !== 'string') {
+    return null;
+  }
+
+  const trimmed = size.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const SMALLFOLK_RACE_KEYWORDS = ['gnome', 'halfling', 'human', 'tiefling'];
+
+export const buildRaceTokenScopeData = (raceName, options = {}) => {
   const nameVariants = buildRaceTokenNameVariants(raceName);
+
+  const normalizedOptions = options && typeof options === 'object' ? options : {};
+  const normalizedSize = normalizeSize(normalizedOptions.size);
+  const normalizedRaceName = typeof raceName === 'string' ? raceName.toLowerCase() : '';
+
+  const isSmallSize = normalizedSize === 'small';
+  const isSmallfolkRace = SMALLFOLK_RACE_KEYWORDS.some(
+    (keyword) => keyword && normalizedRaceName.includes(keyword)
+  );
+  const shouldUseSmallfolk = isSmallSize && isSmallfolkRace;
 
   if (nameVariants.length === 0) {
     return {
@@ -123,20 +148,31 @@ export const buildRaceTokenScopeData = (raceName) => {
 
   const prefixSet = new Set();
 
+  const baseSmallfolkPrefixes = ['Smallfolk', 'Adventurers/Smallfolk', 'Tokens/Adventurers/Smallfolk'];
+
   nameVariants.forEach((variant) => {
     const trimmed = typeof variant === 'string' ? variant.trim() : '';
     if (!trimmed) {
       return;
     }
 
-    prefixSet.add(trimmed);
-    prefixSet.add(`Adventurers/${trimmed}`);
-    prefixSet.add(`Tokens/Adventurers/${trimmed}`);
+    if (shouldUseSmallfolk) {
+      baseSmallfolkPrefixes.forEach((prefix) => {
+        if (typeof prefix === 'string' && prefix.trim() !== '') {
+          prefixSet.add(`${prefix}/${trimmed}`);
+        }
+      });
+    } else {
+      prefixSet.add(trimmed);
+      prefixSet.add(`Adventurers/${trimmed}`);
+      prefixSet.add(`Tokens/Adventurers/${trimmed}`);
+    }
   });
 
   return {
     nameVariants,
     prefixes: Array.from(prefixSet).filter(Boolean),
+    isSmallfolk: shouldUseSmallfolk,
   };
 };
 

--- a/client/src/components/Zombies/utils/raceTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/raceTokenFilters.test.js
@@ -28,5 +28,21 @@ describe('race token filter helpers', () => {
         ])
       );
     });
+
+    it('limits small-sized races to smallfolk token prefixes', () => {
+      const { prefixes, isSmallfolk } = buildRaceTokenScopeData('Halfling', { size: 'Small' });
+
+      expect(isSmallfolk).toBe(true);
+      expect(prefixes).toEqual(
+        expect.arrayContaining([
+          'Smallfolk/Halfling',
+          'Smallfolk/Halflings',
+          'Adventurers/Smallfolk/Halfling',
+          'Adventurers/Smallfolk/Halflings',
+          'Tokens/Adventurers/Smallfolk/Halfling',
+        ])
+      );
+      expect(prefixes).not.toEqual(expect.arrayContaining(['Adventurers/Halfling']));
+    });
   });
 });


### PR DESCRIPTION
## Summary
- update race token scope generation to detect small-sized races and prefer Smallfolk token paths
- ensure the character sheet scopes class and fallback filters to Smallfolk folders when appropriate
- add unit tests covering smallfolk scoping and the associated token picker behavior

## Testing
- CI=1 npm test -- raceTokenFilters.test.js
- CI=1 npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ec367293d48323ae407f4768d26ff2