### PR TITLE
Add 3D polyhedral damage dice animation

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1847,6 +1847,8 @@ $rotateX: -$angle;
   overflow: visible;
   pointer-events: none;
   z-index: 1;
+  perspective: 1400px;
+  transform-style: preserve-3d;
 }
 
 .damage-roller__total {
@@ -1942,23 +1944,38 @@ $rotateX: -$angle;
 
 .damage-die {
   position: absolute;
-  top: -28px;
+  top: 0;
   width: var(--die-size, 36px);
   height: var(--die-size, 36px);
   pointer-events: none;
-  transform: translate(-50%, -120%);
+  transform-origin: center;
+  transform-style: preserve-3d;
   opacity: 0;
   --drop-delay: 0s;
-  --drop-duration: 0.9s;
-  --drop-distance: 48px;
-  --drop-spin-start: -12deg;
-  --drop-spin-mid: 4deg;
-  --drop-spin-end: 0deg;
+  --drop-duration: 0.95s;
+  --flight-start-x: -160px;
+  --flight-start-y: -140px;
+  --flight-start-z: 0px;
+  --flight-mid-x: 0px;
+  --flight-mid-y: -60px;
+  --flight-mid-z: 0px;
+  --flight-end-y: 48px;
+  --flight-settle-bounce: 8px;
+  --rot-x-start: 0deg;
+  --rot-y-start: 0deg;
+  --rot-z-start: 0deg;
+  --rot-x-mid: 240deg;
+  --rot-y-mid: 240deg;
+  --rot-z-mid: 120deg;
+  --rot-x-end: 0deg;
+  --rot-y-end: 0deg;
+  --rot-z-end: 0deg;
   --die-surface-color: var(--dice-face-color, #1f46cc);
-  --die-edge-color: rgba(255, 255, 255, 0.5);
-  animation: damage-die-drop var(--drop-duration) cubic-bezier(0.32, 0.74, 0.23, 0.99) forwards;
-  animation-delay: var(--drop-delay);
   filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45));
+  animation: damage-die-flight var(--drop-duration) cubic-bezier(0.25, 0.72, 0.13, 0.99)
+    forwards;
+  animation-delay: var(--drop-delay);
+  will-change: transform, opacity;
 }
 
 .damage-die__icon {
@@ -1968,22 +1985,106 @@ $rotateX: -$angle;
   display: flex;
   align-items: center;
   justify-content: center;
+  transform-style: preserve-3d;
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.28));
+}
+
+.damage-die__poly {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+}
+
+.damage-die__face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(circle at 24% 28%, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0) 68%),
+    linear-gradient(146deg, rgba(255, 255, 255, 0.32), rgba(0, 0, 0, 0.45)),
+    var(--die-surface-color, #1f46cc);
+  border: 1.4px solid var(--die-edge-color, rgba(255, 255, 255, 0.38));
+  box-shadow:
+    inset 0 3px 6px rgba(255, 255, 255, 0.22),
+    inset 0 -8px 14px rgba(0, 0, 0, 0.45);
+  transform-origin: center;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  clip-path: inherit;
+  opacity: 0.78;
+  transition: opacity 0.4s ease, filter 0.4s ease;
+  will-change: transform;
+}
+
+.damage-die__face::before {
+  content: '';
+  position: absolute;
+  inset: 6%;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  opacity: 0.4;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.damage-die__face::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(0, 0, 0, 0.35), transparent 55%);
+  opacity: 0.55;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+
+.damage-die__face-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  min-height: 16px;
+  padding: 2px 4px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.65);
+  transform: translateZ(1.2px);
+}
+
+.damage-die__face--active {
+  opacity: 1;
+  filter: brightness(1.08);
 }
 
 .damage-die__shape {
   position: absolute;
   inset: 0;
+  border-radius: 18%;
+  clip-path: polygon(18% 6%, 82% 6%, 100% 24%, 100% 76%, 82% 94%, 18% 94%, 0% 76%, 0% 24%);
   background:
     radial-gradient(circle at 28% 24%, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0) 58%),
     linear-gradient(140deg, rgba(255, 255, 255, 0.42), rgba(0, 0, 0, 0.38)),
     var(--die-surface-color);
-  border: 2px solid var(--die-edge-color, rgba(255, 255, 255, 0.45));
+  border: 2px solid rgba(255, 255, 255, 0.35);
   box-shadow:
     inset 0 4px 8px rgba(255, 255, 255, 0.18),
     inset 0 -6px 12px rgba(0, 0, 0, 0.42);
-  border-radius: 18%;
-  clip-path: polygon(18% 6%, 82% 6%, 100% 24%, 100% 76%, 82% 94%, 18% 94%, 0% 76%, 0% 24%);
-  transition: transform 0.2s ease;
+  transform: translateZ(-4px);
+}
+
+.damage-die__shape::before {
+  content: '';
+  position: absolute;
+  inset: 8%;
+  border-radius: inherit;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  opacity: 0.35;
+  mix-blend-mode: multiply;
+  pointer-events: none;
 }
 
 .damage-die__shape::after {
@@ -1991,20 +2092,31 @@ $rotateX: -$angle;
   position: absolute;
   inset: 16%;
   border-radius: inherit;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
-  opacity: 0.85;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0));
+  opacity: 0.9;
   mix-blend-mode: screen;
   pointer-events: none;
 }
 
 .damage-die__value {
-  position: relative;
-  z-index: 1;
-  font-size: 1.1rem;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
   line-height: 1;
   font-weight: 700;
   color: #fff;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.65);
+  pointer-events: none;
+  backface-visibility: hidden;
+  transform: translateZ(6px);
+}
+
+.damage-die__value--back {
+  transform: rotateY(180deg) translateZ(6px);
+  opacity: 0.75;
 }
 
 .damage-die--bonus {
@@ -2056,22 +2168,52 @@ $rotateX: -$angle;
   border-radius: 8%;
 }
 
-@keyframes damage-die-drop {
+@keyframes damage-die-flight {
   0% {
-    transform: translate(-50%, -150%) scale(0.6) rotate(var(--drop-spin-start, 0deg));
     opacity: 0;
+    transform: translateX(-50%)
+      translate3d(
+        var(--flight-start-x, -160px),
+        var(--flight-start-y, -140px),
+        var(--flight-start-z, 0px)
+      )
+      rotateX(var(--rot-x-start, 0deg))
+      rotateY(var(--rot-y-start, 0deg))
+      rotateZ(var(--rot-z-start, 0deg))
+      scale(0.88);
   }
   30% {
     opacity: 1;
   }
-  65% {
-    transform: translate(-50%, calc(var(--drop-distance, 48px) * 0.6)) scale(1.05)
-      rotate(var(--drop-spin-mid, 12deg));
+  58% {
+    transform: translateX(-50%)
+      translate3d(
+        var(--flight-mid-x, 0px),
+        var(--flight-mid-y, -60px),
+        var(--flight-mid-z, 0px)
+      )
+      rotateX(var(--rot-x-mid, 200deg))
+      rotateY(var(--rot-y-mid, 260deg))
+      rotateZ(var(--rot-z-mid, 110deg));
+  }
+  78% {
+    transform: translateX(-50%)
+      translate3d(
+        calc(var(--flight-mid-x, 0px) * 0.25),
+        calc(var(--flight-end-y, 48px) - var(--flight-settle-bounce, 8px)),
+        calc(var(--flight-mid-z, 0px) * 0.2)
+      )
+      rotateX(calc((var(--rot-x-mid, 200deg) + var(--rot-x-end, 0deg)) / 2))
+      rotateY(calc((var(--rot-y-mid, 260deg) + var(--rot-y-end, 0deg)) / 2))
+      rotateZ(calc((var(--rot-z-mid, 110deg) + var(--rot-z-end, 0deg)) / 2));
   }
   100% {
-    transform: translate(-50%, var(--drop-distance, 48px)) scale(1)
-      rotate(var(--drop-spin-end, 0deg));
     opacity: 1;
+    transform: translateX(-50%)
+      translate3d(0, var(--flight-end-y, 48px), 0)
+      rotateX(var(--rot-x-end, 0deg))
+      rotateY(var(--rot-y-end, 0deg))
+      rotateZ(var(--rot-z-end, 0deg));
   }
 }
 

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -15,6 +15,7 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
+import { createPolyhedronFaces } from '../../../utils/dieGeometry';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -36,7 +37,6 @@ const DAMAGE_DIE_WIDTH_PX = 42;
 const DAMAGE_DIE_SPREAD_FACTOR = 1.15;
 const DAMAGE_AREA_BASE_RATIO = 0.42;
 const DAMAGE_AREA_MAX_RATIO = 0.92;
-
 function formatDamageRolls(rolls) {
   return rolls
     .map(({ value, type }) => `${value}${type ? ` ${type}` : ''}`)
@@ -58,13 +58,126 @@ const spellsCatalog = spellsData || {};
 
 const diceExpressionPattern = /\d+d\d+(?:\s*[+-]\s*\d+)?/gi;
 
+const FACE_DATA_CACHE = new Map();
+const IDENTITY_MATRIX_4 = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+];
+
+const toMatrixComponent = (value) => {
+  const rounded = Math.abs(value) < 1e-6 ? 0 : value;
+  return Number(rounded.toFixed(6));
+};
+
+const matrixToCss = (matrix) =>
+  `matrix3d(${matrix.map((value) => toMatrixComponent(value)).join(',')})`;
+
+const radiansToDegrees = (radians) => (radians * 180) / Math.PI;
+
+const FACE_VALUE_OVERRIDES = {
+  4: [1, 2, 3, 4],
+  6: [1, 6, 2, 5, 3, 4],
+  8: [1, 7, 3, 5, 8, 2, 4, 6],
+  10: [1, 7, 9, 3, 5, 10, 8, 2, 4, 6],
+  12: [1, 12, 6, 7, 2, 11, 5, 8, 3, 10, 4, 9],
+  20: [1, 7, 13, 19, 5, 11, 17, 3, 9, 15, 20, 14, 8, 2, 18, 12, 6, 4, 10, 16],
+};
+
+const getFaceValueSequence = (sides) => {
+  const normalized = Math.max(2, Math.round(Number(sides) || 0));
+  const override = FACE_VALUE_OVERRIDES[normalized];
+  if (Array.isArray(override) && override.length === normalized) {
+    return override;
+  }
+  return Array.from({ length: normalized }, (_, index) => index + 1);
+};
+
+const computeFaceAlignment = (face) => {
+  if (!face) {
+    return null;
+  }
+
+  const [tx, ty, tz] = face.tangent || [1, 0, 0];
+  const [bx, by, bz] = face.bitangent || [0, 1, 0];
+  const [nx, ny, nz] = face.normal || [0, 0, 1];
+
+  const matrix = [
+    [tx, ty, tz],
+    [bx, by, bz],
+    [nx, ny, nz],
+  ];
+
+  const sy = Math.hypot(matrix[2][1], matrix[2][2]);
+
+  let ax;
+  let ay;
+  let az;
+
+  if (sy > 1e-6) {
+    ax = Math.atan2(matrix[2][1], matrix[2][2]);
+    ay = Math.atan2(-matrix[2][0], sy);
+    az = Math.atan2(matrix[1][0], matrix[0][0]);
+  } else {
+    ax = Math.atan2(-matrix[1][2], matrix[1][1]);
+    ay = Math.atan2(-matrix[2][0], sy);
+    az = 0;
+  }
+
+  return {
+    x: radiansToDegrees(ax),
+    y: radiansToDegrees(ay),
+    z: radiansToDegrees(az),
+  };
+};
+
+function getFaceDataForSides(sides) {
+  const normalized = Math.max(2, Math.round(Number(sides) || 0));
+  if (FACE_DATA_CACHE.has(normalized)) {
+    return FACE_DATA_CACHE.get(normalized);
+  }
+
+  const geometry = createPolyhedronFaces(normalized, 18);
+  if (!Array.isArray(geometry)) {
+    FACE_DATA_CACHE.set(normalized, null);
+    return null;
+  }
+
+  const valueSequence = getFaceValueSequence(normalized);
+  const faces = geometry.map((face, index) => {
+    const matrixValues =
+      Array.isArray(face.matrix) && face.matrix.length === 16
+        ? face.matrix
+        : IDENTITY_MATRIX_4;
+    return {
+      id: index + 1,
+      value: valueSequence[index % valueSequence.length],
+      matrix: matrixToCss(matrixValues),
+      clipPath: face.clipPath,
+      tangent: face.tangent,
+      bitangent: face.bitangent,
+      normal: face.normal,
+      alignment: computeFaceAlignment(face),
+    };
+  });
+
+  FACE_DATA_CACHE.set(normalized, faces);
+  return faces;
+}
+
 function DamageDieMesh({ die, typeClass }) {
   const finalValue =
     typeof die?.value === 'number' ? die.value : Number(die?.value) || 0;
   const [displayValue, setDisplayValue] = useState(finalValue);
 
+  const faceData = useMemo(() => getFaceDataForSides(die?.sides), [die?.sides]);
+  const fallbackSides = Number.isFinite(die?.sides)
+    ? Math.max(2, Math.round(die.sides))
+    : 20;
+
   useEffect(() => {
-    const sides = Number.isFinite(die?.sides) ? Math.max(2, Math.round(die.sides)) : 20;
+    const sides = fallbackSides;
     const delayMs = Number.isFinite(die?.delay)
       ? Math.max(0, die.delay * 1000)
       : 0;
@@ -100,12 +213,54 @@ function DamageDieMesh({ die, typeClass }) {
       if (scrambleIntervalId) clearInterval(scrambleIntervalId);
       if (scrambleTimeoutId) clearTimeout(scrambleTimeoutId);
     };
-  }, [die?.id, die?.sides, die?.delay, die?.rollDuration, finalValue]);
+  }, [die?.id, die?.delay, die?.rollDuration, fallbackSides, finalValue]);
+
+  const activeValue = useMemo(() => {
+    if (!Array.isArray(faceData) || !faceData.length) {
+      return displayValue;
+    }
+    if (Number.isFinite(displayValue) && displayValue !== 0) {
+      return displayValue;
+    }
+    return finalValue;
+  }, [displayValue, faceData, finalValue]);
+
+  if (!Array.isArray(faceData) || faceData.length === 0) {
+    return (
+      <div className="damage-die__icon">
+        <span className="damage-die__shape" aria-hidden="true" />
+        <span className={`damage-die__value damage-die__value--front ${typeClass}`}>
+          {displayValue}
+        </span>
+        <span
+          className={`damage-die__value damage-die__value--back ${typeClass}`}
+          aria-hidden="true"
+        >
+          {displayValue}
+        </span>
+      </div>
+    );
+  }
 
   return (
-    <div className="damage-die__icon">
-      <span className="damage-die__shape" aria-hidden="true" />
-      <span className={`damage-die__value ${typeClass}`}>{displayValue}</span>
+    <div className="damage-die__icon" aria-hidden="true">
+      <div className="damage-die__poly">
+        {faceData.map((face) => {
+          const isActive = face.value === activeValue;
+          return (
+            <span
+              key={face.id}
+              className={`damage-die__face ${isActive ? 'damage-die__face--active' : ''}`}
+              style={{
+                transform: face.matrix,
+                clipPath: face.clipPath,
+              }}
+            >
+              <span className={`damage-die__face-label ${typeClass}`}>{face.value}</span>
+            </span>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -1106,13 +1261,38 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
     const dropDistance = 60 + Math.random() * 70;
     const delay = index * 0.05;
     const rollDuration = 0.85 + Math.random() * 0.45;
-    const spinEnd = (Math.random() - 0.5) * 60;
-    const spinStart = spinEnd + (Math.random() - 0.5) * 200;
-    const spinMid = (spinStart + spinEnd) / 2;
-    return {
-      id: `${baseTime}-${index}`,
-      value:
+    const entryDirection = Math.random() < 0.5 ? -1 : 1;
+    const startX = entryDirection * (areaWidth * (0.55 + Math.random() * 0.35));
+    const midX = startX * -0.25;
+    const startY = -(120 + Math.random() * 80);
+    const midY = -(40 + Math.random() * 60);
+    const startZ = entryDirection * (30 + Math.random() * 90);
+    const midZ = (Math.random() - 0.5) * 80;
+      const normalizedValue =
         typeof detail?.value === 'number'
+          ? Math.round(detail.value)
+          : Number(detail?.value) || 0;
+      const faces = getFaceDataForSides(detail?.sides);
+      const finalFace = Array.isArray(faces)
+        ? faces.find((face) => face.value === normalizedValue) || faces[0]
+        : null;
+      const finalAlignment = finalFace?.alignment || { x: 0, y: 0, z: 0 };
+      const spinRange = 360 + Math.random() * 360;
+      const rotXEnd = finalAlignment.x;
+      const rotYEnd = finalAlignment.y;
+      const rotZEnd = finalAlignment.z;
+      const rotXStart = rotXEnd + (Math.random() - 0.5) * spinRange;
+      const rotYStart = rotYEnd + (Math.random() - 0.5) * spinRange;
+      const rotZStart = rotZEnd + (Math.random() - 0.5) * spinRange;
+      const rotXMid =
+        (rotXStart + rotXEnd) / 2 + entryDirection * (120 + Math.random() * 80);
+      const rotYMid = (rotYStart + rotYEnd) / 2 + (Math.random() - 0.5) * 160;
+      const rotZMid = (rotZStart + rotZEnd) / 2 + (Math.random() - 0.5) * 150;
+      const settleBounce = 6 + Math.random() * 10;
+      return {
+        id: `${baseTime}-${index}`,
+        value:
+          typeof detail?.value === 'number'
           ? detail.value
           : Number(detail?.value) || 0,
       sides: detail?.sides || 0,
@@ -1122,9 +1302,22 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
       dropDistance,
       delay,
       rollDuration,
-      spinStart,
-      spinMid,
-      spinEnd,
+      startX,
+      startY,
+      startZ,
+      midX,
+      midY,
+      midZ,
+      rotXStart,
+      rotYStart,
+      rotZStart,
+      rotXMid,
+      rotYMid,
+      rotZMid,
+      rotXEnd,
+      rotYEnd,
+      rotZEnd,
+      settleBounce,
     };
   });
 
@@ -1310,11 +1503,24 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
                   style={{
                     left: `${die.left}%`,
                     '--drop-delay': `${die.delay}s`,
-                    '--drop-distance': `${die.dropDistance}px`,
                     '--drop-duration': `${die.rollDuration}s`,
-                    '--drop-spin-start': `${die.spinStart}deg`,
-                    '--drop-spin-mid': `${die.spinMid}deg`,
-                    '--drop-spin-end': `${die.spinEnd}deg`,
+                    '--flight-start-x': `${die.startX}px`,
+                    '--flight-start-y': `${die.startY}px`,
+                    '--flight-start-z': `${die.startZ}px`,
+                    '--flight-mid-x': `${die.midX}px`,
+                    '--flight-mid-y': `${die.midY}px`,
+                    '--flight-mid-z': `${die.midZ}px`,
+                    '--flight-end-y': `${die.dropDistance}px`,
+                    '--flight-settle-bounce': `${die.settleBounce}px`,
+                    '--rot-x-start': `${die.rotXStart}deg`,
+                    '--rot-y-start': `${die.rotYStart}deg`,
+                    '--rot-z-start': `${die.rotZStart}deg`,
+                    '--rot-x-mid': `${die.rotXMid}deg`,
+                    '--rot-y-mid': `${die.rotYMid}deg`,
+                    '--rot-z-mid': `${die.rotZMid}deg`,
+                    '--rot-x-end': `${die.rotXEnd}deg`,
+                    '--rot-y-end': `${die.rotYEnd}deg`,
+                    '--rot-z-end': `${die.rotZEnd}deg`,
                   }}
                 >
                   <DamageDieMesh die={die} typeClass={typeClass} />

--- a/client/src/utils/dieGeometry.js
+++ b/client/src/utils/dieGeometry.js
@@ -595,9 +595,14 @@ export function createPolyhedronFaces(sides, scale = 1) {
 
     const heightRatio = Math.max(height / width, 0.01);
 
+    const faceTangent = tangent;
+    const faceBitangent = bitangent;
+
     faceData.push({
       matrix: cssMatrix,
       normal,
+      tangent: faceTangent,
+      bitangent: faceBitangent,
       clipPath: `polygon(${clipPoints})`,
       heightRatio,
     });


### PR DESCRIPTION
## Summary
- generate cached polyhedral face geometry per die size to render 3D meshes with proper face orientation in the damage roll area
- drive the flight animation to spin toward the rolled face so dice tumble in from off-screen and settle showing the correct value
- refresh the damage die styling to render layered 3D faces with active face highlights for better readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2498ffce0832eaae3d62243f2ec2e