### PR TITLE
Add stat rolling support in stats modal

### DIFF
--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -4,6 +4,7 @@ import DockControls from '../components/DockControls';
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
+import { rollSkill } from './Skills';
 
 const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
@@ -136,6 +137,31 @@ export default function Stats({
     setShowBreakdown(false);
   };
 
+  const handleRoll = useCallback(
+    (statKey) => {
+      const statMod = statMods[statKey] ?? 0;
+      const { result, d20 } = rollSkill(statMod);
+      const statInfo = STATS.find((stat) => stat.key === statKey);
+      const statLabel = statInfo?.label || statKey.toUpperCase();
+
+      window.dispatchEvent(
+        new CustomEvent('damage-roll', {
+          detail: {
+            value: result,
+            source: statLabel,
+            critical: d20 === 20,
+            fumble: d20 === 1,
+          },
+        })
+      );
+
+      if (!isDocked) {
+        handleCloseStats?.();
+      }
+    },
+    [handleCloseStats, isDocked, statMods]
+  );
+
   const dialogClassName = useMemo(() => {
     if (!isDocked) {
       return undefined;
@@ -199,14 +225,24 @@ export default function Stats({
                     <span className="stat-card-key">{key.toUpperCase()}</span>
                     {label && <span className="stat-card-label">{label}</span>}
                   </div>
-                  <Button
-                    onClick={() => handleView(key)}
-                    variant="link"
-                    aria-label={`View ${label || key} details`}
-                    className="stat-card-view"
-                  >
-                    <i className="fa-solid fa-eye"></i>
-                  </Button>
+                  <div className="stat-card-actions">
+                    <Button
+                      onClick={() => handleView(key)}
+                      variant="link"
+                      aria-label={`View ${label || key} details`}
+                      className="stat-card-view"
+                    >
+                      <i className="fa-solid fa-eye"></i>
+                    </Button>
+                    <Button
+                      onClick={() => handleRoll(key)}
+                      variant="link"
+                      aria-label={`Roll ${label || key} check`}
+                      className="stat-card-roll"
+                    >
+                      <i className="fa-solid fa-dice-d20"></i>
+                    </Button>
+                  </div>
                 </div>
                 <div className="stat-card-body">
                   <div className="stat-card-metric">

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -135,3 +135,59 @@ test('stat overrides do not lower higher native scores', async () => {
   expect(screen.queryByText('Override')).not.toBeInTheDocument();
   expect(totalLabel.nextElementSibling).toHaveTextContent('22');
 });
+
+test('rolling a stat dispatches a roll event and closes the modal when undocked', async () => {
+  const form = {
+    str: 14,
+    dex: 0,
+    con: 0,
+    int: 0,
+    wis: 0,
+    cha: 0,
+    race: { abilities: {} },
+    feat: [],
+    item: [],
+    occupation: [],
+  };
+
+  const handleCloseStats = jest.fn();
+  const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+  const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.75);
+
+  render(
+    <Stats
+      form={form}
+      showStats={true}
+      handleCloseStats={handleCloseStats}
+      isDocked={false}
+    />
+  );
+
+  const strengthKey = screen.getByText('STR');
+  const strengthCard = strengthKey.closest('.stat-card');
+  expect(strengthCard).not.toBeNull();
+
+  try {
+    await act(async () => {
+      await userEvent.click(
+        within(strengthCard).getByRole('button', { name: /Roll Strength check/i })
+      );
+    });
+
+    const rollEventCall = dispatchSpy.mock.calls.find(
+      ([event]) => event?.type === 'damage-roll'
+    );
+    expect(rollEventCall).toBeDefined();
+    const [rollEvent] = rollEventCall || [];
+    expect(rollEvent.detail).toMatchObject({
+      value: 18,
+      source: 'Strength',
+      critical: false,
+      fumble: false,
+    });
+    expect(handleCloseStats).toHaveBeenCalled();
+  } finally {
+    randomSpy.mockRestore();
+    dispatchSpy.mockRestore();
+  }
+});


### PR DESCRIPTION
## Summary
- add stat roll buttons alongside each ability score in the stats modal
- reuse the existing skill rolling flow so stat rolls emit the same combat events
- cover the new rolling behavior with unit tests

## Testing
- CI=true npm test -- Stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f017e336c8832e91b690e72e4e3aa5