### PR TITLE
Show rotation handle on token hover

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -431,6 +431,7 @@ const CampaignMapBoard = ({
   const [dragPositions, setDragPositions] = useState({});
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
   const [lastDraggedTokenId, setLastDraggedTokenId] = useState(null);
+  const [hoveredTokenId, setHoveredTokenId] = useState(null);
   const [rotationOverrides, setRotationOverrides] = useState({});
   const rotationOverridesRef = useRef({});
   const [rotationHandleAngles, setRotationHandleAngles] = useState({});
@@ -644,6 +645,7 @@ const CampaignMapBoard = ({
     });
 
     setLastDraggedTokenId((prev) => (prev && !activeIds.has(prev) ? null : prev));
+    setHoveredTokenId((prev) => (prev && !activeIds.has(prev) ? null : prev));
   }, [tokenPositions]);
 
   const resetDragState = useCallback(() => {
@@ -1073,6 +1075,7 @@ const CampaignMapBoard = ({
       stopRotationDrag();
 
       setDraggingRotationTokenId(tokenId);
+      setHoveredTokenId(tokenId);
 
       rotationDragStateRef.current = {
         tokenId,
@@ -1208,6 +1211,30 @@ const CampaignMapBoard = ({
 
         applyTokenRotation(tokenId, rotationToCommit);
 
+        if (dragState.tokenElement && typeof dragState.tokenElement.getBoundingClientRect === 'function') {
+          const rect = dragState.tokenElement.getBoundingClientRect();
+          if (
+            rect &&
+            Number.isFinite(rect.left) &&
+            Number.isFinite(rect.top) &&
+            Number.isFinite(rect.right) &&
+            Number.isFinite(rect.bottom)
+          ) {
+            const isPointerInside =
+              releaseEvent.clientX >= rect.left &&
+              releaseEvent.clientX <= rect.right &&
+              releaseEvent.clientY >= rect.top &&
+              releaseEvent.clientY <= rect.bottom;
+
+            setHoveredTokenId((prev) => {
+              if (isPointerInside) {
+                return tokenId;
+              }
+              return prev === tokenId ? null : prev;
+            });
+          }
+        }
+
         releaseEvent.preventDefault();
         releaseEvent.stopPropagation();
         stopRotationDrag();
@@ -1228,6 +1255,7 @@ const CampaignMapBoard = ({
           previewTokenRotation(tokenId, dragState.baseRotationDegrees);
         }
 
+        setHoveredTokenId((prev) => (prev === tokenId ? null : prev));
         stopRotationDrag();
       };
 
@@ -1261,6 +1289,7 @@ const CampaignMapBoard = ({
       interactionDisabled,
       previewTokenRotation,
       setDraggingRotationTokenId,
+      setHoveredTokenId,
       stopRotationDrag,
     ]
   );
@@ -1412,7 +1441,9 @@ const CampaignMapBoard = ({
                   : fallbackHandleAngle;
                 const rotationHandleStyleValue = `${effectiveHandleAngle}deg`;
                 const isRotationActive = lastDraggedTokenId === characterId;
+                const isRotationHovered = hoveredTokenId === characterId;
                 const isRotationDragging = draggingRotationTokenId === characterId;
+                const isRotationVisible = isRotationHovered || isRotationDragging;
 
                 const labelClassName = classNames(
                   'campaign-map-board__figurine-label',
@@ -1460,6 +1491,27 @@ const CampaignMapBoard = ({
                         prev === characterId ? null : prev
                       );
                       handlePointerCancel(event);
+                    }}
+                    onPointerOver={() => {
+                      if (!interactionDisabled && characterId) {
+                        setHoveredTokenId(characterId);
+                      }
+                    }}
+                    onPointerEnter={() => {
+                      if (!interactionDisabled && characterId) {
+                        setHoveredTokenId(characterId);
+                      }
+                    }}
+                    onPointerLeave={(event) => {
+                      if (
+                        draggingRotationTokenId === characterId ||
+                        (event?.relatedTarget &&
+                          event.currentTarget &&
+                          event.currentTarget.contains(event.relatedTarget))
+                      ) {
+                        return;
+                      }
+                      setHoveredTokenId((prev) => (prev === characterId ? null : prev));
                     }}
                     onContextMenu={(event) => {
                       event.preventDefault();
@@ -1551,7 +1603,7 @@ const CampaignMapBoard = ({
                         </div>
                       </div>
                     </div>
-                    {isRotationActive && (
+                    {isRotationVisible && (
                       <div
                         className="campaign-map-board__rotation-controls"
                         style={{ '--rotation-handle-angle': rotationHandleStyleValue }}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -239,6 +239,18 @@ describe('CampaignMapBoard pointer interactions', () => {
       expect(latestToken).toHaveClass('lastDragged');
     });
 
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    if (tokenElement) {
+      const pointerOverEvent = createEvent.pointerOver(tokenElement, {
+        pointerId: 3,
+        bubbles: true,
+        cancelable: true,
+      });
+      fireEvent(tokenElement, pointerOverEvent);
+    }
+
     const rotationHandle = await findByRole('button', { name: /rotate figurine/i });
     expect(rotationHandle).not.toBeNull();
 


### PR DESCRIPTION
## Summary
- track hovered figurines so the rotation handle appears while the token is hovered or being rotated
- reset hover state appropriately during pointer release/cancel to hide the handle when the cursor leaves
- update the rotation interaction test to simulate hovering the token before asserting the handle is visible

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/CampaignMapBoard.test.js --runInBand *(fails: existing expectations around figurine scale for medium tokens)*

------
https://chatgpt.com/codex/tasks/task_e_68eed2d33824832ead823497a94d6009