### PR TITLE
Add Potion of Growth consumable

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1774,6 +1774,14 @@ export default function ZombiesCharacterSheet() {
           };
           return next;
         });
+      } else if (potionLabel === 'potion of growth') {
+        setActiveEffects((prev = []) => {
+          if (prev.some((effect) => effect?.name === 'Large Form')) {
+            return prev;
+          }
+
+          return [...prev, { name: 'Large Form', icon: largeFormIcon }];
+        });
       }
 
       consumeCircle('bonus');

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -5,6 +5,7 @@ import hasteIcon from '../../../images/spell-haste-icon.png';
 import dragonWingsIcon from '../../../images/dragon-wings-icon.png';
 import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
 import speakWithAnimalsIcon from '../../../images/speak-with-animal.png';
+import largeFormIcon from '../../../images/large-form-icon.png';
 import { EQUIPMENT_SLOT_KEYS } from '../attributes/equipmentSlots';
 
 jest.mock('../../../utils/apiFetch');
@@ -1315,6 +1316,54 @@ test('using Potion of Speed grants Haste effect and extra action circle', async 
   );
   const icon = screen.getByAltText('Haste');
   expect(icon).toHaveAttribute('src', hasteIcon);
+});
+
+test('using Potion of Growth grants Large Form effect and bonuses', async () => {
+  apiFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      occupation: [{ Name: 'Wizard', Level: 1 }],
+      spells: [],
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      startStatTotal: 60,
+      proficiencyPoints: 0,
+      skills: {},
+      item: [],
+      feat: [],
+      weapon: [],
+      armor: [],
+    }),
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  await waitFor(() => expect(mockEquipmentModalProps.current).not.toBeNull());
+  expect(mockEquipmentModalProps.current?.form?.temporarySize).toBeUndefined();
+  expect(mockEquipmentModalProps.current?.form?.temporarySpeedBonus).toBeUndefined();
+
+  await act(async () => {
+    window.dispatchEvent(
+      new CustomEvent('inventory:consumable-used', {
+        detail: {
+          type: 'potion',
+          item: { name: 'potion-growth', displayName: 'Potion of Growth' },
+        },
+      })
+    );
+  });
+
+  await waitFor(() =>
+    expect(mockEquipmentModalProps.current?.form?.temporarySize).toBe('Large')
+  );
+  expect(mockEquipmentModalProps.current?.form?.temporarySpeedBonus).toBe(10);
+
+  const icon = await screen.findByAltText('Large Form');
+  expect(icon).toHaveAttribute('src', largeFormIcon);
 });
 
 test('casting Speak with Animals adds status icon for free and slot casts', async () => {

--- a/server/data/items.js
+++ b/server/data/items.js
@@ -129,6 +129,17 @@ const items = {
       "When you drink this potion, you gain the effect of the Haste spell for 1 minute (no concentration required) without suffering the wave of lethargy typically caused when the effect ends.",
     owned: false,
   },
+  "potion-growth": {
+    name: "Potion of growth",
+    category: "consumable",
+    weight: 0.5,
+    cost: "270 gp",
+    properties: ["consumable"],
+    rarity: "Uncommon",
+    notes:
+      'When you drink this potion, you gain the "enlarge" effect of the Enlarge/Reduce spell for 10 minutes (no concentration required). The red in the potion\'s liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts.',
+    owned: false,
+  },
   pouch: { name: "Pouch", category: "adventuring gear", weight: 1, cost: "5 sp", owned: false },
   quiver: { name: "Quiver", category: "adventuring gear", weight: 1, cost: "1 gp", owned: false },
   "ram-portable": { name: "Ram, portable", category: "adventuring gear", weight: 35, cost: "4 gp", owned: false },


### PR DESCRIPTION
## Summary
- add Potion of Growth item data with notes describing the enlarge effect
- apply the Large Form status when a Potion of Growth is consumed
- cover the new potion with a ZombiesCharacterSheet regression test

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js --testNamePattern="using Potion of Growth grants Large Form effect and bonuses"

------
https://chatgpt.com/codex/tasks/task_e_68f1622344e483239209d8d70d2aede9