### PR TITLE
Improve figurine rotation handle visuals

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3089,9 +3089,9 @@ h1 {
 
   &__rotation-handle {
     position: absolute;
-    top: 25%;
-    left: 75%;
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(1);
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(1);
     transform-origin: 50% 50%;
     background: rgba(51, 154, 240, 0.25);
     border: 1px solid rgba(51, 154, 240, 0.6);
@@ -3115,42 +3115,23 @@ h1 {
     outline-offset: 3px;
     background: rgba(51, 154, 240, 0.35);
     border-color: rgba(102, 187, 255, 0.8);
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(1.05);
+    transform: translate(-50%, -50%) scale(1.05);
   }
 
   &__rotation-handle:hover {
     background: rgba(51, 154, 240, 0.35);
     border-color: rgba(102, 187, 255, 0.8);
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(1.05);
+    transform: translate(-50%, -50%) scale(1.05);
   }
 
   &__rotation-handle:active {
     cursor: grabbing;
-    transform: translate(-50%, calc(var(--figurine-base-size) * -0.08)) scale(0.97);
+    transform: translate(-50%, -50%) scale(0.97);
   }
 
   &__rotation-handle-icon {
-    width: 58%;
-    height: 58%;
-    border: 1.75px solid currentColor;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    border-radius: 50%;
-    transform: rotate(-35deg);
-    position: relative;
-    display: inline-block;
-  }
-
-  &__rotation-handle-icon::after {
-    content: "";
-    position: absolute;
-    top: -0.05rem;
-    right: -0.1rem;
-    width: 0.4rem;
-    height: 0.4rem;
-    border-top: 1.75px solid currentColor;
-    border-right: 1.75px solid currentColor;
-    transform: rotate(35deg);
+    width: 62%;
+    height: 62%;
   }
 
   &__figurine-image-wrapper {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1605,10 +1605,48 @@ const CampaignMapBoard = ({
                               setLastDraggedTokenId((prev) => (prev === characterId ? null : prev))
                             }
                           >
-                            <span
+                            <svg
                               aria-hidden="true"
                               className="campaign-map-board__rotation-handle-icon"
-                            />
+                              viewBox="0 0 48 48"
+                              focusable="false"
+                            >
+                              <circle
+                                cx="24"
+                                cy="24"
+                                r="18"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                                strokeDasharray="90 32"
+                                strokeDashoffset="12"
+                              />
+                              <path
+                                d="M29.5 11.5c4.4-4.4 10.2-6.7 16.3-6.7"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                              />
+                              <polyline
+                                points="34 4 44 4 44 14"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                              <line
+                                x1="44"
+                                y1="4"
+                                x2="33"
+                                y2="15"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                              />
+                            </svg>
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- replace the rotation handle span with an inline SVG icon so the arrow is clearly defined
- retune the handle positioning styles so dragging traces a circular path around the figurine

## Testing
- npm --prefix client start

------
https://chatgpt.com/codex/tasks/task_e_68eef23dd5fc832eb25bc0cfe764028c