### PR TITLE
Fix consumable potion inventory counts

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -518,24 +518,24 @@ function ItemList({
       if (next === prev) {
         return prev;
       }
-      if (typeof onChange === 'function') {
-        onChange(next);
-      }
-      return next;
-    });
 
-    const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
-    if (nextEntries !== ownedEntries) {
       if (item?.healing) {
         triggerHealingRoll(item);
       }
+
       if (isConsumablePotion(item)) {
         dispatchConsumablePotionUsed(item);
         if (typeof onClose === 'function') {
           onClose();
         }
       }
-    }
+
+      if (typeof onChange === 'function') {
+        onChange(next);
+      }
+
+      return next;
+    });
   };
 
   const getCartCount = (item) => {

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -231,3 +231,42 @@ test('use button removes a consumable item copy and triggers onChange', async ()
 
   dispatchSpy.mockRestore();
 });
+
+test('using all copies of a consumable potion removes it from the inventory', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => itemsData });
+  const onChange = jest.fn();
+  const initialItems = Array.from({ length: 3 }, () => ({
+    name: 'potion-healing',
+    displayName: 'Potion of healing',
+    properties: ['consumable'],
+    owned: true,
+  }));
+
+  render(
+    <ItemList
+      ownedOnly
+      embedded
+      initialItems={initialItems}
+      onChange={onChange}
+    />
+  );
+
+  const potionHeading = await screen.findByText('Potion of healing');
+  const potionCard = potionHeading.closest('.card');
+  expect(potionCard).not.toBeNull();
+  expect(within(potionCard).getByText('×3')).toBeInTheDocument();
+
+  const useButton = within(potionCard).getByRole('button', { name: /use/i });
+
+  await userEvent.click(useButton);
+  await userEvent.click(useButton);
+  await userEvent.click(useButton);
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(3));
+  const finalItems = onChange.mock.calls[2][0];
+  expect(finalItems).toHaveLength(0);
+
+  await waitFor(() =>
+    expect(screen.queryByText('Potion of healing')).not.toBeInTheDocument()
+  );
+});


### PR DESCRIPTION
## Summary
- ensure consumable potion usage updates inventory state and fires side effects within a single state update
- add regression test covering consuming stacked potions down to zero copies

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Items/ItemList.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f112ecac288323a49fa23a5e662fa2