### PR TITLE
Fix duplicate potion healing roll dispatch

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -513,29 +513,27 @@ function ItemList({
       return;
     }
 
-    setOwnedEntries((prev) => {
-      const next = removeFirstMatchingEntry(prev, item, dataKey);
-      if (next === prev) {
-        return prev;
-      }
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
+    if (nextEntries === ownedEntries) {
+      return;
+    }
 
-      if (item?.healing) {
-        triggerHealingRoll(item);
-      }
+    setOwnedEntries(nextEntries);
 
-      if (isConsumablePotion(item)) {
-        dispatchConsumablePotionUsed(item);
-        if (typeof onClose === 'function') {
-          onClose();
-        }
-      }
+    if (item?.healing) {
+      triggerHealingRoll(item);
+    }
 
-      if (typeof onChange === 'function') {
-        onChange(next);
+    if (isConsumablePotion(item)) {
+      dispatchConsumablePotionUsed(item);
+      if (typeof onClose === 'function') {
+        onClose();
       }
+    }
 
-      return next;
-    });
+    if (typeof onChange === 'function') {
+      onChange(nextEntries);
+    }
   };
 
   const getCartCount = (item) => {


### PR DESCRIPTION
## Summary
- avoid triggering potion healing side effects inside the owned entries state update
- ensure using a consumable potion only dispatches one damage roll event

## Testing
- npm --prefix client test -- ItemList

------
https://chatgpt.com/codex/tasks/task_e_68f1185c90c88323b8b0f580d7ee1024