### PR TITLE
Allow manual critical toggle from damage total

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1844,6 +1844,7 @@ $rotateX: -$angle;
   border-radius: 24px;
   transition: box-shadow 0.3s ease;
   isolation: isolate;
+  cursor: pointer;
 
   &::before {
     content: '';
@@ -1897,14 +1898,23 @@ $rotateX: -$angle;
 
 .damage-roller__total-value {
   color: #ffffff;
+  transition: color 0.2s ease;
 }
 
 #damageAmount.critical-active .damage-roller__total {
   box-shadow: 0 0 28px rgba(255, 215, 0, 0.45);
 }
 
+#damageAmount.critical-active .damage-roller__total-value {
+  color: #ffd966;
+}
+
 #damageAmount.critical-failure .damage-roller__total {
   box-shadow: 0 0 28px rgba(255, 45, 45, 0.42);
+}
+
+#damageAmount.critical-failure .damage-roller__total-value {
+  color: #ff6b6b;
 }
 
 .damage-die {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -909,10 +909,20 @@ const [pendingSpell, setPendingSpell] = useState(null);
     applyUpcast(spell, spell.level, crit || isCritical);
   };
 
-const handleDamageClick = () => {
+const handleDamageClick = useCallback(() => {
   setIsCritical((prev) => !prev);
   setIsFumble(false);
-};
+}, []);
+
+const handleDamageKeyDown = useCallback(
+  (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleDamageClick();
+    }
+  },
+  [handleDamageClick]
+);
 
 // Spells may come from different caster types (e.g., Wizard, Cleric). Before
 // rendering the spell table, group spells by caster type and sort each group by
@@ -1172,7 +1182,21 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
           className={`${pulseClass} ${isCritical ? 'critical-active' : ''} ${
             isFumble ? 'critical-failure' : ''
           }`}
+          role="button"
+          tabIndex={0}
+          aria-pressed={isCritical}
+          aria-label={
+            isCritical
+              ? 'Critical damage roll enabled. Click to roll normally.'
+              : 'Click to enable a critical damage roll on your next roll.'
+          }
+          title={
+            isCritical
+              ? 'Critical roll ready. Click to roll normally.'
+              : 'Click to make your next damage roll critical.'
+          }
           onClick={handleDamageClick}
+          onKeyDown={handleDamageKeyDown}
         >
           <div className="damage-roller__dice-area" aria-hidden="true">
             {activeDice.map((die) => {


### PR DESCRIPTION
## Summary
- make the damage total display act as an accessible toggle for prepping critical rolls
- update the roller styling so the total number turns gold or red when critical or fumble states are active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f16453eaac832e983ea73b74a7980f