### PR TITLE
Route stat rolls through the damage roller

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { Button, Modal, Card, OverlayTrigger, Popover, Form } from "react-bootstrap";
 import spellsData from '../../../data/spells';
-import D20RollerModal from '../common/D20RollerModal';
 import UpcastModal from './UpcastModal';
 import sword from "../../../images/sword.png";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -817,16 +816,28 @@ const [isFumble, setIsFumble] = useState(false);
     const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
     const { result, d20 } = rollSkill(bonus);
     const weaponLabel = getWeaponDisplayName(slot, weapon);
-    const breakdown = `${d20} (d20) + ${bonus} Attack Bonus`;
+    const segments = [`${d20} (d20)`];
+    if (bonus) {
+      const sign = bonus >= 0 ? '+' : '-';
+      segments.push(`${sign} ${Math.abs(bonus)} Attack Bonus`);
+    }
 
     window.dispatchEvent(
       new CustomEvent('damage-roll', {
         detail: {
           value: result,
-          breakdown,
+          breakdown: segments.join(' '),
           source: `${weaponLabel} Attack Roll`,
           critical: d20 === 20,
           fumble: d20 === 1,
+          diceRolls: [
+            {
+              sides: 20,
+              value: d20,
+              type: 'Attack Roll',
+              category: 'base',
+            },
+          ],
         },
       })
     );
@@ -1333,8 +1344,6 @@ useEffect(() => {
               title="Attack"
             />
           </div>
-          <D20RollerModal renderInline diceColor={form?.diceColor} />
-          <div className="attack-roll-controls__spacer" aria-hidden="true" />
         </div>
       </div>
 {/* Attack Modal */}

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -11,6 +11,21 @@ import DockControls from '../components/DockControls';
 
 const EMPTY_OBJECT = Object.freeze({});
 
+const ABILITY_LABELS = {
+  str: 'Strength',
+  dex: 'Dexterity',
+  con: 'Constitution',
+  int: 'Intelligence',
+  wis: 'Wisdom',
+  cha: 'Charisma',
+};
+
+const formatAdjustmentSegment = (value, label) => {
+  if (!value) return null;
+  const sign = value >= 0 ? '+' : '-';
+  return `${sign} ${Math.abs(value)} ${label}`;
+};
+
 export function rollSkill(bonus = 0) {
   const d20 = Math.floor(Math.random() * 20) + 1;
   if (d20 === 20) {
@@ -293,6 +308,7 @@ export default function Skills({
 
   const handleRoll = (skillKey, ability, proficient, expertise) => {
     const skill = SKILLS.find((s) => s.key === skillKey);
+    const skillLabel = skill?.label || skill?.name || skillKey;
     const armorPenalty = skill?.armorPenalty || 0;
     const penalty = armorPenalty ? armorPenalty * totalCheckPenalty : 0;
     const bonus =
@@ -303,13 +319,46 @@ export default function Skills({
       featTotals[skillKey] +
       raceTotals[skillKey];
     const { result, d20 } = rollSkill(bonus);
+    const abilityLabel =
+      ABILITY_LABELS[ability] || ability?.toUpperCase?.() || ability || 'Ability';
+    const proficiencyValue = profBonus * (expertise ? 2 : proficient ? 1 : 0);
+    const breakdownParts = [`${d20} (d20)`];
+
+    const segments = [
+      formatAdjustmentSegment(modMap[ability], `${abilityLabel} Modifier`),
+      proficiencyValue
+        ? formatAdjustmentSegment(
+            proficiencyValue,
+            expertise ? 'Expertise Bonus' : 'Proficiency Bonus'
+          )
+        : null,
+      formatAdjustmentSegment(penalty, 'Armor Penalty'),
+      formatAdjustmentSegment(itemTotals[skillKey], 'Item Bonus'),
+      formatAdjustmentSegment(featTotals[skillKey], 'Feat Bonus'),
+      formatAdjustmentSegment(raceTotals[skillKey], 'Race Bonus'),
+    ];
+
+    segments.filter(Boolean).forEach((segment) => {
+      breakdownParts.push(segment);
+    });
+
+    const diceRolls = [
+      {
+        sides: 20,
+        value: d20,
+        type: `${skillLabel} Check`,
+        category: 'base',
+      },
+    ];
     window.dispatchEvent(
       new CustomEvent('damage-roll', {
         detail: {
           value: result,
-          source: skill?.name,
+          breakdown: breakdownParts.join(' '),
+          source: skillLabel,
           critical: d20 === 20,
           fumble: d20 === 1,
+          diceRolls,
         },
       })
     );

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -8,6 +8,12 @@ import { rollSkill } from './Skills';
 
 const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
+const formatAdjustmentSegment = (value, label) => {
+  if (!value) return null;
+  const sign = value >= 0 ? '+' : '-';
+  return `${sign} ${Math.abs(value)} ${label}`;
+};
+
 const createEmptyStatMap = () => ({
   str: 0,
   dex: 0,
@@ -143,14 +149,33 @@ export default function Stats({
       const { result, d20 } = rollSkill(statMod);
       const statInfo = STATS.find((stat) => stat.key === statKey);
       const statLabel = statInfo?.label || statKey.toUpperCase();
+      const breakdownParts = [`${d20} (d20)`];
+      const modifierSegment = formatAdjustmentSegment(
+        statMod,
+        `${statLabel} Modifier`
+      );
+      if (modifierSegment) {
+        breakdownParts.push(modifierSegment);
+      }
+
+      const diceRolls = [
+        {
+          sides: 20,
+          value: d20,
+          type: `${statLabel} Check`,
+          category: 'base',
+        },
+      ];
 
       window.dispatchEvent(
         new CustomEvent('damage-roll', {
           detail: {
             value: result,
+            breakdown: breakdownParts.join(' '),
             source: statLabel,
             critical: d20 === 20,
             fumble: d20 === 1,
+            diceRolls,
           },
         })
       );

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -182,8 +182,17 @@ test('rolling a stat dispatches a roll event and closes the modal when undocked'
     expect(rollEvent.detail).toMatchObject({
       value: 18,
       source: 'Strength',
+      breakdown: '16 (d20) + 2 Strength Modifier',
       critical: false,
       fumble: false,
+      diceRolls: [
+        expect.objectContaining({
+          sides: 20,
+          value: 16,
+          type: 'Strength Check',
+          category: 'base',
+        }),
+      ],
     });
     expect(handleCloseStats).toHaveBeenCalled();
   } finally {


### PR DESCRIPTION
## Summary
- remove the inline d20 roller from the player turn actions panel
- send stat, skill, and attack roll details to the damage roller including d20 breakdowns and dice metadata

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/attributes/Stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f147f2d6e8832e970916941ebc425d