### PR TITLE
Render rolling damage dice as 3D polyhedra

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1777,11 +1777,28 @@ $rotateX: -$angle;
 }
 
 @keyframes roll {
-  10% { transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) }
-  30% { transform: rotateX(120deg) rotateY(240deg) rotateZ(0deg) translateX(40px) translateY(40px) }
-  50% { transform: rotateX(240deg) rotateY(480deg) rotateZ(0deg) translateX(-40px) translateY(-40px) }
-  70% { transform: rotateX(360deg) rotateY(720deg) rotateZ(0deg) }
-  90% { transform: rotateX(480deg) rotateY(960deg) rotateZ(0deg) }
+  0% {
+    transform: rotateX($rotateX) rotateY(0deg) rotateZ(0deg);
+  }
+
+  25% {
+    transform: rotateX($rotateX + 120deg) rotateY(240deg) rotateZ(0deg)
+      translate3d(40px, 40px, 20px);
+  }
+
+  50% {
+    transform: rotateX($rotateX + 240deg) rotateY(480deg) rotateZ(0deg)
+      translate3d(-40px, -40px, -20px);
+  }
+
+  75% {
+    transform: rotateX($rotateX + 360deg) rotateY(720deg) rotateZ(0deg)
+      translate3d(20px, -30px, 10px);
+  }
+
+  100% {
+    transform: rotateX($rotateX + 480deg) rotateY(960deg) rotateZ(0deg);
+  }
 }
 
 @include dice-size(min(25vw, 120px));
@@ -1926,8 +1943,8 @@ $rotateX: -$angle;
 .damage-die {
   position: absolute;
   top: -36px;
-  width: 42px;
-  height: 42px;
+  width: var(--die-size, 46px);
+  height: var(--die-size, 46px);
   pointer-events: none;
   transform: translate(-50%, -120%);
   opacity: 0;
@@ -1935,109 +1952,112 @@ $rotateX: -$angle;
   --drop-duration: 0.9s;
   --drop-rotation: 0deg;
   --drop-distance: 60px;
-  --initial-tilt-x: 0deg;
-  --initial-tilt-y: 0deg;
-  --initial-tilt-z: 0deg;
-  --mid-tilt-x: 360deg;
-  --mid-tilt-y: 360deg;
-  --mid-tilt-z: 360deg;
-  --final-tilt-x: 0deg;
-  --final-tilt-y: 0deg;
-  --final-tilt-z: 0deg;
-  --damage-die-clip: polygon(12% 12%, 88% 12%, 100% 50%, 88% 88%, 12% 88%, 0% 50%);
+  --initial-tilt-x: -26deg;
+  --initial-tilt-y: 18deg;
+  --initial-tilt-z: -18deg;
+  --mid-tilt-x: 420deg;
+  --mid-tilt-y: 312deg;
+  --mid-tilt-z: 558deg;
+  --final-tilt-x: 22deg;
+  --final-tilt-y: -16deg;
+  --final-tilt-z: 24deg;
+  --start-depth: 108px;
+  --mid-depth: -28px;
+  --final-depth: 0px;
+  --die-perspective: 760px;
+  --die-model-scale: 40px;
+  --die-label-elevation: 26px;
+  --die-surface-color: #1f46cc;
+  --die-edge-highlight: rgba(255, 255, 255, 0.24);
+  --die-surface-shadow: rgba(0, 0, 0, 0.45);
   animation: damage-die-drop var(--drop-duration) ease-out forwards;
   animation-delay: var(--drop-delay);
   transform-style: preserve-3d;
+  perspective: var(--die-perspective);
+  filter: drop-shadow(0 18px 24px rgba(0, 0, 0, 0.45));
 }
 
-.damage-die__face {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  color: #fff;
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.65);
-  background: linear-gradient(145deg, rgba(0, 76, 255, 0.65), rgba(0, 76, 255, 0.35));
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  border-radius: 12px;
-  clip-path: var(--damage-die-clip);
-  box-shadow:
-    inset 0 1px 8px rgba(255, 255, 255, 0.35),
-    0 4px 12px rgba(0, 0, 0, 0.35);
+.damage-die__mesh {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+}
+
+.damage-die__poly-face {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--die-model-scale);
+  height: var(--die-model-scale);
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  background:
+    linear-gradient(155deg, rgba(255, 255, 255, 0.22), rgba(0, 0, 0, 0.35)),
+    var(--die-surface-color);
+  border: 0 solid transparent;
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25), 0 0 0.75px var(--die-edge-highlight);
   transform-style: preserve-3d;
   backface-visibility: hidden;
 }
 
-.damage-die__face::after {
-  content: '';
+.damage-die__value-wrap {
   position: absolute;
-  inset: 12%;
-  border-radius: inherit;
-  clip-path: inherit;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateZ(var(--die-label-elevation));
   pointer-events: none;
-  opacity: 0.9;
 }
 
 .damage-die__value {
   font-size: 1.1rem;
   line-height: 1;
-  transform: translateZ(1px);
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
 }
 
-.damage-die--d4 {
-  --damage-die-clip: polygon(50% 0%, 0% 100%, 100% 100%);
+.damage-die__face--flat {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 48%),
+    linear-gradient(140deg, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.55)),
+    var(--die-surface-color);
+  border: 1px solid var(--die-edge-highlight);
+  box-shadow:
+    inset 0 1px 12px rgba(255, 255, 255, 0.35),
+    inset 0 -6px 14px rgba(0, 0, 0, 0.45),
+    0 6px 16px rgba(0, 0, 0, 0.35);
+  transform-style: preserve-3d;
 }
 
-.damage-die--d6 {
-  --damage-die-clip: polygon(12% 12%, 88% 12%, 88% 88%, 12% 88%);
-  border-radius: 10px;
+.damage-die--bonus {
+  --die-surface-color: #30b86f;
+  --die-edge-highlight: rgba(190, 255, 213, 0.5);
 }
 
-.damage-die--d8 {
-  --damage-die-clip: polygon(50% 0%, 82% 18%, 100% 50%, 82% 82%, 50% 100%, 18% 82%, 0% 50%, 18% 18%);
+.damage-die--critical {
+  --die-surface-color: #f2c100;
+  --die-edge-highlight: rgba(255, 246, 196, 0.7);
+  filter: drop-shadow(0 0 12px rgba(255, 215, 0, 0.55));
 }
 
-.damage-die--d10 {
-  --damage-die-clip: polygon(50% 0%, 78% 6%, 96% 32%, 100% 50%, 96% 68%, 78% 94%, 50% 100%, 22% 94%, 4% 68%, 0% 50%, 4% 32%, 22% 6%);
-}
-
-.damage-die--d12 {
-  --damage-die-clip: polygon(35% 0%, 65% 0%, 88% 15%, 100% 38%, 100% 62%, 88% 85%, 65% 100%, 35% 100%, 12% 85%, 0% 62%, 0% 38%, 12% 15%);
-}
-
-.damage-die--d20 {
-  --damage-die-clip: polygon(50% 0%, 72% 6%, 88% 18%, 98% 34%, 100% 50%, 98% 66%, 88% 82%, 72% 94%, 50% 100%, 28% 94%, 12% 82%, 2% 66%, 0% 50%, 2% 34%, 12% 18%, 28% 6%);
-}
-
-.damage-die--generic {
-  border-radius: 50%;
-  --damage-die-clip: ellipse(50% 50% at 50% 50%);
-}
-
-.damage-die--bonus .damage-die__face {
-  background: rgba(46, 204, 113, 0.45);
-  border-color: rgba(46, 204, 113, 0.6);
-}
-
-.damage-die--critical .damage-die__face {
-  background: rgba(255, 215, 0, 0.45);
-  border-color: rgba(255, 215, 0, 0.8);
-  box-shadow: 0 0 12px rgba(255, 215, 0, 0.65);
-}
-
-.damage-die--critical-bonus .damage-die__face {
-  background: rgba(255, 111, 0, 0.45);
-  border-color: rgba(255, 167, 38, 0.8);
-  box-shadow: 0 0 12px rgba(255, 167, 38, 0.55);
+.damage-die--critical-bonus {
+  --die-surface-color: #ff8a33;
+  --die-edge-highlight: rgba(255, 212, 162, 0.7);
+  filter: drop-shadow(0 0 12px rgba(255, 167, 38, 0.55));
 }
 
 @keyframes damage-die-drop {
   0% {
-    transform: translate(-50%, -140%) rotateX(var(--initial-tilt-x))
+    transform: perspective(var(--die-perspective))
+      translate3d(-50%, -140%, var(--start-depth))
+      rotateX(var(--initial-tilt-x))
       rotateY(var(--initial-tilt-y))
       rotateZ(calc(var(--initial-tilt-z) + var(--drop-rotation)));
     opacity: 0;
@@ -2046,13 +2066,15 @@ $rotateX: -$angle;
     opacity: 1;
   }
   55% {
-    transform: translate(-50%, calc(var(--drop-distance) * 0.35))
+    transform: perspective(var(--die-perspective))
+      translate3d(-50%, calc(var(--drop-distance) * 0.35), var(--mid-depth))
       rotateX(var(--mid-tilt-x))
       rotateY(var(--mid-tilt-y))
       rotateZ(var(--mid-tilt-z));
   }
   100% {
-    transform: translate(-50%, var(--drop-distance))
+    transform: perspective(var(--die-perspective))
+      translate3d(-50%, var(--drop-distance), var(--final-depth))
       rotateX(var(--final-tilt-x))
       rotateY(var(--final-tilt-y))
       rotateZ(var(--final-tilt-z));

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -15,6 +15,7 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
+import { createPolyhedronFaces } from '../../../utils/dieGeometry';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -57,6 +58,80 @@ const anyDamageDiceRegex = /\d+d\d+(?:[+-]\d+)?/;
 const spellsCatalog = spellsData || {};
 
 const diceExpressionPattern = /\d+d\d+(?:\s*[+-]\s*\d+)?/gi;
+
+const DIE_MODEL_SCALE = 20;
+const LIGHT_VECTOR = normalizeVector([0.35, 0.82, 1]);
+const dieGeometryCache = new Map();
+
+function normalizeVector(vector) {
+  const magnitude = Math.hypot(...vector);
+  if (magnitude === 0) {
+    return [0, 0, 0];
+  }
+  return vector.map((component) => component / magnitude);
+}
+
+function clamp(value, min, max) {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+function getPolyhedronFaces(sides) {
+  if (dieGeometryCache.has(sides)) {
+    return dieGeometryCache.get(sides);
+  }
+
+  const faces = createPolyhedronFaces(sides, DIE_MODEL_SCALE);
+  dieGeometryCache.set(sides, faces);
+  return faces;
+}
+
+function DamageDieMesh({ die, typeClass }) {
+  const faces = useMemo(() => getPolyhedronFaces(die.sides), [die.sides]);
+
+  if (!faces) {
+    return (
+      <div className="damage-die__face damage-die__face--flat">
+        <span className={`damage-die__value ${typeClass}`}>{die.value}</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="damage-die__mesh" aria-hidden="true">
+        {faces.map((face, index) => {
+          const dot =
+            face.normal[0] * LIGHT_VECTOR[0] +
+            face.normal[1] * LIGHT_VECTOR[1] +
+            face.normal[2] * LIGHT_VECTOR[2];
+          const brightness = 0.35 + 0.65 * clamp(dot, 0, 1);
+
+          return (
+            <div
+              key={`die-face-${die.id}-${index}`}
+              className="damage-die__poly-face"
+              style={{
+                transform: `matrix3d(${face.matrix
+                  .map((component) => component.toFixed(6))
+                  .join(',')})`,
+                filter: `brightness(${brightness.toFixed(3)})`,
+              }}
+            />
+          );
+        })}
+      </div>
+      <div className="damage-die__value-wrap">
+        <span className={`damage-die__value ${typeClass}`}>{die.value}</span>
+      </div>
+    </>
+  );
+}
 
 function extractDiceExpression(description = '') {
   diceExpressionPattern.lastIndex = 0;
@@ -1286,11 +1361,7 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                     '--final-tilt-z': `${die.finalTiltZ}deg`,
                   }}
                 >
-                  <div className="damage-die__face">
-                    <span className={`damage-die__value ${typeClass}`}>
-                      {die.value}
-                    </span>
-                  </div>
+                  <DamageDieMesh die={die} typeClass={typeClass} />
                 </div>
               );
             })}

--- a/client/src/utils/dieGeometry.js
+++ b/client/src/utils/dieGeometry.js
@@ -1,0 +1,359 @@
+const SQRT3 = Math.sqrt(3);
+
+const EPSILON = 1e-6;
+
+function normalizeVertices(points) {
+  return points.map(([x, y, z]) => {
+    const length = Math.hypot(x, y, z);
+    return [x / length, y / length, z / length];
+  });
+}
+
+function createTetrahedron() {
+  const vertices = normalizeVertices([
+    [1, 1, 1],
+    [1, -1, -1],
+    [-1, 1, -1],
+    [-1, -1, 1],
+  ]);
+
+  return { vertices };
+}
+
+function createCube() {
+  const vertices = normalizeVertices([
+    [-1, -1, -1],
+    [1, -1, -1],
+    [1, 1, -1],
+    [-1, 1, -1],
+    [-1, -1, 1],
+    [1, -1, 1],
+    [1, 1, 1],
+    [-1, 1, 1],
+  ]);
+
+  return { vertices };
+}
+
+function createOctahedron() {
+  const vertices = normalizeVertices([
+    [1, 0, 0],
+    [-1, 0, 0],
+    [0, 1, 0],
+    [0, -1, 0],
+    [0, 0, 1],
+    [0, 0, -1],
+  ]);
+
+  return { vertices };
+}
+
+function createIcosahedron() {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const vertices = normalizeVertices([
+    [-1, phi, 0],
+    [1, phi, 0],
+    [-1, -phi, 0],
+    [1, -phi, 0],
+    [0, -1, phi],
+    [0, 1, phi],
+    [0, -1, -phi],
+    [0, 1, -phi],
+    [phi, 0, -1],
+    [phi, 0, 1],
+    [-phi, 0, -1],
+    [-phi, 0, 1],
+  ]);
+
+  return { vertices };
+}
+
+function createDodecahedron() {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const invPhi = 1 / phi;
+  const vertices = normalizeVertices([
+    [-1, -1, -1],
+    [1, -1, -1],
+    [1, 1, -1],
+    [-1, 1, -1],
+    [-1, -1, 1],
+    [1, -1, 1],
+    [1, 1, 1],
+    [-1, 1, 1],
+    [0, -invPhi, -phi],
+    [0, invPhi, -phi],
+    [0, -invPhi, phi],
+    [0, invPhi, phi],
+    [-invPhi, -phi, 0],
+    [invPhi, -phi, 0],
+    [-invPhi, phi, 0],
+    [invPhi, phi, 0],
+    [-phi, 0, -invPhi],
+    [-phi, 0, invPhi],
+    [phi, 0, -invPhi],
+    [phi, 0, invPhi],
+  ]);
+
+  return { vertices };
+}
+
+function createPentagonalTrapezohedron() {
+  const top = [0, 0, 1];
+  const bottom = [0, 0, -1];
+  const ring = [];
+  const radius = 0.92;
+  const offset = 0.33;
+  const step = (Math.PI * 2) / 10;
+
+  for (let i = 0; i < 10; i += 1) {
+    const angle = i * step;
+    const x = Math.cos(angle) * radius;
+    const y = Math.sin(angle) * radius;
+    const z = i % 2 === 0 ? offset : -offset;
+    ring.push([x, z, y]);
+  }
+
+  const vertices = normalizeVertices([top, bottom, ...ring]);
+
+  return { vertices };
+}
+
+const polyhedraDefinitions = {
+  4: createTetrahedron,
+  6: createCube,
+  8: createOctahedron,
+  10: createPentagonalTrapezohedron,
+  12: createDodecahedron,
+  20: createIcosahedron,
+};
+
+const baseTriangleHeight = SQRT3 / 2;
+const baseTriangle = [
+  [0, (2 * baseTriangleHeight) / 3, 0],
+  [-0.5, -baseTriangleHeight / 3, 0],
+  [0.5, -baseTriangleHeight / 3, 0],
+];
+
+const baseEdgeLength = Math.hypot(
+  baseTriangle[1][0] - baseTriangle[0][0],
+  baseTriangle[1][1] - baseTriangle[0][1],
+);
+
+function subtract(a, b) {
+  return a.map((v, i) => v - b[i]);
+}
+
+function dot(a, b) {
+  return a.reduce((sum, v, i) => sum + v * b[i], 0);
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function norm(a) {
+  return Math.hypot(...a);
+}
+
+function normalize(a) {
+  const length = norm(a);
+  return a.map((v) => v / length);
+}
+
+function matrixFromColumns(c1, c2, c3) {
+  return [
+    c1[0], c1[1], c1[2],
+    c2[0], c2[1], c2[2],
+    c3[0], c3[1], c3[2],
+  ];
+}
+
+function inverse3x3(m) {
+  const [a11, a21, a31, a12, a22, a32, a13, a23, a33] = m;
+  const det =
+    a11 * (a22 * a33 - a23 * a32) -
+    a12 * (a21 * a33 - a23 * a31) +
+    a13 * (a21 * a32 - a22 * a31);
+
+  if (Math.abs(det) < 1e-8) {
+    throw new Error('Singular matrix');
+  }
+
+  const invDet = 1 / det;
+
+  return [
+    (a22 * a33 - a23 * a32) * invDet,
+    (a23 * a31 - a21 * a33) * invDet,
+    (a21 * a32 - a22 * a31) * invDet,
+    (a13 * a32 - a12 * a33) * invDet,
+    (a11 * a33 - a13 * a31) * invDet,
+    (a12 * a31 - a11 * a32) * invDet,
+    (a12 * a23 - a13 * a22) * invDet,
+    (a13 * a21 - a11 * a23) * invDet,
+    (a11 * a22 - a12 * a21) * invDet,
+  ];
+}
+
+function multiply3x3(a, b) {
+  const result = [];
+
+  for (let row = 0; row < 3; row += 1) {
+    for (let col = 0; col < 3; col += 1) {
+      let sum = 0;
+      for (let k = 0; k < 3; k += 1) {
+        sum += a[row + k * 3] * b[k + col * 3];
+      }
+      result[row + col * 3] = sum;
+    }
+  }
+
+  return result;
+}
+
+function generateConvexHullTriangles(vertices) {
+  const faces = [];
+  const seen = new Set();
+  const centroid = vertices
+    .reduce(
+      (acc, vertex) => acc.map((value, index) => value + vertex[index]),
+      [0, 0, 0],
+    )
+    .map((value) => value / vertices.length);
+
+  for (let i = 0; i < vertices.length - 2; i += 1) {
+    for (let j = i + 1; j < vertices.length - 1; j += 1) {
+      for (let k = j + 1; k < vertices.length; k += 1) {
+        const v0 = vertices[i];
+        const v1 = vertices[j];
+        const v2 = vertices[k];
+        const edge1 = subtract(v1, v0);
+        const edge2 = subtract(v2, v0);
+        const normal = cross(edge1, edge2);
+        const area = norm(normal);
+
+        if (area < EPSILON) {
+          continue;
+        }
+
+        let hasPositive = false;
+        let hasNegative = false;
+
+        for (let m = 0; m < vertices.length; m += 1) {
+          if (m === i || m === j || m === k) {
+            continue;
+          }
+          const distance = dot(normal, subtract(vertices[m], v0));
+          if (distance > EPSILON) {
+            hasPositive = true;
+          } else if (distance < -EPSILON) {
+            hasNegative = true;
+          }
+
+          if (hasPositive && hasNegative) {
+            break;
+          }
+        }
+
+        if (hasPositive && hasNegative) {
+          continue;
+        }
+
+        const key = [i, j, k].sort((a, b) => a - b).join('-');
+
+        if (seen.has(key)) {
+          continue;
+        }
+
+        seen.add(key);
+
+        const orientation = dot(normal, subtract(centroid, v0));
+        if (orientation > 0) {
+          faces.push([i, k, j]);
+        } else {
+          faces.push([i, j, k]);
+        }
+      }
+    }
+  }
+
+  return faces;
+}
+
+const baseU = normalize(subtract(baseTriangle[1], baseTriangle[0]));
+const baseVTemp = subtract(baseTriangle[2], baseTriangle[0]);
+const baseV = normalize(
+  subtract(baseVTemp, baseU.map((v) => v * dot(baseVTemp, baseU))),
+);
+const baseW = cross(baseU, baseV);
+const baseMatrix = matrixFromColumns(baseU, baseV, baseW);
+const baseInverse = inverse3x3(baseMatrix);
+
+export function createPolyhedronFaces(sides, scale = 20) {
+  const geometryFactory = polyhedraDefinitions[sides];
+
+  if (!geometryFactory) {
+    return null;
+  }
+
+  const { vertices, faces: presetFaces } = geometryFactory();
+  const faces = presetFaces || generateConvexHullTriangles(vertices);
+  const faceData = [];
+
+  faces.forEach((face) => {
+    const verts = face.map((index) => vertices[index]);
+    const centroid = verts.reduce(
+      (acc, vertex) => acc.map((v, i) => v + vertex[i] / 3),
+      [0, 0, 0],
+    );
+
+    const uVec = subtract(verts[1], verts[0]);
+    const faceScale = norm(uVec) / baseEdgeLength;
+    const u = normalize(uVec);
+    const vTemp = subtract(verts[2], verts[0]);
+    const v = normalize(
+      subtract(vTemp, u.map((value) => value * dot(vTemp, u))),
+    );
+    const w = cross(u, v);
+
+    const faceMatrix = matrixFromColumns(
+      u.map((value) => value * faceScale),
+      v.map((value) => value * faceScale),
+      w,
+    );
+    const transformMatrix = multiply3x3(faceMatrix, baseInverse);
+
+    const translation = centroid.map((value) => value * scale);
+
+    const cssMatrix = [
+      transformMatrix[0] * scale,
+      transformMatrix[3] * scale,
+      transformMatrix[6] * scale,
+      0,
+      transformMatrix[1] * scale,
+      transformMatrix[4] * scale,
+      transformMatrix[7] * scale,
+      0,
+      transformMatrix[2] * scale,
+      transformMatrix[5] * scale,
+      transformMatrix[8] * scale,
+      0,
+      translation[0],
+      translation[1],
+      translation[2],
+      1,
+    ];
+
+    const normal = normalize(w);
+
+    faceData.push({
+      matrix: cssMatrix,
+      normal,
+    });
+  });
+
+  return faceData;
+}


### PR DESCRIPTION
## Summary
- replace the flat damage die face with a mesh renderer that builds real 3D polyhedra for each die type
- add a reusable geometry helper that procedurally generates the transforms for d4–d20 models
- retheme the die styles to draw their facets, lighting, and value badge using the new mesh structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f174e00fd0832e844fb456201730e1