### PR TITLE
Scale figurines by image footprint

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -44,7 +44,8 @@
       transparent 1px,
       transparent 100%
     );
-  background-size: calc(100% / 24) calc(100% / 24);
+  background-size: var(--campaign-map-grid-cell-width, calc(100% / 24))
+    var(--campaign-map-grid-cell-height, calc(100% / 24));
   background-repeat: repeat;
   mix-blend-mode: screen;
   z-index: 1;
@@ -2840,7 +2841,7 @@ h1 {
   }
 
   &__tokens-layer {
-    --tokens-layer-square-size: calc(100% / 24);
+    --tokens-layer-square-size: var(--campaign-map-grid-cell-width, calc(100% / 24));
     --map-square-size: var(
       --campaign-map-square-size,
       clamp(48px, 10vw, 80px)
@@ -2967,9 +2968,11 @@ h1 {
   &__figurine {
     --figurine-color: #adb5bd;
     width: var(--figurine-base-size);
+    height: var(--figurine-base-size);
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: flex-end;
     pointer-events: none;
     filter: drop-shadow(0 0.35rem 0.85rem rgba(6, 7, 10, 0.65))
       drop-shadow(0 0.05rem 0.25rem rgba(255, 255, 255, 0.12));
@@ -3064,20 +3067,23 @@ h1 {
 
   &__figurine-image-wrapper {
     position: absolute;
-    inset: 0;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: var(--figurine-base-size);
+    height: var(--figurine-base-size);
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-end;
+    align-items: flex-end;
+    justify-content: center;
     pointer-events: none;
     z-index: 2;
   }
 
   &__figurine-image {
-    width: var(--figurine-body-width);
-    max-width: 100%;
-    height: auto;
-    max-height: calc(var(--figurine-base-size) * 2.35);
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
     object-fit: contain;
     filter: drop-shadow(0 0.4rem 0.9rem rgba(0, 0, 0, 0.55));
   }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -71,12 +71,247 @@ const normalizeText = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
 
 const FIGURINE_SIZE_MULTIPLIERS = {
-  tiny: 0.25,
-  small: 0.5,
+  tiny: 0.5,
+  small: 1,
   medium: 1,
   large: 2,
   huge: 3,
   gargantuan: 4,
+};
+
+const MAX_FIGURINE_GRID_SQUARES = FIGURINE_SIZE_MULTIPLIERS.gargantuan;
+const DEFAULT_FIGURINE_GRID_SQUARES = FIGURINE_SIZE_MULTIPLIERS.medium;
+const FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE = 512;
+
+const DEFAULT_GRID_DIMENSION = 24;
+
+const parsePositiveNumber = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const match = value.match(/([0-9]*\.?[0-9]+)/);
+    if (match) {
+      const parsed = Number.parseFloat(match[1]);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+};
+
+const parseGridDimensionsFromValue = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    const [first, second] = value;
+    const firstNumber = parsePositiveNumber(first);
+    const secondNumber = parsePositiveNumber(second);
+
+    if (firstNumber !== null || secondNumber !== null) {
+      const resolvedFirst = firstNumber ?? secondNumber;
+      const resolvedSecond = secondNumber ?? firstNumber;
+      if (resolvedFirst !== null) {
+        return {
+          columns: Math.max(1, Math.round(resolvedFirst)),
+          rows: Math.max(1, Math.round(resolvedSecond ?? resolvedFirst)),
+        };
+      }
+    }
+
+    return null;
+  }
+
+  const numericValue = parsePositiveNumber(value);
+  if (numericValue !== null) {
+    const rounded = Math.max(1, Math.round(numericValue));
+    return { columns: rounded, rows: rounded };
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const pairMatch = trimmed.match(/(\d+)\s*[x×]\s*(\d+)/i);
+    if (pairMatch) {
+      const [, columnMatch, rowMatch] = pairMatch;
+      const parsedColumns = Number.parseInt(columnMatch, 10);
+      const parsedRows = Number.parseInt(rowMatch, 10);
+      if (Number.isFinite(parsedColumns) && Number.isFinite(parsedRows)) {
+        return {
+          columns: Math.max(1, parsedColumns),
+          rows: Math.max(1, parsedRows),
+        };
+      }
+    }
+  }
+
+  return null;
+};
+
+const resolveGridDimensions = (map) => {
+  if (!map || typeof map !== 'object') {
+    return { columns: DEFAULT_GRID_DIMENSION, rows: DEFAULT_GRID_DIMENSION };
+  }
+
+  const assignDimension = (current, value) => {
+    const parsed = parsePositiveNumber(value);
+    if (parsed === null) {
+      return current;
+    }
+
+    const rounded = Math.max(1, Math.round(parsed));
+    return current ?? rounded;
+  };
+
+  let columns = null;
+  let rows = null;
+
+  const gridLikeObjects = [map.grid, map.meta, map.metadata, map.settings, map.details];
+  const directColumnCandidates = [
+    map.gridColumns,
+    map.gridWidth,
+    map.columns,
+    map.widthSquares,
+    map.width,
+  ];
+  const directRowCandidates = [
+    map.gridRows,
+    map.gridHeight,
+    map.rows,
+    map.heightSquares,
+    map.height,
+  ];
+
+  directColumnCandidates.forEach((candidate) => {
+    columns = assignDimension(columns, candidate);
+  });
+  directRowCandidates.forEach((candidate) => {
+    rows = assignDimension(rows, candidate);
+  });
+
+  gridLikeObjects.forEach((obj) => {
+    if (!obj || typeof obj !== 'object') {
+      return;
+    }
+
+    columns = assignDimension(columns, obj.columns ?? obj.cols ?? obj.width);
+    rows = assignDimension(rows, obj.rows ?? obj.height);
+
+    if (columns !== null && rows !== null) {
+      return;
+    }
+
+    const dimensionsValue =
+      obj.dimensions ?? obj.size ?? obj.gridSize ?? obj.gridDimensions ?? obj.shape;
+    const parsedDimensions = parseGridDimensionsFromValue(dimensionsValue);
+    if (parsedDimensions) {
+      if (columns === null && parsedDimensions.columns) {
+        columns = parsedDimensions.columns;
+      }
+      if (rows === null && parsedDimensions.rows) {
+        rows = parsedDimensions.rows;
+      }
+    }
+  });
+
+  const fallbackDimensionStrings = [
+    map.gridSize,
+    map.gridDimensions,
+    map.dimensions,
+    map.size,
+    map.mapSize,
+  ];
+
+  fallbackDimensionStrings.forEach((value) => {
+    if (columns !== null && rows !== null) {
+      return;
+    }
+
+    const parsed = parseGridDimensionsFromValue(value);
+    if (!parsed) {
+      return;
+    }
+
+    if (columns === null && parsed.columns) {
+      columns = parsed.columns;
+    }
+    if (rows === null && parsed.rows) {
+      rows = parsed.rows;
+    }
+  });
+
+  const safeColumns = columns ?? DEFAULT_GRID_DIMENSION;
+  const safeRows = rows ?? safeColumns;
+
+  return {
+    columns: Math.max(1, safeColumns),
+    rows: Math.max(1, safeRows),
+  };
+};
+
+const resolveSquareSizeFromMetadata = (map) => {
+  if (!map || typeof map !== 'object') {
+    return null;
+  }
+
+  const candidatePaths = [
+    ['squareSize'],
+    ['square_size'],
+    ['squareSizePixels'],
+    ['squareSizePx'],
+    ['squarePixelSize'],
+    ['square_pixels'],
+    ['square_size_pixels'],
+    ['squareDimension'],
+    ['pixelsPerSquare'],
+    ['pixelPerSquare'],
+    ['gridSquareSize'],
+    ['grid', 'squareSize'],
+    ['grid', 'cellSize'],
+    ['grid', 'pixelsPerSquare'],
+    ['grid', 'squarePixels'],
+    ['meta', 'squareSize'],
+    ['meta', 'pixelsPerSquare'],
+    ['metadata', 'squareSize'],
+    ['metadata', 'pixelsPerSquare'],
+    ['settings', 'squareSize'],
+    ['settings', 'pixelsPerSquare'],
+    ['details', 'squareSize'],
+    ['details', 'pixelsPerSquare'],
+  ];
+
+  for (const path of candidatePaths) {
+    let current = map;
+    let found = true;
+
+    for (const key of path) {
+      if (current && typeof current === 'object' && key in current) {
+        current = current[key];
+      } else {
+        found = false;
+        break;
+      }
+    }
+
+    if (!found) {
+      continue;
+    }
+
+    const parsed = parsePositiveNumber(current);
+    if (parsed !== null) {
+      return parsed;
+    }
+  }
+
+  return null;
 };
 
 const resolveFigurineSizeKey = (value) => {
@@ -107,6 +342,42 @@ const resolveFigurineSizeKey = (value) => {
   }
 
   return 'medium';
+};
+
+const resolveFigurineSquaresFromImageSize = (metrics, metadataSquareSize) => {
+  if (!metrics || typeof metrics !== 'object') {
+    return null;
+  }
+
+  const { width, height } = metrics;
+  const numericWidth = Number(width);
+  const numericHeight = Number(height);
+
+  if (!Number.isFinite(numericWidth) || !Number.isFinite(numericHeight)) {
+    return null;
+  }
+
+  if (numericWidth <= 0 || numericHeight <= 0) {
+    return null;
+  }
+
+  const maxDimension = Math.max(numericWidth, numericHeight);
+  const squareSize = Number.isFinite(metadataSquareSize) && metadataSquareSize > 0
+    ? metadataSquareSize
+    : FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE;
+
+  if (!Number.isFinite(squareSize) || squareSize <= 0) {
+    return null;
+  }
+
+  const rawSquares = maxDimension / squareSize;
+
+  if (!Number.isFinite(rawSquares) || rawSquares <= 0) {
+    return null;
+  }
+
+  const rounded = Math.round(rawSquares);
+  return Math.max(1, Math.min(MAX_FIGURINE_GRID_SQUARES, rounded));
 };
 
 const ROTATION_STEP_DEGREES = 15;
@@ -149,6 +420,7 @@ const CampaignMapBoard = ({
 
   const interactionDisabled = disabled || !imageSrc;
 
+  const boardRef = useRef(null);
   const layerRef = useRef(null);
   const dragStateRef = useRef({ tokenId: null, pointerId: null });
   const [dragPositions, setDragPositions] = useState({});
@@ -157,9 +429,138 @@ const CampaignMapBoard = ({
   const [rotationOverrides, setRotationOverrides] = useState({});
   const rotationOverridesRef = useRef({});
   const tokenPositionsRef = useRef([]);
+  const [layerNode, setLayerNode] = useState(null);
+  const [figurineImageMetrics, setFigurineImageMetrics] = useState({});
   const handleLayerRef = useCallback((node) => {
     layerRef.current = node;
+    setLayerNode(node);
   }, []);
+
+  const handleFigurineImageLoad = useCallback((metricKey, target) => {
+    if (!metricKey || !target) {
+      return;
+    }
+
+    const { naturalWidth, naturalHeight } = target;
+
+    if (!Number.isFinite(naturalWidth) || !Number.isFinite(naturalHeight)) {
+      return;
+    }
+
+    setFigurineImageMetrics((prev) => {
+      const nextWidth = Math.round(naturalWidth);
+      const nextHeight = Math.round(naturalHeight);
+      const existing = prev[metricKey];
+
+      if (existing && existing.width === nextWidth && existing.height === nextHeight) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [metricKey]: {
+          width: nextWidth,
+          height: nextHeight,
+        },
+      };
+    });
+  }, []);
+
+  const { columns: gridColumns, rows: gridRows } = useMemo(
+    () => resolveGridDimensions(map),
+    [map]
+  );
+  const metadataSquareSize = useMemo(() => resolveSquareSizeFromMetadata(map), [map]);
+
+  useEffect(() => {
+    const boardElement = boardRef.current;
+
+    if (!boardElement) {
+      return () => {};
+    }
+
+    const safeColumns = Math.max(1, gridColumns || DEFAULT_GRID_DIMENSION);
+    const safeRows = Math.max(1, gridRows || safeColumns);
+    const columnWidthPercent = `${100 / safeColumns}%`;
+    const rowHeightPercent = `${100 / safeRows}%`;
+
+    boardElement.style.setProperty('--campaign-map-grid-columns', `${safeColumns}`);
+    boardElement.style.setProperty('--campaign-map-grid-rows', `${safeRows}`);
+    boardElement.style.setProperty('--campaign-map-grid-cell-width', columnWidthPercent);
+    boardElement.style.setProperty('--campaign-map-grid-cell-height', rowHeightPercent);
+
+    const cleanupGridVariables = () => {
+      boardElement.style.removeProperty('--campaign-map-grid-columns');
+      boardElement.style.removeProperty('--campaign-map-grid-rows');
+      boardElement.style.removeProperty('--campaign-map-grid-cell-width');
+      boardElement.style.removeProperty('--campaign-map-grid-cell-height');
+    };
+
+    if (metadataSquareSize !== null) {
+      boardElement.style.setProperty(
+        '--campaign-map-square-size',
+        `${metadataSquareSize}px`
+      );
+
+      return () => {
+        boardElement.style.removeProperty('--campaign-map-square-size');
+        cleanupGridVariables();
+      };
+    }
+
+    const layerElement = layerNode;
+
+    if (!layerElement) {
+      boardElement.style.removeProperty('--campaign-map-square-size');
+      return () => {
+        cleanupGridVariables();
+      };
+    }
+
+    const updateSquareSize = () => {
+      const rect = layerElement.getBoundingClientRect();
+      const widthPerColumn = rect.width ? rect.width / safeColumns : null;
+      const heightPerRow = rect.height ? rect.height / safeRows : null;
+      const candidates = [widthPerColumn, heightPerRow].filter(
+        (value) => Number.isFinite(value) && value > 0
+      );
+
+      if (candidates.length === 0) {
+        boardElement.style.removeProperty('--campaign-map-square-size');
+        return;
+      }
+
+      const resolved = Math.min(...candidates);
+      boardElement.style.setProperty('--campaign-map-square-size', `${resolved}px`);
+    };
+
+    updateSquareSize();
+
+    if (typeof ResizeObserver === 'function') {
+      const observer = new ResizeObserver(() => {
+        updateSquareSize();
+      });
+      observer.observe(layerElement);
+
+      return () => {
+        observer.disconnect();
+        boardElement.style.removeProperty('--campaign-map-square-size');
+        cleanupGridVariables();
+      };
+    }
+
+    const handleResize = () => {
+      updateSquareSize();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      boardElement.style.removeProperty('--campaign-map-square-size');
+      cleanupGridVariables();
+    };
+  }, [gridColumns, gridRows, layerNode, metadataSquareSize]);
 
   const tokenPositions = useMemo(() => {
     if (!Array.isArray(tokens)) {
@@ -564,7 +965,14 @@ const CampaignMapBoard = ({
   }, [lastDraggedTokenId, lockRotation, rotateTokenBy]);
 
   return (
-    <div className={classNames('campaign-map-board', className, interactionDisabled && 'campaign-map-board--disabled')}>
+    <div
+      ref={boardRef}
+      className={classNames(
+        'campaign-map-board',
+        className,
+        interactionDisabled && 'campaign-map-board--disabled'
+      )}
+    >
       {title && <h5 className="campaign-map-board__title">{title}</h5>}
       {imageSrc ? (
         <div className="campaign-map-board__stage">
@@ -576,7 +984,7 @@ const CampaignMapBoard = ({
               ref={handleLayerRef}
               onPointerDown={handleLayerPointerDown}
             >
-              {tokenPositions.map((token) => {
+              {tokenPositions.map((token, tokenIndex) => {
                 const {
                   characterId,
                   position,
@@ -609,21 +1017,26 @@ const CampaignMapBoard = ({
                     ? variant.trim().toLowerCase()
                     : null;
 
+                const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(token);
+                const hasFigurineImage = Boolean(figurineImageUrl);
+                const figurineMetricKey = figurineImageUrl || characterId || `token-${tokenIndex}`;
+                const metrics = figurineMetricKey ? figurineImageMetrics[figurineMetricKey] : null;
+                const imageFootprint = hasFigurineImage
+                  ? resolveFigurineSquaresFromImageSize(metrics, metadataSquareSize)
+                  : null;
                 const sizeKey = resolveFigurineSizeKey(size);
                 const baseFigurineScale =
-                  FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? FIGURINE_SIZE_MULTIPLIERS.medium;
-                const scaleMultiplier = normalizedVariant === 'enemy' ? 0.75 : 1;
-                const figurineScale = Number.isFinite(baseFigurineScale)
-                  ? baseFigurineScale * scaleMultiplier
-                  : FIGURINE_SIZE_MULTIPLIERS.medium * scaleMultiplier;
+                  FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? DEFAULT_FIGURINE_GRID_SQUARES;
+                const figurineScale = Number.isFinite(imageFootprint)
+                  ? imageFootprint
+                  : Number.isFinite(baseFigurineScale)
+                    ? baseFigurineScale
+                    : DEFAULT_FIGURINE_GRID_SQUARES;
 
                 const figurineColor =
                   normalizedVariant === 'enemy'
                     ? ENEMY_FIGURINE_COLOR
                     : normalizeText(color) || undefined;
-
-                const { figurineImageUrl, figurineImagePublicId } = resolveFigurineImageData(token);
-                const hasFigurineImage = Boolean(figurineImageUrl);
                 const resolvedRotation = getResolvedRotationForToken(token);
                 const rotationValue = Number.isFinite(resolvedRotation)
                   ? resolvedRotation
@@ -746,6 +1159,12 @@ const CampaignMapBoard = ({
                             className="campaign-map-board__figurine-image"
                             data-figurine-public-id={figurineImagePublicId || undefined}
                             loading="lazy"
+                            onLoad={(event) =>
+                              handleFigurineImageLoad(
+                                figurineMetricKey,
+                                event?.currentTarget || event?.target || null
+                              )
+                            }
                           />
                         </span>
                       )}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -296,7 +296,7 @@ describe('CampaignMapBoard pointer interactions', () => {
     expect(figurineImage?.getAttribute('alt')).toBe('');
   });
 
-  it('applies a reduced figurine scale for enemy variants', () => {
+  it('keeps enemy figurine scale aligned with their size category', () => {
     const { container } = renderBoard({
       token: {
         variant: 'enemy',
@@ -309,7 +309,7 @@ describe('CampaignMapBoard pointer interactions', () => {
     const scaleValue = Number.parseFloat(
       tokenElement?.style.getPropertyValue('--figurine-size-scale') ?? ''
     );
-    expect(scaleValue).toBeCloseTo(1.5, 5);
+    expect(scaleValue).toBeCloseTo(2, 5);
   });
 
   it('provides a finite figurine scale when no size is specified', () => {
@@ -326,5 +326,81 @@ describe('CampaignMapBoard pointer interactions', () => {
     );
     expect(Number.isFinite(scaleValue)).toBe(true);
     expect(scaleValue).toBeCloseTo(1, 5);
+  });
+
+  it('derives figurine footprint from image size when map metadata defines pixels per square', async () => {
+    const { container } = render(
+      <CampaignMapBoard
+        map={{ ...baseMap, pixelsPerSquare: 256 }}
+        tokens={[
+          {
+            ...baseToken,
+            size: 'medium',
+            figurineImageUrl: 'https://example.com/figurines/large.png',
+          },
+        ]}
+      />
+    );
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    const figurineImage = tokenElement?.querySelector('.campaign-map-board__figurine-image');
+    expect(figurineImage).not.toBeNull();
+
+    if (figurineImage) {
+      Object.defineProperty(figurineImage, 'naturalWidth', {
+        configurable: true,
+        value: 512,
+      });
+      Object.defineProperty(figurineImage, 'naturalHeight', {
+        configurable: true,
+        value: 512,
+      });
+
+      fireEvent.load(figurineImage);
+
+      await waitFor(() => {
+        expect(tokenElement?.style.getPropertyValue('--figurine-size-scale')).toBe('2');
+      });
+    }
+  });
+
+  it('falls back to image dimensions when metadata is unavailable', async () => {
+    const { container } = render(
+      <CampaignMapBoard
+        map={baseMap}
+        tokens={[
+          {
+            ...baseToken,
+            size: 'medium',
+            figurineImageUrl: 'https://example.com/figurines/colossal.png',
+          },
+        ]}
+      />
+    );
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    const figurineImage = tokenElement?.querySelector('.campaign-map-board__figurine-image');
+    expect(figurineImage).not.toBeNull();
+
+    if (figurineImage) {
+      Object.defineProperty(figurineImage, 'naturalWidth', {
+        configurable: true,
+        value: 1024,
+      });
+      Object.defineProperty(figurineImage, 'naturalHeight', {
+        configurable: true,
+        value: 1024,
+      });
+
+      fireEvent.load(figurineImage);
+
+      await waitFor(() => {
+        expect(tokenElement?.style.getPropertyValue('--figurine-size-scale')).toBe('2');
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- derive token grid footprint from figurine image dimensions with metadata-aware fallbacks
- update map board styling so figurine images fill their allotted grid squares
- expand CampaignMapBoard tests to cover image-based scaling behaviour

## Testing
- npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js src/components/Zombies/attributes/MapModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed1dde029c832eb1f9d0182261955d