### PR TITLE
Allow legacy weight strings in inventory updates

### DIFF
--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -691,6 +691,25 @@ describe('Equipment routes', () => {
         .send({ item: ['potion-healing'] });
       expect(res.status).toBe(400);
     });
+
+    test('update item allows numeric strings with units for weight', async () => {
+      const updateOne = jest
+        .fn()
+        .mockResolvedValue({ matchedCount: 1 });
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne })
+      });
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({ item: [{ name: 'Lantern', weight: ' 1 lb. ' }] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Item updated');
+      expect(updateOne).toHaveBeenCalledTimes(1);
+      const callArgs = updateOne.mock.calls[0];
+      expect(callArgs[1].$set.item).toEqual([
+        expect.objectContaining({ name: 'Lantern', weight: '1 lb.' })
+      ]);
+    });
   });
 
   describe('update-accessories', () => {
@@ -775,6 +794,25 @@ describe('Equipment routes', () => {
           accessories: [{ ...baseAccessory, weight: 'heavy' }],
         });
       expect(res.status).toBe(400);
+    });
+
+    test('update accessories allows numeric strings with units for weight', async () => {
+      const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, weight: ' 0.5 lb. ' }],
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Accessories updated');
+      expect(updateOne).toHaveBeenCalledTimes(1);
+      const callArgs = updateOne.mock.calls[0];
+      expect(callArgs[1].$set.accessories).toEqual([
+        expect.objectContaining({ weight: '0.5 lb.' })
+      ]);
     });
   });
 

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -125,6 +125,36 @@ const normalizeAccessorySlots = (slots = []) => {
   );
 };
 
+const validateWeightField = (value) => {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('weight must be a finite number');
+    }
+    return true;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return true;
+    }
+    if (Number.isNaN(Number.parseFloat(trimmed))) {
+      throw new Error('weight must be a number or numeric string');
+    }
+    return true;
+  }
+  throw new Error('weight must be a number or string');
+};
+
+const sanitizeWeightField = (value) => {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return value;
+};
+
 module.exports = (router) => {
   const equipmentRouter = express.Router();
 
@@ -632,7 +662,10 @@ module.exports = (router) => {
       body('item.*').isObject().withMessage('each item must be an object'),
       body('item.*.name').trim().notEmpty().withMessage('name is required'),
       body('item.*.category').optional().isString().trim(),
-      body('item.*.weight').optional({ checkFalsy: true }).isFloat().toFloat(),
+      body('item.*.weight')
+        .optional({ nullable: true })
+        .custom(validateWeightField)
+        .customSanitizer(sanitizeWeightField),
       body('item.*.cost').optional().isString().trim(),
       body('item.*.notes').optional().isString().trim(),
       body('item.*.statBonuses').optional().custom(validateBonusObject),
@@ -686,9 +719,9 @@ module.exports = (router) => {
         }),
       body('accessories.*.rarity').optional().isString().trim(),
       body('accessories.*.weight')
-        .optional({ checkFalsy: true })
-        .isFloat()
-        .toFloat(),
+        .optional({ nullable: true })
+        .custom(validateWeightField)
+        .customSanitizer(sanitizeWeightField),
       body('accessories.*.cost').optional().isString().trim(),
       body('accessories.*.notes').optional().isString().trim(),
       body('accessories.*.statBonuses')


### PR DESCRIPTION
## Summary
- allow numeric legacy weight strings when validating character inventory and accessory payloads
- trim weight strings while keeping numeric values with units intact for persistence
- add regression coverage ensuring the update routes accept normalized legacy weights

## Testing
- npm test -- equipment

------
https://chatgpt.com/codex/tasks/task_e_68f137bd310c832382ecdc1cff600c9b