### PR TITLE
Improve dice roll animation visuals

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1928,22 +1928,13 @@ $rotateX: -$angle;
   top: -36px;
   width: 42px;
   height: 42px;
-  background: linear-gradient(145deg, rgba(0, 76, 255, 0.65), rgba(0, 76, 255, 0.35));
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  color: #fff;
   pointer-events: none;
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.65);
   transform: translate(-50%, -120%);
   opacity: 0;
   --drop-delay: 0s;
   --drop-duration: 0.9s;
   --drop-rotation: 0deg;
   --drop-distance: 60px;
-  --roll-duration: 1s;
   --initial-tilt-x: 0deg;
   --initial-tilt-y: 0deg;
   --initial-tilt-z: 0deg;
@@ -1954,44 +1945,33 @@ $rotateX: -$angle;
   --final-tilt-y: 0deg;
   --final-tilt-z: 0deg;
   --damage-die-clip: polygon(12% 12%, 88% 12%, 100% 50%, 88% 88%, 12% 88%, 0% 50%);
-  clip-path: var(--damage-die-clip);
+  animation: damage-die-drop var(--drop-duration) ease-out forwards;
+  animation-delay: var(--drop-delay);
+  transform-style: preserve-3d;
+}
+
+.damage-die__face {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.65);
+  background: linear-gradient(145deg, rgba(0, 76, 255, 0.65), rgba(0, 76, 255, 0.35));
+  border: 1px solid rgba(255, 255, 255, 0.5);
   border-radius: 12px;
+  clip-path: var(--damage-die-clip);
   box-shadow:
     inset 0 1px 8px rgba(255, 255, 255, 0.35),
     0 4px 12px rgba(0, 0, 0, 0.35);
-  animation: damage-die-drop var(--drop-duration) ease-out forwards;
-  animation-delay: var(--drop-delay);
-}
-
-.damage-die__inner {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   transform-style: preserve-3d;
-  transform: rotateX(var(--initial-tilt-x)) rotateY(var(--initial-tilt-y)) rotateZ(var(--initial-tilt-z));
-  animation: damage-die-roll var(--roll-duration) ease-out forwards;
-  animation-delay: var(--drop-delay);
+  backface-visibility: hidden;
 }
 
-.damage-die__value {
-  font-size: 1.1rem;
-  line-height: 1;
-  transform: translateZ(1px);
-}
-
-.damage-die__sides {
-  font-size: 0.6rem;
-  line-height: 1;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  opacity: 0.85;
-  transform: translateZ(1px);
-}
-
-.damage-die:after {
+.damage-die__face::after {
   content: '';
   position: absolute;
   inset: 12%;
@@ -2000,6 +1980,12 @@ $rotateX: -$angle;
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
   pointer-events: none;
   opacity: 0.9;
+}
+
+.damage-die__value {
+  font-size: 1.1rem;
+  line-height: 1;
+  transform: translateZ(1px);
 }
 
 .damage-die--d4 {
@@ -2032,18 +2018,18 @@ $rotateX: -$angle;
   --damage-die-clip: ellipse(50% 50% at 50% 50%);
 }
 
-.damage-die--bonus {
+.damage-die--bonus .damage-die__face {
   background: rgba(46, 204, 113, 0.45);
   border-color: rgba(46, 204, 113, 0.6);
 }
 
-.damage-die--critical {
+.damage-die--critical .damage-die__face {
   background: rgba(255, 215, 0, 0.45);
   border-color: rgba(255, 215, 0, 0.8);
   box-shadow: 0 0 12px rgba(255, 215, 0, 0.65);
 }
 
-.damage-die--critical-bonus {
+.damage-die--critical-bonus .damage-die__face {
   background: rgba(255, 111, 0, 0.45);
   border-color: rgba(255, 167, 38, 0.8);
   box-shadow: 0 0 12px rgba(255, 167, 38, 0.55);
@@ -2051,27 +2037,26 @@ $rotateX: -$angle;
 
 @keyframes damage-die-drop {
   0% {
-    transform: translate(-50%, -120%) rotate(var(--drop-rotation));
+    transform: translate(-50%, -140%) rotateX(var(--initial-tilt-x))
+      rotateY(var(--initial-tilt-y))
+      rotateZ(calc(var(--initial-tilt-z) + var(--drop-rotation)));
     opacity: 0;
   }
   20% {
     opacity: 1;
   }
-  100% {
-    transform: translate(-50%, var(--drop-distance)) rotate(0deg);
-    opacity: 1;
-  }
-}
-
-@keyframes damage-die-roll {
-  0% {
-    transform: rotateX(var(--initial-tilt-x)) rotateY(var(--initial-tilt-y)) rotateZ(var(--initial-tilt-z));
-  }
   55% {
-    transform: rotateX(var(--mid-tilt-x)) rotateY(var(--mid-tilt-y)) rotateZ(var(--mid-tilt-z));
+    transform: translate(-50%, calc(var(--drop-distance) * 0.35))
+      rotateX(var(--mid-tilt-x))
+      rotateY(var(--mid-tilt-y))
+      rotateZ(var(--mid-tilt-z));
   }
   100% {
-    transform: rotateX(var(--final-tilt-x)) rotateY(var(--final-tilt-y)) rotateZ(var(--final-tilt-z));
+    transform: translate(-50%, var(--drop-distance))
+      rotateX(var(--final-tilt-x))
+      rotateY(var(--final-tilt-y))
+      rotateZ(var(--final-tilt-z));
+    opacity: 1;
   }
 }
 

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1274,7 +1274,7 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                     '--drop-delay': `${die.delay}s`,
                     '--drop-distance': `${die.dropDistance}px`,
                     '--drop-rotation': `${die.rotation}deg`,
-                    '--roll-duration': `${die.rollDuration}s`,
+                    '--drop-duration': `${die.rollDuration}s`,
                     '--initial-tilt-x': `${die.initialTiltX}deg`,
                     '--initial-tilt-y': `${die.initialTiltY}deg`,
                     '--initial-tilt-z': `${die.initialTiltZ}deg`,
@@ -1286,11 +1286,10 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                     '--final-tilt-z': `${die.finalTiltZ}deg`,
                   }}
                 >
-                  <div className="damage-die__inner">
+                  <div className="damage-die__face">
                     <span className={`damage-die__value ${typeClass}`}>
                       {die.value}
                     </span>
-                    <span className="damage-die__sides">d{die.sides}</span>
                   </div>
                 </div>
               );


### PR DESCRIPTION
## Summary
- remove the printed dice type from the rendered damage dice
- update the damage dice animation so the entire die rotates with the roll instead of only the face value

## Testing
- npm test -- --watchAll=false (terminated manually after initialization)

------
https://chatgpt.com/codex/tasks/task_e_68f1736848f0832e8e5464e4b828dfaa