### PR TITLE
Fix damage die mesh aspect ratio

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1988,7 +1988,7 @@ $rotateX: -$angle;
   top: 50%;
   left: 50%;
   width: var(--die-model-scale);
-  height: var(--die-model-scale);
+  height: calc(var(--die-model-scale) * 0.8660254);
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
   background:
     linear-gradient(155deg, rgba(255, 255, 255, 0.22), rgba(0, 0, 0, 0.35)),


### PR DESCRIPTION
## Summary
- adjust the damage die face height to match an equilateral triangle so the mesh renders correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1851eafa4832eabb63ce390333ba7