### PR TITLE
Keep rotation handle aligned with figurine front

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3049,10 +3049,10 @@ h1 {
     position: absolute;
     left: 50%;
     top: 50%;
-    width: calc(var(--figurine-base-size) * 2.4);
-    height: calc(var(--figurine-base-size) * 2.4);
-    margin-left: calc(var(--figurine-base-size) * -1.2);
-    margin-top: calc(var(--figurine-base-size) * -1.2);
+    width: calc(var(--figurine-base-size) * 1.9);
+    height: calc(var(--figurine-base-size) * 1.9);
+    margin-left: calc(var(--figurine-base-size) * -0.95);
+    margin-top: calc(var(--figurine-base-size) * -0.95);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -3085,21 +3085,20 @@ h1 {
   &__token.lastDragged &__rotation-controls,
   &__rotation-controls:focus-within {
     opacity: 1;
-    pointer-events: auto;
   }
 
   &__rotation-handle {
     position: absolute;
     top: 0;
     left: 50%;
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.12)) scale(1);
+    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(1);
     transform-origin: 50% 50%;
     background: rgba(51, 154, 240, 0.25);
     border: 1px solid rgba(51, 154, 240, 0.6);
     color: #f8f9fa;
     border-radius: 50%;
-    width: clamp(2.1rem, calc(var(--figurine-base-size) * 0.72), 2.9rem);
-    height: clamp(2.1rem, calc(var(--figurine-base-size) * 0.72), 2.9rem);
+    width: clamp(1.65rem, calc(var(--figurine-base-size) * 0.55), 2.25rem);
+    height: clamp(1.65rem, calc(var(--figurine-base-size) * 0.55), 2.25rem);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -3116,24 +3115,24 @@ h1 {
     outline-offset: 3px;
     background: rgba(51, 154, 240, 0.35);
     border-color: rgba(102, 187, 255, 0.8);
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.12)) scale(1.05);
+    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(1.05);
   }
 
   &__rotation-handle:hover {
     background: rgba(51, 154, 240, 0.35);
     border-color: rgba(102, 187, 255, 0.8);
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.12)) scale(1.05);
+    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(1.05);
   }
 
   &__rotation-handle:active {
     cursor: grabbing;
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.12)) scale(0.97);
+    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(0.97);
   }
 
   &__rotation-handle-icon {
-    width: 60%;
-    height: 60%;
-    border: 2px solid currentColor;
+    width: 58%;
+    height: 58%;
+    border: 1.75px solid currentColor;
     border-right-color: transparent;
     border-bottom-color: transparent;
     border-radius: 50%;
@@ -3147,10 +3146,10 @@ h1 {
     position: absolute;
     top: -0.05rem;
     right: -0.1rem;
-    width: 0.45rem;
-    height: 0.45rem;
-    border-top: 2px solid currentColor;
-    border-right: 2px solid currentColor;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-top: 1.75px solid currentColor;
+    border-right: 1.75px solid currentColor;
     transform: rotate(35deg);
   }
 

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -431,9 +431,9 @@ const CampaignMapBoard = ({
   const [dragPositions, setDragPositions] = useState({});
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
   const [lastDraggedTokenId, setLastDraggedTokenId] = useState(null);
+  const [hoveredTokenId, setHoveredTokenId] = useState(null);
   const [rotationOverrides, setRotationOverrides] = useState({});
   const rotationOverridesRef = useRef({});
-  const [rotationHandleAngles, setRotationHandleAngles] = useState({});
   const [draggingRotationTokenId, setDraggingRotationTokenId] = useState(null);
   const tokenPositionsRef = useRef([]);
   const [layerNode, setLayerNode] = useState(null);
@@ -626,24 +626,8 @@ const CampaignMapBoard = ({
       return next;
     });
 
-    setRotationHandleAngles((prev) => {
-      const next = {};
-      activeIds.forEach((id) => {
-        if (Object.prototype.hasOwnProperty.call(prev, id)) {
-          next[id] = prev[id];
-        }
-      });
-
-      const prevKeys = Object.keys(prev);
-      const nextKeys = Object.keys(next);
-      if (prevKeys.length === nextKeys.length && prevKeys.every((key) => next[key] === prev[key])) {
-        return prev;
-      }
-
-      return next;
-    });
-
     setLastDraggedTokenId((prev) => (prev && !activeIds.has(prev) ? null : prev));
+    setHoveredTokenId((prev) => (prev && !activeIds.has(prev) ? null : prev));
   }, [tokenPositions]);
 
   const resetDragState = useCallback(() => {
@@ -1036,6 +1020,10 @@ const CampaignMapBoard = ({
         return;
       }
 
+      if (typeof event?.stopPropagation === 'function') {
+        event.stopPropagation();
+      }
+
       const tokenElement = event.currentTarget?.closest('.campaign-map-board__token');
       if (!tokenElement) {
         return;
@@ -1049,34 +1037,23 @@ const CampaignMapBoard = ({
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
       const pointerAngle = Math.atan2(event.clientY - centerY, event.clientX - centerX);
-      const pointerDegrees = normalizeDegrees(radiansToDegrees(pointerAngle));
       const normalizedCurrent = normalizeDegrees(currentRotation);
-      const currentRotationRadians = degreesToRadians(normalizedCurrent);
-      const initialHandleAngle = normalizeDegrees(pointerDegrees + 90);
+      const initialHandleAngle = normalizeDegrees(normalizedCurrent + 90);
 
       if (tokenElement.style && typeof tokenElement.style.setProperty === 'function') {
         tokenElement.style.setProperty('--figurine-rotation', `${normalizedCurrent}deg`);
         tokenElement.style.setProperty('--rotation-handle-angle', `${initialHandleAngle}deg`);
       }
 
-      setRotationHandleAngles((prev) => {
-        if (prev[tokenId] === initialHandleAngle) {
-          return prev;
-        }
-
-        return {
-          ...prev,
-          [tokenId]: initialHandleAngle,
-        };
-      });
-
       stopRotationDrag();
 
       setDraggingRotationTokenId(tokenId);
+      setHoveredTokenId(tokenId);
 
       rotationDragStateRef.current = {
         tokenId,
         pointerId: event.pointerId,
+        pointerType: event.pointerType || null,
         centerX,
         centerY,
         tokenElement,
@@ -1099,6 +1076,60 @@ const CampaignMapBoard = ({
           // Ignore capture errors – some browsers might throw if capture isn't supported
         }
       }
+
+      const handleRelease = (releaseEvent) => {
+        const dragState = rotationDragStateRef.current;
+        if (!dragState || dragState.tokenId !== tokenId) {
+          stopRotationDrag();
+          return;
+        }
+
+        if (
+          dragState.pointerId !== undefined &&
+          releaseEvent.pointerId !== undefined &&
+          releaseEvent.pointerId !== dragState.pointerId
+        ) {
+          return;
+        }
+
+        const { pendingRotationDegrees, baseRotationDegrees } = dragState;
+
+        const rotationToCommit = Number.isFinite(pendingRotationDegrees)
+          ? pendingRotationDegrees
+          : Number.isFinite(baseRotationDegrees)
+            ? baseRotationDegrees
+            : normalizedCurrent;
+
+        applyTokenRotation(tokenId, rotationToCommit);
+
+        if (dragState.tokenElement && typeof dragState.tokenElement.getBoundingClientRect === 'function') {
+          const rect = dragState.tokenElement.getBoundingClientRect();
+          if (
+            rect &&
+            Number.isFinite(rect.left) &&
+            Number.isFinite(rect.top) &&
+            Number.isFinite(rect.right) &&
+            Number.isFinite(rect.bottom)
+          ) {
+            const isPointerInside =
+              releaseEvent.clientX >= rect.left &&
+              releaseEvent.clientX <= rect.right &&
+              releaseEvent.clientY >= rect.top &&
+              releaseEvent.clientY <= rect.bottom;
+
+            setHoveredTokenId((prev) => {
+              if (isPointerInside) {
+                return tokenId;
+              }
+              return prev === tokenId ? null : prev;
+            });
+          }
+        }
+
+        releaseEvent.preventDefault();
+        releaseEvent.stopPropagation();
+        stopRotationDrag();
+      };
 
       const handleMove = (moveEvent) => {
         const dragState = rotationDragStateRef.current;
@@ -1156,7 +1187,7 @@ const CampaignMapBoard = ({
         const nextRotation = normalizeDegrees(
           baseRotationDegrees + radiansToDegrees(deltaRadians)
         );
-        const handleAngle = normalizeDegrees(radiansToDegrees(nextUnwrappedAngle) + 90);
+        const handleAngle = normalizeDegrees(nextRotation + 90);
 
         if (
           dragState.tokenElement &&
@@ -1167,50 +1198,9 @@ const CampaignMapBoard = ({
           dragState.tokenElement.style.setProperty('--rotation-handle-angle', `${handleAngle}deg`);
         }
 
-        setRotationHandleAngles((prev) => {
-          if (prev[tokenId] === handleAngle) {
-            return prev;
-          }
-
-          return {
-            ...prev,
-            [tokenId]: handleAngle,
-          };
-        });
-
         dragState.pendingRotationDegrees = nextRotation;
 
         previewTokenRotation(tokenId, nextRotation);
-      };
-
-      const handleRelease = (releaseEvent) => {
-        const dragState = rotationDragStateRef.current;
-        if (!dragState || dragState.tokenId !== tokenId) {
-          stopRotationDrag();
-          return;
-        }
-
-        if (
-          dragState.pointerId !== undefined &&
-          releaseEvent.pointerId !== undefined &&
-          releaseEvent.pointerId !== dragState.pointerId
-        ) {
-          return;
-        }
-
-        const { pendingRotationDegrees, baseRotationDegrees } = dragState;
-
-        const rotationToCommit = Number.isFinite(pendingRotationDegrees)
-          ? pendingRotationDegrees
-          : Number.isFinite(baseRotationDegrees)
-            ? baseRotationDegrees
-            : normalizedCurrent;
-
-        applyTokenRotation(tokenId, rotationToCommit);
-
-        releaseEvent.preventDefault();
-        releaseEvent.stopPropagation();
-        stopRotationDrag();
       };
 
       const handleCancel = (cancelEvent) => {
@@ -1228,6 +1218,7 @@ const CampaignMapBoard = ({
           previewTokenRotation(tokenId, dragState.baseRotationDegrees);
         }
 
+        setHoveredTokenId((prev) => (prev === tokenId ? null : prev));
         stopRotationDrag();
       };
 
@@ -1261,6 +1252,7 @@ const CampaignMapBoard = ({
       interactionDisabled,
       previewTokenRotation,
       setDraggingRotationTokenId,
+      setHoveredTokenId,
       stopRotationDrag,
     ]
   );
@@ -1405,14 +1397,11 @@ const CampaignMapBoard = ({
                   : 0;
                 const rotationDisplay = Math.round(rotationValue * 10) / 10;
                 const rotationStyleValue = `${rotationValue}deg`;
-                const storedHandleAngle = rotationHandleAngles[characterId];
-                const fallbackHandleAngle = normalizeDegrees(rotationValue + 90);
-                const effectiveHandleAngle = Number.isFinite(storedHandleAngle)
-                  ? storedHandleAngle
-                  : fallbackHandleAngle;
-                const rotationHandleStyleValue = `${effectiveHandleAngle}deg`;
+                const rotationHandleStyleValue = `${normalizeDegrees(rotationValue + 90)}deg`;
                 const isRotationActive = lastDraggedTokenId === characterId;
+                const isRotationHovered = hoveredTokenId === characterId;
                 const isRotationDragging = draggingRotationTokenId === characterId;
+                const isRotationVisible = isRotationHovered || isRotationDragging;
 
                 const labelClassName = classNames(
                   'campaign-map-board__figurine-label',
@@ -1460,6 +1449,27 @@ const CampaignMapBoard = ({
                         prev === characterId ? null : prev
                       );
                       handlePointerCancel(event);
+                    }}
+                    onPointerOver={() => {
+                      if (!interactionDisabled && characterId) {
+                        setHoveredTokenId(characterId);
+                      }
+                    }}
+                    onPointerEnter={() => {
+                      if (!interactionDisabled && characterId) {
+                        setHoveredTokenId(characterId);
+                      }
+                    }}
+                    onPointerLeave={(event) => {
+                      if (
+                        draggingRotationTokenId === characterId ||
+                        (event?.relatedTarget &&
+                          event.currentTarget &&
+                          event.currentTarget.contains(event.relatedTarget))
+                      ) {
+                        return;
+                      }
+                      setHoveredTokenId((prev) => (prev === characterId ? null : prev));
                     }}
                     onContextMenu={(event) => {
                       event.preventDefault();
@@ -1551,13 +1561,21 @@ const CampaignMapBoard = ({
                         </div>
                       </div>
                     </div>
-                    {isRotationActive && (
+                    {isRotationVisible && (
                       <div
                         className="campaign-map-board__rotation-controls"
                         style={{ '--rotation-handle-angle': rotationHandleStyleValue }}
                         onPointerDown={(event) => event.stopPropagation()}
-                        onPointerMove={(event) => event.stopPropagation()}
-                        onPointerUp={(event) => event.stopPropagation()}
+                        onPointerMove={(event) => {
+                          if (!isRotationDragging) {
+                            event.stopPropagation();
+                          }
+                        }}
+                        onPointerUp={(event) => {
+                          if (!isRotationDragging) {
+                            event.stopPropagation();
+                          }
+                        }}
                       >
                         <div className="campaign-map-board__rotation-handle-track">
                           <button

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -239,6 +239,18 @@ describe('CampaignMapBoard pointer interactions', () => {
       expect(latestToken).toHaveClass('lastDragged');
     });
 
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    if (tokenElement) {
+      const pointerOverEvent = createEvent.pointerOver(tokenElement, {
+        pointerId: 3,
+        bubbles: true,
+        cancelable: true,
+      });
+      fireEvent(tokenElement, pointerOverEvent);
+    }
+
     const rotationHandle = await findByRole('button', { name: /rotate figurine/i });
     expect(rotationHandle).not.toBeNull();
 
@@ -263,25 +275,70 @@ describe('CampaignMapBoard pointer interactions', () => {
     });
     Object.defineProperty(pointerDownHandle, 'clientX', { value: 180 });
     Object.defineProperty(pointerDownHandle, 'clientY', { value: 140 });
+    Object.defineProperty(pointerDownHandle, 'pointerType', { value: 'mouse' });
+    Object.defineProperty(pointerDownHandle, 'buttons', { value: 1, configurable: true });
     fireEvent(rotationHandle, pointerDownHandle);
 
-    const pointerMoveHandle = createEvent.pointerMove(document.body, {
+    const pointerUpWithoutDrag = createEvent.pointerUp(document.body, {
       pointerId: 2,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(pointerUpWithoutDrag, 'clientX', { value: 120 });
+    Object.defineProperty(pointerUpWithoutDrag, 'clientY', { value: 180 });
+    Object.defineProperty(pointerUpWithoutDrag, 'pointerType', { value: 'mouse' });
+    fireEvent(document.body, pointerUpWithoutDrag);
+
+    const pointerMoveAfterRelease = createEvent.pointerMove(document.body, {
+      pointerId: 2,
+      bubbles: true,
+      cancelable: true,
+      buttons: 0,
+    });
+    Object.defineProperty(pointerMoveAfterRelease, 'clientX', { value: 120 });
+    Object.defineProperty(pointerMoveAfterRelease, 'clientY', { value: 180 });
+    Object.defineProperty(pointerMoveAfterRelease, 'pointerType', { value: 'mouse' });
+    Object.defineProperty(pointerMoveAfterRelease, 'buttons', { value: 0, configurable: true });
+    fireEvent(document.body, pointerMoveAfterRelease);
+
+    await waitFor(() => {
+      const latestToken = container.querySelector('[data-token-id="char-1"]');
+      expect(latestToken).not.toBeNull();
+      expect(Number(latestToken?.getAttribute('data-rotation'))).toBeCloseTo(0, 3);
+    });
+
+    const pointerDownHandleActive = createEvent.pointerDown(rotationHandle, {
+      button: 0,
+      pointerId: 4,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(pointerDownHandleActive, 'clientX', { value: 180 });
+    Object.defineProperty(pointerDownHandleActive, 'clientY', { value: 140 });
+    Object.defineProperty(pointerDownHandleActive, 'pointerType', { value: 'mouse' });
+    Object.defineProperty(pointerDownHandleActive, 'buttons', { value: 1, configurable: true });
+    fireEvent(rotationHandle, pointerDownHandleActive);
+
+    const pointerMoveHandle = createEvent.pointerMove(document.body, {
+      pointerId: 4,
       bubbles: true,
       cancelable: true,
       buttons: 1,
     });
     Object.defineProperty(pointerMoveHandle, 'clientX', { value: 140 });
     Object.defineProperty(pointerMoveHandle, 'clientY', { value: 180 });
+    Object.defineProperty(pointerMoveHandle, 'pointerType', { value: 'mouse' });
+    Object.defineProperty(pointerMoveHandle, 'buttons', { value: 1, configurable: true });
     fireEvent(document.body, pointerMoveHandle);
 
     const pointerUpHandle = createEvent.pointerUp(document.body, {
-      pointerId: 2,
+      pointerId: 4,
       bubbles: true,
       cancelable: true,
     });
     Object.defineProperty(pointerUpHandle, 'clientX', { value: 140 });
     Object.defineProperty(pointerUpHandle, 'clientY', { value: 180 });
+    Object.defineProperty(pointerUpHandle, 'pointerType', { value: 'mouse' });
     fireEvent(document.body, pointerUpHandle);
 
     expect(onTokenPositionChange).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- keep the rotation handle locked in front of each figurine so it follows their facing while dragging
- stop the rotation overlay from swallowing pointer events so tokens can be dragged even when the handle is visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eed2d33824832ead823497a94d6009