### PR TITLE
Consume bonus action when potion is used

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -109,6 +109,30 @@ const isConsumableItem = (item) =>
     (prop) => typeof prop === 'string' && prop.trim().toLowerCase() === 'consumable'
   );
 
+const dispatchConsumablePotionUsed = (item) => {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return;
+  }
+
+  if (!isConsumableItem(item)) {
+    return;
+  }
+
+  const label = `${item?.displayName || item?.name || ''}`.toLowerCase();
+  if (!label.includes('potion')) {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent('inventory:consumable-used', {
+      detail: {
+        type: 'potion',
+        item,
+      },
+    })
+  );
+};
+
 /** @typedef {import('../../../../types/item').Item} Item */
 
 /**
@@ -499,6 +523,7 @@ function ItemList({
     const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
     if (nextEntries !== ownedEntries && item?.healing) {
       triggerHealingRoll(item);
+      dispatchConsumablePotionUsed(item);
     }
   };
 

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -212,13 +212,22 @@ test('use button removes a consumable item copy and triggers onChange', async ()
   expect(screen.getAllByText('Potion of healing')).toHaveLength(1);
 
   await waitFor(() => expect(dispatchSpy).toHaveBeenCalled());
-  const [event] = dispatchSpy.mock.calls.pop() || [];
-  expect(event).toBeInstanceOf(CustomEvent);
-  expect(event?.detail?.source).toMatch(/potion of healing/i);
-  expect(typeof event?.detail?.value).toBe('number');
-  expect(event.detail.value).toBeGreaterThanOrEqual(4);
-  expect(event.detail.value).toBeLessThanOrEqual(10);
-  expect(typeof event.detail.breakdown).toBe('string');
+  const events = dispatchSpy.mock.calls.map(([evt]) => evt);
+
+  const healingEvent = events.find((evt) => evt?.type === 'damage-roll');
+  expect(healingEvent).toBeInstanceOf(CustomEvent);
+  expect(healingEvent?.detail?.source).toMatch(/potion of healing/i);
+  expect(typeof healingEvent?.detail?.value).toBe('number');
+  expect(healingEvent.detail.value).toBeGreaterThanOrEqual(4);
+  expect(healingEvent.detail.value).toBeLessThanOrEqual(10);
+  expect(typeof healingEvent.detail.breakdown).toBe('string');
+
+  const consumableEvent = events.find(
+    (evt) => evt?.type === 'inventory:consumable-used'
+  );
+  expect(consumableEvent).toBeInstanceOf(CustomEvent);
+  expect(consumableEvent?.detail?.type).toBe('potion');
+  expect(consumableEvent?.detail?.item?.displayName).toMatch(/potion/i);
 
   dispatchSpy.mockRestore();
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1740,6 +1740,22 @@ export default function ZombiesCharacterSheet() {
     []
   );
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handler = (event) => {
+      if (event?.detail?.type !== 'potion') {
+        return;
+      }
+      consumeCircle('bonus');
+    };
+
+    window.addEventListener('inventory:consumable-used', handler);
+    return () => window.removeEventListener('inventory:consumable-used', handler);
+  }, [consumeCircle]);
+
   const handleActionSurge = useCallback(() => {
     setActionCount((prev) => {
       const next = prev + 1;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -2265,6 +2265,47 @@ test('pass-turn event resets action and bonus usage', async () => {
   });
 });
 
+test('using a consumable potion consumes the bonus action circle', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      spellPoints: 0,
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  const { container } = render(<ZombiesCharacterSheet />);
+  await waitFor(() => expect(container.querySelector('.bonus-circle')).toBeTruthy());
+  const bonus = container.querySelector('.bonus-circle');
+  expect(bonus).toHaveClass('slot-active');
+
+  await act(async () => {
+    window.dispatchEvent(
+      new CustomEvent('inventory:consumable-used', {
+        detail: { type: 'potion' },
+      })
+    );
+  });
+
+  await waitFor(() => {
+    expect(bonus).toHaveClass('slot-used');
+  });
+});
+
 test('action and bonus markers cycle through states', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- dispatch an `inventory:consumable-used` event when a consumable potion is used so other components can react
- have the character sheet listen for potion use events and mark the bonus action circle as spent
- extend unit tests for item usage and player turn tracking to cover the new behavior

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Items/ItemList.test.js
- CI=1 npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --testNamePattern="using a consumable potion consumes the bonus action circle"


------
https://chatgpt.com/codex/tasks/task_e_68f107087f64832388c5681f5f0f726d