### PR TITLE
Ensure inventory consumable usage persists

### DIFF
--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -21,6 +21,10 @@ export default function InventoryModal({
   onTabChange,
   form = {},
   characterId,
+  onWeaponsChange,
+  onArmorChange,
+  onItemsChange,
+  onAccessoriesChange,
   isDocked = false,
   dockedSide = null,
   onDockClose,
@@ -81,6 +85,7 @@ export default function InventoryModal({
             <WeaponList
               campaign={form.campaign}
               initialWeapons={normalizedWeapons}
+              onChange={onWeaponsChange}
               characterId={characterId}
               show={isActive}
               embedded
@@ -100,6 +105,7 @@ export default function InventoryModal({
             <ArmorList
               campaign={form.campaign}
               initialArmor={normalizedArmor}
+              onChange={onArmorChange}
               characterId={characterId}
               show={isActive}
               embedded
@@ -119,6 +125,7 @@ export default function InventoryModal({
             <ItemList
               campaign={form.campaign}
               initialItems={normalizedItems}
+              onChange={onItemsChange}
               characterId={characterId}
               show={isActive}
               embedded
@@ -138,6 +145,7 @@ export default function InventoryModal({
             <AccessoryList
               campaign={form.campaign}
               initialAccessories={normalizedAccessories}
+              onChange={onAccessoriesChange}
               show={isActive}
               embedded
               ownedOnly
@@ -152,6 +160,10 @@ export default function InventoryModal({
       normalizedItems,
       normalizedAccessories,
       normalizedWeapons,
+      onArmorChange,
+      onItemsChange,
+      onAccessoriesChange,
+      onWeaponsChange,
     ]
   );
 

--- a/client/src/components/Zombies/attributes/InventoryModal.test.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.test.js
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 const mockWeaponListProps = { current: null };
 const mockArmorListProps = { current: null };
 const mockItemListProps = { current: null };
+const mockAccessoryListProps = { current: null };
 
 jest.mock('../../Weapons/WeaponList', () => {
   const React = require('react');
@@ -51,6 +52,21 @@ jest.mock('../../Items/ItemList', () => {
   };
 });
 
+jest.mock('../../Accessories/AccessoryList', () => {
+  const React = require('react');
+  return (props) => {
+    mockAccessoryListProps.current = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid="accessory-list">
+        {(props.initialAccessories || []).map((accessory) => (
+          <span key={accessory.name}>{accessory.name}</span>
+        ))}
+      </div>
+    );
+  };
+});
+
 import InventoryModal from './InventoryModal';
 
 describe('InventoryModal', () => {
@@ -58,6 +74,7 @@ describe('InventoryModal', () => {
     mockWeaponListProps.current = null;
     mockArmorListProps.current = null;
     mockItemListProps.current = null;
+    mockAccessoryListProps.current = null;
   });
 
   test('switches tabs between weapons, armor, and items', async () => {
@@ -160,4 +177,52 @@ describe('InventoryModal', () => {
     expect(mockItemListProps.current?.ownedOnly).toBe(true);
   });
 
+  test('forwards change handlers to equipment lists', async () => {
+    const form = {
+      weapon: [['Sword']],
+      armor: [['Shield Mail']],
+      item: [['Rations']],
+      accessories: [['Ring']],
+    };
+
+    const handlers = {
+      onWeaponsChange: jest.fn(),
+      onArmorChange: jest.fn(),
+      onItemsChange: jest.fn(),
+      onAccessoriesChange: jest.fn(),
+    };
+
+    render(
+      <InventoryModal
+        show
+        onHide={jest.fn()}
+        onTabChange={jest.fn()}
+        form={form}
+        {...handlers}
+      />
+    );
+
+    await screen.findByTestId('weapon-list');
+    expect(mockWeaponListProps.current?.onChange).toBe(handlers.onWeaponsChange);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Armor' }));
+    });
+    await screen.findByTestId('armor-list');
+    expect(mockArmorListProps.current?.onChange).toBe(handlers.onArmorChange);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
+    });
+    await screen.findByTestId('item-list');
+    expect(mockItemListProps.current?.onChange).toBe(handlers.onItemsChange);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Accessories' }));
+    });
+    await screen.findByTestId('accessory-list');
+    expect(mockAccessoryListProps.current?.onChange).toBe(
+      handlers.onAccessoriesChange
+    );
+  });
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -4823,6 +4823,10 @@ export default function ZombiesCharacterSheet() {
           onHide: handleCloseInventory,
           onTabChange: setInventoryTab,
           characterId,
+          onWeaponsChange: handleWeaponsChange,
+          onArmorChange: handleArmorChange,
+          onItemsChange: handleItemsChange,
+          onAccessoriesChange: handleAccessoriesChange,
           onDockChange: (side) => handleDockChange('inventory', side),
         }),
       },
@@ -5336,6 +5340,10 @@ export default function ZombiesCharacterSheet() {
           onTabChange={setInventoryTab}
           form={form}
           characterId={characterId}
+          onWeaponsChange={handleWeaponsChange}
+          onArmorChange={handleArmorChange}
+          onItemsChange={handleItemsChange}
+          onAccessoriesChange={handleAccessoriesChange}
           dockedSide={getDockedSide('inventory')}
           onDockChange={(side) => handleDockChange('inventory', side)}
         />


### PR DESCRIPTION
## Summary
- forward weapon, armor, item, and accessory change handlers through the inventory modal so embedded lists can persist changes
- update the zombies character sheet to supply the handlers for both docked and standard inventory views
- extend the inventory modal tests to cover forwarding of change handlers and accessory list mocking

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/attributes/InventoryModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f10b67392c8323bfa43e15a4bcd16e