### PR TITLE
Revamp damage roll display with RPG dice results

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@capacitor/android": "^5.6.0",
     "@capacitor/core": "^5.6.0",
     "@capacitor/ios": "^5.6.0",
+    "@dice-roller/rpg-dice-roller": "^5.1.0",
     "@fortawesome/fontawesome": "^1.1.8",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1849,6 +1849,168 @@ $rotateX: -$angle;
   z-index: 1;
 }
 
+.damage-roller__dice-area--3d-ready .damage-roller__dice-fallback {
+  opacity: 0;
+}
+
+.damage-roller__dice-box {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+
+  canvas {
+    width: 100% !important;
+    height: 100% !important;
+  }
+}
+
+.damage-roller__dice-fallback {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 12px 16px;
+  color: #f1f6ff;
+  text-align: center;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  transition: opacity 0.3s ease;
+}
+
+.damage-roller__dice-notation {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, rgba(38, 132, 255, 0.5), rgba(90, 45, 255, 0.55));
+  border: 1px solid rgba(138, 204, 255, 0.7);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.damage-roller__dice-notation-label {
+  font-weight: 600;
+  opacity: 0.82;
+}
+
+.damage-roller__dice-notation-value {
+  font-weight: 700;
+}
+
+.damage-roller__dice-groups {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 460px;
+}
+
+.damage-die-group {
+  min-width: 132px;
+  max-width: 210px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(8, 24, 42, 0.78);
+  border: 1px solid rgba(82, 192, 255, 0.55);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.damage-die-group--bonus {
+  background: rgba(8, 42, 24, 0.78);
+  border-color: rgba(144, 244, 198, 0.6);
+}
+
+.damage-die-group--critical {
+  background: rgba(42, 28, 4, 0.82);
+  border-color: rgba(255, 206, 112, 0.65);
+}
+
+.damage-die-group--critical-bonus {
+  background: rgba(50, 18, 36, 0.82);
+  border-color: rgba(255, 160, 210, 0.68);
+}
+
+.damage-die-group__header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-transform: uppercase;
+}
+
+.damage-die-group__title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.damage-die-group__subtitle {
+  font-size: 0.75rem;
+  opacity: 0.8;
+  letter-spacing: 0.06em;
+}
+
+.damage-die-group__dice {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.damage-die-chip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: linear-gradient(150deg, rgba(54, 146, 255, 0.85), rgba(32, 86, 210, 0.85));
+  border: 1px solid rgba(132, 214, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.4);
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  letter-spacing: 0.04em;
+}
+
+.damage-die-chip--category-bonus {
+  background: linear-gradient(150deg, rgba(78, 214, 144, 0.85), rgba(26, 132, 84, 0.9));
+  border-color: rgba(178, 255, 214, 0.7);
+}
+
+.damage-die-chip--category-critical {
+  background: linear-gradient(150deg, rgba(240, 186, 58, 0.85), rgba(204, 112, 12, 0.9));
+  border-color: rgba(255, 224, 168, 0.7);
+}
+
+.damage-die-chip--category-critical-bonus {
+  background: linear-gradient(150deg, rgba(255, 138, 196, 0.85), rgba(180, 52, 132, 0.88));
+  border-color: rgba(255, 190, 224, 0.7);
+}
+
+.damage-die-chip__sides {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.damage-die-chip__value {
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
 .damage-roller__total {
   position: relative;
   z-index: 2;
@@ -1940,140 +2102,6 @@ $rotateX: -$angle;
   color: #ff6b6b;
 }
 
-.damage-die {
-  position: absolute;
-  top: -28px;
-  width: var(--die-size, 36px);
-  height: var(--die-size, 36px);
-  pointer-events: none;
-  transform: translate(-50%, -120%);
-  opacity: 0;
-  --drop-delay: 0s;
-  --drop-duration: 0.9s;
-  --drop-distance: 48px;
-  --drop-spin-start: -12deg;
-  --drop-spin-mid: 4deg;
-  --drop-spin-end: 0deg;
-  --die-surface-color: var(--dice-face-color, #1f46cc);
-  --die-edge-color: rgba(255, 255, 255, 0.5);
-  animation: damage-die-drop var(--drop-duration) cubic-bezier(0.32, 0.74, 0.23, 0.99) forwards;
-  animation-delay: var(--drop-delay);
-  filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45));
-}
-
-.damage-die__icon {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.damage-die__shape {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(circle at 28% 24%, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0) 58%),
-    linear-gradient(140deg, rgba(255, 255, 255, 0.42), rgba(0, 0, 0, 0.38)),
-    var(--die-surface-color);
-  border: 2px solid var(--die-edge-color, rgba(255, 255, 255, 0.45));
-  box-shadow:
-    inset 0 4px 8px rgba(255, 255, 255, 0.18),
-    inset 0 -6px 12px rgba(0, 0, 0, 0.42);
-  border-radius: 18%;
-  clip-path: polygon(18% 6%, 82% 6%, 100% 24%, 100% 76%, 82% 94%, 18% 94%, 0% 76%, 0% 24%);
-  transition: transform 0.2s ease;
-}
-
-.damage-die__shape::after {
-  content: '';
-  position: absolute;
-  inset: 16%;
-  border-radius: inherit;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
-  opacity: 0.85;
-  mix-blend-mode: screen;
-  pointer-events: none;
-}
-
-.damage-die__value {
-  position: relative;
-  z-index: 1;
-  font-size: 1.1rem;
-  line-height: 1;
-  font-weight: 700;
-  color: #fff;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
-}
-
-.damage-die--bonus {
-  --die-surface-color: #30b86f;
-  --die-edge-color: rgba(190, 255, 213, 0.6);
-}
-
-.damage-die--critical {
-  --die-surface-color: #f2c100;
-  --die-edge-color: rgba(255, 246, 196, 0.75);
-  filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 0 12px rgba(255, 215, 0, 0.55));
-}
-
-.damage-die--critical-bonus {
-  --die-surface-color: #ff8a33;
-  --die-edge-color: rgba(255, 212, 162, 0.7);
-  filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 0 12px rgba(255, 167, 38, 0.55));
-}
-
-.damage-die--d4 .damage-die__shape {
-  clip-path: polygon(50% 4%, 95% 86%, 5% 86%);
-  border-radius: 10%;
-}
-
-.damage-die--d6 .damage-die__shape,
-.damage-die--generic .damage-die__shape {
-  clip-path: polygon(18% 6%, 82% 6%, 100% 24%, 100% 76%, 82% 94%, 18% 94%, 0% 76%, 0% 24%);
-}
-
-.damage-die--d8 .damage-die__shape {
-  clip-path: polygon(50% 4%, 88% 26%, 98% 50%, 88% 74%, 50% 96%, 12% 74%, 2% 50%, 12% 26%);
-  border-radius: 12%;
-}
-
-.damage-die--d10 .damage-die__shape {
-  clip-path: polygon(50% 3%, 78% 12%, 95% 32%, 98% 55%, 86% 84%, 50% 97%, 14% 84%, 2% 55%, 5% 32%, 22% 12%);
-  border-radius: 12%;
-}
-
-.damage-die--d12 .damage-die__shape {
-  clip-path: polygon(50% 2%, 72% 8%, 90% 22%, 98% 40%, 98% 60%, 90% 78%, 72% 92%, 50% 98%, 28% 92%, 10% 78%, 2% 60%, 2% 40%, 10% 22%, 28% 8%);
-  border-radius: 10%;
-}
-
-.damage-die--d20 .damage-die__shape {
-  clip-path: polygon(50% 1%, 68% 6%, 84% 17%, 94% 32%, 99% 50%, 94% 68%, 84% 83%, 68% 94%, 50% 99%, 32% 94%, 16% 83%, 6% 68%, 1% 50%, 6% 32%, 16% 17%, 32% 6%);
-  border-radius: 8%;
-}
-
-@keyframes damage-die-drop {
-  0% {
-    transform: translate(-50%, -150%) scale(0.6) rotate(var(--drop-spin-start, 0deg));
-    opacity: 0;
-  }
-  30% {
-    opacity: 1;
-  }
-  65% {
-    transform: translate(-50%, calc(var(--drop-distance, 48px) * 0.6)) scale(1.05)
-      rotate(var(--drop-spin-mid, 12deg));
-  }
-  100% {
-    transform: translate(-50%, var(--drop-distance, 48px)) scale(1)
-      rotate(var(--drop-spin-end, 0deg));
-    opacity: 1;
-  }
-}
 
 /* Hidden class to hide elements */
 .hidden {

--- a/client/src/__mocks__/@dice-roller/rpg-dice-roller.js
+++ b/client/src/__mocks__/@dice-roller/rpg-dice-roller.js
@@ -1,0 +1,25 @@
+export class DiceRoller {
+  roll(notation) {
+    const sanitized = typeof notation === 'string' ? notation.trim() : '';
+    const match = sanitized.match(/(\d+)d(\d+)/i);
+    const count = match ? Math.max(1, parseInt(match[1], 10) || 1) : 1;
+    const sides = match ? Math.max(2, parseInt(match[2], 10) || 20) : 20;
+    const values = Array.from({ length: count }, (_, index) => ((index % sides) + 1));
+    return {
+      rolls: values.map((value) => ({ value })),
+      export(format) {
+        if (format === 'json') {
+          return {
+            notation: sanitized || `${count}d${sides}`,
+            rolls: values.map((value) => ({ value })),
+            total: values.reduce((sum, value) => sum + value, 0),
+          };
+        }
+        return {
+          notation: sanitized || `${count}d${sides}`,
+          total: values.reduce((sum, value) => sum + value, 0),
+        };
+      },
+    };
+  }
+}

--- a/client/src/components/Zombies/attributes/DamageDiceBox.js
+++ b/client/src/components/Zombies/attributes/DamageDiceBox.js
@@ -1,0 +1,243 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+const DICE_BOX_SCRIPT_ID = 'dice-box-lib';
+const DICE_BOX_SCRIPT_SRC =
+  'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1.0.10/dist/dice-box.min.js';
+const DICE_BOX_ASSET_PATH =
+  'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1.0.10/dist/';
+
+let diceBoxScriptPromise = null;
+
+function logDiceBoxError(error) {
+  if (process.env.NODE_ENV !== 'test') {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+}
+
+function loadDiceBoxScript() {
+  if (diceBoxScriptPromise) {
+    return diceBoxScriptPromise;
+  }
+
+  if (typeof document === 'undefined') {
+    return Promise.reject(new Error('DiceBox unavailable in this environment.'));
+  }
+
+  const existing = document.getElementById(DICE_BOX_SCRIPT_ID);
+  if (existing) {
+    diceBoxScriptPromise = new Promise((resolve, reject) => {
+      if (existing.getAttribute('data-loaded') === 'true') {
+        resolve();
+        return;
+      }
+
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener(
+        'error',
+        () => reject(new Error('Failed to load DiceBox script.')),
+        { once: true }
+      );
+    });
+
+    return diceBoxScriptPromise;
+  }
+
+  diceBoxScriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = DICE_BOX_SCRIPT_ID;
+    script.src = DICE_BOX_SCRIPT_SRC;
+    script.async = true;
+    script.onload = () => {
+      script.setAttribute('data-loaded', 'true');
+      resolve();
+    };
+    script.onerror = () => {
+      script.remove();
+      diceBoxScriptPromise = null;
+      reject(new Error('Failed to load DiceBox script.'));
+    };
+    document.body.appendChild(script);
+  });
+
+  return diceBoxScriptPromise;
+}
+
+export const sanitizeDiceDetails = (details) => {
+  if (!Array.isArray(details)) {
+    return [];
+  }
+
+  return details
+    .map((die) => {
+      if (!die) return null;
+      const sides = Number(die.sides);
+      if (!Number.isFinite(sides) || sides < 2) {
+        return null;
+      }
+
+      const value = Number(die.value);
+      return {
+        ...die,
+        sides,
+        value: Number.isFinite(value) ? value : die.value,
+      };
+    })
+    .filter(Boolean);
+};
+
+export const buildDiceNotation = (dice) => {
+  if (!Array.isArray(dice) || dice.length === 0) {
+    return '';
+  }
+
+  const counts = dice.reduce((acc, die) => {
+    const key = Number(die.sides);
+    if (!Number.isFinite(key) || key < 2) {
+      return acc;
+    }
+    const prev = acc.get(key) || 0;
+    acc.set(key, prev + 1);
+    return acc;
+  }, new Map());
+
+  return Array.from(counts.entries())
+    .map(([sides, count]) => `${count}d${sides}`)
+    .join(' + ');
+};
+
+const DamageDiceBox = forwardRef(({ color, onStateChange }, ref) => {
+  const containerRef = useRef(null);
+  const diceBoxRef = useRef(null);
+  const statusRef = useRef('idle');
+  const colorRef = useRef(color || '#4cc9f0');
+  const [status, setStatus] = useState('idle');
+
+  useEffect(() => {
+    colorRef.current = color || '#4cc9f0';
+  }, [color]);
+
+  useEffect(() => {
+    statusRef.current = status;
+    if (typeof onStateChange === 'function') {
+      onStateChange(status);
+    }
+  }, [status, onStateChange]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      setStatus('error');
+      return undefined;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      setStatus('error');
+      return undefined;
+    }
+
+    let isMounted = true;
+    setStatus('loading');
+
+    loadDiceBoxScript()
+      .then(() => {
+        if (!isMounted) return;
+        if (typeof window.DiceBox !== 'function') {
+          throw new Error('DiceBox global not available.');
+        }
+
+        const elementId =
+          container.id || `damage-dice-box-${Math.random().toString(36).slice(2)}`;
+        container.id = elementId;
+
+        const instance = new window.DiceBox(`#${elementId}`, {
+          assetPath: DICE_BOX_ASSET_PATH,
+          theme: 'default',
+          themeColor: colorRef.current,
+        });
+
+        diceBoxRef.current = instance;
+
+        return instance.init().then(() => {
+          if (!isMounted) return;
+          setStatus('ready');
+        });
+      })
+      .catch((error) => {
+        logDiceBoxError(error);
+        if (isMounted) {
+          setStatus('error');
+        }
+      });
+
+    return () => {
+      isMounted = false;
+      const instance = diceBoxRef.current;
+      diceBoxRef.current = null;
+      if (instance) {
+        try {
+          if (typeof instance.destroy === 'function') {
+            instance.destroy();
+          } else if (typeof instance.clear === 'function') {
+            instance.clear();
+          }
+        } catch (error) {
+          logDiceBoxError(error);
+        }
+      }
+    };
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      rollDice(rawDetails = []) {
+        const sanitized = sanitizeDiceDetails(rawDetails);
+
+        if (
+          !diceBoxRef.current ||
+          statusRef.current !== 'ready' ||
+          sanitized.length === 0
+        ) {
+          return { used3d: false, sanitized };
+        }
+
+        const notation = buildDiceNotation(sanitized);
+        if (!notation) {
+          return { used3d: false, sanitized };
+        }
+
+        try {
+          const maybePromise = diceBoxRef.current.roll(notation, {
+            theme: 'default',
+            themeColor: colorRef.current,
+          });
+
+          if (maybePromise && typeof maybePromise.catch === 'function') {
+            maybePromise.catch((error) => {
+              logDiceBoxError(error);
+            });
+          }
+
+          return { used3d: true, sanitized };
+        } catch (error) {
+          logDiceBoxError(error);
+          return { used3d: false, sanitized };
+        }
+      },
+    }),
+    []
+  );
+
+  return <div ref={containerRef} className="damage-roller__dice-box" aria-hidden="true" />;
+});
+
+DamageDiceBox.displayName = 'DamageDiceBox';
+
+export default DamageDiceBox;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -6,6 +6,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
+import { DiceRoller } from '@dice-roller/rpg-dice-roller';
 import { Button, Modal, Card, OverlayTrigger, Popover, Form } from "react-bootstrap";
 import spellsData from '../../../data/spells';
 import UpcastModal from './UpcastModal';
@@ -15,6 +16,55 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
+import DamageDiceBox, { sanitizeDiceDetails, buildDiceNotation } from './DamageDiceBox';
+
+const sharedDiceRoller = (() => {
+  try {
+    return new DiceRoller();
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'test') {
+      // eslint-disable-next-line no-console
+      console.error('Failed to initialize DiceRoller', error);
+    }
+    return null;
+  }
+})();
+
+const collectRollValues = (node, acc = []) => {
+  if (!node) {
+    return acc;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((item) => collectRollValues(item, acc));
+    return acc;
+  }
+
+  if (typeof node === 'number') {
+    acc.push(node);
+    return acc;
+  }
+
+  if (typeof node === 'object') {
+    if (typeof node.value === 'number') {
+      acc.push(node.value);
+    }
+
+    if (Array.isArray(node.rolls)) {
+      collectRollValues(node.rolls, acc);
+    }
+
+    if (Array.isArray(node.results)) {
+      collectRollValues(node.results, acc);
+    }
+
+    if (Array.isArray(node.values)) {
+      collectRollValues(node.values, acc);
+    }
+  }
+
+  return acc;
+};
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -22,20 +72,37 @@ function rollDice(numberOfDiceValue, sidesOfDiceValue) {
     return "Both the number of dice and sides must be greater than zero.";
   }
 
+  if (sharedDiceRoller && typeof sharedDiceRoller.roll === 'function') {
+    try {
+      const notation = `${numberOfDiceValue}d${sidesOfDiceValue}`;
+      const roll = sharedDiceRoller.roll(notation);
+
+      const exported =
+        roll && typeof roll.export === 'function' ? roll.export('json') : null;
+
+      let values = collectRollValues(exported);
+      if (!values.length) {
+        values = collectRollValues(roll?.rolls);
+      }
+
+      if (values.length) {
+        return values.slice(0, numberOfDiceValue);
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'test') {
+        // eslint-disable-next-line no-console
+        console.error('Dice roll failed, falling back to Math.random()', error);
+      }
+    }
+  }
+
   const results = [];
   for (let i = 0; i < numberOfDiceValue; i++) {
-    // Generate a random number between 1 and sidesOfDiceValue (inclusive)
-    const result = Math.floor(Math.random() * sidesOfDiceValue) + 1;
-    results.push(result);
+    results.push(Math.floor(Math.random() * sidesOfDiceValue) + 1);
   }
 
   return results;
 }
-
-const DAMAGE_DIE_WIDTH_PX = 42;
-const DAMAGE_DIE_SPREAD_FACTOR = 1.15;
-const DAMAGE_AREA_BASE_RATIO = 0.42;
-const DAMAGE_AREA_MAX_RATIO = 0.92;
 
 function formatDamageRolls(rolls) {
   return rolls
@@ -58,57 +125,27 @@ const spellsCatalog = spellsData || {};
 
 const diceExpressionPattern = /\d+d\d+(?:\s*[+-]\s*\d+)?/gi;
 
-function DamageDieMesh({ die, typeClass }) {
-  const finalValue =
-    typeof die?.value === 'number' ? die.value : Number(die?.value) || 0;
-  const [displayValue, setDisplayValue] = useState(finalValue);
+const getDiceCategoryLabel = (category) => {
+  switch (category) {
+    case 'bonus':
+      return 'Bonus';
+    case 'critical':
+      return 'Critical';
+    case 'critical-bonus':
+      return 'Critical Bonus';
+    default:
+      return '';
+  }
+};
 
-  useEffect(() => {
-    const sides = Number.isFinite(die?.sides) ? Math.max(2, Math.round(die.sides)) : 20;
-    const delayMs = Number.isFinite(die?.delay)
-      ? Math.max(0, die.delay * 1000)
-      : 0;
-    const durationMs = Number.isFinite(die?.rollDuration)
-      ? Math.max(350, die.rollDuration * 1000)
-      : 900;
-
-    let scrambleIntervalId = null;
-    let scrambleTimeoutId = null;
-    let startTimeoutId = null;
-
-    const startScramble = () => {
-      if (sides < 2 || durationMs <= 0) {
-        setDisplayValue(finalValue);
-        return;
-      }
-
-      const intervalMs = Math.max(65, Math.min(160, durationMs / 6));
-      scrambleIntervalId = setInterval(() => {
-        setDisplayValue(Math.floor(Math.random() * sides) + 1);
-      }, intervalMs);
-
-      scrambleTimeoutId = setTimeout(() => {
-        if (scrambleIntervalId) clearInterval(scrambleIntervalId);
-        setDisplayValue(finalValue);
-      }, durationMs);
-    };
-
-    startTimeoutId = setTimeout(startScramble, delayMs);
-
-    return () => {
-      if (startTimeoutId) clearTimeout(startTimeoutId);
-      if (scrambleIntervalId) clearInterval(scrambleIntervalId);
-      if (scrambleTimeoutId) clearTimeout(scrambleTimeoutId);
-    };
-  }, [die?.id, die?.sides, die?.delay, die?.rollDuration, finalValue]);
-
-  return (
-    <div className="damage-die__icon">
-      <span className="damage-die__shape" aria-hidden="true" />
-      <span className={`damage-die__value ${typeClass}`}>{displayValue}</span>
-    </div>
-  );
-}
+const formatDiceGroupSubtitle = (group) => {
+  const count = group.dice.length;
+  const parts = [`${count} × d${group.sides}`];
+  if (group.categoryLabel) {
+    parts.push(group.categoryLabel);
+  }
+  return parts.join(' • ');
+};
 
 function extractDiceExpression(description = '') {
   diceExpressionPattern.lastIndex = 0;
@@ -1010,126 +1047,74 @@ const sortedSpells = useMemo(() => {
 const [damageValue, setDamageValue] = useState(0);
 const [damageLog, setDamageLog] = useState([]);
 const [showLog, setShowLog] = useState(false);
-const [activeDice, setActiveDice] = useState([]);
+const [diceGroups, setDiceGroups] = useState([]);
+const [diceNotation, setDiceNotation] = useState('');
 const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
-const diceAreaRef = useRef(null);
-
-const getDieShapeClass = (sides) => {
-  if (!Number.isFinite(sides)) {
-    return 'damage-die--generic';
-  }
-
-  const normalized = Math.max(0, Math.round(sides));
-
-  switch (normalized) {
-    case 4:
-      return 'damage-die--d4';
-    case 6:
-      return 'damage-die--d6';
-    case 8:
-      return 'damage-die--d8';
-    case 10:
-    case 100:
-      return 'damage-die--d10';
-    case 12:
-      return 'damage-die--d12';
-    case 20:
-      return 'damage-die--d20';
-    default:
-      return 'damage-die--generic';
-  }
-};
+const diceBoxControllerRef = useRef(null);
+const [diceBoxStatus, setDiceBoxStatus] = useState('idle');
 
 const triggerDiceAnimation = useCallback((diceDetails = []) => {
-  if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
-    setActiveDice([]);
+  const controller = diceBoxControllerRef.current;
+  let sanitizedDetails = sanitizeDiceDetails(diceDetails);
+  let used3d = false;
+
+  if (controller && typeof controller.rollDice === 'function') {
+    const result = controller.rollDice(diceDetails);
+    if (result && Array.isArray(result.sanitized)) {
+      sanitizedDetails = result.sanitized;
+    }
+    used3d = !!result?.used3d;
+  }
+
+  if (used3d) {
+    setDiceGroups([]);
+    setDiceNotation('');
     return;
   }
 
-  const baseTime = Date.now();
-  const areaWidth = Math.max(
-    1,
-    diceAreaRef.current?.offsetWidth ||
-      diceAreaRef.current?.parentElement?.offsetWidth ||
-      520
-  );
+  if (!Array.isArray(sanitizedDetails) || sanitizedDetails.length === 0) {
+    setDiceGroups([]);
+    setDiceNotation('');
+    return;
+  }
 
-  const diceCount = diceDetails.length;
-  const usableWidthPx = (() => {
-    if (diceCount <= 1) {
-      return Math.min(
-        areaWidth * DAMAGE_AREA_MAX_RATIO,
-        areaWidth * DAMAGE_AREA_BASE_RATIO
-      );
+  const timestamp = Date.now();
+  const normalizedDice = sanitizedDetails.map((detail, index) => ({
+    id: `${timestamp}-${index}`,
+    sides: Math.max(0, Number(detail?.sides) || 0),
+    value:
+      typeof detail?.value === 'number'
+        ? detail.value
+        : Number(detail?.value) || 0,
+    type: typeof detail?.type === 'string' ? detail.type : '',
+    category: typeof detail?.category === 'string' ? detail.category : 'base',
+  }));
+
+  const groupMap = new Map();
+  normalizedDice.forEach((die) => {
+    const key = `${die.sides}|${die.type}|${die.category}`;
+    if (!groupMap.has(key)) {
+      const categoryLabel = getDiceCategoryLabel(die.category);
+      groupMap.set(key, {
+        id: `${key}-${timestamp}`,
+        typeLabel: die.type ? die.type : 'Damage',
+        categoryLabel,
+        category: die.category,
+        sides: die.sides,
+        dice: [],
+      });
     }
-    const desiredClusterWidth = Math.max(
-      areaWidth * DAMAGE_AREA_BASE_RATIO,
-      (diceCount - 1) * DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR
-    );
-    return Math.min(areaWidth * DAMAGE_AREA_MAX_RATIO, desiredClusterWidth);
-  })();
-
-  const slotWidthPx =
-    diceCount > 1 ? usableWidthPx / (diceCount - 1) : usableWidthPx || areaWidth;
-  const minGapPx =
-    diceCount > 1
-      ? Math.min(DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR, slotWidthPx)
-      : 0;
-  const startPx = (areaWidth - usableWidthPx) / 2;
-  const maxPx = startPx + usableWidthPx;
-  const jitterPx = Math.min(slotWidthPx * 0.25, DAMAGE_DIE_WIDTH_PX * 0.4);
-  let previousLeftPx = null;
-
-  const nextDice = diceDetails.map((detail, index) => {
-    const fraction = diceCount === 1 ? 0.5 : index / (diceCount - 1 || 1);
-    const baseLeftPx = startPx + fraction * usableWidthPx;
-    const rawOffsetPx = jitterPx
-      ? (Math.random() - 0.5) * 2 * jitterPx
-      : 0;
-    const remainingDice = diceCount - index - 1;
-    const minAllowedPx = startPx + index * minGapPx;
-    const maxAllowedPx = maxPx - remainingDice * minGapPx;
-
-    let leftPx = baseLeftPx + rawOffsetPx;
-    if (Number.isFinite(minAllowedPx)) {
-      leftPx = Math.max(leftPx, minAllowedPx);
-    }
-    if (Number.isFinite(maxAllowedPx)) {
-      leftPx = Math.min(leftPx, maxAllowedPx);
-    }
-    if (previousLeftPx !== null && leftPx - previousLeftPx < minGapPx) {
-      leftPx = Math.min(maxAllowedPx, previousLeftPx + minGapPx);
-    }
-
-    previousLeftPx = leftPx;
-    const left = (leftPx / areaWidth) * 100;
-    const dropDistance = 60 + Math.random() * 70;
-    const delay = index * 0.05;
-    const rollDuration = 0.85 + Math.random() * 0.45;
-    const spinEnd = (Math.random() - 0.5) * 60;
-    const spinStart = spinEnd + (Math.random() - 0.5) * 200;
-    const spinMid = (spinStart + spinEnd) / 2;
-    return {
-      id: `${baseTime}-${index}`,
-      value:
-        typeof detail?.value === 'number'
-          ? detail.value
-          : Number(detail?.value) || 0,
-      sides: detail?.sides || 0,
-      type: detail?.type || '',
-      category: detail?.category || 'base',
-      left,
-      dropDistance,
-      delay,
-      rollDuration,
-      spinStart,
-      spinMid,
-      spinEnd,
-    };
+    groupMap.get(key).dice.push(die);
   });
 
-  setActiveDice(nextDice);
-}, [diceAreaRef]);
+  const groups = Array.from(groupMap.values()).map((group) => ({
+    ...group,
+    subtitle: formatDiceGroupSubtitle(group),
+  }));
+
+  setDiceGroups(groups);
+  setDiceNotation(buildDiceNotation(normalizedDice));
+}, []);
 
 const updateDamageValueWithAnimation = (
   newValue,
@@ -1202,6 +1187,9 @@ useEffect(() => {
 }, []);
 
 const passDisabled = !canPassTurn || isPassTurnInProgress;
+const diceAreaClassName = `damage-roller__dice-area ${
+  diceBoxStatus === 'ready' ? 'damage-roller__dice-area--3d-ready' : ''
+}`.trim();
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div
@@ -1291,36 +1279,70 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
             isFumble ? 'critical-failure' : ''
           }`}
         >
-          <div
-            className="damage-roller__dice-area"
-            aria-hidden="true"
-            ref={diceAreaRef}
-          >
-            {activeDice.map((die) => {
-              const normalizedType = normalizeDamageTypeForClass(die.type);
-              const typeClass = normalizedType ? `damage-${normalizedType}` : '';
-              const categoryClass = die.category
-                ? `damage-die--${die.category}`
-                : '';
-              const shapeClass = getDieShapeClass(die.sides);
-              return (
-                <div
-                  key={die.id}
-                  className={`damage-die ${shapeClass} ${categoryClass}`}
-                  style={{
-                    left: `${die.left}%`,
-                    '--drop-delay': `${die.delay}s`,
-                    '--drop-distance': `${die.dropDistance}px`,
-                    '--drop-duration': `${die.rollDuration}s`,
-                    '--drop-spin-start': `${die.spinStart}deg`,
-                    '--drop-spin-mid': `${die.spinMid}deg`,
-                    '--drop-spin-end': `${die.spinEnd}deg`,
-                  }}
-                >
-                  <DamageDieMesh die={die} typeClass={typeClass} />
+          <div className={diceAreaClassName} aria-hidden="true">
+            <DamageDiceBox
+              ref={diceBoxControllerRef}
+              color={form?.diceColor}
+              onStateChange={setDiceBoxStatus}
+            />
+            {diceGroups.length > 0 && (
+              <div
+                className="damage-roller__dice-fallback"
+                role="list"
+                aria-live="polite"
+                aria-label={
+                  diceNotation
+                    ? `RPG Dice Roller results: ${diceNotation}`
+                    : 'RPG Dice Roller results'
+                }
+              >
+                {diceNotation && (
+                  <div className="damage-roller__dice-notation">
+                    <span className="damage-roller__dice-notation-label">Roll</span>
+                    <span className="damage-roller__dice-notation-value">
+                      {diceNotation}
+                    </span>
+                  </div>
+                )}
+                <div className="damage-roller__dice-groups">
+                  {diceGroups.map((group) => (
+                    <div
+                      key={group.id}
+                      className={`damage-die-group damage-die-group--${group.category}`}
+                      role="listitem"
+                    >
+                      <div className="damage-die-group__header">
+                        <span className="damage-die-group__title">{group.typeLabel}</span>
+                        <span className="damage-die-group__subtitle">{group.subtitle}</span>
+                      </div>
+                      <div className="damage-die-group__dice" role="list">
+                        {group.dice.map((die) => {
+                          const sides = Math.max(0, Number(die.sides) || 0);
+                          const displaySides = sides >= 2 ? sides : '?';
+                          const normalizedType = normalizeDamageTypeForClass(die.type);
+                          const chipClasses = [
+                            'damage-die-chip',
+                            `damage-die-chip--category-${group.category || 'base'}`,
+                          ];
+                          if (sides >= 2) {
+                            chipClasses.push(`damage-die-chip--d${Math.round(sides)}`);
+                          }
+                          if (normalizedType) {
+                            chipClasses.push(`damage-die-chip--${normalizedType}`);
+                          }
+                          return (
+                            <span key={die.id} className={chipClasses.join(' ')}>
+                              <span className="damage-die-chip__sides">d{displaySides}</span>
+                              <span className="damage-die-chip__value">{die.value}</span>
+                            </span>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              );
-            })}
+              </div>
+            )}
           </div>
           <div className="damage-roller__total">
             <span className="damage-roller__total-label">Total</span>


### PR DESCRIPTION
## Summary
- replace the falling dice overlay with grouped RPG dice results and notation rendered from the roll metadata
- expose the DiceBox notation helper for reuse and keep the 3D canvas ready without forcing an offscreen render
- style the damage roller chips for clarity and add a Jest mock for @dice-roller/rpg-dice-roller so tests can import it

## Testing
- npm test --prefix client -- --watchAll=false *(fails: existing act() warnings and CampaignMapBoard size assertions in the Zombies test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68f2658c2fec832ebe684a8749db5352