### PR TITLE
Add attack roll support to attack modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -670,6 +670,7 @@ body.docked-modal--resizing {
   margin-top: auto;
   display: flex;
   justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .attack-card__roll {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -14,6 +14,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
+import { rollSkill } from './Skills';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -737,6 +738,27 @@ const [isFumble, setIsFumble] = useState(false);
     return formatDamageSegments(damageString, ability);
   };
 
+  const getWeaponDisplayName = (slot, weapon) => {
+    if (weapon?.name && typeof weapon.name === 'string') {
+      const trimmed = weapon.name.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    if (typeof slot === 'string') {
+      const normalized = slot
+        .replace(/([A-Z])/g, ' $1')
+        .replace(/[_-]+/g, ' ')
+        .trim();
+      if (normalized) {
+        return toTitleCase(normalized);
+      }
+    }
+
+    return 'Attack';
+  };
+
   const handleWeaponAttack = (slot, weapon) => {
     const ability = abilityForWeapon(weapon, slot);
     const damageString = getDamageStringForHandSelection(slot, weapon);
@@ -747,6 +769,26 @@ const [isFumble, setIsFumble] = useState(false);
       result.total,
       result.breakdown,
       weapon.name
+    );
+  };
+
+  const handleWeaponAttackRoll = (slot, weapon) => {
+    const rawBonus = Number(getAttackBonus(slot, weapon));
+    const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
+    const { result, d20 } = rollSkill(bonus);
+    const weaponLabel = getWeaponDisplayName(slot, weapon);
+    const breakdown = `${d20} (d20) + ${bonus} Attack Bonus`;
+
+    window.dispatchEvent(
+      new CustomEvent('damage-roll', {
+        detail: {
+          value: result,
+          breakdown,
+          source: `${weaponLabel} Attack Roll`,
+          critical: d20 === 20,
+          fumble: d20 === 1,
+        },
+      })
     );
   };
 
@@ -1233,11 +1275,22 @@ useEffect(() => {
                       <div className="attack-card__actions">
                         <Button
                           onClick={() => {
+                            handleWeaponAttackRoll(slot, weapon);
+                            handleCloseAttack();
+                          }}
+                          variant="link"
+                          aria-label="Roll to hit"
+                          className="attack-card__roll"
+                        >
+                          <i className="fa-solid fa-bullseye"></i>
+                        </Button>
+                        <Button
+                          onClick={() => {
                             handleWeaponAttack(slot, weapon);
                             handleCloseAttack();
                           }}
                           variant="link"
-                          aria-label="roll"
+                          aria-label="Roll damage"
                           className="attack-card__roll"
                         >
                           <i className="fa-solid fa-dice-d20"></i>
@@ -1291,7 +1344,7 @@ useEffect(() => {
                           handleCloseAttack();
                         }}
                         variant="link"
-                        aria-label="roll"
+                        aria-label="Roll damage"
                         className="attack-card__roll"
                       >
                         <i className="fa-solid fa-dice-d20"></i>
@@ -1341,7 +1394,7 @@ useEffect(() => {
                               handleCloseAttack();
                             }}
                             variant="link"
-                            aria-label="roll"
+                            aria-label="Roll damage"
                             className="attack-card__roll"
                           >
                             <i className="fa-solid fa-dice-d20"></i>
@@ -1390,7 +1443,7 @@ useEffect(() => {
                             handleCloseAttack();
                           }}
                           variant="link"
-                          aria-label="roll"
+                          aria-label="Roll damage"
                           className="attack-card__roll"
                         >
                           <i className="fa-solid fa-dice-d20"></i>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -334,7 +334,7 @@ describe('PlayerTurnActions weapon damage display', () => {
       expect(fireBoltCard).not.toBeNull();
       if (!fireBoltCard) throw new Error('missing Fire Bolt card');
 
-      const rollButton = within(fireBoltCard).getByLabelText('roll');
+      const rollButton = within(fireBoltCard).getByLabelText(/Roll damage/i);
       await act(async () => {
         fireEvent.click(rollButton);
       });
@@ -346,6 +346,55 @@ describe('PlayerTurnActions weapon damage display', () => {
         if (!/^\d+$/.test(text) || text === '0') {
           throw new Error('waiting');
         }
+      });
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  test('weapon attack roll adds attack bonus to d20 result', async () => {
+    const weapon = {
+      name: 'Longsword',
+      damage: '1d8 slashing',
+      category: 'martial melee weapon',
+      source: 'weapon',
+      attackBonus: 1,
+    };
+    const originalRandom = Math.random;
+    Math.random = () => 0.4;
+
+    try {
+      render(
+        <PlayerTurnActions
+          form={{
+            diceColor: '#000000',
+            equipment: { mainHand: weapon },
+            spells: [],
+            proficiencyBonus: 3,
+          }}
+          strMod={2}
+          dexMod={0}
+        />
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByTitle('Attack'));
+      });
+
+      const card = screen.getByText('Longsword').closest('.attack-card');
+      expect(card).not.toBeNull();
+      if (!card) throw new Error('missing Longsword card');
+
+      const toHitButton = within(card).getByLabelText(/Roll to hit/i);
+
+      await act(async () => {
+        fireEvent.click(toHitButton);
+      });
+
+      await waitFor(() => {
+        const valueNode = document.getElementById('damageValue');
+        if (!valueNode) throw new Error('missing damage value node');
+        expect(valueNode.textContent).toBe('15');
       });
     } finally {
       Math.random = originalRandom;
@@ -377,7 +426,7 @@ describe('PlayerTurnActions weapon damage display', () => {
       });
       const card = screen.getByText('Healing Word').closest('.attack-card');
       expect(card).not.toBeNull();
-      const rollButton = within(card).getByLabelText('roll');
+      const rollButton = within(card).getByLabelText(/Roll damage/i);
       await act(async () => {
         fireEvent.click(rollButton);
       });
@@ -529,7 +578,7 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -575,7 +624,7 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -628,7 +677,7 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -675,7 +724,7 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -875,7 +924,7 @@ describe('PlayerTurnActions spell casting', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
 
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -917,7 +966,7 @@ describe('PlayerTurnActions spell casting', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
 
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -965,7 +1014,7 @@ describe('PlayerTurnActions spell casting', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -1006,7 +1055,7 @@ describe('PlayerTurnActions spell casting', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -1095,7 +1144,7 @@ describe('cantrip scaling', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText('roll');
+    const rollButton = await screen.findByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });


### PR DESCRIPTION
## Summary
- add an attack roll button for weapons in the attack modal that rolls a d20 plus the attack bonus
- dispatch attack roll results through the existing damage log and tweak styling for the new control
- update tests to exercise the new to-hit flow and account for renamed damage roll controls

## Testing
- CI=1 npm test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f01c87c78c832eb5a9d2393ad7d31d