### PR TITLE
Fix campaign map figurine image scaling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3168,8 +3168,7 @@ h1 {
     z-index: 2;
   }
 
-  &__figurine-image__scale-up {
-    scale: 2.7;
+  &__figurine-image {
     width: 100%;
     height: 100%;
     max-width: none;
@@ -3178,13 +3177,9 @@ h1 {
     filter: drop-shadow(0 0.4rem 0.9rem rgba(0, 0, 0, 0.55));
   }
 
-  &__figurine-image {
-    width: 100%;
-    height: 100%;
-    max-width: none;
-    max-height: none;
-    object-fit: contain;
-    filter: drop-shadow(0 0.4rem 0.9rem rgba(0, 0, 0, 0.55));
+  &__figurine-image__scale-up {
+    transform: scale(2.7);
+    transform-origin: center bottom;
   }
 
 

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1386,14 +1386,11 @@ const CampaignMapBoard = ({
                 const sizeKey = resolveFigurineSizeKey(size);
                 const baseFigurineScale =
                   FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? DEFAULT_FIGURINE_GRID_SQUARES;
-                const figurineScale =
-                  sizeKey === 'medium'
-                    ? 1
-                    : Number.isFinite(imageFootprint)
-                      ? imageFootprint
-                      : Number.isFinite(baseFigurineScale)
-                        ? baseFigurineScale
-                        : DEFAULT_FIGURINE_GRID_SQUARES;
+                const figurineScale = Number.isFinite(imageFootprint)
+                  ? imageFootprint
+                  : Number.isFinite(baseFigurineScale)
+                    ? baseFigurineScale
+                    : DEFAULT_FIGURINE_GRID_SQUARES;
 
                 const figurineColor =
                   normalizedVariant === 'enemy'
@@ -1411,6 +1408,9 @@ const CampaignMapBoard = ({
                   ? storedHandleAngle
                   : fallbackHandleAngle;
                 const rotationHandleStyleValue = `${effectiveHandleAngle}deg`;
+                const shouldScaleUpFigurineImage =
+                  typeof figurineImageUrl === 'string' &&
+                  figurineImageUrl.toLowerCase().includes('scale300_');
                 const isRotationActive = lastDraggedTokenId === characterId;
                 const isRotationDragging = draggingRotationTokenId === characterId;
 
@@ -1531,7 +1531,11 @@ const CampaignMapBoard = ({
                               <img
                                 src={figurineImageUrl}
                                 alt=""
-                                className={figurineImageUrl.includes("Scale300_01") ?"campaign-map-board__figurine-image__scale-up":"campaign-map-board__figurine-image"}
+                                className={classNames(
+                                  'campaign-map-board__figurine-image',
+                                  shouldScaleUpFigurineImage &&
+                                    'campaign-map-board__figurine-image__scale-up'
+                                )}
                                 data-figurine-public-id={figurineImagePublicId || undefined}
                                 loading="lazy"
                                 onLoad={(event) =>


### PR DESCRIPTION
## Summary
- allow campaign map figurine scaling to use measured image footprint regardless of declared medium size so high-resolution tokens render sharply
- add robust Scale300 detection so matching figurines reuse the shared base class with an optional scale-up modifier
- update figurine image styles to use a transform-based scale-up and share the base styling between classes

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68eea6b842548323959bb5a2aac38316