### PR TITLE
Add Potion of Speed haste effect

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1749,6 +1749,33 @@ export default function ZombiesCharacterSheet() {
       if (event?.detail?.type !== 'potion') {
         return;
       }
+
+      const potionLabel = `${
+        event?.detail?.item?.displayName || event?.detail?.item?.name || ''
+      }`
+        .trim()
+        .toLowerCase();
+
+      if (potionLabel === 'potion of speed') {
+        setActiveEffects((prev = []) => {
+          const existingIndex = prev.findIndex((effect) => effect?.name === 'Haste');
+
+          if (existingIndex === -1) {
+            return [...prev, { name: 'Haste', icon: hasteIcon, remaining: 10 }];
+          }
+
+          const existing = prev[existingIndex] || {};
+          const next = [...prev];
+          next[existingIndex] = {
+            ...existing,
+            name: 'Haste',
+            icon: hasteIcon,
+            remaining: 10,
+          };
+          return next;
+        });
+      }
+
       consumeCircle('bonus');
     };
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1274,6 +1274,49 @@ test('casting Haste adds status icon and extra action circle', async () => {
   expect(icon).toHaveAttribute('src', hasteIcon);
 });
 
+test('using Potion of Speed grants Haste effect and extra action circle', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+  const { container } = render(<ZombiesCharacterSheet />);
+  await waitFor(() => expect(container.querySelector('.action-circle')).toBeTruthy());
+  expect(container.querySelectorAll('.action-circle').length).toBe(1);
+
+  await act(async () => {
+    window.dispatchEvent(
+      new CustomEvent('inventory:consumable-used', {
+        detail: {
+          type: 'potion',
+          item: { name: 'potion-speed', displayName: 'Potion of Speed' },
+        },
+      })
+    );
+  });
+
+  await waitFor(() =>
+    expect(container.querySelectorAll('.action-circle').length).toBe(2)
+  );
+  const icon = screen.getByAltText('Haste');
+  expect(icon).toHaveAttribute('src', hasteIcon);
+});
+
 test('casting Speak with Animals adds status icon for free and slot casts', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,

--- a/server/data/items.js
+++ b/server/data/items.js
@@ -118,6 +118,17 @@ const items = {
       "You regain hit points when you drink this potion. Whatever its potency, the potion's red liquid glimmers when agitated.",
     owned: false,
   },
+  "potion-speed": {
+    name: "Potion of speed",
+    category: "consumable",
+    weight: 0.5,
+    cost: "3000 gp",
+    properties: ["consumable"],
+    rarity: "Very Rare",
+    notes:
+      "When you drink this potion, you gain the effect of the Haste spell for 1 minute (no concentration required) without suffering the wave of lethargy typically caused when the effect ends.",
+    owned: false,
+  },
   pouch: { name: "Pouch", category: "adventuring gear", weight: 1, cost: "5 sp", owned: false },
   quiver: { name: "Quiver", category: "adventuring gear", weight: 1, cost: "1 gp", owned: false },
   "ram-portable": { name: "Ram, portable", category: "adventuring gear", weight: 35, cost: "4 gp", owned: false },


### PR DESCRIPTION
## Summary
- add Potion of Speed to the Player's Handbook item dataset
- apply Haste when the potion is consumed from the character sheet
- cover the new behavior with a targeted unit test

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --testNamePattern="Potion of Speed"


------
https://chatgpt.com/codex/tasks/task_e_68f157418eb883238767065cf954eeec