### PR TITLE
Stop rotating campaign map health bars with figurines

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2910,12 +2910,21 @@ h1 {
     align-items: center;
     justify-content: flex-end;
     gap: clamp(1px, calc(var(--figurine-base-size) * 0.05), 0.25rem);
+  }
+
+  &__figurine-rotation-wrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
     transform: rotate(var(--figurine-rotation, 0deg));
     transform-origin: 50% calc(var(--figurine-base-size) * 0.75);
     transition: transform 0.2s ease;
   }
 
-  &__token--rotation-active &__token-figure {
+  &__token--rotation-active &__figurine-rotation-wrapper {
     transition: transform 0s linear;
   }
 
@@ -2952,7 +2961,7 @@ h1 {
     justify-content: flex-end;
     filter: drop-shadow(0 0.1rem 0.25rem rgba(0, 0, 0, 0.65));
     transform-origin: 50% 50%;
-    transform: translate(-50%, -50%) rotate(var(--figurine-rotation, 0deg));
+    transform: translate(-50%, -50%);
     pointer-events: none;
     z-index: 1;
   }
@@ -2963,8 +2972,6 @@ h1 {
     align-items: stretch;
     justify-content: flex-end;
     width: 100%;
-    transform: rotate(calc(var(--figurine-rotation, 0deg) * -1));
-    transform-origin: 50% 50%;
   }
 
   &__health-track {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1513,37 +1513,39 @@ const CampaignMapBoard = ({
                           </div>
                         </div>
                       )}
-                      <div
-                        className={classNames(
-                          'campaign-map-board__figurine',
-                          draggable && 'campaign-map-board__figurine--active',
-                          isActiveTurn && 'campaign-map-board__figurine--active-turn',
-                          hasFigurineImage && 'campaign-map-board__figurine--has-image'
-                        )}
-                        style={{ '--figurine-color': figurineColor }}
-                      >
-                        {hasFigurineImage && (
-                          <span className="campaign-map-board__figurine-image-wrapper" aria-hidden="true">
-                            <img
-                              src={figurineImageUrl}
-                              alt=""
-                              className="campaign-map-board__figurine-image"
-                              data-figurine-public-id={figurineImagePublicId || undefined}
-                              loading="lazy"
-                              onLoad={(event) =>
-                                handleFigurineImageLoad(
-                                  figurineMetricKey,
-                                  event?.currentTarget || event?.target || null
-                                )
-                              }
-                            />
+                      <div className="campaign-map-board__figurine-rotation-wrapper">
+                        <div
+                          className={classNames(
+                            'campaign-map-board__figurine',
+                            draggable && 'campaign-map-board__figurine--active',
+                            isActiveTurn && 'campaign-map-board__figurine--active-turn',
+                            hasFigurineImage && 'campaign-map-board__figurine--has-image'
+                          )}
+                          style={{ '--figurine-color': figurineColor }}
+                        >
+                          {hasFigurineImage && (
+                            <span className="campaign-map-board__figurine-image-wrapper" aria-hidden="true">
+                              <img
+                                src={figurineImageUrl}
+                                alt=""
+                                className="campaign-map-board__figurine-image"
+                                data-figurine-public-id={figurineImagePublicId || undefined}
+                                loading="lazy"
+                                onLoad={(event) =>
+                                  handleFigurineImageLoad(
+                                    figurineMetricKey,
+                                    event?.currentTarget || event?.target || null
+                                  )
+                                }
+                              />
+                            </span>
+                          )}
+                          <span className="campaign-map-board__figurine-figure" aria-hidden="true">
+                            <span className="campaign-map-board__figurine-head" />
+                            <span className="campaign-map-board__figurine-torso" />
+                            <span className="campaign-map-board__figurine-cloak" />
                           </span>
-                        )}
-                        <span className="campaign-map-board__figurine-figure" aria-hidden="true">
-                          <span className="campaign-map-board__figurine-head" />
-                          <span className="campaign-map-board__figurine-torso" />
-                          <span className="campaign-map-board__figurine-cloak" />
-                        </span>
+                        </div>
                       </div>
                     </div>
                     {isRotationActive && (


### PR DESCRIPTION
## Summary
- wrap figurine content in a rotation wrapper so the health container can remain static
- update campaign map styles to rotate only the figurine wrapper and keep health bars upright

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed780ee484832e8f9824f753f31562