### PR TITLE
Consolidate consumable inventory cards and roll healing amounts

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1244,6 +1244,18 @@ body.docked-modal--resizing {
   color: var(--bs-body-color);
 }
 
+.item-card__quantity {
+  position: absolute;
+  bottom: 0.75rem;
+  left: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background-color: rgba(33, 37, 41, 0.9);
+  pointer-events: none;
+}
+
 .weapon-card .card-title,
 .weapon-card .card-text,
 .armor-card .card-title,

--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -162,6 +162,115 @@ const buildItemOwnershipMap = (initialItems) => {
   return map;
 };
 
+const HEALING_DICE_REGEX = /(\d+)d(\d+)/gi;
+const HEALING_MODIFIER_REGEX = /([+-]\s*\d+)/gi;
+
+const sanitizeHealingString = (healing) => {
+  if (typeof healing !== 'string') {
+    return '';
+  }
+
+  const withoutHpText = healing
+    .replace(/hit points?.*$/i, '')
+    .replace(/hp.*$/i, '')
+    .trim();
+
+  return withoutHpText.replace(/\s+/g, ' ').trim();
+};
+
+const rollHealingValue = (healing) => {
+  const sanitized = sanitizeHealingString(healing);
+  if (!sanitized) {
+    return null;
+  }
+
+  HEALING_DICE_REGEX.lastIndex = 0;
+  const diceMatches = Array.from(sanitized.matchAll(HEALING_DICE_REGEX));
+  if (diceMatches.length === 0) {
+    return null;
+  }
+
+  let total = 0;
+  const diceSections = diceMatches
+    .map((match) => {
+      const count = parseInt(match[1], 10);
+      const sides = parseInt(match[2], 10);
+      if (!Number.isFinite(count) || !Number.isFinite(sides)) {
+        return null;
+      }
+
+      const rolls = Array.from({ length: count }, () =>
+        Math.floor(Math.random() * sides) + 1
+      );
+      const subtotal = rolls.reduce((sum, value) => sum + value, 0);
+      total += subtotal;
+      return { label: match[0], rolls };
+    })
+    .filter(Boolean);
+
+  HEALING_MODIFIER_REGEX.lastIndex = 0;
+  const modifierMatches = Array.from(
+    sanitized.matchAll(HEALING_MODIFIER_REGEX)
+  );
+  const modifierValues = modifierMatches
+    .map((match) => {
+      const raw = (match[1] || match[0] || '').replace(/\s+/g, '');
+      const value = parseInt(raw, 10);
+      if (!Number.isFinite(value)) {
+        return null;
+      }
+      total += value;
+      return value;
+    })
+    .filter((value) => value !== null);
+
+  const breakdownSections = [];
+  if (diceSections.length > 0) {
+    breakdownSections.push(
+      diceSections
+        .map(
+          ({ label, rolls }) => `${rolls.join(' + ')} (${label.trim()})`
+        )
+        .join(' + ')
+    );
+  }
+  if (modifierValues.length > 0) {
+    breakdownSections.push(
+      modifierValues
+        .map(
+          (value) => `${value >= 0 ? '+' : '-'}${Math.abs(value)} modifier`
+        )
+        .join(' + ')
+    );
+  }
+
+  return {
+    total,
+    breakdown: breakdownSections.join('; '),
+    expression: sanitized,
+  };
+};
+
+const triggerHealingRoll = (item) => {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return;
+  }
+
+  const result = rollHealingValue(item?.healing);
+  if (!result) {
+    return;
+  }
+
+  const sourceLabel = item?.displayName || item?.name || 'Healing Potion';
+  const detail = {
+    value: result.total,
+    breakdown: result.breakdown || result.expression,
+    source: `${sourceLabel} Healing`,
+  };
+
+  window.dispatchEvent(new CustomEvent('damage-roll', { detail }));
+};
+
 function ItemList({
   campaign,
   onChange,
@@ -320,6 +429,7 @@ function ItemList({
     if (!ownedOnly || !isConsumableItem(item)) {
       return;
     }
+
     setOwnedEntries((prev) => {
       const next = removeFirstMatchingEntry(prev, item, dataKey);
       if (next === prev) {
@@ -330,6 +440,11 @@ function ItemList({
       }
       return next;
     });
+
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
+    if (nextEntries !== ownedEntries && item?.healing) {
+      triggerHealingRoll(item);
+    }
   };
 
   const getCartCount = (item) => {
@@ -345,36 +460,11 @@ function ItemList({
   const filteredEntries = Object.entries(items).filter(([, item]) =>
     ownedOnly ? (item.ownedCount ?? 0) > 0 : true
   );
-  const expandedEntries = ownedOnly
-    ? filteredEntries.flatMap(([key, item]) => {
-        const count = item.ownedCount ?? 0;
-        if (count <= 0) return [];
-        if (count === 1) {
-          return [
-            {
-              reactKey: key,
-              dataKey: key,
-              item,
-              copyIndex: 0,
-              copyCount: 1,
-            },
-          ];
-        }
-        return Array.from({ length: count }, (_, index) => ({
-          reactKey: `${key}-${index}`,
-          dataKey: key,
-          item,
-          copyIndex: index,
-          copyCount: count,
-        }));
-      })
-    : filteredEntries.map(([key, item]) => ({
-        reactKey: key,
-        dataKey: key,
-        item,
-        copyIndex: 0,
-        copyCount: item.ownedCount ?? 0,
-      }));
+  const displayEntries = filteredEntries.map(([key, item]) => ({
+    reactKey: key,
+    dataKey: key,
+    item,
+  }));
   const bodyContent = (
     <>
       {error && (
@@ -389,7 +479,7 @@ function ItemList({
           Unrecognized items from server: {unknownItems.join(', ')}
         </Alert>
       )}
-      {expandedEntries.length === 0 ? (
+      {displayEntries.length === 0 ? (
         <div className="text-center text-muted py-3">
           {ownedOnly
             ? 'No items in inventory.'
@@ -397,16 +487,22 @@ function ItemList({
         </div>
       ) : (
         <Row className="row-cols-2 row-cols-lg-3 g-3">
-          {expandedEntries.map(({ reactKey, dataKey, item, copyIndex, copyCount }) => {
+          {displayEntries.map(({ reactKey, dataKey, item }) => {
             const categoryKey =
               typeof item.category === 'string'
                 ? item.category.toLowerCase()
                 : '';
             const Icon = categoryIcons[categoryKey] || GiTreasureMap;
             const canUseItem = ownedOnly && isConsumableItem(item);
+            const quantity = ownedOnly ? item.ownedCount ?? 0 : 0;
             return (
               <Col key={reactKey}>
-                <Card className="item-card h-100">
+                <Card className="item-card h-100 position-relative">
+                  {ownedOnly && quantity > 1 ? (
+                    <span className="item-card__quantity badge bg-dark">
+                      ×{quantity}
+                    </span>
+                  ) : null}
                   <Card.Body className="d-flex flex-column">
                     <div className="d-flex justify-content-center mb-2">
                       <Icon size={40} title={item.category} />
@@ -437,23 +533,16 @@ function ItemList({
                         )}
                       </Card.Text>
                     )}
-                    {(item.notes || (ownedOnly && copyCount > 1)) && (
+                    {item.notes && (
                       <div className="mt-auto d-flex flex-column align-items-start gap-1">
-                        {item.notes && (
-                          <Button
-                            variant="link"
-                            size="sm"
-                            className="p-0"
-                            onClick={handleShowNotes(item)}
-                          >
-                            Notes
-                          </Button>
-                        )}
-                        {ownedOnly && copyCount > 1 && (
-                          <span className="text-muted small">
-                            Copy {copyIndex + 1} of {copyCount}
-                          </span>
-                        )}
+                        <Button
+                          variant="link"
+                          size="sm"
+                          className="p-0"
+                          onClick={handleShowNotes(item)}
+                        >
+                          Notes
+                        </Button>
                       </div>
                     )}
                   </Card.Body>

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -138,7 +138,7 @@ test('omits card header and footer when embedded', async () => {
   expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
 });
 
-test('renders duplicate item cards when multiple copies are owned', async () => {
+test('shows quantity badge when multiple copies are owned', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => itemsData });
 
   render(
@@ -154,10 +154,11 @@ test('renders duplicate item cards when multiple copies are owned', async () => 
     />
   );
 
-  const torches = await screen.findAllByText('Torch');
-  expect(torches).toHaveLength(2);
-  expect(screen.getByText('Copy 1 of 2')).toBeInTheDocument();
-  expect(screen.getByText('Copy 2 of 2')).toBeInTheDocument();
+  const torchHeading = await screen.findByText('Torch');
+  const torchCard = torchHeading.closest('.card');
+  expect(torchCard).not.toBeNull();
+  expect(screen.getAllByText('Torch')).toHaveLength(1);
+  expect(within(torchCard).getByText('×2')).toBeInTheDocument();
   expect(screen.getAllByText('Potion of healing')).toHaveLength(1);
 });
 
@@ -188,10 +189,14 @@ test('use button removes a consumable item copy and triggers onChange', async ()
     />
   );
 
-  const initialCards = await screen.findAllByText('Potion of healing');
-  expect(initialCards).toHaveLength(2);
+  const potionHeading = await screen.findByText('Potion of healing');
+  const potionCard = potionHeading.closest('.card');
+  expect(potionCard).not.toBeNull();
+  expect(within(potionCard).getByText('×2')).toBeInTheDocument();
 
-  const useButton = within(initialCards[0].closest('.card')).getByRole('button', {
+  const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+  const useButton = within(potionCard).getByRole('button', {
     name: /use/i,
   });
   await userEvent.click(useButton);
@@ -202,6 +207,18 @@ test('use button removes a consumable item copy and triggers onChange', async ()
   expect(updatedItems).toHaveLength(1);
 
   await waitFor(() =>
-    expect(screen.getAllByText('Potion of healing')).toHaveLength(1)
+    expect(within(potionCard).queryByText('×2')).not.toBeInTheDocument()
   );
+  expect(screen.getAllByText('Potion of healing')).toHaveLength(1);
+
+  await waitFor(() => expect(dispatchSpy).toHaveBeenCalled());
+  const [event] = dispatchSpy.mock.calls.pop() || [];
+  expect(event).toBeInstanceOf(CustomEvent);
+  expect(event?.detail?.source).toMatch(/potion of healing/i);
+  expect(typeof event?.detail?.value).toBe('number');
+  expect(event.detail.value).toBeGreaterThanOrEqual(4);
+  expect(event.detail.value).toBeLessThanOrEqual(10);
+  expect(typeof event.detail.breakdown).toBe('string');
+
+  dispatchSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- consolidate duplicate owned items into a single inventory card with a quantity badge
- dispatch healing potion rolls to the inline dice display when consumables are used
- adjust item card styling and tests for the new quantity presentation

## Testing
- npm test -- ItemList.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f066e00a088323a3abdfd21ad6f2c8