### PR TITLE
Adjust figurine rotation origin to align with figurine center

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2926,7 +2926,7 @@ h1 {
     align-items: center;
     justify-content: flex-end;
     transform: rotate(var(--figurine-rotation, 0deg));
-    transform-origin: 50% calc(var(--figurine-base-size) * 0.75);
+    transform-origin: 50% calc(var(--figurine-base-size) * 0.65);
     transition: transform 0.2s ease;
   }
 


### PR DESCRIPTION
## Summary
- update the figurine rotation transform origin so spinning occurs around the center of the figurine image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efeabd91e4832e82fd30ac1124f4cf