### PR TITLE
Remove damage roller circle background

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1793,46 +1793,37 @@ $rotateX: -$angle;
 // Damage display-------------------------------------------------------
 #damageAmount {
   position: relative;
-  width: clamp(90px, 18vw, 140px);
-  height: clamp(90px, 18vw, 140px);
-  border: 2px solid #0040ff;
-  border-radius: 50%;
-  color: #ffffff;
-  font-weight: bold;
-  font-family: 'Courier New', monospace;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-  padding: 12px 10px 16px;
-  background: radial-gradient(
-      circle at 25% 20%,
-      rgba(0, 64, 255, 0.55),
-      rgba(0, 0, 0, 0)
-    ),
-    radial-gradient(circle at bottom, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.2));
-  box-shadow: inset 0 0 14px rgba(0, 64, 255, 0.45), 0 0 22px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(1px);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  width: min(90vw, 520px);
+  min-height: clamp(220px, 45vh, 360px);
+  margin: 0 auto;
+  padding: 24px 24px 80px;
+  color: #ffffff;
+  font-weight: bold;
+  font-family: 'Courier New', monospace;
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  overflow: visible;
+  transition: transform 0.2s ease;
 }
 
 #damageAmount.critical-active {
-  border: 2px solid #ffd700;
-  box-shadow: 0 0 16px rgba(255, 215, 0, 0.75),
-    inset 0 0 14px rgba(255, 215, 0, 0.55);
+  box-shadow: 0 0 32px rgba(255, 215, 0, 0.45);
 }
 
 #damageAmount.critical-failure {
-  border: 2px solid #ff0000;
-  box-shadow: 0 0 16px rgba(255, 0, 0, 0.75),
-    inset 0 0 14px rgba(255, 0, 0, 0.4);
+  box-shadow: 0 0 32px rgba(255, 0, 0, 0.4);
 }
 
 .damage-roller__dice-area {
   position: absolute;
   inset: 0;
-  overflow: hidden;
+  overflow: visible;
   pointer-events: none;
   z-index: 1;
 }
@@ -1843,7 +1834,8 @@ $rotateX: -$angle;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: 6px;
+  margin-top: auto;
 }
 
 .damage-roller__total-label {
@@ -1851,6 +1843,7 @@ $rotateX: -$angle;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.65);
+  text-align: center;
 }
 
 #damageValue {
@@ -2660,7 +2653,7 @@ h1 {
 }
 
 #damageAmount {
-  transition: background-color 0.5s ease, transform 0.5s ease;
+  transition: transform 0.5s ease;
 }
 
 .pulse {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -974,9 +974,9 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
 
   const baseTime = Date.now();
   const nextDice = diceDetails.map((detail, index) => {
-    const left = 15 + Math.random() * 70;
+    const left = 5 + Math.random() * 90;
     const rotation = (Math.random() - 0.5) * 40;
-    const dropDistance = 40 + Math.random() * 50;
+    const dropDistance = 80 + Math.random() * 110;
     const delay = index * 0.05;
     const rollDuration = 0.85 + Math.random() * 0.45;
     const initialTiltX = (Math.random() - 0.5) * 90;
@@ -1159,7 +1159,14 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
           ⚔️ Log
         </Button>
       </div>
-      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '4px' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          marginTop: '4px',
+          width: '100%',
+        }}
+      >
         <div
           id="damageAmount"
           className={`${pulseClass} ${isCritical ? 'critical-active' : ''} ${


### PR DESCRIPTION
## Summary
- remove the circular damage roller styling in favor of a wider, unobstructed layout
- expand the dice animation spread so rolls occupy more space and appear less crowded

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f154d2db04832ead467100a86f01bb