### PR TITLE
Add 3D dice animation support to damage roller

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1849,6 +1849,30 @@ $rotateX: -$angle;
   z-index: 1;
 }
 
+.damage-roller__dice-area--3d-ready .damage-roller__dice-fallback {
+  opacity: 0;
+}
+
+.damage-roller__dice-box {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+
+  canvas {
+    width: 100% !important;
+    height: 100% !important;
+  }
+}
+
+.damage-roller__dice-fallback {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  transition: opacity 0.3s ease;
+}
+
 .damage-roller__total {
   position: relative;
   z-index: 2;

--- a/client/src/components/Zombies/attributes/DamageDiceBox.js
+++ b/client/src/components/Zombies/attributes/DamageDiceBox.js
@@ -1,0 +1,244 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+const DICE_BOX_SCRIPT_ID = 'dice-box-lib';
+const DICE_BOX_SCRIPT_SRC =
+  'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1.0.10/dist/dice-box.min.js';
+const DICE_BOX_ASSET_PATH =
+  'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1.0.10/dist/';
+
+let diceBoxScriptPromise = null;
+
+function logDiceBoxError(error) {
+  if (process.env.NODE_ENV !== 'test') {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+}
+
+function loadDiceBoxScript() {
+  if (diceBoxScriptPromise) {
+    return diceBoxScriptPromise;
+  }
+
+  if (typeof document === 'undefined') {
+    return Promise.reject(new Error('DiceBox unavailable in this environment.'));
+  }
+
+  const existing = document.getElementById(DICE_BOX_SCRIPT_ID);
+  if (existing) {
+    diceBoxScriptPromise = new Promise((resolve, reject) => {
+      if (existing.getAttribute('data-loaded') === 'true') {
+        resolve();
+        return;
+      }
+
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener(
+        'error',
+        () => reject(new Error('Failed to load DiceBox script.')),
+        { once: true }
+      );
+    });
+
+    return diceBoxScriptPromise;
+  }
+
+  diceBoxScriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = DICE_BOX_SCRIPT_ID;
+    script.src = DICE_BOX_SCRIPT_SRC;
+    script.async = true;
+    script.onload = () => {
+      script.setAttribute('data-loaded', 'true');
+      resolve();
+    };
+    script.onerror = () => {
+      script.remove();
+      diceBoxScriptPromise = null;
+      reject(new Error('Failed to load DiceBox script.'));
+    };
+    document.body.appendChild(script);
+  });
+
+  return diceBoxScriptPromise;
+}
+
+export const sanitizeDiceDetails = (details) => {
+  if (!Array.isArray(details)) {
+    return [];
+  }
+
+  return details
+    .map((die) => {
+      if (!die) return null;
+      const sides = Number(die.sides);
+      if (!Number.isFinite(sides) || sides < 2) {
+        return null;
+      }
+
+      const value = Number(die.value);
+      return {
+        ...die,
+        sides,
+        value: Number.isFinite(value) ? value : die.value,
+      };
+    })
+    .filter(Boolean);
+};
+
+const buildDiceNotation = (dice) => {
+  if (!Array.isArray(dice) || dice.length === 0) {
+    return '';
+  }
+
+  const counts = dice.reduce((acc, die) => {
+    const key = Number(die.sides);
+    if (!Number.isFinite(key) || key < 2) {
+      return acc;
+    }
+    const prev = acc.get(key) || 0;
+    acc.set(key, prev + 1);
+    return acc;
+  }, new Map());
+
+  return Array.from(counts.entries())
+    .map(([sides, count]) => `${count}d${sides}`)
+    .join(' + ');
+};
+
+const DamageDiceBox = forwardRef(({ color, onStateChange }, ref) => {
+  const containerRef = useRef(null);
+  const diceBoxRef = useRef(null);
+  const statusRef = useRef('idle');
+  const colorRef = useRef(color || '#4cc9f0');
+  const [status, setStatus] = useState('idle');
+
+  useEffect(() => {
+    colorRef.current = color || '#4cc9f0';
+  }, [color]);
+
+  useEffect(() => {
+    statusRef.current = status;
+    if (typeof onStateChange === 'function') {
+      onStateChange(status);
+    }
+  }, [status, onStateChange]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      setStatus('error');
+      return undefined;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      setStatus('error');
+      return undefined;
+    }
+
+    let isMounted = true;
+    setStatus('loading');
+
+    loadDiceBoxScript()
+      .then(() => {
+        if (!isMounted) return;
+        if (typeof window.DiceBox !== 'function') {
+          throw new Error('DiceBox global not available.');
+        }
+
+        const elementId =
+          container.id || `damage-dice-box-${Math.random().toString(36).slice(2)}`;
+        container.id = elementId;
+
+        const instance = new window.DiceBox(`#${elementId}`, {
+          assetPath: DICE_BOX_ASSET_PATH,
+          theme: 'default',
+          themeColor: colorRef.current,
+          offscreen: true,
+        });
+
+        diceBoxRef.current = instance;
+
+        return instance.init().then(() => {
+          if (!isMounted) return;
+          setStatus('ready');
+        });
+      })
+      .catch((error) => {
+        logDiceBoxError(error);
+        if (isMounted) {
+          setStatus('error');
+        }
+      });
+
+    return () => {
+      isMounted = false;
+      const instance = diceBoxRef.current;
+      diceBoxRef.current = null;
+      if (instance) {
+        try {
+          if (typeof instance.destroy === 'function') {
+            instance.destroy();
+          } else if (typeof instance.clear === 'function') {
+            instance.clear();
+          }
+        } catch (error) {
+          logDiceBoxError(error);
+        }
+      }
+    };
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      rollDice(rawDetails = []) {
+        const sanitized = sanitizeDiceDetails(rawDetails);
+
+        if (
+          !diceBoxRef.current ||
+          statusRef.current !== 'ready' ||
+          sanitized.length === 0
+        ) {
+          return { used3d: false, sanitized };
+        }
+
+        const notation = buildDiceNotation(sanitized);
+        if (!notation) {
+          return { used3d: false, sanitized };
+        }
+
+        try {
+          const maybePromise = diceBoxRef.current.roll(notation, {
+            theme: 'default',
+            themeColor: colorRef.current,
+          });
+
+          if (maybePromise && typeof maybePromise.catch === 'function') {
+            maybePromise.catch((error) => {
+              logDiceBoxError(error);
+            });
+          }
+
+          return { used3d: true, sanitized };
+        } catch (error) {
+          logDiceBoxError(error);
+          return { used3d: false, sanitized };
+        }
+      },
+    }),
+    []
+  );
+
+  return <div ref={containerRef} className="damage-roller__dice-box" aria-hidden="true" />;
+});
+
+DamageDiceBox.displayName = 'DamageDiceBox';
+
+export default DamageDiceBox;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -15,6 +15,7 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
+import DamageDiceBox, { sanitizeDiceDetails } from './DamageDiceBox';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -1013,6 +1014,8 @@ const [showLog, setShowLog] = useState(false);
 const [activeDice, setActiveDice] = useState([]);
 const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
 const diceAreaRef = useRef(null);
+const diceBoxControllerRef = useRef(null);
+const [diceBoxStatus, setDiceBoxStatus] = useState('idle');
 
 const getDieShapeClass = (sides) => {
   if (!Number.isFinite(sides)) {
@@ -1040,96 +1043,116 @@ const getDieShapeClass = (sides) => {
   }
 };
 
-const triggerDiceAnimation = useCallback((diceDetails = []) => {
-  if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
-    setActiveDice([]);
-    return;
-  }
+const triggerDiceAnimation = useCallback(
+  (diceDetails = []) => {
+    const controller = diceBoxControllerRef.current;
+    let sanitizedDetails = sanitizeDiceDetails(diceDetails);
+    let used3d = false;
 
-  const baseTime = Date.now();
-  const areaWidth = Math.max(
-    1,
-    diceAreaRef.current?.offsetWidth ||
-      diceAreaRef.current?.parentElement?.offsetWidth ||
-      520
-  );
-
-  const diceCount = diceDetails.length;
-  const usableWidthPx = (() => {
-    if (diceCount <= 1) {
-      return Math.min(
-        areaWidth * DAMAGE_AREA_MAX_RATIO,
-        areaWidth * DAMAGE_AREA_BASE_RATIO
-      );
+    if (controller && typeof controller.rollDice === 'function') {
+      const result = controller.rollDice(diceDetails);
+      if (result && Array.isArray(result.sanitized)) {
+        sanitizedDetails = result.sanitized;
+      }
+      used3d = !!result?.used3d;
     }
-    const desiredClusterWidth = Math.max(
-      areaWidth * DAMAGE_AREA_BASE_RATIO,
-      (diceCount - 1) * DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR
+
+    if (used3d) {
+      setActiveDice([]);
+      return;
+    }
+
+    if (!Array.isArray(sanitizedDetails) || sanitizedDetails.length === 0) {
+      setActiveDice([]);
+      return;
+    }
+
+    const areaWidth = Math.max(
+      1,
+      diceAreaRef.current?.offsetWidth ||
+        diceAreaRef.current?.parentElement?.offsetWidth ||
+        520
     );
-    return Math.min(areaWidth * DAMAGE_AREA_MAX_RATIO, desiredClusterWidth);
-  })();
 
-  const slotWidthPx =
-    diceCount > 1 ? usableWidthPx / (diceCount - 1) : usableWidthPx || areaWidth;
-  const minGapPx =
-    diceCount > 1
-      ? Math.min(DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR, slotWidthPx)
-      : 0;
-  const startPx = (areaWidth - usableWidthPx) / 2;
-  const maxPx = startPx + usableWidthPx;
-  const jitterPx = Math.min(slotWidthPx * 0.25, DAMAGE_DIE_WIDTH_PX * 0.4);
-  let previousLeftPx = null;
+    const diceCount = sanitizedDetails.length;
+    const usableWidthPx = (() => {
+      if (diceCount <= 1) {
+        return Math.min(
+          areaWidth * DAMAGE_AREA_MAX_RATIO,
+          areaWidth * DAMAGE_AREA_BASE_RATIO
+        );
+      }
+      const desiredClusterWidth = Math.max(
+        areaWidth * DAMAGE_AREA_BASE_RATIO,
+        (diceCount - 1) * DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR
+      );
+      return Math.min(areaWidth * DAMAGE_AREA_MAX_RATIO, desiredClusterWidth);
+    })();
 
-  const nextDice = diceDetails.map((detail, index) => {
-    const fraction = diceCount === 1 ? 0.5 : index / (diceCount - 1 || 1);
-    const baseLeftPx = startPx + fraction * usableWidthPx;
-    const rawOffsetPx = jitterPx
-      ? (Math.random() - 0.5) * 2 * jitterPx
-      : 0;
-    const remainingDice = diceCount - index - 1;
-    const minAllowedPx = startPx + index * minGapPx;
-    const maxAllowedPx = maxPx - remainingDice * minGapPx;
+    const slotWidthPx =
+      diceCount > 1 ? usableWidthPx / (diceCount - 1) : usableWidthPx || areaWidth;
+    const minGapPx =
+      diceCount > 1
+        ? Math.min(DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR, slotWidthPx)
+        : 0;
+    const startPx = (areaWidth - usableWidthPx) / 2;
+    const maxPx = startPx + usableWidthPx;
+    const jitterPx = Math.min(slotWidthPx * 0.25, DAMAGE_DIE_WIDTH_PX * 0.4);
+    let previousLeftPx = null;
+    const baseTime = Date.now();
 
-    let leftPx = baseLeftPx + rawOffsetPx;
-    if (Number.isFinite(minAllowedPx)) {
-      leftPx = Math.max(leftPx, minAllowedPx);
-    }
-    if (Number.isFinite(maxAllowedPx)) {
-      leftPx = Math.min(leftPx, maxAllowedPx);
-    }
-    if (previousLeftPx !== null && leftPx - previousLeftPx < minGapPx) {
-      leftPx = Math.min(maxAllowedPx, previousLeftPx + minGapPx);
-    }
+    const nextDice = sanitizedDetails.map((detail, index) => {
+      const fraction = diceCount === 1 ? 0.5 : index / (diceCount - 1 || 1);
+      const baseLeftPx = startPx + fraction * usableWidthPx;
+      const rawOffsetPx = jitterPx
+        ? (Math.random() - 0.5) * 2 * jitterPx
+        : 0;
+      const remainingDice = diceCount - index - 1;
+      const minAllowedPx = startPx + index * minGapPx;
+      const maxAllowedPx = maxPx - remainingDice * minGapPx;
 
-    previousLeftPx = leftPx;
-    const left = (leftPx / areaWidth) * 100;
-    const dropDistance = 60 + Math.random() * 70;
-    const delay = index * 0.05;
-    const rollDuration = 0.85 + Math.random() * 0.45;
-    const spinEnd = (Math.random() - 0.5) * 60;
-    const spinStart = spinEnd + (Math.random() - 0.5) * 200;
-    const spinMid = (spinStart + spinEnd) / 2;
-    return {
-      id: `${baseTime}-${index}`,
-      value:
-        typeof detail?.value === 'number'
-          ? detail.value
-          : Number(detail?.value) || 0,
-      sides: detail?.sides || 0,
-      type: detail?.type || '',
-      category: detail?.category || 'base',
-      left,
-      dropDistance,
-      delay,
-      rollDuration,
-      spinStart,
-      spinMid,
-      spinEnd,
-    };
-  });
+      let leftPx = baseLeftPx + rawOffsetPx;
+      if (Number.isFinite(minAllowedPx)) {
+        leftPx = Math.max(leftPx, minAllowedPx);
+      }
+      if (Number.isFinite(maxAllowedPx)) {
+        leftPx = Math.min(leftPx, maxAllowedPx);
+      }
+      if (previousLeftPx !== null && leftPx - previousLeftPx < minGapPx) {
+        leftPx = Math.min(maxAllowedPx, previousLeftPx + minGapPx);
+      }
 
-  setActiveDice(nextDice);
-}, [diceAreaRef]);
+      previousLeftPx = leftPx;
+      const left = (leftPx / areaWidth) * 100;
+      const dropDistance = 60 + Math.random() * 70;
+      const delay = index * 0.05;
+      const rollDuration = 0.85 + Math.random() * 0.45;
+      const spinEnd = (Math.random() - 0.5) * 60;
+      const spinStart = spinEnd + (Math.random() - 0.5) * 200;
+      const spinMid = (spinStart + spinEnd) / 2;
+      return {
+        id: `${baseTime}-${index}`,
+        value:
+          typeof detail?.value === 'number'
+            ? detail.value
+            : Number(detail?.value) || 0,
+        sides: detail?.sides || 0,
+        type: detail?.type || '',
+        category: detail?.category || 'base',
+        left,
+        dropDistance,
+        delay,
+        rollDuration,
+        spinStart,
+        spinMid,
+        spinEnd,
+      };
+    });
+
+    setActiveDice(nextDice);
+  },
+  [diceAreaRef]
+);
 
 const updateDamageValueWithAnimation = (
   newValue,
@@ -1202,6 +1225,9 @@ useEffect(() => {
 }, []);
 
 const passDisabled = !canPassTurn || isPassTurnInProgress;
+const diceAreaClassName = `damage-roller__dice-area ${
+  diceBoxStatus === 'ready' ? 'damage-roller__dice-area--3d-ready' : ''
+}`.trim();
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div
@@ -1292,35 +1318,46 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
           }`}
         >
           <div
-            className="damage-roller__dice-area"
+            className={diceAreaClassName}
             aria-hidden="true"
             ref={diceAreaRef}
           >
-            {activeDice.map((die) => {
-              const normalizedType = normalizeDamageTypeForClass(die.type);
-              const typeClass = normalizedType ? `damage-${normalizedType}` : '';
-              const categoryClass = die.category
-                ? `damage-die--${die.category}`
-                : '';
-              const shapeClass = getDieShapeClass(die.sides);
-              return (
-                <div
-                  key={die.id}
-                  className={`damage-die ${shapeClass} ${categoryClass}`}
-                  style={{
-                    left: `${die.left}%`,
-                    '--drop-delay': `${die.delay}s`,
-                    '--drop-distance': `${die.dropDistance}px`,
-                    '--drop-duration': `${die.rollDuration}s`,
-                    '--drop-spin-start': `${die.spinStart}deg`,
-                    '--drop-spin-mid': `${die.spinMid}deg`,
-                    '--drop-spin-end': `${die.spinEnd}deg`,
-                  }}
-                >
-                  <DamageDieMesh die={die} typeClass={typeClass} />
-                </div>
-              );
-            })}
+            <DamageDiceBox
+              ref={diceBoxControllerRef}
+              color={form?.diceColor}
+              onStateChange={setDiceBoxStatus}
+            />
+            {activeDice.length > 0 && (
+              <div className="damage-roller__dice-fallback">
+                {activeDice.map((die) => {
+                  const normalizedType = normalizeDamageTypeForClass(die.type);
+                  const typeClass = normalizedType
+                    ? `damage-${normalizedType}`
+                    : '';
+                  const categoryClass = die.category
+                    ? `damage-die--${die.category}`
+                    : '';
+                  const shapeClass = getDieShapeClass(die.sides);
+                  return (
+                    <div
+                      key={die.id}
+                      className={`damage-die ${shapeClass} ${categoryClass}`}
+                      style={{
+                        left: `${die.left}%`,
+                        '--drop-delay': `${die.delay}s`,
+                        '--drop-distance': `${die.dropDistance}px`,
+                        '--drop-duration': `${die.rollDuration}s`,
+                        '--drop-spin-start': `${die.spinStart}deg`,
+                        '--drop-spin-mid': `${die.spinMid}deg`,
+                        '--drop-spin-end': `${die.spinEnd}deg`,
+                      }}
+                    >
+                      <DamageDieMesh die={die} typeClass={typeClass} />
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
           <div className="damage-roller__total">
             <span className="damage-roller__total-label">Total</span>


### PR DESCRIPTION
## Summary
- add a DamageDiceBox component that asynchronously loads the Dice Box library for 3D dice rolls
- integrate the DiceBox controller into the damage roller with graceful fallback to the legacy animation
- update damage roller styling to host the 3D canvas and fallback dice overlay

## Testing
- npm test --prefix client -- --watchAll=false *(fails: existing act() warnings in ZombiesCharacterSheet and TokenPickerModal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f2658c2fec832ebe684a8749db5352