### PR TITLE
Center D20 roller between attack and spell controls

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1715,13 +1715,23 @@ $rotateX: -$angle;
 // Layout helpers for the attack button and dice roller
 .attack-roll-controls {
   --attack-die-size: min(25vw, 120px);
+  --attack-roll-footer-height: clamp(84px, var(--attack-die-size), 140px);
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
   gap: calc(var(--attack-die-size) * 0.25);
-  min-height: calc(var(--attack-die-size) + 88px);
-  padding-bottom: calc(var(--attack-die-size) * 0.35);
+  min-height: calc(var(--attack-die-size) + var(--attack-roll-footer-height));
+  width: 100%;
+  max-width: min(70vw, 360px);
+  margin: 0 auto;
+  flex: 1 1 auto;
+}
+
+.attack-roll-controls__button {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  flex-shrink: 0;
 }
 
 .attack-roll-controls__die {
@@ -1729,31 +1739,27 @@ $rotateX: -$angle;
   align-items: center;
   justify-content: center;
   width: 100%;
-  margin-bottom: calc(var(--attack-die-size) * 0.2);
+  margin: auto 0;
+}
+
+.attack-roll-controls__spacer {
+  height: var(--attack-roll-footer-height);
+  flex-shrink: 0;
+  width: 100%;
 }
 
 @media (max-height: 600px) {
   .attack-roll-controls {
     --attack-die-size: min(20vw, 100px);
+    --attack-roll-footer-height: clamp(64px, var(--attack-die-size) * 0.9, 110px);
     gap: calc(var(--attack-die-size) * 0.25);
-    min-height: calc(var(--attack-die-size) + 88px);
-    padding-bottom: calc(var(--attack-die-size) * 0.35);
-  }
-
-  .attack-roll-controls__die {
-    margin-bottom: calc(var(--attack-die-size) * 0.2);
   }
 }
 
 @media (max-width: 576px) {
   .attack-roll-controls {
-    gap: calc(var(--attack-die-size) * 0.4);
-    min-height: calc(var(--attack-die-size) * 1.9);
-    padding-bottom: calc(var(--attack-die-size) * 0.5);
-  }
-
-  .attack-roll-controls__die {
-    margin-bottom: calc(var(--attack-die-size) * 0.3);
+    gap: calc(var(--attack-die-size) * 0.3);
+    max-width: min(80vw, 320px);
   }
 }
 

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1044,25 +1044,28 @@ useEffect(() => {
         }}
       >
         <div className="attack-roll-controls">
-          {/* Attack Button */}
-          <button
-            onClick={handleShowAttack}
-            style={{
-              width: '64px',
-              height: '64px',
-              backgroundImage: `url(${sword})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-              border: 'none',
-              transition: 'transform 0.2s ease',
-              cursor: 'pointer',
-              backgroundColor: 'transparent',
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
-            onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
-            title="Attack"
-          />
+          <div className="attack-roll-controls__button">
+            {/* Attack Button */}
+            <button
+              onClick={handleShowAttack}
+              style={{
+                width: '64px',
+                height: '64px',
+                backgroundImage: `url(${sword})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+                border: 'none',
+                transition: 'transform 0.2s ease',
+                cursor: 'pointer',
+                backgroundColor: 'transparent',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
+              onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+              title="Attack"
+            />
+          </div>
           <D20RollerModal renderInline diceColor={form?.diceColor} />
+          <div className="attack-roll-controls__spacer" aria-hidden="true" />
         </div>
       </div>
 {/* Attack Modal */}


### PR DESCRIPTION
## Summary
- wrap the attack button and inline d20 roller with new layout helpers so the die can sit between the weapon action button and spell slots
- adjust the attack roll SCSS to reserve footer space and keep the inline d20 centered across responsive breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed7ff6a760832ebf839023e6a3dd6d