### PR TITLE
Rebuild D20 dice mesh

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1589,139 +1589,61 @@ label {
 $transitionDuration: 0.5s;
 $animationDuration:  3s;
 
-$angle: 53deg;
-$ringAngle: -11deg;
-$sideAngle: calc(360deg / 5);
-$color: var(--dice-face-color);
-
-$rotateX: -$angle;
-
-@mixin dice-size($containerWidth) {
-  $containerHeight: $containerWidth;
-  $faceWidth:  calc(#{$containerWidth} * 0.5);
-  $faceHeight: calc(#{$faceWidth} * 0.86);
-
-  $translateZ: calc(#{$faceWidth} * 0.335);
-  $translateY: calc(#{$faceHeight} * -0.15);
-  $translateRingZ: calc(#{$faceWidth} * 0.75);
-  $translateRingY: calc(#{$faceHeight} * 0.78 + #{$translateY});
-  $translateLowerZ: $translateZ;
-  $translateLowerY: calc(#{$faceHeight} * 0.78 + #{$translateRingY});
+.attack-roll-controls__die {
+  --d20-scale: calc(var(--attack-die-size) / 2);
 
   .content {
     margin: 0 auto;
     position: relative;
-    top: calc(#{$containerHeight} * -0.18);
-    width: $containerWidth;
-    height: $containerHeight;
+    top: calc(var(--attack-die-size) * -0.18);
+    width: var(--attack-die-size);
+    height: var(--attack-die-size);
     perspective: 1500px;
 
     @media (max-width: 576px), (max-height: 600px) {
-      top: calc(#{$containerHeight} * -0.06);
+      top: calc(var(--attack-die-size) * -0.06);
     }
   }
 
   .die {
     position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     transform-style: preserve-3d;
     transition: transform $transitionDuration ease-out;
     cursor: pointer;
 
-    transform: rotateX($rotateX);
-
     &.rolling {
-      animation: roll $animationDuration linear;
+      animation: d20-roll $animationDuration linear infinite;
     }
+  }
 
-    @for $i from 1 through 5 {
-      &[data-face="#{$i}"] {
-        $angleMultiplier: $i - 1;
-        transform: rotateX(-$angle) rotateY($sideAngle * $angleMultiplier);
-      }
-    }
+  .face {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: calc(var(--d20-scale) * 1.0514622242);
+    height: calc(var(--d20-scale) * 0.9105929973);
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    background: var(--dice-face-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.8);
+    font-size: calc(var(--d20-scale) * 0.42);
+    font-weight: 700;
+    line-height: 1;
+    backface-visibility: hidden;
+    transform-origin: 0 0 0;
+    border-radius: 4px;
+    box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.35);
+  }
 
-    @for $i from 16 through 20 {
-      &[data-face="#{$i}"] {
-        $angleMultiplier: $i - 15;
-        transform: rotateX(-$angle + 180deg) rotateY(-$sideAngle * $angleMultiplier);
-      }
-    }
-
-    @for $i from 6 through 10 {
-      &[data-face="#{$i}"] {
-        $angleMultiplier: $i - 6;
-        transform: rotateX(-$ringAngle) rotateZ(180deg) rotateY($sideAngle * $angleMultiplier);
-      }
-    }
-
-    @for $i from 11 through 15 {
-      &[data-face="#{$i}"] {
-        $angleMultiplier: $i - 8;
-        transform: rotateX(-$ringAngle) rotateY(-$sideAngle * $angleMultiplier - calc($sideAngle / 2));
-      }
-    }
-
-    .face {
-      $horizontalMargin: calc(#{$faceWidth} * -0.5);
-
-      position: absolute;
-      left: 50%;
-      top: 0;
-      margin: 0 $horizontalMargin;
-      border-left: calc(#{$faceWidth} * 0.5) solid transparent;
-      border-right: calc(#{$faceWidth} * 0.5) solid transparent;
-      border-bottom: $faceHeight solid $color;
-      width: 0px;
-      height: 0px;
-      transform-style: preserve-3d;
-      backface-visibility: hidden;
-
-      counter-increment: steps 1;
-
-      &:before {
-        content: counter(steps);
-        position: absolute;
-        top: calc(#{$faceHeight} * 0.25);
-        left: calc(#{$faceWidth} * -1);
-        color: #fff;
-        text-shadow: 1px 1px 3px #000;
-        font-size: calc(#{$faceHeight} * 0.5);
-        text-align: center;
-        line-height: calc(#{$faceHeight} * 0.9);
-        width: calc(#{$faceWidth} * 2);
-        height: $faceHeight;
-      }
-
-      @for $i from 1 through 5 {
-        &:nth-child(#{$i}) {
-          $angleMultiplier: $i - 1;
-          transform: rotateY(-$sideAngle * $angleMultiplier) translateZ($translateZ) translateY($translateY) rotateX($angle);
-        }
-      }
-
-      @for $i from 16 through 20 {
-        &:nth-child(#{$i}) {
-          $angleMultiplier: $i - 18;
-          transform: rotateY($sideAngle * $angleMultiplier + calc($sideAngle / 2)) translateZ($translateLowerZ) translateY($translateLowerY) rotateZ(180deg) rotateX($angle);
-        }
-      }
-
-      @for $i from 6 through 10 {
-        &:nth-child(#{$i}) {
-          $angleMultiplier: $i - 11;
-          transform: rotateY(-$sideAngle * $angleMultiplier) translateZ($translateRingZ) translateY($translateRingY) rotateZ(180deg) rotateX($ringAngle);
-        }
-      }
-
-      @for $i from 11 through 15 {
-        &:nth-child(#{$i}) {
-          $angleMultiplier: $i - 8;
-          transform: rotateY($sideAngle * $angleMultiplier + calc($sideAngle / 2)) translateZ($translateRingZ) translateY($translateRingY) rotateX($ringAngle);
-        }
-      }
-    }
+  .face__label {
+    position: relative;
+    top: calc(var(--d20-scale) * -0.02);
   }
 }
 
@@ -1776,35 +1698,26 @@ $rotateX: -$angle;
   }
 }
 
-@keyframes roll {
+@keyframes d20-roll {
   0% {
-    transform: rotateX($rotateX) rotateY(0deg) rotateZ(0deg);
+    transform: rotate3d(0.35, 0.2, 0.91, 0deg);
   }
 
   25% {
-    transform: rotateX($rotateX + 120deg) rotateY(240deg) rotateZ(0deg)
-      translate3d(40px, 40px, 20px);
+    transform: rotate3d(-0.75, 0.44, 0.5, 180deg);
   }
 
   50% {
-    transform: rotateX($rotateX + 240deg) rotateY(480deg) rotateZ(0deg)
-      translate3d(-40px, -40px, -20px);
+    transform: rotate3d(0.18, -0.83, 0.53, 360deg);
   }
 
   75% {
-    transform: rotateX($rotateX + 360deg) rotateY(720deg) rotateZ(0deg)
-      translate3d(20px, -30px, 10px);
+    transform: rotate3d(0.66, 0.74, -0.1, 540deg);
   }
 
   100% {
-    transform: rotateX($rotateX + 480deg) rotateY(960deg) rotateZ(0deg);
+    transform: rotate3d(-0.35, 0.24, -0.91, 720deg);
   }
-}
-
-@include dice-size(min(25vw, 120px));
-
-@media (max-height: 600px) {
-  @include dice-size(min(20vw, 100px));
 }
 
 // Damage display-------------------------------------------------------

--- a/client/src/components/Zombies/common/D20RollerModal.js
+++ b/client/src/components/Zombies/common/D20RollerModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Modal } from 'react-bootstrap';
 
 const DEFAULT_DICE_COLOR = '#3366ff';
@@ -8,6 +8,132 @@ const DICE_SIDES = 20;
 const INITIAL_SIDE = 1;
 const ANIMATION_DURATION_MS = 3000;
 const DICE_OPACITY = 0.85;
+
+const FACE_TRANSFORMS = [
+  {
+    translate: [0, -0.525731112119, 0.850650808352],
+    axis: [0.178507761564, 0.178507761564, 0.967610437171],
+    angle: 91.886163660962,
+  },
+  {
+    translate: [0, -0.525731112119, 0.850650808352],
+    axis: [0.778114545054, 0.517357488073, 0.356200764052],
+    angle: 58.940212151671,
+  },
+  {
+    translate: [0, -0.525731112119, 0.850650808352],
+    axis: [0.700738012384, 0.404571280081, -0.587612386981],
+    angle: 88.990592827419,
+  },
+  {
+    translate: [0, -0.525731112119, 0.850650808352],
+    axis: [0.429453677404, 0.213001650302, -0.877610298443],
+    angle: 147.056319603168,
+  },
+  {
+    translate: [0, -0.525731112119, 0.850650808352],
+    axis: [-0.181207684822, -0.04855445281, 0.982245509063],
+    angle: 150.50923099225,
+  },
+  {
+    translate: [0, 0.525731112119, 0.850650808352],
+    axis: [-0.378179891472, 0.76248585343, 0.524971706861],
+    angle: 65.382669633819,
+  },
+  {
+    translate: [0, 0.525731112119, 0.850650808352],
+    axis: [-0.311155597754, 0.53893730437, 0.782769938069],
+    angle: 131.360492344111,
+  },
+  {
+    translate: [0, 0.525731112119, 0.850650808352],
+    axis: [0.258524514791, -0.388825309093, -0.884296304561],
+    angle: 159.814765094897,
+  },
+  {
+    translate: [0.850650808352, 0, 0.525731112119],
+    axis: [0.280683716343, 0.790546362353, 0.544291374496],
+    angle: 114.895552708161,
+  },
+  {
+    translate: [0.850650808352, 0, 0.525731112119],
+    axis: [0.178507761564, 0.967610437171, -0.178507761564],
+    angle: 91.886163660962,
+  },
+  {
+    translate: [0.525731112119, -0.850650808352, 0],
+    axis: [0.749934399504, 0.660705469355, 0.032660055187],
+    angle: 125.382669633819,
+  },
+  {
+    translate: [0.525731112119, -0.850650808352, 0],
+    axis: [0.429453677404, 0.74383558876, -0.512130994823],
+    angle: 147.056319603168,
+  },
+  {
+    translate: [-0.525731112119, -0.850650808352, 0],
+    axis: [0.859718176595, 0.289650866037, -0.420698267927],
+    angle: 156.427645261959,
+  },
+  {
+    translate: [-0.525731112119, -0.850650808352, 0],
+    axis: [-0.553790277491, -0.472189446794, 0.685823195068],
+    angle: 152.629422163337,
+  },
+  {
+    translate: [-0.850650808352, 0, 0.525731112119],
+    axis: [-0.701166074566, 0.129353282734, 0.701166074566],
+    angle: 165.259058481999,
+  },
+  {
+    translate: [0, -0.525731112119, -0.850650808352],
+    axis: [0.950945577591, 0.254805099561, 0.175433376805],
+    angle: 174.617330366181,
+  },
+  {
+    translate: [0.850650808352, 0, -0.525731112119],
+    axis: [0.5873157892, 0.66663337012, 0.458977247365],
+    angle: 176.674083488341,
+  },
+  {
+    translate: [0.525731112119, 0.850650808352, 0],
+    axis: [0, 1, 0],
+    angle: 180,
+  },
+  {
+    translate: [-0.525731112119, 0.850650808352, 0],
+    axis: [0.5873157892, -0.66663337012, -0.458977247365],
+    angle: 176.674083488341,
+  },
+  {
+    translate: [-0.850650808352, 0, -0.525731112119],
+    axis: [-0.950945577591, -0.254805099561, -0.175433376805],
+    angle: 174.617330366181,
+  },
+];
+
+const DIE_FACE_ROTATIONS = [
+  { axis: [0.701166, -0.701166, -0.129353], angle: 91.886164 },
+  { axis: [0.181208, -0.900261, -0.395845], angle: 97.444455 },
+  { axis: [-0.429454, -0.743836, -0.512131], angle: 99.253014 },
+  { axis: [-0.859718, -0.289651, -0.420698], angle: 94.786567 },
+  { axis: [-0.950946, 0.254805, -0.175433], angle: 90.252653 },
+  { axis: [0.311156, -0.923547, 0.224151], angle: 109.828478 },
+  { axis: [0.818863, -0.472771, 0.325503], angle: 118.841184 },
+  { axis: [0.942397, 0.189689, 0.27551], angle: 107.042726 },
+  { axis: [0.615291, -0.721622, -0.317298], angle: 152.629422 },
+  { axis: [-0.178508, -0.96761, -0.178508], angle: 165.259058 },
+  { axis: [0.035848, -0.566724, -0.823128], angle: 133.574619 },
+  { axis: [0, 1, 0], angle: 180 },
+  { axis: [-0.429454, -0.213002, -0.87761], angle: 99.253014 },
+  { axis: [-0.749934, 0.266264, -0.605559], angle: 114.895553 },
+  { axis: [0.701166, -0.129353, 0.701166], angle: 91.886164 },
+  { axis: [0.181208, -0.048554, -0.982246], angle: 97.444455 },
+  { axis: [0.615291, -0.03892, -0.787338], angle: 152.629422 },
+  { axis: [0, 1, 0], angle: 180 },
+  { axis: [0.615291, 0.03892, 0.787338], angle: 152.629422 },
+  { axis: [0.181208, 0.048554, 0.982246], angle: 97.444455 },
+];
 
 const normalizeDiceColor = (value) => {
   if (typeof value !== 'string') {
@@ -37,8 +163,10 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
   const sparkleTimeoutRef = useRef(null);
   const sparkleRepeatTimeoutRef = useRef(null);
   const previousColorRef = useRef(null);
+  const dieRef = useRef(null);
 
   const shouldApplyColor = renderInline || show;
+  const [dieSize, setDieSize] = useState(0);
 
   useEffect(() => {
     if (typeof document === 'undefined' || !shouldApplyColor) {
@@ -62,6 +190,40 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
     clearTimeout(rollTimeoutRef.current);
     clearTimeout(sparkleTimeoutRef.current);
     clearTimeout(sparkleRepeatTimeoutRef.current);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const element = dieRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    const updateSize = () => {
+      const { width } = element.getBoundingClientRect();
+      setDieSize(width);
+    };
+
+    updateSize();
+
+    let observer;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(() => updateSize());
+      observer.observe(element);
+    } else {
+      window.addEventListener('resize', updateSize);
+    }
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      } else {
+        window.removeEventListener('resize', updateSize);
+      }
+    };
   }, []);
 
   const getRandomFace = () => Math.floor(Math.random() * DICE_SIDES) + INITIAL_SIDE;
@@ -123,12 +285,33 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
   };
 
   const faceElements = useMemo(() => {
-    const faces = [];
-    for (let i = 1; i <= DICE_SIDES; i += 1) {
-      faces.push(<figure className={`face face-${i}`} key={i}></figure>);
+    const scale = dieSize > 0 ? dieSize / 2 : 1;
+    const center = dieSize > 0 ? dieSize / 2 : 0;
+
+    return FACE_TRANSFORMS.map(({ translate, axis, angle }, index) => {
+      const [tx, ty, tz] = translate;
+      const transform = `translate3d(${center + tx * scale}px, ${center + ty * scale}px, ${tz * scale}px) rotate3d(${axis[0]}, ${axis[1]}, ${axis[2]}, ${angle}deg)`;
+      return (
+        <figure className={`face face-${index + 1}`} key={index + 1} style={{ transform }}>
+          <span className="face__label">{index + 1}</span>
+        </figure>
+      );
+    });
+  }, [dieSize]);
+
+  const dieTransform = useMemo(() => {
+    if (rolling) {
+      return undefined;
     }
-    return faces;
-  }, []);
+
+    const orientation = DIE_FACE_ROTATIONS[activeFace - 1];
+    if (!orientation) {
+      return undefined;
+    }
+
+    const [ax, ay, az] = orientation.axis;
+    return `rotate3d(${ax}, ${ay}, ${az}, ${orientation.angle}deg)`;
+  }, [activeFace, rolling]);
 
   const dieContent = (
     <div className="attack-roll-controls__die">
@@ -140,7 +323,8 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
           aria-label="Roll a d20"
           onClick={handleRandomizeClick}
           className={`die ${rolling ? 'rolling' : ''}`}
-          data-face={activeFace}
+          ref={dieRef}
+          style={dieTransform ? { transform: dieTransform } : undefined}
         >
           {faceElements}
         </div>


### PR DESCRIPTION
## Summary
- replace the SCSS-generated d20 mesh with a responsive layout that positions faces using precomputed transforms
- render each face of the roller with accurate geometry, inline numbering, and resize-aware transforms in `D20RollerModal`
- drive die orientation through explicit rotation data so the selected face appears correctly when rolling stops

## Testing
- ⚠️ `npm test -- --watch=false --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js` *(terminated after repeated pre-existing act() warnings without new failures)*

------
https://chatgpt.com/codex/tasks/task_e_68f1884c69fc832eaf4d68375486f182