### PR TITLE
Ensure medium figurines keep default scale

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1386,16 +1386,24 @@ const CampaignMapBoard = ({
                 const sizeKey = resolveFigurineSizeKey(size);
                 const baseFigurineScale =
                   FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? DEFAULT_FIGURINE_GRID_SQUARES;
-                const figurineScale = Number.isFinite(imageFootprint)
-                  ? imageFootprint
-                  : Number.isFinite(baseFigurineScale)
-                    ? baseFigurineScale
-                    : DEFAULT_FIGURINE_GRID_SQUARES;
+                const figurineScale =
+                  sizeKey === 'medium'
+                    ? 1
+                    : Number.isFinite(imageFootprint)
+                      ? imageFootprint
+                      : Number.isFinite(baseFigurineScale)
+                        ? baseFigurineScale
+                        : DEFAULT_FIGURINE_GRID_SQUARES;
 
                 const figurineColor =
                   normalizedVariant === 'enemy'
                     ? ENEMY_FIGURINE_COLOR
                     : normalizeText(color) || undefined;
+                const shouldScaleFigurineImage =
+                  metrics?.width === 1200 && metrics?.height === 1200
+                    ? true
+                    : typeof figurineImageUrl === 'string' &&
+                        figurineImageUrl.includes('Scale300_01');
                 const resolvedRotation = getResolvedRotationForToken(token);
                 const rotationValue = Number.isFinite(resolvedRotation)
                   ? resolvedRotation
@@ -1531,6 +1539,7 @@ const CampaignMapBoard = ({
                                 className="campaign-map-board__figurine-image"
                                 data-figurine-public-id={figurineImagePublicId || undefined}
                                 loading="lazy"
+                                style={shouldScaleFigurineImage ? { scale: 3 } : undefined}
                                 onLoad={(event) =>
                                   handleFigurineImageLoad(
                                     figurineMetricKey,


### PR DESCRIPTION
## Summary
- keep medium-sized tokens at a figurine size scale of 1 regardless of image footprint
- apply a CSS scale of 3 to figurine images when they are 1200x1200 or the URL indicates a Scale300 asset

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee87756c808323875b483cc532ae9e