### PR TITLE
Adjust figurine scaling for specific assets

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1380,20 +1380,25 @@ const CampaignMapBoard = ({
                 const hasFigurineImage = Boolean(figurineImageUrl);
                 const figurineMetricKey = figurineImageUrl || characterId || `token-${tokenIndex}`;
                 const metrics = figurineMetricKey ? figurineImageMetrics[figurineMetricKey] : null;
+                const normalizedFigurinePublicId =
+                  typeof figurineImagePublicId === 'string'
+                    ? figurineImagePublicId.trim()
+                    : null;
+                const shouldScaleFigurineImage =
+                  (metrics?.width === 1200 && metrics?.height === 1200) ||
+                  (typeof normalizedFigurinePublicId === 'string' &&
+                    normalizedFigurinePublicId.toLowerCase().includes('scale300_01'));
                 const imageFootprint = hasFigurineImage
                   ? resolveFigurineSquaresFromImageSize(metrics, metadataSquareSize)
                   : null;
                 const sizeKey = resolveFigurineSizeKey(size);
                 const baseFigurineScale =
                   FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? DEFAULT_FIGURINE_GRID_SQUARES;
-                const figurineScale =
-                  sizeKey === 'medium'
-                    ? 1
-                    : Number.isFinite(imageFootprint)
-                      ? imageFootprint
-                      : Number.isFinite(baseFigurineScale)
-                        ? baseFigurineScale
-                        : DEFAULT_FIGURINE_GRID_SQUARES;
+                const figurineScale = Number.isFinite(imageFootprint)
+                  ? imageFootprint
+                  : Number.isFinite(baseFigurineScale)
+                    ? baseFigurineScale
+                    : DEFAULT_FIGURINE_GRID_SQUARES;
 
                 const figurineColor =
                   normalizedVariant === 'enemy'
@@ -1534,11 +1539,7 @@ const CampaignMapBoard = ({
                                 className="campaign-map-board__figurine-image"
                                 data-figurine-public-id={figurineImagePublicId || undefined}
                                 loading="lazy"
-                                style={
-                                  metrics?.width === 1200 && metrics?.height === 1200
-                                    ? { scale: 3 }
-                                    : undefined
-                                }
+                                style={shouldScaleFigurineImage ? { scale: '3' } : undefined}
                                 onLoad={(event) =>
                                   handleFigurineImageLoad(
                                     figurineMetricKey,

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -332,6 +332,25 @@ describe('CampaignMapBoard pointer interactions', () => {
     expect(figurineImage?.getAttribute('alt')).toBe('');
   });
 
+  it('forces figurine image scale when public id indicates Scale300_01 asset', () => {
+    const { container } = renderBoard({
+      token: {
+        figurineImageUrl: 'https://example.com/figurines/special.png',
+        figurineImagePublicId: ' Figurines/SCALE300_01 ',
+      },
+    });
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    const figurineImage = tokenElement?.querySelector('.campaign-map-board__figurine-image');
+    expect(figurineImage).not.toBeNull();
+
+    const inlineStyle = figurineImage?.getAttribute('style') ?? '';
+    const scaleProperty = figurineImage?.style?.scale ?? '';
+    expect(inlineStyle.includes('scale: 3') || scaleProperty === '3').toBe(true);
+  });
+
   it('keeps enemy figurine scale aligned with their size category', () => {
     const { container } = renderBoard({
       token: {


### PR DESCRIPTION
## Summary
- ensure figurine images with the Scale300_01 public id are forced to render with scale: 3
- let image-derived footprints influence figurine size scaling and normalize public id handling
- cover the new scaling behavior with a dedicated CampaignMapBoard test

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ee897610f08323add362348d6cd73a