### PR TITLE
Improve token rotation drag smoothness and health bar alignment

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2930,7 +2930,7 @@ h1 {
     justify-content: flex-end;
     filter: drop-shadow(0 0.1rem 0.25rem rgba(0, 0, 0, 0.65));
     transform: rotate(var(--figurine-rotation, 0deg));
-    transform-origin: 50% 50%;
+    transform-origin: 50% 100%;
   }
 
   &__health-track {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -382,6 +382,8 @@ const resolveFigurineSquaresFromImageSize = (metrics, metadataSquareSize) => {
 
 const ROTATION_STEP_DEGREES = 15;
 
+const TWO_PI = Math.PI * 2;
+
 const normalizeDegrees = (value) => {
   if (value === null || value === undefined || value === '') {
     return 0;
@@ -395,6 +397,10 @@ const normalizeDegrees = (value) => {
   const normalized = parsed % 360;
   return normalized < 0 ? normalized + 360 : normalized;
 };
+
+const degreesToRadians = (degrees) => (Number(degrees) * Math.PI) / 180;
+
+const radiansToDegrees = (radians) => (Number(radians) * 180) / Math.PI;
 
 const CampaignMapBoard = ({
   map,
@@ -868,12 +874,26 @@ const CampaignMapBoard = ({
   );
 
   const stopRotationDrag = useCallback(() => {
+    const activeDragState = rotationDragStateRef.current;
     const targets = [];
     if (typeof window !== 'undefined') {
       targets.push(window);
     }
     if (typeof document !== 'undefined') {
       targets.push(document);
+    }
+
+    if (
+      activeDragState &&
+      activeDragState.handleElement &&
+      typeof activeDragState.handleElement.releasePointerCapture === 'function' &&
+      activeDragState.pointerId !== undefined
+    ) {
+      try {
+        activeDragState.handleElement.releasePointerCapture(activeDragState.pointerId);
+      } catch (releaseError) {
+        // Ignore release errors – capturing might not be active or supported
+      }
     }
 
     if (rotationMoveHandlerRef.current) {
@@ -1026,8 +1046,9 @@ const CampaignMapBoard = ({
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
-      const pointerDegrees = normalizeDegrees((pointerAngle * 180) / Math.PI);
+      const pointerDegrees = normalizeDegrees(radiansToDegrees(pointerAngle));
       const normalizedCurrent = normalizeDegrees(currentRotation);
+      const currentRotationRadians = degreesToRadians(normalizedCurrent);
       const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
 
       setRotationHandleAngles((prev) => {
@@ -1048,8 +1069,23 @@ const CampaignMapBoard = ({
         pointerId: event.pointerId,
         centerX,
         centerY,
-        offset: normalizeDegrees(normalizedCurrent - pointerDegrees),
+        initialRotationRadians: currentRotationRadians,
+        lastPointerAngle: pointerAngle,
+        accumulatedDelta: 0,
+        handleElement: event.currentTarget || null,
       };
+
+      if (
+        event.currentTarget &&
+        typeof event.currentTarget.setPointerCapture === 'function' &&
+        event.pointerId !== undefined
+      ) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch (captureError) {
+          // Ignore capture errors – some browsers might throw if capture isn't supported
+        }
+      }
 
       const handleMove = (moveEvent) => {
         const dragState = rotationDragStateRef.current;
@@ -1069,9 +1105,21 @@ const CampaignMapBoard = ({
         moveEvent.stopPropagation();
 
         const angle = Math.atan2(moveEvent.clientY - dragState.centerY, moveEvent.clientX - dragState.centerX);
-        const angleDegrees = normalizeDegrees((angle * 180) / Math.PI);
-        const nextRotation = normalizeDegrees(angleDegrees + dragState.offset);
-        const handleAngle = normalizeDegrees(angleDegrees + 90);
+        const { lastPointerAngle = angle, accumulatedDelta = 0 } = dragState;
+        let delta = angle - lastPointerAngle;
+        if (delta > Math.PI) {
+          delta -= TWO_PI;
+        } else if (delta < -Math.PI) {
+          delta += TWO_PI;
+        }
+
+        const nextAccumulatedDelta = accumulatedDelta + delta;
+        dragState.lastPointerAngle = angle;
+        dragState.accumulatedDelta = nextAccumulatedDelta;
+
+        const nextRotationRadians = dragState.initialRotationRadians + nextAccumulatedDelta;
+        const nextRotation = normalizeDegrees(radiansToDegrees(nextRotationRadians));
+        const handleAngle = normalizeDegrees(radiansToDegrees(angle) + 90);
 
         setRotationHandleAngles((prev) => {
           if (prev[tokenId] === handleAngle) {


### PR DESCRIPTION
## Summary
- make token rotation dragging accumulate pointer movement in radians for smoother, continuous updates
- release pointer capture when finishing a drag to avoid stuck events and anchor the health bar rotation to the figurine head

## Testing
- CI=true npm test -- CampaignMapBoard

------
https://chatgpt.com/codex/tasks/task_e_68ed4882a2e8832ebc90df762e792c79