### PR TITLE
Fix inventory consumable usage persistence and auto-close after potion use

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -109,17 +109,21 @@ const isConsumableItem = (item) =>
     (prop) => typeof prop === 'string' && prop.trim().toLowerCase() === 'consumable'
   );
 
+const isConsumablePotion = (item) => {
+  if (!isConsumableItem(item)) {
+    return false;
+  }
+
+  const label = `${item?.displayName || item?.name || ''}`.toLowerCase();
+  return label.includes('potion');
+};
+
 const dispatchConsumablePotionUsed = (item) => {
   if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
     return;
   }
 
-  if (!isConsumableItem(item)) {
-    return;
-  }
-
-  const label = `${item?.displayName || item?.name || ''}`.toLowerCase();
-  if (!label.includes('potion')) {
+  if (!isConsumablePotion(item)) {
     return;
   }
 
@@ -521,9 +525,16 @@ function ItemList({
     });
 
     const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
-    if (nextEntries !== ownedEntries && item?.healing) {
-      triggerHealingRoll(item);
-      dispatchConsumablePotionUsed(item);
+    if (nextEntries !== ownedEntries) {
+      if (item?.healing) {
+        triggerHealingRoll(item);
+      }
+      if (isConsumablePotion(item)) {
+        dispatchConsumablePotionUsed(item);
+        if (typeof onClose === 'function') {
+          onClose();
+        }
+      }
     }
   };
 

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -25,6 +25,7 @@ export default function InventoryModal({
   dockedSide = null,
   onDockClose,
   onDockChange,
+  onItemsChange,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -66,6 +67,17 @@ export default function InventoryModal({
       onTabChange(key);
     }
   };
+
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    onHide?.();
+  }, [isDocked, onDockClose, onHide]);
 
   const tabConfigs = useMemo(
     () => [
@@ -123,6 +135,8 @@ export default function InventoryModal({
               show={isActive}
               embedded
               ownedOnly
+              onChange={onItemsChange}
+              onClose={handleModalHide}
             />
           ),
       },
@@ -152,6 +166,8 @@ export default function InventoryModal({
       normalizedItems,
       normalizedAccessories,
       normalizedWeapons,
+      onItemsChange,
+      handleModalHide,
     ]
   );
 
@@ -175,17 +191,6 @@ export default function InventoryModal({
     }
     return classes.join(' ');
   }, [isDocked]);
-
-  const handleModalHide = useCallback(() => {
-    if (isDocked) {
-      if (typeof onDockClose === 'function') {
-        onDockClose();
-      }
-      return;
-    }
-
-    onHide?.();
-  }, [isDocked, onDockClose, onHide]);
 
   return (
     <Modal

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5338,6 +5338,7 @@ export default function ZombiesCharacterSheet() {
           characterId={characterId}
           dockedSide={getDockedSide('inventory')}
           onDockChange={(side) => handleDockChange('inventory', side)}
+          onItemsChange={handleItemsChange}
         />
         <EquipmentModal
           show={showEquipment}


### PR DESCRIPTION
## Summary
- ensure consumable potion usage in the inventory removes the item, triggers healing, and closes the modal
- plumb inventory item updates back to the character sheet so consumed items persist across modal sessions

## Testing
- npm test -- --runTestsByPath src/components/Items/ItemList.test.js
- CI=true npm test -- --runTestsByPath src/components/Zombies/attributes/InventoryModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f10f7510a483239b353c721bd7f99b