### PR TITLE
Keep damage total critical toggle active

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -4,6 +4,7 @@ import React, {
   useImperativeHandle,
   useMemo,
   useCallback,
+  useRef,
 } from 'react';
 import { Button, Modal, Card, OverlayTrigger, Popover, Form } from "react-bootstrap";
 import spellsData from '../../../data/spells';
@@ -390,6 +391,7 @@ const PlayerTurnActions = React.forwardRef(
 //--------------------------------------------Critical status------------------------------------------------
 const [isCritical, setIsCritical] = useState(false);
 const [isFumble, setIsFumble] = useState(false);
+const manualCriticalRef = useRef(false);
   const equipmentProvided = useMemo(
     () => typeof form?.equipment === 'object' && form.equipment !== null,
     [form.equipment]
@@ -910,7 +912,11 @@ const [pendingSpell, setPendingSpell] = useState(null);
   };
 
 const handleDamageClick = useCallback(() => {
-  setIsCritical((prev) => !prev);
+  setIsCritical((prev) => {
+    const next = !prev;
+    manualCriticalRef.current = next;
+    return next;
+  });
   setIsFumble(false);
 }, []);
 
@@ -1038,6 +1044,7 @@ const updateDamageValueWithAnimation = (
   const details = Array.isArray(extra?.diceRolls) ? extra.diceRolls : [];
   triggerDiceAnimation(details);
   setLastRollTimestamp(Date.now());
+  manualCriticalRef.current = false;
   if (newValue !== undefined) {
     setDamageLog((prev) => {
       const entry = {
@@ -1074,7 +1081,9 @@ useEffect(() => {
   setPulseClass(cls);
   const timer = setTimeout(() => {
     setPulseClass('');
-    setIsCritical(false);
+    if (!manualCriticalRef.current) {
+      setIsCritical(false);
+    }
     setIsFumble(false);
   }, 2000);
   return () => clearTimeout(timer);
@@ -1086,6 +1095,7 @@ useEffect(() => {
     const { value, breakdown, source, critical, fumble, ...extra } =
       e.detail || {};
     updateDamageValueWithAnimation(value, breakdown, source, extra);
+    manualCriticalRef.current = false;
     setIsCritical(!!critical && !fumble);
     setIsFumble(!!fumble);
   };

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -904,20 +904,56 @@ describe('PlayerTurnActions critical events', () => {
     );
 
     const damage = document.getElementById('damageAmount');
+    const toggle = document.getElementById('damageValue');
 
     expect(damage.classList.contains('critical-active')).toBe(false);
 
     act(() => {
-      fireEvent.click(damage);
+      fireEvent.click(toggle);
     });
 
     expect(damage.classList.contains('critical-active')).toBe(true);
 
     act(() => {
-      fireEvent.click(damage);
+      fireEvent.click(toggle);
     });
 
     expect(damage.classList.contains('critical-active')).toBe(false);
+  });
+
+  test('manual critical toggle persists after automatic reset timer', () => {
+    jest.useFakeTimers();
+
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', equipment: {}, spells: [] }}
+        strMod={0}
+        dexMod={0}
+      />
+    );
+
+    const damage = document.getElementById('damageAmount');
+    const toggle = document.getElementById('damageValue');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('damage-roll', { detail: { value: 7 } })
+      );
+    });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(damage.classList.contains('critical-active')).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(damage.classList.contains('critical-active')).toBe(true);
+
+    jest.useRealTimers();
   });
 });
 


### PR DESCRIPTION
## Summary
- track whether the damage total was toggled manually so the automatic reset does not clear it
- clear the manual flag when rolls are dispatched and ensure critical/fumble state updates follow the new flow
- update and extend PlayerTurnActions tests to cover the persistent critical toggle

## Testing
- CI=true npm test -- PlayerTurnActions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f16c4c83a0832e97aa4cce6540fa09