### PR TITLE
Fix duplicate rotateTokenBy logic and clean rotation handlers

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -960,49 +960,6 @@ const CampaignMapBoard = ({
     [onTokenPositionChange]
   );
 
-  const rotateTokenBy = useCallback(
-    (tokenId, delta) => {
-      if (!tokenId || !Number.isFinite(delta)) {
-        return;
-      }
-
-    if (rotationMoveHandlerRef.current) {
-      targets.forEach((target) => {
-        if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointermove', rotationMoveHandlerRef.current);
-        }
-      });
-      rotationMoveHandlerRef.current = null;
-    }
-
-    if (rotationUpHandlerRef.current) {
-      targets.forEach((target) => {
-        if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointerup', rotationUpHandlerRef.current);
-        }
-      });
-      rotationUpHandlerRef.current = null;
-    }
-
-    if (rotationCancelHandlerRef.current) {
-      targets.forEach((target) => {
-        if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointercancel', rotationCancelHandlerRef.current);
-        }
-      });
-      rotationCancelHandlerRef.current = null;
-    }
-
-    rotationDragStateRef.current = null;
-  }, []);
-
-  useEffect(() => () => stopRotationDrag(), [stopRotationDrag]);
-
-  useEffect(() => {
-    if (interactionDisabled) {
-      stopRotationDrag();
-    }
-  }, [interactionDisabled, stopRotationDrag]);
 
   const applyTokenRotation = useCallback(
     (tokenId, rotation) => {
@@ -1010,357 +967,11 @@ const CampaignMapBoard = ({
         return;
       }
 
-      updateTokenRotation(tokenId, nextRotation);
+      updateTokenRotation(tokenId, rotation);
     },
     [updateTokenRotation]
   );
 
-  const handleRotationHandlePointerDown = useCallback(
-    (event, tokenId, currentRotation) => {
-      if (interactionDisabled || !tokenId) {
-        return;
-      }
-
-      if (typeof event?.button === 'number' && event.button !== 0) {
-        return;
-      }
-
-      const tokenElement = event.currentTarget?.closest('.campaign-map-board__token');
-      if (!tokenElement) {
-        return;
-      }
-
-      const rect = tokenElement.getBoundingClientRect();
-      if (!rect || !Number.isFinite(rect.left) || !Number.isFinite(rect.top)) {
-        return;
-      }
-
-      const centerX = rect.left + rect.width / 2;
-      const centerY = rect.top + rect.height / 2;
-      const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
-      const pointerDegrees = normalizeDegrees((pointerAngle * 180) / Math.PI);
-      const normalizedCurrent = normalizeDegrees(currentRotation);
-      const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
-
-      setRotationHandleAngles((prev) => {
-        if (prev[tokenId] === initialHandleAngle) {
-          return prev;
-        }
-
-        return {
-          ...prev,
-          [tokenId]: initialHandleAngle,
-        };
-      });
-
-      stopRotationDrag();
-
-      rotationDragStateRef.current = {
-        tokenId,
-        pointerId: event.pointerId,
-        centerX,
-        centerY,
-        offset: normalizeDegrees(normalizedCurrent - pointerDegrees),
-      };
-
-      const handleMove = (moveEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (!dragState || dragState.tokenId !== tokenId) {
-          return;
-        }
-
-        if (
-          dragState.pointerId !== undefined &&
-          moveEvent.pointerId !== undefined &&
-          moveEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        moveEvent.preventDefault();
-        moveEvent.stopPropagation();
-
-        const angle = Math.atan2(moveEvent.clientY - dragState.centerY, moveEvent.clientX - dragState.centerX);
-        const angleDegrees = normalizeDegrees((angle * 180) / Math.PI);
-        const nextRotation = normalizeDegrees(angleDegrees + dragState.offset);
-        const handleAngle = normalizeDegrees(angleDegrees + 90);
-
-        setRotationHandleAngles((prev) => {
-          if (prev[tokenId] === handleAngle) {
-            return prev;
-          }
-
-          return {
-            ...prev,
-            [tokenId]: handleAngle,
-          };
-        });
-
-        updateTokenRotation(tokenId, nextRotation);
-      };
-
-      const handleRelease = (releaseEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (!dragState || dragState.tokenId !== tokenId) {
-          stopRotationDrag();
-          return;
-        }
-
-        if (
-          dragState.pointerId !== undefined &&
-          releaseEvent.pointerId !== undefined &&
-          releaseEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        releaseEvent.preventDefault();
-        releaseEvent.stopPropagation();
-        stopRotationDrag();
-      };
-
-      const handleCancel = (cancelEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (
-          dragState &&
-          dragState.pointerId !== undefined &&
-          cancelEvent.pointerId !== undefined &&
-          cancelEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        stopRotationDrag();
-      };
-
-      rotationMoveHandlerRef.current = handleMove;
-      rotationUpHandlerRef.current = handleRelease;
-      rotationCancelHandlerRef.current = handleCancel;
-
-      const targets = [];
-      if (typeof window !== 'undefined') {
-        targets.push(window);
-      }
-      if (typeof document !== 'undefined') {
-        targets.push(document);
-      }
-
-      targets.forEach((target) => {
-        if (target && typeof target.addEventListener === 'function') {
-          target.addEventListener('pointermove', handleMove, { passive: false });
-          target.addEventListener('pointerup', handleRelease, { passive: false });
-          target.addEventListener('pointercancel', handleCancel, { passive: false });
-        }
-      });
-
-      setLastDraggedTokenId(tokenId);
-
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    [updateTokenRotation, interactionDisabled, stopRotationDrag]
-  );
-
-  const rotateTokenBy = useCallback(
-    (tokenId, delta) => {
-      if (!tokenId || !Number.isFinite(delta)) {
-        return;
-      }
-
-    if (rotationMoveHandlerRef.current) {
-      targets.forEach((target) => {
-        if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointermove', rotationMoveHandlerRef.current);
-        }
-      });
-      rotationMoveHandlerRef.current = null;
-    }
-
-    if (rotationUpHandlerRef.current) {
-      targets.forEach((target) => {
-        if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointerup', rotationUpHandlerRef.current);
-        }
-      });
-      rotationUpHandlerRef.current = null;
-    }
-
-    if (rotationCancelHandlerRef.current) {
-      targets.forEach((target) => {
-        if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointercancel', rotationCancelHandlerRef.current);
-        }
-      });
-      rotationCancelHandlerRef.current = null;
-    }
-
-    rotationDragStateRef.current = null;
-  }, []);
-
-  useEffect(() => () => stopRotationDrag(), [stopRotationDrag]);
-
-  useEffect(() => {
-    if (interactionDisabled) {
-      stopRotationDrag();
-    }
-  }, [interactionDisabled, stopRotationDrag]);
-
-  const applyTokenRotation = useCallback(
-    (tokenId, rotation) => {
-      if (!tokenId || !Number.isFinite(rotation)) {
-        return;
-      }
-
-      applyTokenRotation(tokenId, nextRotation);
-    },
-    [applyTokenRotation]
-  );
-
-  const handleRotationHandlePointerDown = useCallback(
-    (event, tokenId, currentRotation) => {
-      if (interactionDisabled || !tokenId) {
-        return;
-      }
-
-      if (typeof event?.button === 'number' && event.button !== 0) {
-        return;
-      }
-
-      const tokenElement = event.currentTarget?.closest('.campaign-map-board__token');
-      if (!tokenElement) {
-        return;
-      }
-
-      const rect = tokenElement.getBoundingClientRect();
-      if (!rect || !Number.isFinite(rect.left) || !Number.isFinite(rect.top)) {
-        return;
-      }
-
-      const centerX = rect.left + rect.width / 2;
-      const centerY = rect.top + rect.height / 2;
-      const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
-      const pointerDegrees = normalizeDegrees((pointerAngle * 180) / Math.PI);
-      const normalizedCurrent = normalizeDegrees(currentRotation);
-      const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
-
-      setRotationHandleAngles((prev) => {
-        if (prev[tokenId] === initialHandleAngle) {
-          return prev;
-        }
-
-        return {
-          ...prev,
-          [tokenId]: initialHandleAngle,
-        };
-      });
-
-      stopRotationDrag();
-
-      rotationDragStateRef.current = {
-        tokenId,
-        pointerId: event.pointerId,
-        centerX,
-        centerY,
-        offset: normalizeDegrees(normalizedCurrent - pointerDegrees),
-      };
-
-      const handleMove = (moveEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (!dragState || dragState.tokenId !== tokenId) {
-          return;
-        }
-
-        if (
-          dragState.pointerId !== undefined &&
-          moveEvent.pointerId !== undefined &&
-          moveEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        moveEvent.preventDefault();
-        moveEvent.stopPropagation();
-
-        const angle = Math.atan2(moveEvent.clientY - dragState.centerY, moveEvent.clientX - dragState.centerX);
-        const angleDegrees = normalizeDegrees((angle * 180) / Math.PI);
-        const nextRotation = normalizeDegrees(angleDegrees + dragState.offset);
-        const handleAngle = normalizeDegrees(angleDegrees + 90);
-
-        setRotationHandleAngles((prev) => {
-          if (prev[tokenId] === handleAngle) {
-            return prev;
-          }
-
-          return {
-            ...prev,
-            [tokenId]: handleAngle,
-          };
-        });
-
-        applyTokenRotation(tokenId, nextRotation);
-      };
-
-      const handleRelease = (releaseEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (!dragState || dragState.tokenId !== tokenId) {
-          stopRotationDrag();
-          return;
-        }
-
-        if (
-          dragState.pointerId !== undefined &&
-          releaseEvent.pointerId !== undefined &&
-          releaseEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        releaseEvent.preventDefault();
-        releaseEvent.stopPropagation();
-        stopRotationDrag();
-      };
-
-      const handleCancel = (cancelEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (
-          dragState &&
-          dragState.pointerId !== undefined &&
-          cancelEvent.pointerId !== undefined &&
-          cancelEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        stopRotationDrag();
-      };
-
-      rotationMoveHandlerRef.current = handleMove;
-      rotationUpHandlerRef.current = handleRelease;
-      rotationCancelHandlerRef.current = handleCancel;
-
-      const targets = [];
-      if (typeof window !== 'undefined') {
-        targets.push(window);
-      }
-      if (typeof document !== 'undefined') {
-        targets.push(document);
-      }
-
-      targets.forEach((target) => {
-        if (target && typeof target.addEventListener === 'function') {
-          target.addEventListener('pointermove', handleMove, { passive: false });
-          target.addEventListener('pointerup', handleRelease, { passive: false });
-          target.addEventListener('pointercancel', handleCancel, { passive: false });
-        }
-      });
-
-      setLastDraggedTokenId(tokenId);
-
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    [applyTokenRotation, interactionDisabled, stopRotationDrag]
-  );
 
   const rotateTokenBy = useCallback(
     (tokenId, delta) => {
@@ -1371,7 +982,7 @@ const CampaignMapBoard = ({
       const tokensList = tokenPositionsRef.current;
       const overrides = rotationOverridesRef.current || {};
       const currentOverride = overrides[tokenId];
-      let baseRotation = Number.isFinite(currentOverride)
+      const baseRotation = Number.isFinite(currentOverride)
         ? currentOverride
         : (() => {
             if (!Array.isArray(tokensList)) {
@@ -1417,6 +1028,18 @@ const CampaignMapBoard = ({
       const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
       const pointerDegrees = normalizeDegrees((pointerAngle * 180) / Math.PI);
       const normalizedCurrent = normalizeDegrees(currentRotation);
+      const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
+
+      setRotationHandleAngles((prev) => {
+        if (prev[tokenId] === initialHandleAngle) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [tokenId]: initialHandleAngle,
+        };
+      });
 
       stopRotationDrag();
 
@@ -1448,6 +1071,19 @@ const CampaignMapBoard = ({
         const angle = Math.atan2(moveEvent.clientY - dragState.centerY, moveEvent.clientX - dragState.centerX);
         const angleDegrees = normalizeDegrees((angle * 180) / Math.PI);
         const nextRotation = normalizeDegrees(angleDegrees + dragState.offset);
+        const handleAngle = normalizeDegrees(angleDegrees + 90);
+
+        setRotationHandleAngles((prev) => {
+          if (prev[tokenId] === handleAngle) {
+            return prev;
+          }
+
+          return {
+            ...prev,
+            [tokenId]: handleAngle,
+          };
+        });
+
         applyTokenRotation(tokenId, nextRotation);
       };
 


### PR DESCRIPTION
## Summary
- remove duplicated rotation handlers that caused rotateTokenBy to be defined multiple times
- add a single rotateTokenBy implementation that derives base rotation from overrides and current token data
- keep rotation drag handlers intact while ensuring keyboard shortcuts update the same helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed45434014832e84b0906617132159