### PR TITLE
Persist character map token rotation and add draggable handle

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2994,13 +2994,10 @@ h1 {
     transform: translate(-50%, -100%) scale(0.92);
     display: inline-flex;
     align-items: center;
-    gap: clamp(0.25rem, calc(var(--figurine-base-size) * 0.12), 0.45rem);
-    padding: clamp(0.25rem, calc(var(--figurine-base-size) * 0.18), 0.4rem)
-      clamp(0.45rem, calc(var(--figurine-base-size) * 0.22), 0.65rem);
-    background: rgba(18, 16, 14, 0.92);
-    border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    box-shadow: 0 0.45rem 1.1rem rgba(0, 0, 0, 0.45);
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border-radius: 50%;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s ease, transform 0.2s ease;
@@ -3014,55 +3011,62 @@ h1 {
     transform: translate(-50%, -100%) scale(1);
   }
 
-  &__rotation-button {
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.28);
+  &__rotation-handle {
+    background: rgba(51, 154, 240, 0.25);
+    border: 1px solid rgba(51, 154, 240, 0.6);
     color: #f8f9fa;
     border-radius: 50%;
-    width: clamp(1.75rem, calc(var(--figurine-base-size) * 0.6), 2.35rem);
-    height: clamp(1.75rem, calc(var(--figurine-base-size) * 0.6), 2.35rem);
+    width: clamp(2.1rem, calc(var(--figurine-base-size) * 0.72), 2.9rem);
+    height: clamp(2.1rem, calc(var(--figurine-base-size) * 0.72), 2.9rem);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: clamp(0.85rem, calc(var(--figurine-base-size) * 0.34), 1.05rem);
-    cursor: pointer;
-    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+    cursor: grab;
+    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease,
+      box-shadow 0.15s ease;
+    box-shadow: 0 0.35rem 0.85rem rgba(8, 11, 19, 0.4);
+    padding: 0;
   }
 
-  &__rotation-button:hover,
-  &__rotation-button:focus-visible {
-    background: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.45);
+  &__rotation-handle:focus-visible {
+    outline: 2px solid rgba(51, 154, 240, 0.9);
+    outline-offset: 3px;
+  }
+
+  &__rotation-handle:hover,
+  &__rotation-handle:focus-visible {
+    background: rgba(51, 154, 240, 0.35);
+    border-color: rgba(102, 187, 255, 0.8);
     transform: scale(1.05);
   }
 
-  &__rotation-angle {
-    min-width: clamp(2.1rem, calc(var(--figurine-base-size) * 0.9), 2.75rem);
-    text-align: center;
-    font-weight: 600;
-    font-size: clamp(0.75rem, calc(var(--figurine-base-size) * 0.32), 0.95rem);
-    color: #f1f3f5;
+  &__rotation-handle:active {
+    cursor: grabbing;
+    transform: scale(0.97);
   }
 
-  &__rotation-lock {
-    background: rgba(51, 154, 240, 0.25);
-    border: 1px solid rgba(51, 154, 240, 0.55);
-    color: #f8f9fa;
-    border-radius: 999px;
-    padding: clamp(0.2rem, calc(var(--figurine-base-size) * 0.16), 0.35rem)
-      clamp(0.55rem, calc(var(--figurine-base-size) * 0.28), 0.8rem);
-    font-size: clamp(0.7rem, calc(var(--figurine-base-size) * 0.27), 0.9rem);
-    font-weight: 600;
-    cursor: pointer;
-    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
-    white-space: nowrap;
+  &__rotation-handle-icon {
+    width: 60%;
+    height: 60%;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    transform: rotate(-35deg);
+    position: relative;
+    display: inline-block;
   }
 
-  &__rotation-lock:hover,
-  &__rotation-lock:focus-visible {
-    background: rgba(51, 154, 240, 0.38);
-    border-color: rgba(51, 154, 240, 0.7);
-    transform: translateY(-1px);
+  &__rotation-handle-icon::after {
+    content: "";
+    position: absolute;
+    top: -0.05rem;
+    right: -0.1rem;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-top: 2px solid currentColor;
+    border-right: 2px solid currentColor;
+    transform: rotate(35deg);
   }
 
   &__figurine-image-wrapper {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -431,6 +431,10 @@ const CampaignMapBoard = ({
   const tokenPositionsRef = useRef([]);
   const [layerNode, setLayerNode] = useState(null);
   const [figurineImageMetrics, setFigurineImageMetrics] = useState({});
+  const rotationDragStateRef = useRef(null);
+  const rotationMoveHandlerRef = useRef(null);
+  const rotationUpHandlerRef = useRef(null);
+  const rotationCancelHandlerRef = useRef(null);
   const handleLayerRef = useCallback((node) => {
     layerRef.current = node;
     setLayerNode(node);
@@ -844,6 +848,99 @@ const CampaignMapBoard = ({
     [rotationOverrides]
   );
 
+  const stopRotationDrag = useCallback(() => {
+    const targets = [];
+    if (typeof window !== 'undefined') {
+      targets.push(window);
+    }
+    if (typeof document !== 'undefined') {
+      targets.push(document);
+    }
+
+    if (rotationMoveHandlerRef.current) {
+      targets.forEach((target) => {
+        if (target && typeof target.removeEventListener === 'function') {
+          target.removeEventListener('pointermove', rotationMoveHandlerRef.current);
+        }
+      });
+      rotationMoveHandlerRef.current = null;
+    }
+
+    if (rotationUpHandlerRef.current) {
+      targets.forEach((target) => {
+        if (target && typeof target.removeEventListener === 'function') {
+          target.removeEventListener('pointerup', rotationUpHandlerRef.current);
+        }
+      });
+      rotationUpHandlerRef.current = null;
+    }
+
+    if (rotationCancelHandlerRef.current) {
+      targets.forEach((target) => {
+        if (target && typeof target.removeEventListener === 'function') {
+          target.removeEventListener('pointercancel', rotationCancelHandlerRef.current);
+        }
+      });
+      rotationCancelHandlerRef.current = null;
+    }
+
+    rotationDragStateRef.current = null;
+  }, []);
+
+  useEffect(() => () => stopRotationDrag(), [stopRotationDrag]);
+
+  useEffect(() => {
+    if (interactionDisabled) {
+      stopRotationDrag();
+    }
+  }, [interactionDisabled, stopRotationDrag]);
+
+  const applyTokenRotation = useCallback(
+    (tokenId, rotation) => {
+      if (!tokenId || !Number.isFinite(rotation)) {
+        return;
+      }
+
+      const tokensList = tokenPositionsRef.current;
+      const normalizedRotation = normalizeDegrees(rotation);
+
+      setRotationOverrides((prev) => {
+        if (prev[tokenId] === normalizedRotation) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [tokenId]: normalizedRotation,
+        };
+      });
+
+      setLastDraggedTokenId(tokenId);
+
+      if (typeof onTokenPositionChange === 'function' && Array.isArray(tokensList)) {
+        const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
+        if (foundToken) {
+          const candidatePosition =
+            foundToken.position && typeof foundToken.position === 'object'
+              ? foundToken.position
+              : null;
+          const normalizedX = clamp01(candidatePosition?.x ?? foundToken.x);
+          const normalizedY = clamp01(candidatePosition?.y ?? foundToken.y);
+
+          if (normalizedX !== null && normalizedY !== null) {
+            onTokenPositionChange({
+              characterId: tokenId,
+              x: normalizedX,
+              y: normalizedY,
+              rotation: normalizedRotation,
+            });
+          }
+        }
+      }
+    },
+    [onTokenPositionChange]
+  );
+
   const rotateTokenBy = useCallback(
     (tokenId, delta) => {
       if (!tokenId || !Number.isFinite(delta)) {
@@ -869,41 +966,130 @@ const CampaignMapBoard = ({
         return;
       }
 
-      setRotationOverrides((prev) => {
-        if (prev[tokenId] === nextRotation) {
-          return prev;
+      applyTokenRotation(tokenId, nextRotation);
+    },
+    [applyTokenRotation]
+  );
+
+  const handleRotationHandlePointerDown = useCallback(
+    (event, tokenId, currentRotation) => {
+      if (interactionDisabled || !tokenId) {
+        return;
+      }
+
+      if (typeof event?.button === 'number' && event.button !== 0) {
+        return;
+      }
+
+      const tokenElement = event.currentTarget?.closest('.campaign-map-board__token');
+      if (!tokenElement) {
+        return;
+      }
+
+      const rect = tokenElement.getBoundingClientRect();
+      if (!rect || !Number.isFinite(rect.left) || !Number.isFinite(rect.top)) {
+        return;
+      }
+
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
+      const pointerDegrees = normalizeDegrees((pointerAngle * 180) / Math.PI);
+      const normalizedCurrent = normalizeDegrees(currentRotation);
+
+      stopRotationDrag();
+
+      rotationDragStateRef.current = {
+        tokenId,
+        pointerId: event.pointerId,
+        centerX,
+        centerY,
+        offset: normalizeDegrees(normalizedCurrent - pointerDegrees),
+      };
+
+      const handleMove = (moveEvent) => {
+        const dragState = rotationDragStateRef.current;
+        if (!dragState || dragState.tokenId !== tokenId) {
+          return;
         }
 
-        return {
-          ...prev,
-          [tokenId]: nextRotation,
-        };
+        if (
+          dragState.pointerId !== undefined &&
+          moveEvent.pointerId !== undefined &&
+          moveEvent.pointerId !== dragState.pointerId
+        ) {
+          return;
+        }
+
+        moveEvent.preventDefault();
+        moveEvent.stopPropagation();
+
+        const angle = Math.atan2(moveEvent.clientY - dragState.centerY, moveEvent.clientX - dragState.centerX);
+        const angleDegrees = normalizeDegrees((angle * 180) / Math.PI);
+        const nextRotation = normalizeDegrees(angleDegrees + dragState.offset);
+        applyTokenRotation(tokenId, nextRotation);
+      };
+
+      const handleRelease = (releaseEvent) => {
+        const dragState = rotationDragStateRef.current;
+        if (!dragState || dragState.tokenId !== tokenId) {
+          stopRotationDrag();
+          return;
+        }
+
+        if (
+          dragState.pointerId !== undefined &&
+          releaseEvent.pointerId !== undefined &&
+          releaseEvent.pointerId !== dragState.pointerId
+        ) {
+          return;
+        }
+
+        releaseEvent.preventDefault();
+        releaseEvent.stopPropagation();
+        stopRotationDrag();
+      };
+
+      const handleCancel = (cancelEvent) => {
+        const dragState = rotationDragStateRef.current;
+        if (
+          dragState &&
+          dragState.pointerId !== undefined &&
+          cancelEvent.pointerId !== undefined &&
+          cancelEvent.pointerId !== dragState.pointerId
+        ) {
+          return;
+        }
+
+        stopRotationDrag();
+      };
+
+      rotationMoveHandlerRef.current = handleMove;
+      rotationUpHandlerRef.current = handleRelease;
+      rotationCancelHandlerRef.current = handleCancel;
+
+      const targets = [];
+      if (typeof window !== 'undefined') {
+        targets.push(window);
+      }
+      if (typeof document !== 'undefined') {
+        targets.push(document);
+      }
+
+      targets.forEach((target) => {
+        if (target && typeof target.addEventListener === 'function') {
+          target.addEventListener('pointermove', handleMove, { passive: false });
+          target.addEventListener('pointerup', handleRelease, { passive: false });
+          target.addEventListener('pointercancel', handleCancel, { passive: false });
+        }
       });
 
       setLastDraggedTokenId(tokenId);
 
-      if (typeof onTokenPositionChange === 'function' && Array.isArray(tokensList)) {
-        const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
-        if (foundToken) {
-          const candidatePosition =
-            foundToken.position && typeof foundToken.position === 'object'
-              ? foundToken.position
-              : null;
-          const normalizedX = clamp01(candidatePosition?.x ?? foundToken.x);
-          const normalizedY = clamp01(candidatePosition?.y ?? foundToken.y);
-
-          if (normalizedX !== null && normalizedY !== null) {
-            onTokenPositionChange({
-              characterId: tokenId,
-              x: normalizedX,
-              y: normalizedY,
-              rotation: nextRotation,
-            });
-          }
-        }
-      }
+      event.preventDefault();
+      event.stopPropagation();
     },
-    [onTokenPositionChange]
+    [applyTokenRotation, interactionDisabled, stopRotationDrag]
   );
 
   const lockRotation = useCallback((tokenId) => {
@@ -1177,47 +1363,30 @@ const CampaignMapBoard = ({
                     {isRotationActive && (
                       <div
                         className="campaign-map-board__rotation-controls"
-                        role="group"
-                        aria-label="Figurine rotation controls"
                         onPointerDown={(event) => event.stopPropagation()}
+                        onPointerMove={(event) => event.stopPropagation()}
                         onPointerUp={(event) => event.stopPropagation()}
-                        onClick={(event) => event.stopPropagation()}
                       >
                         <button
                           type="button"
-                          className="campaign-map-board__rotation-button"
-                          onClick={(event) => {
-                            event.preventDefault();
-                            rotateTokenBy(characterId, -ROTATION_STEP_DEGREES);
-                          }}
-                          aria-label="Rotate counterclockwise"
+                          className="campaign-map-board__rotation-handle"
+                          aria-label={
+                            Number.isFinite(rotationDisplay)
+                              ? `Rotate figurine (current ${rotationDisplay}°)`
+                              : 'Rotate figurine'
+                          }
+                          onPointerDown={(event) =>
+                            handleRotationHandlePointerDown(event, characterId, rotationValue)
+                          }
+                          onFocus={() => setLastDraggedTokenId(characterId)}
+                          onBlur={() =>
+                            setLastDraggedTokenId((prev) => (prev === characterId ? null : prev))
+                          }
                         >
-                          <span aria-hidden="true">⟲</span>
-                        </button>
-                        <div className="campaign-map-board__rotation-angle" aria-live="polite">
-                          {`${rotationDisplay}°`}
-                        </div>
-                        <button
-                          type="button"
-                          className="campaign-map-board__rotation-button"
-                          onClick={(event) => {
-                            event.preventDefault();
-                            rotateTokenBy(characterId, ROTATION_STEP_DEGREES);
-                          }}
-                          aria-label="Rotate clockwise"
-                        >
-                          <span aria-hidden="true">⟳</span>
-                        </button>
-                        <button
-                          type="button"
-                          className="campaign-map-board__rotation-lock"
-                          onClick={(event) => {
-                            event.preventDefault();
-                            lockRotation(characterId);
-                          }}
-                          aria-label="Lock rotation"
-                        >
-                          Lock
+                          <span
+                            aria-hidden="true"
+                            className="campaign-map-board__rotation-handle-icon"
+                          />
                         </button>
                       </div>
                     )}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -177,7 +177,7 @@ describe('CampaignMapBoard pointer interactions', () => {
 
   it('marks the last dragged token and enables rotation controls', async () => {
     const onTokenPositionChange = jest.fn();
-    const { container, findByRole, queryByRole } = renderBoard({ onTokenPositionChange });
+    const { container, findByRole } = renderBoard({ onTokenPositionChange });
 
     const applyLayerRect = () => {
       const layer = container.querySelector('.campaign-map-board__tokens-layer');
@@ -239,42 +239,78 @@ describe('CampaignMapBoard pointer interactions', () => {
       expect(latestToken).toHaveClass('lastDragged');
     });
 
-    const rotateClockwiseButton = await findByRole('button', { name: /rotate clockwise/i });
-    fireEvent.click(rotateClockwiseButton);
-
-    expect(onTokenPositionChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        characterId: 'char-1',
-        rotation: 15,
-        x: expect.any(Number),
-        y: expect.any(Number),
-      })
-    );
-
-    tokenElement = container.querySelector('[data-token-id="char-1"]');
-    expect(tokenElement?.getAttribute('data-rotation')).toBe('15');
-
-    fireEvent.keyDown(window, { key: 'ArrowLeft' });
-
-    expect(onTokenPositionChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        characterId: 'char-1',
-        rotation: 0,
-        x: expect.any(Number),
-        y: expect.any(Number),
-      })
-    );
-
-    tokenElement = container.querySelector('[data-token-id="char-1"]');
-    expect(tokenElement?.getAttribute('data-rotation')).toBe('0');
-
-    const lockButton = await findByRole('button', { name: /lock rotation/i });
-    fireEvent.click(lockButton);
+    const rotationHandle = await findByRole('button', { name: /rotate figurine/i });
+    expect(rotationHandle).not.toBeNull();
 
     tokenElement = container.querySelector('[data-token-id="char-1"]');
     expect(tokenElement).not.toBeNull();
-    expect(tokenElement).not.toHaveClass('lastDragged');
-    expect(queryByRole('button', { name: /lock rotation/i })).toBeNull();
+    if (tokenElement) {
+      tokenElement.getBoundingClientRect = () => ({
+        left: 100,
+        top: 100,
+        right: 180,
+        bottom: 180,
+        width: 80,
+        height: 80,
+      });
+    }
+
+    const pointerDownHandle = createEvent.pointerDown(rotationHandle, {
+      button: 0,
+      pointerId: 2,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(pointerDownHandle, 'clientX', { value: 180 });
+    Object.defineProperty(pointerDownHandle, 'clientY', { value: 140 });
+    fireEvent(rotationHandle, pointerDownHandle);
+
+    const pointerMoveHandle = createEvent.pointerMove(document.body, {
+      pointerId: 2,
+      bubbles: true,
+      cancelable: true,
+      buttons: 1,
+    });
+    Object.defineProperty(pointerMoveHandle, 'clientX', { value: 140 });
+    Object.defineProperty(pointerMoveHandle, 'clientY', { value: 180 });
+    fireEvent(document.body, pointerMoveHandle);
+
+    const pointerUpHandle = createEvent.pointerUp(document.body, {
+      pointerId: 2,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(pointerUpHandle, 'clientX', { value: 140 });
+    Object.defineProperty(pointerUpHandle, 'clientY', { value: 180 });
+    fireEvent(document.body, pointerUpHandle);
+
+    expect(onTokenPositionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        characterId: 'char-1',
+        rotation: expect.any(Number),
+        x: expect.any(Number),
+        y: expect.any(Number),
+      })
+    );
+
+    let lastCall =
+      onTokenPositionChange.mock.calls[onTokenPositionChange.mock.calls.length - 1]?.[0];
+    expect(lastCall).toBeDefined();
+    expect(lastCall.rotation).toBeCloseTo(90, 3);
+
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+    expect(Number(tokenElement?.getAttribute('data-rotation'))).toBeCloseTo(90, 3);
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    lastCall = onTokenPositionChange.mock.calls[onTokenPositionChange.mock.calls.length - 1]?.[0];
+    expect(lastCall).toBeDefined();
+    expect(lastCall.rotation).toBeCloseTo(75, 3);
+
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+    expect(Number(tokenElement?.getAttribute('data-rotation'))).toBeCloseTo(75, 3);
   });
 
   it('renders a figurine image overlay when provided and preserves accessibility labels', () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -216,6 +216,21 @@ const clamp01 = (value) => {
   return parsed;
 };
 
+const normalizeRotation = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  const normalized = parsed % 360;
+  const resolved = normalized < 0 ? normalized + 360 : normalized;
+  return Math.round(resolved * 1000) / 1000;
+};
+
 const createCircleState = () => ({
   0: 'active',
   1: 'active',
@@ -4306,7 +4321,7 @@ export default function ZombiesCharacterSheet() {
   }, [activeMapTokens, campaignMap, campaignMapTokens]);
 
   const handleTokenMove = useCallback(
-    async ({ mapId, characterId: tokenCharacterId, x, y }) => {
+    async ({ mapId, characterId: tokenCharacterId, x, y, rotation }) => {
       const normalizedCampaign =
         typeof campaignId === 'string' && campaignId.trim() !== '' ? campaignId.trim() : null;
       const normalizedMapId =
@@ -4340,6 +4355,7 @@ export default function ZombiesCharacterSheet() {
       const previousCampaignTokens = campaignMapTokensRef.current || {};
       const previousActiveTokens = activeMapTokensRef.current || {};
       const previousCampaignMap = campaignMapRef.current || null;
+      const normalizedRotation = normalizeRotation(rotation);
 
       const nextToken = {
         ...(previousCampaignTokens?.[normalizedMapId]?.[normalizedCharacterId] || {}),
@@ -4347,6 +4363,7 @@ export default function ZombiesCharacterSheet() {
         x: clampedX,
         y: clampedY,
         updatedAt: new Date().toISOString(),
+        ...(normalizedRotation !== null ? { rotation: normalizedRotation } : {}),
       };
 
       setCampaignMapTokens((prev) => {
@@ -4407,7 +4424,11 @@ export default function ZombiesCharacterSheet() {
           {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ x: clampedX, y: clampedY }),
+            body: JSON.stringify({
+              x: clampedX,
+              y: clampedY,
+              ...(normalizedRotation !== null ? { rotation: normalizedRotation } : {}),
+            }),
           }
         );
 


### PR DESCRIPTION
## Summary
- persist figurine rotation changes when characters move tokens on campaign maps
- replace the counter/clockwise rotation buttons with a draggable circular handle and refreshed styling
- extend the campaign map board tests for the new rotation interaction model

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed3a9f60c4832e8350b26807a1c3af