### PR TITLE
Add 3D flight animation for character sheet damage dice

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1847,6 +1847,8 @@ $rotateX: -$angle;
   overflow: visible;
   pointer-events: none;
   z-index: 1;
+  perspective: 1400px;
+  transform-style: preserve-3d;
 }
 
 .damage-roller__total {
@@ -1942,23 +1944,38 @@ $rotateX: -$angle;
 
 .damage-die {
   position: absolute;
-  top: -28px;
+  top: 0;
   width: var(--die-size, 36px);
   height: var(--die-size, 36px);
   pointer-events: none;
-  transform: translate(-50%, -120%);
+  transform-origin: center;
+  transform-style: preserve-3d;
   opacity: 0;
   --drop-delay: 0s;
-  --drop-duration: 0.9s;
-  --drop-distance: 48px;
-  --drop-spin-start: -12deg;
-  --drop-spin-mid: 4deg;
-  --drop-spin-end: 0deg;
+  --drop-duration: 0.95s;
+  --flight-start-x: -160px;
+  --flight-start-y: -140px;
+  --flight-start-z: 0px;
+  --flight-mid-x: 0px;
+  --flight-mid-y: -60px;
+  --flight-mid-z: 0px;
+  --flight-end-y: 48px;
+  --flight-settle-bounce: 8px;
+  --rot-x-start: 0deg;
+  --rot-y-start: 0deg;
+  --rot-z-start: 0deg;
+  --rot-x-mid: 240deg;
+  --rot-y-mid: 240deg;
+  --rot-z-mid: 120deg;
+  --rot-x-end: 0deg;
+  --rot-y-end: 0deg;
+  --rot-z-end: 0deg;
   --die-surface-color: var(--dice-face-color, #1f46cc);
-  --die-edge-color: rgba(255, 255, 255, 0.5);
-  animation: damage-die-drop var(--drop-duration) cubic-bezier(0.32, 0.74, 0.23, 0.99) forwards;
-  animation-delay: var(--drop-delay);
   filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45));
+  animation: damage-die-flight var(--drop-duration) cubic-bezier(0.25, 0.72, 0.13, 0.99)
+    forwards;
+  animation-delay: var(--drop-delay);
+  will-change: transform, opacity;
 }
 
 .damage-die__icon {
@@ -1968,6 +1985,35 @@ $rotateX: -$angle;
   display: flex;
   align-items: center;
   justify-content: center;
+  transform-style: preserve-3d;
+}
+
+.damage-die__mesh {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.28));
+}
+
+.damage-die__mesh-inner {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+}
+
+.damage-die__face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform-origin: center;
+  backface-visibility: hidden;
+  border-radius: 14%;
+  box-shadow:
+    inset 0 3px 6px rgba(255, 255, 255, 0.18),
+    inset 0 -5px 10px rgba(0, 0, 0, 0.45);
 }
 
 .damage-die__shape {
@@ -1977,13 +2023,12 @@ $rotateX: -$angle;
     radial-gradient(circle at 28% 24%, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0) 58%),
     linear-gradient(140deg, rgba(255, 255, 255, 0.42), rgba(0, 0, 0, 0.38)),
     var(--die-surface-color);
-  border: 2px solid var(--die-edge-color, rgba(255, 255, 255, 0.45));
+  border: 2px solid rgba(255, 255, 255, 0.4);
   box-shadow:
     inset 0 4px 8px rgba(255, 255, 255, 0.18),
     inset 0 -6px 12px rgba(0, 0, 0, 0.42);
   border-radius: 18%;
   clip-path: polygon(18% 6%, 82% 6%, 100% 24%, 100% 76%, 82% 94%, 18% 94%, 0% 76%, 0% 24%);
-  transition: transform 0.2s ease;
 }
 
 .damage-die__shape::after {
@@ -1999,12 +2044,16 @@ $rotateX: -$angle;
 
 .damage-die__value {
   position: relative;
-  z-index: 1;
-  font-size: 1.1rem;
+  z-index: 2;
+  font-size: 1.05rem;
   line-height: 1;
   font-weight: 700;
   color: #fff;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .damage-die--bonus {
@@ -2056,22 +2105,52 @@ $rotateX: -$angle;
   border-radius: 8%;
 }
 
-@keyframes damage-die-drop {
+@keyframes damage-die-flight {
   0% {
-    transform: translate(-50%, -150%) scale(0.6) rotate(var(--drop-spin-start, 0deg));
     opacity: 0;
+    transform: translateX(-50%)
+      translate3d(
+        var(--flight-start-x, -160px),
+        var(--flight-start-y, -140px),
+        var(--flight-start-z, 0px)
+      )
+      rotateX(var(--rot-x-start, 0deg))
+      rotateY(var(--rot-y-start, 0deg))
+      rotateZ(var(--rot-z-start, 0deg))
+      scale(0.88);
   }
   30% {
     opacity: 1;
   }
-  65% {
-    transform: translate(-50%, calc(var(--drop-distance, 48px) * 0.6)) scale(1.05)
-      rotate(var(--drop-spin-mid, 12deg));
+  58% {
+    transform: translateX(-50%)
+      translate3d(
+        var(--flight-mid-x, 0px),
+        var(--flight-mid-y, -60px),
+        var(--flight-mid-z, 0px)
+      )
+      rotateX(var(--rot-x-mid, 200deg))
+      rotateY(var(--rot-y-mid, 260deg))
+      rotateZ(var(--rot-z-mid, 110deg));
+  }
+  78% {
+    transform: translateX(-50%)
+      translate3d(
+        calc(var(--flight-mid-x, 0px) * 0.25),
+        calc(var(--flight-end-y, 48px) - var(--flight-settle-bounce, 8px)),
+        calc(var(--flight-mid-z, 0px) * 0.2)
+      )
+      rotateX(calc((var(--rot-x-mid, 200deg) + var(--rot-x-end, 0deg)) / 2))
+      rotateY(calc((var(--rot-y-mid, 260deg) + var(--rot-y-end, 0deg)) / 2))
+      rotateZ(calc((var(--rot-z-mid, 110deg) + var(--rot-z-end, 0deg)) / 2));
   }
   100% {
-    transform: translate(-50%, var(--drop-distance, 48px)) scale(1)
-      rotate(var(--drop-spin-end, 0deg));
     opacity: 1;
+    transform: translateX(-50%)
+      translate3d(0, var(--flight-end-y, 48px), 0)
+      rotateX(var(--rot-x-end, 0deg))
+      rotateY(var(--rot-y-end, 0deg))
+      rotateZ(var(--rot-z-end, 0deg));
   }
 }
 

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -15,6 +15,7 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
+import { createPolyhedronFaces } from '../../../utils/dieGeometry';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -36,6 +37,33 @@ const DAMAGE_DIE_WIDTH_PX = 42;
 const DAMAGE_DIE_SPREAD_FACTOR = 1.15;
 const DAMAGE_AREA_BASE_RATIO = 0.42;
 const DAMAGE_AREA_MAX_RATIO = 0.92;
+const DAMAGE_DIE_SCALE_PX = 18;
+
+const LIGHT_VECTOR = (() => {
+  const vector = [0.32, 0.84, 0.45];
+  const length = Math.hypot(...vector) || 1;
+  return vector.map((value) => value / length);
+})();
+
+const FACE_CACHE = new Map();
+
+function getFaceDataForSides(sides = 20) {
+  const normalizedSides = Number.isFinite(sides)
+    ? Math.max(4, Math.round(sides))
+    : 20;
+  const lookupSides = normalizedSides === 100 ? 10 : normalizedSides;
+
+  if (!FACE_CACHE.has(lookupSides)) {
+    try {
+      const faces = createPolyhedronFaces(lookupSides, DAMAGE_DIE_SCALE_PX) || [];
+      FACE_CACHE.set(lookupSides, faces);
+    } catch (error) {
+      FACE_CACHE.set(lookupSides, []);
+    }
+  }
+
+  return FACE_CACHE.get(lookupSides);
+}
 
 function formatDamageRolls(rolls) {
   return rolls
@@ -62,6 +90,7 @@ function DamageDieMesh({ die, typeClass }) {
   const finalValue =
     typeof die?.value === 'number' ? die.value : Number(die?.value) || 0;
   const [displayValue, setDisplayValue] = useState(finalValue);
+  const faceData = useMemo(() => getFaceDataForSides(die?.sides), [die?.sides]);
 
   useEffect(() => {
     const sides = Number.isFinite(die?.sides) ? Math.max(2, Math.round(die.sides)) : 20;
@@ -102,9 +131,53 @@ function DamageDieMesh({ die, typeClass }) {
     };
   }, [die?.id, die?.sides, die?.delay, die?.rollDuration, finalValue]);
 
+  if (!Array.isArray(faceData) || faceData.length === 0) {
+    return (
+      <div className="damage-die__icon">
+        <span className="damage-die__shape" aria-hidden="true" />
+        <span className={`damage-die__value ${typeClass}`}>{displayValue}</span>
+      </div>
+    );
+  }
+
   return (
     <div className="damage-die__icon">
-      <span className="damage-die__shape" aria-hidden="true" />
+      <div className="damage-die__mesh" aria-hidden="true">
+        <div className="damage-die__mesh-inner">
+          {faceData.map((face, index) => {
+            const intensity = (() => {
+              if (!Array.isArray(face.normal)) {
+                return 0.5;
+              }
+              const dot = face.normal.reduce(
+                (sum, value, axis) => sum + value * LIGHT_VECTOR[axis],
+                0,
+              );
+              return Math.min(1, Math.max(0, (dot + 1) / 2));
+            })();
+
+            const highlight = (0.22 + 0.45 * intensity).toFixed(3);
+            const shadow = (0.55 + 0.35 * (1 - intensity)).toFixed(3);
+            const brightness = (0.7 + intensity * 0.45).toFixed(3);
+            const matrix = Array.isArray(face.matrix)
+              ? face.matrix.map((value) => value.toFixed(6)).join(', ')
+              : '1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1';
+
+            return (
+              <div
+                key={`face-${index}`}
+                className="damage-die__face"
+                style={{
+                  clipPath: face.clipPath,
+                  transform: `matrix3d(${matrix})`,
+                  background: `linear-gradient(145deg, rgba(255,255,255,${highlight}), rgba(0,0,0,${shadow})), var(--die-surface-color)`,
+                  filter: `brightness(${brightness}) saturate(1.05)`,
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
       <span className={`damage-die__value ${typeClass}`}>{displayValue}</span>
     </div>
   );
@@ -1106,9 +1179,23 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
     const dropDistance = 60 + Math.random() * 70;
     const delay = index * 0.05;
     const rollDuration = 0.85 + Math.random() * 0.45;
-    const spinEnd = (Math.random() - 0.5) * 60;
-    const spinStart = spinEnd + (Math.random() - 0.5) * 200;
-    const spinMid = (spinStart + spinEnd) / 2;
+    const entryDirection = Math.random() < 0.5 ? -1 : 1;
+    const startX = entryDirection * (areaWidth * (0.55 + Math.random() * 0.35));
+    const midX = startX * -0.25;
+    const startY = -(120 + Math.random() * 80);
+    const midY = -(40 + Math.random() * 60);
+    const startZ = entryDirection * (30 + Math.random() * 90);
+    const midZ = (Math.random() - 0.5) * 80;
+    const rotXStart = (Math.random() - 0.5) * 220;
+    const rotYStart = (Math.random() - 0.5) * 220;
+    const rotZStart = (Math.random() - 0.5) * 220;
+    const rotXMid = rotXStart + entryDirection * (240 + Math.random() * 240);
+    const rotYMid = rotYStart + (Math.random() - 0.5) * 480;
+    const rotZMid = rotZStart + (Math.random() - 0.5) * 420;
+    const rotXEnd = (Math.random() - 0.5) * 90;
+    const rotYEnd = (Math.random() - 0.5) * 90;
+    const rotZEnd = (Math.random() - 0.5) * 90;
+    const settleBounce = 6 + Math.random() * 10;
     return {
       id: `${baseTime}-${index}`,
       value:
@@ -1122,9 +1209,22 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
       dropDistance,
       delay,
       rollDuration,
-      spinStart,
-      spinMid,
-      spinEnd,
+      startX,
+      startY,
+      startZ,
+      midX,
+      midY,
+      midZ,
+      rotXStart,
+      rotYStart,
+      rotZStart,
+      rotXMid,
+      rotYMid,
+      rotZMid,
+      rotXEnd,
+      rotYEnd,
+      rotZEnd,
+      settleBounce,
     };
   });
 
@@ -1310,11 +1410,24 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                   style={{
                     left: `${die.left}%`,
                     '--drop-delay': `${die.delay}s`,
-                    '--drop-distance': `${die.dropDistance}px`,
                     '--drop-duration': `${die.rollDuration}s`,
-                    '--drop-spin-start': `${die.spinStart}deg`,
-                    '--drop-spin-mid': `${die.spinMid}deg`,
-                    '--drop-spin-end': `${die.spinEnd}deg`,
+                    '--flight-start-x': `${die.startX}px`,
+                    '--flight-start-y': `${die.startY}px`,
+                    '--flight-start-z': `${die.startZ}px`,
+                    '--flight-mid-x': `${die.midX}px`,
+                    '--flight-mid-y': `${die.midY}px`,
+                    '--flight-mid-z': `${die.midZ}px`,
+                    '--flight-end-y': `${die.dropDistance}px`,
+                    '--flight-settle-bounce': `${die.settleBounce}px`,
+                    '--rot-x-start': `${die.rotXStart}deg`,
+                    '--rot-y-start': `${die.rotYStart}deg`,
+                    '--rot-z-start': `${die.rotZStart}deg`,
+                    '--rot-x-mid': `${die.rotXMid}deg`,
+                    '--rot-y-mid': `${die.rotYMid}deg`,
+                    '--rot-z-mid': `${die.rotZMid}deg`,
+                    '--rot-x-end': `${die.rotXEnd}deg`,
+                    '--rot-y-end': `${die.rotYEnd}deg`,
+                    '--rot-z-end': `${die.rotZEnd}deg`,
                   }}
                 >
                   <DamageDieMesh die={die} typeClass={typeClass} />


### PR DESCRIPTION
## Summary
- convert the damage roll dice mesh to build 3D polyhedral faces from cached geometry
- update the dice animation logic to launch dice from off-screen with tumbling, 3D flight paths
- refresh the dice area styling with perspective transforms and a new flight keyframe sequence

## Testing
- CI=true npm test -- --watchAll=false *(fails: existing Zombies test warnings/timeouts in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68f2498ffce0832eaae3d62243f2ec2e