### PR TITLE
Make rotation handle follow continuous drags

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2983,6 +2983,10 @@ h1 {
     transform: rotate(var(--figurine-rotation, 0deg));
   }
 
+  &__token--rotation-active &__figurine {
+    transition: transform 0s linear, filter 0.2s ease;
+  }
+
   &__figurine--active {
     transform: rotate(var(--figurine-rotation, 0deg)) translateY(-3px) scale(1.02);
     filter: drop-shadow(0 0.55rem 1.25rem rgba(7, 8, 13, 0.75))
@@ -3020,6 +3024,10 @@ h1 {
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  &__token--rotation-active &__rotation-handle-track {
+    transition: none;
   }
 
   &__token.lastDragged &__rotation-controls,

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -382,6 +382,8 @@ const resolveFigurineSquaresFromImageSize = (metrics, metadataSquareSize) => {
 
 const ROTATION_STEP_DEGREES = 15;
 
+const TWO_PI = Math.PI * 2;
+
 const normalizeDegrees = (value) => {
   if (value === null || value === undefined || value === '') {
     return 0;
@@ -395,6 +397,8 @@ const normalizeDegrees = (value) => {
   const normalized = parsed % 360;
   return normalized < 0 ? normalized + 360 : normalized;
 };
+
+const radiansToDegrees = (radians) => (Number(radians) * 180) / Math.PI;
 
 const CampaignMapBoard = ({
   map,
@@ -429,6 +433,7 @@ const CampaignMapBoard = ({
   const [rotationOverrides, setRotationOverrides] = useState({});
   const rotationOverridesRef = useRef({});
   const [rotationHandleAngles, setRotationHandleAngles] = useState({});
+  const [draggingRotationTokenId, setDraggingRotationTokenId] = useState(null);
   const tokenPositionsRef = useRef([]);
   const [layerNode, setLayerNode] = useState(null);
   const [figurineImageMetrics, setFigurineImageMetrics] = useState({});
@@ -868,12 +873,26 @@ const CampaignMapBoard = ({
   );
 
   const stopRotationDrag = useCallback(() => {
+    const activeDragState = rotationDragStateRef.current;
     const targets = [];
     if (typeof window !== 'undefined') {
       targets.push(window);
     }
     if (typeof document !== 'undefined') {
       targets.push(document);
+    }
+
+    if (
+      activeDragState &&
+      activeDragState.handleElement &&
+      typeof activeDragState.handleElement.releasePointerCapture === 'function' &&
+      activeDragState.pointerId !== undefined
+    ) {
+      try {
+        activeDragState.handleElement.releasePointerCapture(activeDragState.pointerId);
+      } catch (releaseError) {
+        // Ignore release errors – capturing might not be active or supported
+      }
     }
 
     if (rotationMoveHandlerRef.current) {
@@ -904,7 +923,8 @@ const CampaignMapBoard = ({
     }
 
     rotationDragStateRef.current = null;
-  }, []);
+    setDraggingRotationTokenId(null);
+  }, [setDraggingRotationTokenId]);
 
   useEffect(() => () => stopRotationDrag(), [stopRotationDrag]);
 
@@ -1026,7 +1046,7 @@ const CampaignMapBoard = ({
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
-      const pointerDegrees = normalizeDegrees((pointerAngle * 180) / Math.PI);
+      const pointerDegrees = normalizeDegrees(radiansToDegrees(pointerAngle));
       const normalizedCurrent = normalizeDegrees(currentRotation);
       const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
 
@@ -1043,13 +1063,32 @@ const CampaignMapBoard = ({
 
       stopRotationDrag();
 
+      setDraggingRotationTokenId(tokenId);
+
       rotationDragStateRef.current = {
         tokenId,
         pointerId: event.pointerId,
         centerX,
         centerY,
-        offset: normalizeDegrees(normalizedCurrent - pointerDegrees),
+        tokenElement,
+        baseRotationDegrees: normalizedCurrent,
+        initialPointerAngle: pointerAngle,
+        lastPointerAngle: pointerAngle,
+        unwrappedPointerAngle: pointerAngle,
+        handleElement: event.currentTarget || null,
       };
+
+      if (
+        event.currentTarget &&
+        typeof event.currentTarget.setPointerCapture === 'function' &&
+        event.pointerId !== undefined
+      ) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch (captureError) {
+          // Ignore capture errors – some browsers might throw if capture isn't supported
+        }
+      }
 
       const handleMove = (moveEvent) => {
         const dragState = rotationDragStateRef.current;
@@ -1068,10 +1107,46 @@ const CampaignMapBoard = ({
         moveEvent.preventDefault();
         moveEvent.stopPropagation();
 
-        const angle = Math.atan2(moveEvent.clientY - dragState.centerY, moveEvent.clientX - dragState.centerX);
-        const angleDegrees = normalizeDegrees((angle * 180) / Math.PI);
-        const nextRotation = normalizeDegrees(angleDegrees + dragState.offset);
-        const handleAngle = normalizeDegrees(angleDegrees + 90);
+        let centerX = dragState.centerX;
+        let centerY = dragState.centerY;
+
+        if (
+          dragState.tokenElement &&
+          typeof dragState.tokenElement.getBoundingClientRect === 'function'
+        ) {
+          const updatedRect = dragState.tokenElement.getBoundingClientRect();
+          if (
+            updatedRect &&
+            Number.isFinite(updatedRect.left) &&
+            Number.isFinite(updatedRect.top)
+          ) {
+            centerX = updatedRect.left + updatedRect.width / 2;
+            centerY = updatedRect.top + updatedRect.height / 2;
+            dragState.centerX = centerX;
+            dragState.centerY = centerY;
+          }
+        }
+
+        const angle = Math.atan2(moveEvent.clientY - centerY, moveEvent.clientX - centerX);
+        const { lastPointerAngle = angle, unwrappedPointerAngle = lastPointerAngle } = dragState;
+        let delta = angle - lastPointerAngle;
+        if (delta > Math.PI) {
+          delta -= TWO_PI;
+        } else if (delta < -Math.PI) {
+          delta += TWO_PI;
+        }
+
+        const nextUnwrappedAngle = unwrappedPointerAngle + delta;
+        dragState.lastPointerAngle = angle;
+        dragState.unwrappedPointerAngle = nextUnwrappedAngle;
+
+        const initialPointerAngle = dragState.initialPointerAngle ?? nextUnwrappedAngle;
+        const baseRotationDegrees = dragState.baseRotationDegrees ?? 0;
+        const deltaRadians = nextUnwrappedAngle - initialPointerAngle;
+        const nextRotation = normalizeDegrees(
+          baseRotationDegrees + radiansToDegrees(deltaRadians)
+        );
+        const handleAngle = normalizeDegrees(radiansToDegrees(nextUnwrappedAngle) + 90);
 
         setRotationHandleAngles((prev) => {
           if (prev[tokenId] === handleAngle) {
@@ -1146,7 +1221,7 @@ const CampaignMapBoard = ({
       event.preventDefault();
       event.stopPropagation();
     },
-    [applyTokenRotation, interactionDisabled, stopRotationDrag]
+    [applyTokenRotation, interactionDisabled, setDraggingRotationTokenId, stopRotationDrag]
   );
 
   const lockRotation = useCallback((tokenId) => {
@@ -1293,6 +1368,7 @@ const CampaignMapBoard = ({
                   : fallbackHandleAngle;
                 const rotationHandleStyleValue = `${effectiveHandleAngle}deg`;
                 const isRotationActive = lastDraggedTokenId === characterId;
+                const isRotationDragging = draggingRotationTokenId === characterId;
 
                 const labelClassName = classNames(
                   'campaign-map-board__figurine-label',
@@ -1311,7 +1387,8 @@ const CampaignMapBoard = ({
                       isLabelActive && 'campaign-map-board__token--label-active',
                       isActiveTurn && 'campaign-map-board__token--active-turn',
                       `campaign-map-board__token--size-${sizeKey}`,
-                      isRotationActive && 'lastDragged'
+                      isRotationActive && 'lastDragged',
+                      isRotationDragging && 'campaign-map-board__token--rotation-active'
                     )}
                     style={{
                       left: `${(position?.x ?? 0) * 100}%`,


### PR DESCRIPTION
## Summary
- track the unwrapped pointer angle during rotation drags so figurines rotate continuously with the cursor
- refresh the figurine center from the live DOM rect while dragging so the handle stays aligned

## Testing
- CI=true npm test -- CampaignMapBoard

------
https://chatgpt.com/codex/tasks/task_e_68ed4882a2e8832ebc90df762e792c79