### PR TITLE
Format healing potion damage log entries

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -248,6 +248,8 @@ const rollHealingValue = (healing) => {
     total,
     breakdown: breakdownSections.join('; '),
     expression: sanitized,
+    diceSections,
+    modifierValues,
   };
 };
 
@@ -262,10 +264,27 @@ const triggerHealingRoll = (item) => {
   }
 
   const sourceLabel = item?.displayName || item?.name || 'Healing Potion';
+  const expression = result.expression
+    ? result.expression.replace(/([+-])/g, ' $1').trim()
+    : undefined;
+  const rollValues = Array.isArray(result.diceSections)
+    ? result.diceSections.flatMap(({ rolls }) => rolls)
+    : undefined;
+  const modifierLabels = Array.isArray(result.modifierValues)
+    ? result.modifierValues.map((value) =>
+        `${value >= 0 ? '+' : '-'}${Math.abs(value)} modifier`
+      )
+    : undefined;
+
   const detail = {
     value: result.total,
     breakdown: result.breakdown || result.expression,
     source: `${sourceLabel} Healing`,
+    sourceLabel,
+    actionLabel: 'Healing',
+    expression,
+    rollValues,
+    modifierValues: modifierLabels,
   };
 
   window.dispatchEvent(new CustomEvent('damage-roll', { detail }));

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -895,7 +895,12 @@ useEffect(() => {
   }
 }, [loading]);
 
-const updateDamageValueWithAnimation = (newValue, breakdown, source) => {
+const updateDamageValueWithAnimation = (
+  newValue,
+  breakdown,
+  source,
+  extra = {}
+) => {
   setLoading(true);
   setPulseClass('');
   setDamageValue(newValue);
@@ -904,7 +909,19 @@ const updateDamageValueWithAnimation = (newValue, breakdown, source) => {
       const entry = {
         total: newValue,
         breakdown,
-        source: source ? toTitleCase(source) : undefined,
+        source: extra.sourceLabel
+          ? extra.sourceLabel
+          : source
+          ? toTitleCase(source)
+          : undefined,
+        actionLabel: extra.actionLabel,
+        expression: extra.expression,
+        rollValues: Array.isArray(extra.rollValues)
+          ? extra.rollValues
+          : undefined,
+        modifierValues: Array.isArray(extra.modifierValues)
+          ? extra.modifierValues
+          : undefined,
       };
       return [entry, { divider: true }, ...prev].slice(0, 10);
     });
@@ -918,8 +935,9 @@ const [pulseClass, setPulseClass] = useState('');
 // Allow other components to display values in the damage circle
 useEffect(() => {
   const handler = (e) => {
-    const { value, breakdown, source, critical, fumble } = e.detail || {};
-    updateDamageValueWithAnimation(value, breakdown, source);
+    const { value, breakdown, source, critical, fumble, ...extra } =
+      e.detail || {};
+    updateDamageValueWithAnimation(value, breakdown, source, extra);
     setIsCritical(!!critical && !fumble);
     setIsFumble(!!fumble);
   };
@@ -1049,26 +1067,58 @@ useEffect(() => {
               ) : (
                 <li key={idx}>
                   <div>
-                    {entry.source ? `${entry.source} (${entry.total})` : entry.total}
+                    {entry.source
+                      ? `${entry.source}${entry.actionLabel ? ' -' : ''} (${entry.total})`
+                      : entry.total}
                   </div>
-                  {entry.breakdown && (
+                  {entry.actionLabel && entry.expression ? (
                     <div>
-                      {entry.breakdown.split(' + ').map((segment, i) => {
-                        const [valueToken, ...typeParts] = segment.trim().split(/\s+/);
-                        const value = valueToken || segment;
-                        const type = typeParts.join(' ');
-                        const normalizedType = normalizeDamageTypeForClass(type);
-                        return (
-                          <div key={i}>
-                            -{' '}
-                            <span className={normalizedType ? `damage-${normalizedType}` : ''}>
-                              {value}
-                              {type ? ` ${type}` : ''}
-                            </span>
-                          </div>
-                        );
-                      })}
+                      <div>{`${entry.actionLabel} - (${entry.expression})`}</div>
+                      {Array.isArray(entry.rollValues) &&
+                        entry.rollValues.map((value, rollIdx) => (
+                          <div key={`roll-${rollIdx}`}>- {value}</div>
+                        ))}
+                      {Array.isArray(entry.modifierValues) &&
+                        entry.modifierValues.map((value, modIdx) => (
+                          <div key={`mod-${modIdx}`}>- {value}</div>
+                        ))}
                     </div>
+                  ) : (
+                    entry.breakdown && (
+                      <div>
+                        {entry.breakdown
+                          .split(';')
+                          .map((section) => section.trim())
+                          .filter(Boolean)
+                          .flatMap((section) =>
+                            section
+                              .split(' + ')
+                              .map((segment) => segment.trim())
+                              .filter(Boolean)
+                          )
+                          .map((segment, i) => {
+                            const [valueToken, ...typeParts] = segment
+                              .trim()
+                              .split(/\s+/);
+                            const value = valueToken || segment;
+                            const type = typeParts.join(' ');
+                            const normalizedType = normalizeDamageTypeForClass(type);
+                            return (
+                              <div key={i}>
+                                -{' '}
+                                <span
+                                  className={
+                                    normalizedType ? `damage-${normalizedType}` : ''
+                                  }
+                                >
+                                  {value}
+                                  {type ? ` ${type}` : ''}
+                                </span>
+                              </div>
+                            );
+                          })}
+                      </div>
+                    )
                   )}
                 </li>
               )


### PR DESCRIPTION
## Summary
- capture healing potion roll details and share them with the damage log renderer
- present healing potion entries with their dice expression, individual rolls, and modifier lines while keeping existing breakdown logic for other sources

## Testing
- CI=true npm test -- ItemList.test.js
- CI=true npm test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f070cd2c888323b960fb3be047cdb3