### PR TITLE
Keep docked inventory modal open when using consumables

### DIFF
--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -79,6 +79,14 @@ export default function InventoryModal({
     onHide?.();
   }, [isDocked, onDockClose, onHide]);
 
+  const handleItemListClose = useCallback(() => {
+    if (isDocked) {
+      return;
+    }
+
+    handleModalHide();
+  }, [isDocked, handleModalHide]);
+
   const tabConfigs = useMemo(
     () => [
       {
@@ -136,7 +144,7 @@ export default function InventoryModal({
               embedded
               ownedOnly
               onChange={onItemsChange}
-              onClose={handleModalHide}
+              onClose={handleItemListClose}
             />
           ),
       },
@@ -167,7 +175,7 @@ export default function InventoryModal({
       normalizedAccessories,
       normalizedWeapons,
       onItemsChange,
-      handleModalHide,
+      handleItemListClose,
     ]
   );
 

--- a/client/src/components/Zombies/attributes/InventoryModal.test.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.test.js
@@ -160,4 +160,64 @@ describe('InventoryModal', () => {
     expect(mockItemListProps.current?.ownedOnly).toBe(true);
   });
 
+  test('item list close handler hides the modal when not docked', async () => {
+    const onHide = jest.fn();
+    const form = {
+      item: [['Potion']],
+    };
+
+    render(
+      <InventoryModal
+        show
+        onHide={onHide}
+        onTabChange={jest.fn()}
+        form={form}
+      />
+    );
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
+    });
+
+    expect(typeof mockItemListProps.current?.onClose).toBe('function');
+
+    await act(async () => {
+      mockItemListProps.current?.onClose?.();
+    });
+
+    expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  test('item list close handler is ignored when docked', async () => {
+    const onHide = jest.fn();
+    const onDockClose = jest.fn();
+    const form = {
+      item: [['Potion']],
+    };
+
+    render(
+      <InventoryModal
+        show
+        isDocked
+        onHide={onHide}
+        onDockClose={onDockClose}
+        onTabChange={jest.fn()}
+        form={form}
+      />
+    );
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
+    });
+
+    expect(typeof mockItemListProps.current?.onClose).toBe('function');
+
+    await act(async () => {
+      mockItemListProps.current?.onClose?.();
+    });
+
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onDockClose).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
## Summary
- stop the docked inventory modal from closing when consumables like potions are used
- add regression tests covering docked and undocked close handler behavior

## Testing
- CI=1 npm test -- InventoryModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f11d6acb48832396b5ba0091d9cc8f