### PR TITLE
Fix damage die 3D scale so faces render correctly

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -59,7 +59,7 @@ const spellsCatalog = spellsData || {};
 
 const diceExpressionPattern = /\d+d\d+(?:\s*[+-]\s*\d+)?/gi;
 
-const DIE_MODEL_SCALE = 1;
+const DIE_MODEL_SCALE = 26; // keep in sync with --die-model-scale in App.scss
 const LIGHT_VECTOR = normalizeVector([0.35, 0.82, 1]);
 const dieGeometryCache = new Map();
 
@@ -1346,6 +1346,7 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                   className={`damage-die ${shapeClass} ${categoryClass}`}
                   style={{
                     left: `${die.left}%`,
+                    '--die-model-scale': `${DIE_MODEL_SCALE}px`,
                     '--drop-delay': `${die.delay}s`,
                     '--drop-distance': `${die.dropDistance}px`,
                     '--drop-rotation': `${die.rotation}deg`,


### PR DESCRIPTION
## Summary
- update the damage die model scale used for 3D geometry so the mesh renders with the intended shape
- pass the scale to each rendered die to keep the CSS custom property in sync with the geometry calculations

## Testing
- npm test -- --watchAll=false PlayerTurnActions

------
https://chatgpt.com/codex/tasks/task_e_68f17fb5fcbc832e82227f371d7cb47b