### PR TITLE
Avoid persisting rotation while dragging tokens

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -935,13 +935,12 @@ const CampaignMapBoard = ({
     }
   }, [interactionDisabled, stopRotationDrag]);
 
-  const updateTokenRotation = useCallback(
+  const previewTokenRotation = useCallback(
     (tokenId, rotation) => {
       if (!tokenId || !Number.isFinite(rotation)) {
         return;
       }
 
-      const tokensList = tokenPositionsRef.current;
       const normalizedRotation = normalizeDegrees(rotation);
 
       setRotationOverrides((prev) => {
@@ -956,6 +955,21 @@ const CampaignMapBoard = ({
       });
 
       setLastDraggedTokenId(tokenId);
+    },
+    []
+  );
+
+
+  const applyTokenRotation = useCallback(
+    (tokenId, rotation) => {
+      if (!tokenId || !Number.isFinite(rotation)) {
+        return;
+      }
+
+      previewTokenRotation(tokenId, rotation);
+
+      const tokensList = tokenPositionsRef.current;
+      const normalizedRotation = normalizeDegrees(rotation);
 
       if (typeof onTokenPositionChange === 'function' && Array.isArray(tokensList)) {
         const foundToken = tokensList.find((entry) => entry?.characterId === tokenId);
@@ -978,19 +992,7 @@ const CampaignMapBoard = ({
         }
       }
     },
-    [onTokenPositionChange]
-  );
-
-
-  const applyTokenRotation = useCallback(
-    (tokenId, rotation) => {
-      if (!tokenId || !Number.isFinite(rotation)) {
-        return;
-      }
-
-      updateTokenRotation(tokenId, rotation);
-    },
-    [updateTokenRotation]
+    [onTokenPositionChange, previewTokenRotation]
   );
 
 
@@ -1052,6 +1054,11 @@ const CampaignMapBoard = ({
       const currentRotationRadians = degreesToRadians(normalizedCurrent);
       const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
 
+      if (tokenElement.style && typeof tokenElement.style.setProperty === 'function') {
+        tokenElement.style.setProperty('--figurine-rotation', `${normalizedCurrent}deg`);
+        tokenElement.style.setProperty('--rotation-handle-angle', `${initialHandleAngle}deg`);
+      }
+
       setRotationHandleAngles((prev) => {
         if (prev[tokenId] === initialHandleAngle) {
           return prev;
@@ -1077,6 +1084,7 @@ const CampaignMapBoard = ({
         initialPointerAngle: pointerAngle,
         lastPointerAngle: pointerAngle,
         unwrappedPointerAngle: pointerAngle,
+        pendingRotationDegrees: normalizedCurrent,
         handleElement: event.currentTarget || null,
       };
 
@@ -1150,6 +1158,15 @@ const CampaignMapBoard = ({
         );
         const handleAngle = normalizeDegrees(radiansToDegrees(nextUnwrappedAngle) + 90);
 
+        if (
+          dragState.tokenElement &&
+          dragState.tokenElement.style &&
+          typeof dragState.tokenElement.style.setProperty === 'function'
+        ) {
+          dragState.tokenElement.style.setProperty('--figurine-rotation', `${nextRotation}deg`);
+          dragState.tokenElement.style.setProperty('--rotation-handle-angle', `${handleAngle}deg`);
+        }
+
         setRotationHandleAngles((prev) => {
           if (prev[tokenId] === handleAngle) {
             return prev;
@@ -1161,7 +1178,9 @@ const CampaignMapBoard = ({
           };
         });
 
-        applyTokenRotation(tokenId, nextRotation);
+        dragState.pendingRotationDegrees = nextRotation;
+
+        previewTokenRotation(tokenId, nextRotation);
       };
 
       const handleRelease = (releaseEvent) => {
@@ -1179,6 +1198,16 @@ const CampaignMapBoard = ({
           return;
         }
 
+        const { pendingRotationDegrees, baseRotationDegrees } = dragState;
+
+        const rotationToCommit = Number.isFinite(pendingRotationDegrees)
+          ? pendingRotationDegrees
+          : Number.isFinite(baseRotationDegrees)
+            ? baseRotationDegrees
+            : normalizedCurrent;
+
+        applyTokenRotation(tokenId, rotationToCommit);
+
         releaseEvent.preventDefault();
         releaseEvent.stopPropagation();
         stopRotationDrag();
@@ -1193,6 +1222,10 @@ const CampaignMapBoard = ({
           cancelEvent.pointerId !== dragState.pointerId
         ) {
           return;
+        }
+
+        if (dragState && Number.isFinite(dragState.baseRotationDegrees)) {
+          previewTokenRotation(tokenId, dragState.baseRotationDegrees);
         }
 
         stopRotationDrag();
@@ -1223,7 +1256,13 @@ const CampaignMapBoard = ({
       event.preventDefault();
       event.stopPropagation();
     },
-    [applyTokenRotation, interactionDisabled, setDraggingRotationTokenId, stopRotationDrag]
+    [
+      applyTokenRotation,
+      interactionDisabled,
+      previewTokenRotation,
+      setDraggingRotationTokenId,
+      stopRotationDrag,
+    ]
   );
 
   const lockRotation = useCallback((tokenId) => {


### PR DESCRIPTION
## Summary
- preview token rotation updates locally during pointer movement instead of persisting on every frame
- commit the final rotation once the drag ends and restore the starting rotation when the drag is cancelled

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed54cae724832ead8d2878e72162c0