### PR TITLE
Persist temporary character size state

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1643,10 +1643,168 @@ export default function ZombiesCharacterSheet() {
   const temporarySize = form?.temporarySize;
   const temporarySpeedBonus = form?.temporarySpeedBonus;
 
+  const updateLocalTemporarySize = useCallback(
+    (incomingCharacterId, nextSizeRaw) => {
+      const normalizedCharacterId =
+        typeof incomingCharacterId === 'string' && incomingCharacterId.trim() !== ''
+          ? incomingCharacterId.trim()
+          : null;
+      if (!normalizedCharacterId) {
+        return;
+      }
+
+      const normalizedSize =
+        typeof nextSizeRaw === 'string' && nextSizeRaw.trim() !== ''
+          ? nextSizeRaw.trim()
+          : null;
+
+      setCampaignCharacters((prev) => {
+        if (!prev || typeof prev !== 'object' || Object.keys(prev).length === 0) {
+          return prev;
+        }
+
+        let didUpdate = false;
+        const next = { ...prev };
+
+        Object.entries(prev).forEach(([key, value]) => {
+          if (!value || typeof value !== 'object') {
+            return;
+          }
+
+          const identifiers = new Set([
+            ...collectCharacterIdentifiers(value),
+            typeof key === 'string' && key.trim() !== '' ? key.trim() : null,
+          ].filter(Boolean));
+
+          if (!identifiers.has(normalizedCharacterId)) {
+            return;
+          }
+
+          const currentSize =
+            typeof value.temporarySize === 'string' && value.temporarySize.trim() !== ''
+              ? value.temporarySize.trim()
+              : null;
+          const hasProperty = Object.prototype.hasOwnProperty.call(value, 'temporarySize');
+
+          if (currentSize === normalizedSize && (normalizedSize !== null || !hasProperty)) {
+            return;
+          }
+
+          const updated = { ...value };
+          if (normalizedSize) {
+            updated.temporarySize = normalizedSize;
+          } else if (hasProperty) {
+            delete updated.temporarySize;
+          } else {
+            return;
+          }
+
+          next[key] = updated;
+          didUpdate = true;
+        });
+
+        return didUpdate ? next : prev;
+      });
+
+      setForm((prev) => {
+        if (!prev || typeof prev !== 'object') {
+          return prev;
+        }
+
+        const identifiers = collectCharacterIdentifiers(prev);
+        if (!identifiers.includes(normalizedCharacterId)) {
+          return prev;
+        }
+
+        const currentSize =
+          typeof prev.temporarySize === 'string' && prev.temporarySize.trim() !== ''
+            ? prev.temporarySize.trim()
+            : null;
+        const hasProperty = Object.prototype.hasOwnProperty.call(prev, 'temporarySize');
+
+        if (currentSize === normalizedSize && (normalizedSize !== null || !hasProperty)) {
+          return prev;
+        }
+
+        const nextForm = { ...prev };
+        if (normalizedSize) {
+          nextForm.temporarySize = normalizedSize;
+        } else if (hasProperty) {
+          delete nextForm.temporarySize;
+        } else {
+          return prev;
+        }
+
+        return nextForm;
+      });
+
+      if (
+        typeof characterId === 'string' &&
+        characterId.trim() !== '' &&
+        normalizedCharacterId === characterId.trim()
+      ) {
+        lastPersistedTempSizeRef.current = normalizedSize;
+      }
+    },
+    [characterId, setCampaignCharacters, setForm]
+  );
+
+  const persistTemporarySize = useCallback(
+    async (nextSizeRaw) => {
+      if (typeof characterId !== 'string' || characterId.trim() === '') {
+        return;
+      }
+
+      const normalizedCharacterId = characterId.trim();
+      const normalizedSize =
+        typeof nextSizeRaw === 'string' && nextSizeRaw.trim() !== ''
+          ? nextSizeRaw.trim()
+          : null;
+
+      const previous = lastPersistedTempSizeRef.current;
+      if (previous === normalizedSize) {
+        return;
+      }
+
+      lastPersistedTempSizeRef.current = normalizedSize;
+
+      try {
+        const response = await apiFetch(`/characters/${normalizedCharacterId}/temporary-size`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ temporarySize: normalizedSize }),
+        });
+
+        if (!response.ok) {
+          const message = await parseErrorMessage(
+            response,
+            'Failed to update temporary size.'
+          );
+          throw new Error(message);
+        }
+
+        const result = await response.json().catch(() => ({}));
+        const persistedSize =
+          typeof result?.temporarySize === 'string' && result.temporarySize.trim() !== ''
+            ? result.temporarySize.trim()
+            : null;
+        lastPersistedTempSizeRef.current = persistedSize;
+      } catch (error) {
+        console.error(error);
+        lastPersistedTempSizeRef.current = previous;
+      }
+    },
+    [characterId]
+  );
+
   useEffect(() => {
     if (!form) {
       return;
     }
+
+    const resolvedId = resolvedCharacterIdRef.current;
+    const normalizedCharacterId =
+      typeof resolvedId === 'string' && resolvedId.trim() !== '' ? resolvedId.trim() : null;
 
     const hasLargeForm = activeEffects.some(
       (effect) => effect && effect.name === 'Large Form'
@@ -1655,10 +1813,13 @@ export default function ZombiesCharacterSheet() {
     if (hasLargeForm) {
       const desiredSize = 'Large';
       const desiredSpeedBonus = 10;
-      const nextSize = form.temporarySize;
-      const nextSpeedBonus = Number(form.temporarySpeedBonus ?? 0);
+      const currentSize =
+        typeof form.temporarySize === 'string' && form.temporarySize.trim() !== ''
+          ? form.temporarySize.trim()
+          : null;
+      const currentSpeedBonus = Number(form.temporarySpeedBonus ?? 0);
 
-      if (nextSize === desiredSize && nextSpeedBonus === desiredSpeedBonus) {
+      if (currentSize === desiredSize && currentSpeedBonus === desiredSpeedBonus) {
         return;
       }
 
@@ -1667,13 +1828,13 @@ export default function ZombiesCharacterSheet() {
           return prev;
         }
 
-        const currentSize = prev.temporarySize;
-        const currentSpeedBonus = Number(prev.temporarySpeedBonus ?? 0);
+        const prevSize =
+          typeof prev.temporarySize === 'string' && prev.temporarySize.trim() !== ''
+            ? prev.temporarySize.trim()
+            : null;
+        const prevSpeed = Number(prev.temporarySpeedBonus ?? 0);
 
-        if (
-          currentSize === desiredSize &&
-          currentSpeedBonus === desiredSpeedBonus
-        ) {
+        if (prevSize === desiredSize && prevSpeed === desiredSpeedBonus) {
           return prev;
         }
 
@@ -1683,6 +1844,11 @@ export default function ZombiesCharacterSheet() {
           temporarySpeedBonus: desiredSpeedBonus,
         };
       });
+
+      if (normalizedCharacterId) {
+        updateLocalTemporarySize(normalizedCharacterId, desiredSize);
+        persistTemporarySize(desiredSize);
+      }
 
       return;
     }
@@ -1700,10 +1866,7 @@ export default function ZombiesCharacterSheet() {
         return prev;
       }
 
-      const ownsTemporarySize = Object.prototype.hasOwnProperty.call(
-        prev,
-        'temporarySize'
-      );
+      const ownsTemporarySize = Object.prototype.hasOwnProperty.call(prev, 'temporarySize');
       const ownsTemporarySpeed = Object.prototype.hasOwnProperty.call(
         prev,
         'temporarySpeedBonus'
@@ -1713,14 +1876,21 @@ export default function ZombiesCharacterSheet() {
         return prev;
       }
 
-      const {
-        temporarySize: _ignoredSize,
-        temporarySpeedBonus: _ignoredSpeed,
-        ...rest
-      } = prev;
-      return rest;
+      const next = { ...prev };
+      if (ownsTemporarySize) {
+        delete next.temporarySize;
+      }
+      if (ownsTemporarySpeed) {
+        delete next.temporarySpeedBonus;
+      }
+      return next;
     });
-  }, [activeEffects, form]);
+
+    if (normalizedCharacterId) {
+      updateLocalTemporarySize(normalizedCharacterId, null);
+      persistTemporarySize(null);
+    }
+  }, [activeEffects, form, persistTemporarySize, updateLocalTemporarySize]);
 
   const consumeCircle = useCallback(
     (type, index) => {
@@ -2499,6 +2669,12 @@ export default function ZombiesCharacterSheet() {
           accessory: accessories,
           equipment: normalizeEquipmentMap(data.equipment),
         });
+
+        const normalizedTemporarySize =
+          typeof data?.temporarySize === 'string' && data.temporarySize.trim() !== ''
+            ? data.temporarySize.trim()
+            : null;
+        lastPersistedTempSizeRef.current = normalizedTemporarySize;
 
         setCampaignId(normalizedCampaign);
         setEnemies([]);
@@ -3367,10 +3543,15 @@ export default function ZombiesCharacterSheet() {
   }, [characterId, form]);
 
   const resolvedCharacterIdRef = useRef(resolvedCharacterId);
+  const lastPersistedTempSizeRef = useRef(null);
 
   useEffect(() => {
     resolvedCharacterIdRef.current = resolvedCharacterId;
   }, [resolvedCharacterId]);
+
+  useEffect(() => {
+    lastPersistedTempSizeRef.current = null;
+  }, [characterId]);
 
   const characterFigurine = useMemo(() => resolveFigurineImageData(form), [form]);
 
@@ -3674,6 +3855,7 @@ export default function ZombiesCharacterSheet() {
     },
     [setCampaignCharacters, setForm]
   );
+
 
   useEffect(() => {
     if (!campaignId) {
@@ -4002,8 +4184,17 @@ export default function ZombiesCharacterSheet() {
         update,
         'figurineImagePublicId'
       );
+      const hasTemporarySizeUpdate = Object.prototype.hasOwnProperty.call(
+        update,
+        'temporarySize'
+      );
 
-      if (!hasDiceColorUpdate && !hasFigurineUrlUpdate && !hasFigurineIdUpdate) {
+      if (
+        !hasDiceColorUpdate &&
+        !hasFigurineUrlUpdate &&
+        !hasFigurineIdUpdate &&
+        !hasTemporarySizeUpdate
+      ) {
         return;
       }
 
@@ -4029,6 +4220,10 @@ export default function ZombiesCharacterSheet() {
             : null;
         updateLocalFigurineImage(normalizedCharacterId, normalizedUrl, normalizedPublicId);
       }
+
+      if (hasTemporarySizeUpdate) {
+        updateLocalTemporarySize(normalizedCharacterId, update.temporarySize);
+      }
     };
 
     socket.on('combat:update', handleCombatUpdate);
@@ -4048,7 +4243,13 @@ export default function ZombiesCharacterSheet() {
       socket.disconnect();
       socketRef.current = null;
     };
-  }, [campaignId, applyMapPayload, updateLocalDiceColor, updateLocalFigurineImage]);
+  }, [
+    campaignId,
+    applyMapPayload,
+    updateLocalDiceColor,
+    updateLocalFigurineImage,
+    updateLocalTemporarySize,
+  ]);
 
   const handleDiceColorChange = useCallback(
     (nextColor) => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -106,7 +106,7 @@ jest.mock('../attributes/Features', () => (props) => {
 
 import ZombiesCharacterSheet from './ZombiesCharacterSheet';
 
-const defaultApiFetchImplementation = (url) => {
+const defaultApiFetchImplementation = (url, options = {}) => {
   if (typeof url === 'string' && url.includes('/maps')) {
     return Promise.resolve({ ok: false, status: 404 });
   }
@@ -117,6 +117,25 @@ const defaultApiFetchImplementation = (url) => {
 
   if (typeof url === 'string' && url.includes('/classes/')) {
     return Promise.resolve({ ok: true, json: async () => ({ spellsKnown: 0 }) });
+  }
+
+  if (typeof url === 'string' && url.includes('/temporary-size')) {
+    let parsedSize = null;
+    if (options && typeof options.body === 'string') {
+      try {
+        const parsed = JSON.parse(options.body);
+        if (typeof parsed.temporarySize === 'string' && parsed.temporarySize.trim() !== '') {
+          parsedSize = parsed.temporarySize.trim();
+        }
+      } catch (error) {
+        // Ignore JSON parsing errors for test mocks
+      }
+    }
+
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ temporarySize: parsedSize }),
+    });
   }
 
   if (typeof url === 'string' && url.includes('/combat')) {
@@ -309,15 +328,16 @@ test('reapplies Large Form bonuses after persisted effects and refetch', async (
     campaign: null,
   };
 
-  apiFetch
-    .mockResolvedValueOnce({
-      ok: true,
-      json: async () => baseCharacter,
-    })
-    .mockResolvedValueOnce({
-      ok: true,
-      json: async () => baseCharacter,
-    });
+  apiFetch.mockImplementation((url, options) => {
+    if (typeof url === 'string' && url.includes('/characters/1') && (!options || !options.method)) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => baseCharacter,
+      });
+    }
+
+    return defaultApiFetchImplementation(url, options);
+  });
 
   const { rerender } = render(<ZombiesCharacterSheet key="initial" />);
 

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -2029,12 +2029,16 @@ export default function ZombiesDM() {
           return;
         }
 
-        const normalizedDiceColor =
-          typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
-            ? update.diceColor.trim()
-            : null;
+        const hasDiceColorUpdate = Object.prototype.hasOwnProperty.call(
+          update,
+          'diceColor'
+        );
+        const hasTemporarySizeUpdate = Object.prototype.hasOwnProperty.call(
+          update,
+          'temporarySize'
+        );
 
-        if (!normalizedDiceColor) {
+        if (!hasDiceColorUpdate && !hasTemporarySizeUpdate) {
           return;
         }
 
@@ -2061,15 +2065,61 @@ export default function ZombiesDM() {
               return record;
             }
 
-            if (
-              typeof record.diceColor === 'string' &&
-              record.diceColor.trim() === normalizedDiceColor
-            ) {
+            let updatedRecord = record;
+            let recordChanged = false;
+
+            if (hasDiceColorUpdate) {
+              const normalizedDiceColor =
+                typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
+                  ? update.diceColor.trim()
+                  : null;
+
+              if (
+                normalizedDiceColor &&
+                (!record.diceColor || record.diceColor.trim() !== normalizedDiceColor)
+              ) {
+                updatedRecord = { ...updatedRecord, diceColor: normalizedDiceColor };
+                recordChanged = true;
+              }
+            }
+
+            if (hasTemporarySizeUpdate) {
+              const normalizedSize =
+                typeof update.temporarySize === 'string' && update.temporarySize.trim() !== ''
+                  ? update.temporarySize.trim()
+                  : null;
+              const currentSize =
+                typeof record.temporarySize === 'string' && record.temporarySize.trim() !== ''
+                  ? record.temporarySize.trim()
+                  : null;
+              const hasSizeProp = Object.prototype.hasOwnProperty.call(
+                record,
+                'temporarySize'
+              );
+
+              if (normalizedSize) {
+                if (currentSize !== normalizedSize) {
+                  if (updatedRecord === record) {
+                    updatedRecord = { ...record };
+                  }
+                  updatedRecord.temporarySize = normalizedSize;
+                  recordChanged = true;
+                }
+              } else if (hasSizeProp) {
+                if (updatedRecord === record) {
+                  updatedRecord = { ...record };
+                }
+                delete updatedRecord.temporarySize;
+                recordChanged = true;
+              }
+            }
+
+            if (!recordChanged) {
               return record;
             }
 
             didUpdate = true;
-            return { ...record, diceColor: normalizedDiceColor };
+            return updatedRecord;
           });
 
           return didUpdate ? next : prev;
@@ -2890,7 +2940,8 @@ export default function ZombiesDM() {
           );
 
           const recordSize = normalizeCreatureSize(
-            record.size ??
+            record.temporarySize ??
+              record.size ??
               record.characterSize ??
               record?.character?.size ??
               record?.creature?.size ??

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -16,7 +16,7 @@ jest.mock('../utils/socket', () => ({
 const charactersRouter = require('../routes');
 const classes = require('../data/classes');
 const { EQUIPMENT_SLOT_KEYS } = require('../constants/equipmentSlots');
-const { emitMapUpdate, emitCombatUpdate } = require('../utils/socket');
+const { emitMapUpdate, emitCombatUpdate, emitCharacterMetadataUpdate } = require('../utils/socket');
 const { ObjectId } = require('mongodb');
 
 const app = express();
@@ -649,6 +649,99 @@ describe('Character routes', () => {
       .put('/characters/update-dice-color/507f1f77bcf86cd799439011')
       .send({ diceColor: 5 });
     expect(res.status).toBe(400);
+  });
+
+  test('update temporary size invalid id', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/characters/invalid-id/temporary-size')
+      .send({ temporarySize: 'Large' });
+    expect(res.status).toBe(400);
+  });
+
+  test('update temporary size invalid body', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/characters/507f1f77bcf86cd799439011/temporary-size')
+      .send({ temporarySize: 42 });
+    expect(res.status).toBe(400);
+  });
+
+  test('update temporary size sets value and emits update', async () => {
+    const characterIdString = '507f1f77bcf86cd799439011';
+    const objectId = new ObjectId(characterIdString);
+    const findOneAndUpdate = jest.fn().mockResolvedValue({
+      value: {
+        _id: objectId,
+        campaign: 'Test Campaign',
+        temporarySize: 'Large',
+      },
+    });
+
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOneAndUpdate,
+      }),
+    });
+
+    const res = await request(app)
+      .put(`/characters/${characterIdString}/temporary-size`)
+      .send({ temporarySize: ' Large ' });
+
+    expect(res.status).toBe(200);
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: objectId },
+      { $set: { temporarySize: 'Large' } },
+      { returnDocument: 'after' }
+    );
+    expect(res.body).toEqual({
+      campaignId: 'Test Campaign',
+      characterId: characterIdString,
+      temporarySize: 'Large',
+    });
+    expect(emitCharacterMetadataUpdate).toHaveBeenCalledWith('Test Campaign', {
+      campaignId: 'Test Campaign',
+      characterId: characterIdString,
+      temporarySize: 'Large',
+    });
+  });
+
+  test('update temporary size clears value when null provided', async () => {
+    const characterIdString = '507f1f77bcf86cd799439011';
+    const objectId = new ObjectId(characterIdString);
+    const findOneAndUpdate = jest.fn().mockResolvedValue({
+      value: {
+        _id: objectId,
+        campaignId: 'Test Campaign',
+      },
+    });
+
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOneAndUpdate,
+      }),
+    });
+
+    const res = await request(app)
+      .put(`/characters/${characterIdString}/temporary-size`)
+      .send({ temporarySize: null });
+
+    expect(res.status).toBe(200);
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: objectId },
+      { $unset: { temporarySize: '' } },
+      { returnDocument: 'after' }
+    );
+    expect(res.body).toEqual({
+      campaignId: 'Test Campaign',
+      characterId: characterIdString,
+      temporarySize: null,
+    });
+    expect(emitCharacterMetadataUpdate).toHaveBeenCalledWith('Test Campaign', {
+      campaignId: 'Test Campaign',
+      characterId: characterIdString,
+      temporarySize: null,
+    });
   });
 
   test('update feats success', async () => {

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -630,6 +630,105 @@ module.exports = (router) => {
     }
   );
 
+  characterRouter.route('/:id/temporary-size').put(
+    [
+      body('temporarySize')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('temporarySize must be a string')
+        .trim(),
+    ],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid ID' });
+      }
+
+      const db_connect = req.db;
+      const { temporarySize } = matchedData(req, {
+        locations: ['body'],
+        includeOptionals: true,
+      });
+
+      const updates = {};
+      const unset = {};
+
+      if (temporarySize !== undefined) {
+        const trimmedSize =
+          typeof temporarySize === 'string' ? temporarySize.trim() : '';
+        if (trimmedSize) {
+          updates.temporarySize = trimmedSize;
+        } else {
+          unset.temporarySize = '';
+        }
+      }
+
+      if (Object.keys(updates).length === 0 && Object.keys(unset).length === 0) {
+        return res.status(400).json({ message: 'No updates provided' });
+      }
+
+      const updateDoc = {};
+      if (Object.keys(updates).length > 0) {
+        updateDoc.$set = updates;
+      }
+      if (Object.keys(unset).length > 0) {
+        updateDoc.$unset = unset;
+      }
+
+      try {
+        const result = await db_connect.collection('Characters').findOneAndUpdate(
+          { _id: ObjectId(req.params.id) },
+          updateDoc,
+          { returnDocument: 'after' }
+        );
+
+        const updatedCharacter = result && result.value ? result.value : null;
+        if (!updatedCharacter) {
+          return res.status(404).json({ message: 'Character not found' });
+        }
+
+        const normalizedTemporarySize =
+          typeof updatedCharacter.temporarySize === 'string' &&
+          updatedCharacter.temporarySize.trim() !== ''
+            ? updatedCharacter.temporarySize.trim()
+            : null;
+
+        const rawCampaignId =
+          typeof updatedCharacter.campaign === 'string'
+            ? updatedCharacter.campaign
+            : typeof updatedCharacter.campaignId === 'string'
+              ? updatedCharacter.campaignId
+              : null;
+        const campaignId =
+          rawCampaignId && rawCampaignId.trim() !== '' ? rawCampaignId.trim() : null;
+        const characterId =
+          updatedCharacter._id && typeof updatedCharacter._id.toString === 'function'
+            ? updatedCharacter._id.toString()
+            : typeof updatedCharacter.characterId === 'string'
+              ? updatedCharacter.characterId
+              : null;
+
+        if (campaignId && characterId) {
+          emitCharacterMetadataUpdate(campaignId, {
+            characterId,
+            campaignId,
+            temporarySize: normalizedTemporarySize,
+          });
+        }
+
+        logger.info('Temporary size updated for character');
+
+        res.json({
+          campaignId,
+          characterId,
+          temporarySize: normalizedTemporarySize,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
   characterRouter.route('/:id/figurine').put(
     [
       body('figurineImageUrl')


### PR DESCRIPTION
## Summary
- add a `PUT /characters/:id/temporary-size` route that stores a character's temporary size and emits the existing metadata event
- cover the new API with jest tests and wire the shared mocks for the temporary-size calls
- persist temporary size on the Zombies character sheet and DM view, including websocket handling and token sizing, and move the helper definitions ahead of their usages

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js *(fails: token picker modal button not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f1691d069c8323996c376c192f9347