### PR TITLE
Fix undefined degreesToRadians helper usage

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -399,6 +399,7 @@ const normalizeDegrees = (value) => {
 };
 
 const radiansToDegrees = (radians) => (Number(radians) * 180) / Math.PI;
+const degreesToRadians = (degrees) => (Number(degrees) * Math.PI) / 180;
 
 const CampaignMapBoard = ({
   map,


### PR DESCRIPTION
## Summary
- add a degreesToRadians helper next to radiansToDegrees
- ensure the rotation logic can convert degrees without eslint errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed532ec310832e8cb41d03d5bbd417