### PR TITLE
Fix dice face alignment for damage roller

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -118,7 +118,7 @@ function DamageDieMesh({ die, typeClass }) {
               key={`die-face-${die.id}-${index}`}
               className="damage-die__poly-face"
               style={{
-                transform: `matrix3d(${face.matrix
+                transform: `translate(-50%, -50%) matrix3d(${face.matrix
                   .map((component) => component.toFixed(6))
                   .join(',')})`,
                 filter: `brightness(${brightness.toFixed(3)})`,


### PR DESCRIPTION
## Summary
- adjust the die face transform to translate from the element center before applying the 3D matrix
- correct the rendered geometry so the dice mesh appears as solid dice rather than starbursts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1841a48dc832eab8e4ccb0aa38f6f