### PR TITLE
Restrict manual crit toggle to total number

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1897,14 +1897,29 @@ $rotateX: -$angle;
 
 .damage-roller__total-value {
   color: #ffffff;
+  transition: color 0.2s ease;
+  cursor: pointer;
+}
+
+#damageValue:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 4px;
 }
 
 #damageAmount.critical-active .damage-roller__total {
   box-shadow: 0 0 28px rgba(255, 215, 0, 0.45);
 }
 
+#damageAmount.critical-active .damage-roller__total-value {
+  color: #ffd966;
+}
+
 #damageAmount.critical-failure .damage-roller__total {
   box-shadow: 0 0 28px rgba(255, 45, 45, 0.42);
+}
+
+#damageAmount.critical-failure .damage-roller__total-value {
+  color: #ff6b6b;
 }
 
 .damage-die {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -909,10 +909,20 @@ const [pendingSpell, setPendingSpell] = useState(null);
     applyUpcast(spell, spell.level, crit || isCritical);
   };
 
-const handleDamageClick = () => {
+const handleDamageClick = useCallback(() => {
   setIsCritical((prev) => !prev);
   setIsFumble(false);
-};
+}, []);
+
+const handleDamageKeyDown = useCallback(
+  (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleDamageClick();
+    }
+  },
+  [handleDamageClick]
+);
 
 // Spells may come from different caster types (e.g., Wizard, Cleric). Before
 // rendering the spell table, group spells by caster type and sort each group by
@@ -1172,7 +1182,6 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
           className={`${pulseClass} ${isCritical ? 'critical-active' : ''} ${
             isFumble ? 'critical-failure' : ''
           }`}
-          onClick={handleDamageClick}
         >
           <div className="damage-roller__dice-area" aria-hidden="true">
             {activeDice.map((die) => {
@@ -1220,6 +1229,21 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
               className={`damage-roller__total-value ${
                 typeof damageValue === 'string' ? 'spell-cast-label' : ''
               }`}
+              role="button"
+              tabIndex={0}
+              aria-pressed={isCritical}
+              aria-label={
+                isCritical
+                  ? 'Critical damage roll enabled. Click to roll normally.'
+                  : 'Click to enable a critical damage roll on your next roll.'
+              }
+              title={
+                isCritical
+                  ? 'Critical roll ready. Click to roll normally.'
+                  : 'Click to make your next damage roll critical.'
+              }
+              onClick={handleDamageClick}
+              onKeyDown={handleDamageKeyDown}
             >
               {damageValue}
             </span>


### PR DESCRIPTION
## Summary
- move the manual critical toggle behavior from the whole damage roller container to the total value itself
- update styles so only the total value shows a pointer cursor and gains a focus outline when toggled via keyboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f16453eaac832e983ea73b74a7980f