### PR TITLE
Add 3D-inspired roll animation to damage dice

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1847,6 +1847,9 @@ $rotateX: -$angle;
   overflow: visible;
   pointer-events: none;
   z-index: 1;
+  perspective: 1400px;
+  perspective-origin: 50% calc(100% - 28px);
+  transform-style: preserve-3d;
 }
 
 .damage-roller__total {
@@ -1951,14 +1954,14 @@ $rotateX: -$angle;
   --drop-delay: 0s;
   --drop-duration: 0.9s;
   --drop-distance: 48px;
-  --drop-spin-start: -12deg;
-  --drop-spin-mid: 4deg;
-  --drop-spin-end: 0deg;
   --die-surface-color: var(--dice-face-color, #1f46cc);
   --die-edge-color: rgba(255, 255, 255, 0.5);
-  animation: damage-die-drop var(--drop-duration) cubic-bezier(0.32, 0.74, 0.23, 0.99) forwards;
+  animation: damage-die-roll var(--drop-duration)
+    cubic-bezier(0.22, 0.74, 0.22, 0.99) forwards;
   animation-delay: var(--drop-delay);
   filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45));
+  transform-style: preserve-3d;
+  will-change: transform;
 }
 
 .damage-die__icon {
@@ -1968,6 +1971,7 @@ $rotateX: -$angle;
   display: flex;
   align-items: center;
   justify-content: center;
+  transform-style: preserve-3d;
 }
 
 .damage-die__shape {
@@ -1984,6 +1988,7 @@ $rotateX: -$angle;
   border-radius: 18%;
   clip-path: polygon(18% 6%, 82% 6%, 100% 24%, 100% 76%, 82% 94%, 18% 94%, 0% 76%, 0% 24%);
   transition: transform 0.2s ease;
+  backface-visibility: hidden;
 }
 
 .damage-die__shape::after {
@@ -2005,6 +2010,8 @@ $rotateX: -$angle;
   font-weight: 700;
   color: #fff;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  backface-visibility: hidden;
+  transform: translateZ(0.8px);
 }
 
 .damage-die--bonus {
@@ -2056,22 +2063,61 @@ $rotateX: -$angle;
   border-radius: 8%;
 }
 
-@keyframes damage-die-drop {
+@keyframes damage-die-roll {
   0% {
-    transform: translate(-50%, -150%) scale(0.6) rotate(var(--drop-spin-start, 0deg));
     opacity: 0;
+    transform: translate3d(
+        calc(-50% + var(--roll-horizontal-start, 0px)),
+        calc(-140% + var(--roll-vertical-offset, 0px)),
+        var(--roll-depth-start, -120px)
+      )
+      scale(var(--roll-scale-start, 0.7))
+      rotateX(var(--roll-tilt-x-start, -180deg))
+      rotateY(var(--roll-tilt-y-start, 120deg))
+      rotateZ(var(--roll-tilt-z-start, 0deg));
   }
-  30% {
+  18% {
     opacity: 1;
   }
-  65% {
-    transform: translate(-50%, calc(var(--drop-distance, 48px) * 0.6)) scale(1.05)
-      rotate(var(--drop-spin-mid, 12deg));
+  55% {
+    transform: translate3d(
+        calc(-50% + var(--roll-horizontal-mid, 0px)),
+        calc(var(--drop-distance, 48px) * 0.55),
+        var(--roll-depth-mid, -40px)
+      )
+      scale(var(--roll-scale-mid, 1.05))
+      rotateX(var(--roll-tilt-x-mid, 240deg))
+      rotateY(var(--roll-tilt-y-mid, 210deg))
+      rotateZ(var(--roll-tilt-z-mid, 120deg));
+  }
+  78% {
+    transform: translate3d(
+        -50%,
+        var(--drop-distance, 48px),
+        0px
+      )
+      scale(1)
+      rotateX(var(--roll-tilt-x-end, 360deg))
+      rotateY(var(--roll-tilt-y-end, 360deg))
+      rotateZ(var(--roll-tilt-z-end, 90deg));
+  }
+  90% {
+    transform: translate3d(
+        -50%,
+        calc(var(--drop-distance, 48px) - var(--roll-bounce-height, 14px)),
+        0px
+      )
+      scale(1)
+      rotateX(var(--roll-tilt-x-settle, 12deg))
+      rotateY(var(--roll-tilt-y-settle, -10deg))
+      rotateZ(var(--roll-tilt-z-settle, 6deg));
   }
   100% {
-    transform: translate(-50%, var(--drop-distance, 48px)) scale(1)
-      rotate(var(--drop-spin-end, 0deg));
     opacity: 1;
+    transform: translate3d(-50%, var(--drop-distance, 48px), 0px) scale(1)
+      rotateX(0deg)
+      rotateY(0deg)
+      rotateZ(0deg);
   }
 }
 

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1106,9 +1106,26 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
     const dropDistance = 60 + Math.random() * 70;
     const delay = index * 0.05;
     const rollDuration = 0.85 + Math.random() * 0.45;
-    const spinEnd = (Math.random() - 0.5) * 60;
-    const spinStart = spinEnd + (Math.random() - 0.5) * 200;
-    const spinMid = (spinStart + spinEnd) / 2;
+    const horizontalStart = (Math.random() - 0.5) * 120;
+    const horizontalMid = horizontalStart * (0.35 + Math.random() * 0.25);
+    const verticalOffset = (Math.random() - 0.5) * 60;
+    const depthStart = -120 - Math.random() * 90;
+    const depthMid = -30 - Math.random() * 60;
+    const scaleStart = 0.62 + Math.random() * 0.18;
+    const scaleMid = 1.04 + Math.random() * 0.16;
+    const bounceHeight = 12 + Math.random() * 18;
+    const tiltXStart = (Math.random() - 0.5) * 240;
+    const tiltYStart = (Math.random() - 0.5) * 240;
+    const tiltZStart = (Math.random() - 0.5) * 200;
+    const tiltXMid = tiltXStart + (Math.random() - 0.5) * 540;
+    const tiltYMid = tiltYStart + (Math.random() - 0.5) * 540;
+    const tiltZMid = tiltZStart + (Math.random() - 0.5) * 360;
+    const tiltXEnd = tiltXMid + (Math.random() - 0.5) * 260;
+    const tiltYEnd = tiltYMid + (Math.random() - 0.5) * 260;
+    const tiltZEnd = tiltZMid + (Math.random() - 0.5) * 200;
+    const tiltXSettle = (Math.random() - 0.5) * 16;
+    const tiltYSettle = (Math.random() - 0.5) * 16;
+    const tiltZSettle = (Math.random() - 0.5) * 12;
     return {
       id: `${baseTime}-${index}`,
       value:
@@ -1122,9 +1139,26 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
       dropDistance,
       delay,
       rollDuration,
-      spinStart,
-      spinMid,
-      spinEnd,
+      horizontalStart,
+      horizontalMid,
+      verticalOffset,
+      depthStart,
+      depthMid,
+      scaleStart,
+      scaleMid,
+      bounceHeight,
+      tiltXStart,
+      tiltYStart,
+      tiltZStart,
+      tiltXMid,
+      tiltYMid,
+      tiltZMid,
+      tiltXEnd,
+      tiltYEnd,
+      tiltZEnd,
+      tiltXSettle,
+      tiltYSettle,
+      tiltZSettle,
     };
   });
 
@@ -1312,9 +1346,26 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                     '--drop-delay': `${die.delay}s`,
                     '--drop-distance': `${die.dropDistance}px`,
                     '--drop-duration': `${die.rollDuration}s`,
-                    '--drop-spin-start': `${die.spinStart}deg`,
-                    '--drop-spin-mid': `${die.spinMid}deg`,
-                    '--drop-spin-end': `${die.spinEnd}deg`,
+                    '--roll-horizontal-start': `${die.horizontalStart}px`,
+                    '--roll-horizontal-mid': `${die.horizontalMid}px`,
+                    '--roll-vertical-offset': `${die.verticalOffset}px`,
+                    '--roll-depth-start': `${die.depthStart}px`,
+                    '--roll-depth-mid': `${die.depthMid}px`,
+                    '--roll-scale-start': die.scaleStart,
+                    '--roll-scale-mid': die.scaleMid,
+                    '--roll-bounce-height': `${die.bounceHeight}px`,
+                    '--roll-tilt-x-start': `${die.tiltXStart}deg`,
+                    '--roll-tilt-y-start': `${die.tiltYStart}deg`,
+                    '--roll-tilt-z-start': `${die.tiltZStart}deg`,
+                    '--roll-tilt-x-mid': `${die.tiltXMid}deg`,
+                    '--roll-tilt-y-mid': `${die.tiltYMid}deg`,
+                    '--roll-tilt-z-mid': `${die.tiltZMid}deg`,
+                    '--roll-tilt-x-end': `${die.tiltXEnd}deg`,
+                    '--roll-tilt-y-end': `${die.tiltYEnd}deg`,
+                    '--roll-tilt-z-end': `${die.tiltZEnd}deg`,
+                    '--roll-tilt-x-settle': `${die.tiltXSettle}deg`,
+                    '--roll-tilt-y-settle': `${die.tiltYSettle}deg`,
+                    '--roll-tilt-z-settle': `${die.tiltZSettle}deg`,
                   }}
                 >
                   <DamageDieMesh die={die} typeClass={typeClass} />


### PR DESCRIPTION
## Summary
- add perspective and 3D roll keyframes so floating dice animate with a tumbling motion
- randomize dice trajectories and rotation values for each roll to create a more physical feel

## Testing
- npm test -- --watch=false *(fails: pre-existing ZombiesCharacterSheet and ZombiesDM test expectations/timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68f2417bf14c832eb219c22eea18291e