### PR TITLE
Ensure consumables persist after use

### DIFF
--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -25,6 +25,7 @@ export default function InventoryModal({
   dockedSide = null,
   onDockClose,
   onDockChange,
+  onItemsChange,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -123,6 +124,7 @@ export default function InventoryModal({
               show={isActive}
               embedded
               ownedOnly
+              onChange={onItemsChange}
             />
           ),
       },
@@ -152,6 +154,7 @@ export default function InventoryModal({
       normalizedItems,
       normalizedAccessories,
       normalizedWeapons,
+      onItemsChange,
     ]
   );
 

--- a/client/src/components/Zombies/attributes/InventoryModal.test.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.test.js
@@ -160,4 +160,34 @@ describe('InventoryModal', () => {
     expect(mockItemListProps.current?.ownedOnly).toBe(true);
   });
 
+  test('forwards onItemsChange to the embedded ItemList', async () => {
+    const handleItemsChange = jest.fn();
+    const form = {
+      item: [
+        [
+          'Potion of Healing',
+          'consumable',
+          '',
+          '',
+          '',
+          {},
+          {},
+        ],
+      ],
+    };
+
+    render(
+      <InventoryModal
+        show
+        activeTab="items"
+        onHide={jest.fn()}
+        onTabChange={jest.fn()}
+        form={form}
+        onItemsChange={handleItemsChange}
+      />
+    );
+
+    expect(await screen.findByTestId('item-list')).toBeInTheDocument();
+    expect(mockItemListProps.current?.onChange).toBe(handleItemsChange);
+  });
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5338,6 +5338,7 @@ export default function ZombiesCharacterSheet() {
           characterId={characterId}
           dockedSide={getDockedSide('inventory')}
           onDockChange={(side) => handleDockChange('inventory', side)}
+          onItemsChange={handleItemsChange}
         />
         <EquipmentModal
           show={showEquipment}


### PR DESCRIPTION
## Summary
- pass the InventoryModal onItemsChange callback through to ItemList so consumable usage updates persisted inventory
- forward the handler from ZombiesCharacterSheet and cover the behavior with a dedicated InventoryModal test

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/InventoryModal.test.js client/src/components/Items/ItemList.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f10979733c83238f2782cb67063b47