### PR TITLE
Fix rotation handle feedback while dragging

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1052,6 +1052,11 @@ const CampaignMapBoard = ({
       const currentRotationRadians = degreesToRadians(normalizedCurrent);
       const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
 
+      if (tokenElement.style && typeof tokenElement.style.setProperty === 'function') {
+        tokenElement.style.setProperty('--figurine-rotation', `${normalizedCurrent}deg`);
+        tokenElement.style.setProperty('--rotation-handle-angle', `${initialHandleAngle}deg`);
+      }
+
       setRotationHandleAngles((prev) => {
         if (prev[tokenId] === initialHandleAngle) {
           return prev;
@@ -1149,6 +1154,15 @@ const CampaignMapBoard = ({
           baseRotationDegrees + radiansToDegrees(deltaRadians)
         );
         const handleAngle = normalizeDegrees(radiansToDegrees(nextUnwrappedAngle) + 90);
+
+        if (
+          dragState.tokenElement &&
+          dragState.tokenElement.style &&
+          typeof dragState.tokenElement.style.setProperty === 'function'
+        ) {
+          dragState.tokenElement.style.setProperty('--figurine-rotation', `${nextRotation}deg`);
+          dragState.tokenElement.style.setProperty('--rotation-handle-angle', `${handleAngle}deg`);
+        }
 
         setRotationHandleAngles((prev) => {
           if (prev[tokenId] === handleAngle) {


### PR DESCRIPTION
## Summary
- update rotation drag handling to push live CSS custom property updates during pointer movement
- keep the rotation handle aligned with the cursor by mirroring the active rotation onto the token element immediately

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed54cae724832ead8d2878e72162c0