### PR TITLE
Grant enlarge effect from Potion of Speed

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1648,11 +1648,12 @@ export default function ZombiesCharacterSheet() {
       return;
     }
 
-    const hasLargeForm = activeEffects.some(
-      (effect) => effect && effect.name === 'Large Form'
+    const hasGrowthEffect = activeEffects.some(
+      (effect) =>
+        effect && (effect.name === 'Large Form' || effect.name === 'Enlarge')
     );
 
-    if (hasLargeForm) {
+    if (hasGrowthEffect) {
       const desiredSize = 'Large';
       const desiredSpeedBonus = 10;
       const nextSize = form.temporarySize;
@@ -1758,20 +1759,20 @@ export default function ZombiesCharacterSheet() {
 
       if (potionLabel === 'potion of speed') {
         setActiveEffects((prev = []) => {
-          const existingIndex = prev.findIndex((effect) => effect?.name === 'Haste');
-
-          if (existingIndex === -1) {
-            return [...prev, { name: 'Haste', icon: hasteIcon, remaining: 10 }];
-          }
-
-          const existing = prev[existingIndex] || {};
           const next = [...prev];
-          next[existingIndex] = {
-            ...existing,
-            name: 'Haste',
-            icon: hasteIcon,
-            remaining: 10,
+
+          const upsertEffect = (effect) => {
+            const index = next.findIndex((entry) => entry?.name === effect.name);
+            if (index === -1) {
+              next.push(effect);
+              return;
+            }
+            next[index] = { ...next[index], ...effect };
           };
+
+          upsertEffect({ name: 'Haste', icon: hasteIcon, remaining: 10 });
+          upsertEffect({ name: 'Enlarge', icon: largeFormIcon });
+
           return next;
         });
       }
@@ -1796,7 +1797,12 @@ export default function ZombiesCharacterSheet() {
 
   const handleLargeForm = useCallback(() => {
     setActiveEffects((prev) => {
-      if (prev.some((effect) => effect.name === 'Large Form')) {
+      if (
+        prev.some(
+          (effect) =>
+            effect && (effect.name === 'Large Form' || effect.name === 'Enlarge')
+        )
+      ) {
         return prev;
       }
       return [...prev, { name: 'Large Form', icon: largeFormIcon }];

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent, act, within } from '@testing-librar
 import userEvent from '@testing-library/user-event';
 import hasteIcon from '../../../images/spell-haste-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
+import largeFormIcon from '../../../images/large-form-icon.png';
 import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
 import speakWithAnimalsIcon from '../../../images/speak-with-animal.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
@@ -1274,7 +1275,7 @@ test('casting Haste adds status icon and extra action circle', async () => {
   expect(icon).toHaveAttribute('src', hasteIcon);
 });
 
-test('using Potion of Speed grants Haste effect and extra action circle', async () => {
+test('using Potion of Speed grants Haste and Enlarge effects plus extra action circle', async () => {
   apiFetch.mockResolvedValueOnce({
     ok: true,
     json: async () => ({
@@ -1313,8 +1314,16 @@ test('using Potion of Speed grants Haste effect and extra action circle', async 
   await waitFor(() =>
     expect(container.querySelectorAll('.action-circle').length).toBe(2)
   );
-  const icon = screen.getByAltText('Haste');
-  expect(icon).toHaveAttribute('src', hasteIcon);
+  const hasteEffectIcon = screen.getByAltText('Haste');
+  expect(hasteEffectIcon).toHaveAttribute('src', hasteIcon);
+
+  const enlargeEffectIcon = await screen.findByAltText('Enlarge');
+  expect(enlargeEffectIcon).toHaveAttribute('src', largeFormIcon);
+
+  await waitFor(() =>
+    expect(mockEquipmentModalProps.current?.form?.temporarySize).toBe('Large')
+  );
+  expect(mockEquipmentModalProps.current?.form?.temporarySpeedBonus).toBe(10);
 });
 
 test('casting Speak with Animals adds status icon for free and slot casts', async () => {


### PR DESCRIPTION
## Summary
- treat Potion of Speed as granting both Haste and Enlarge so characters grow like Large Form
- guard Large Form handling and size updates to recognize Enlarge as an equivalent growth effect
- expand the Potion of Speed test to cover the new Enlarge status icon and temporary size bonuses

## Testing
- npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --testNamePattern="using Potion of Speed"

------
https://chatgpt.com/codex/tasks/task_e_68f15de276448323b1d4814b6acfa06c