### PR TITLE
Adjust turn indicator positioning above health bar

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2944,6 +2944,8 @@ h1 {
       0 0 1rem rgba(255, 125, 127, 0.75);
     animation: campaignMapBoardTurnIndicatorPulse 1.4s ease-in-out infinite;
     filter: drop-shadow(0 0.2rem 0.45rem rgba(0, 0, 0, 0.55));
+    z-index: 2;
+    transform: translateY(calc(var(--figurine-base-size) * -0.35));
   }
 
   &__health {


### PR DESCRIPTION
## Summary
- raise the active turn indicator so it sits above the token health bar and renders in front of it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed7a5a749c832eb7679e9ff92d46df