### PR TITLE
Integrate DiceBox-based 3D damage roller

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1847,6 +1847,32 @@ $rotateX: -$angle;
   overflow: visible;
   pointer-events: none;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.damage-roller__dice-box {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.damage-roller__dice-box canvas {
+  width: 100% !important;
+  height: 100% !important;
+  pointer-events: none;
+}
+
+.damage-roller__dice-fallback {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .damage-roller__total {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -15,6 +15,7 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
+import DiceBoxCanvas from '../common/DiceBoxCanvas';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -1013,6 +1014,12 @@ const [showLog, setShowLog] = useState(false);
 const [activeDice, setActiveDice] = useState([]);
 const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
 const diceAreaRef = useRef(null);
+const diceBoxControllerRef = useRef(null);
+const [isDiceBoxReady, setIsDiceBoxReady] = useState(false);
+
+const handleDiceBoxReadyChange = useCallback((ready) => {
+  setIsDiceBoxReady(!!ready);
+}, []);
 
 const getDieShapeClass = (sides) => {
   if (!Number.isFinite(sides)) {
@@ -1040,96 +1047,126 @@ const getDieShapeClass = (sides) => {
   }
 };
 
-const triggerDiceAnimation = useCallback((diceDetails = []) => {
-  if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
-    setActiveDice([]);
-    return;
-  }
+const triggerDiceAnimation = useCallback(
+  (diceDetails = [], options = {}) => {
+    const diceBox = diceBoxControllerRef.current;
+    let used3dAnimation = false;
 
-  const baseTime = Date.now();
-  const areaWidth = Math.max(
-    1,
-    diceAreaRef.current?.offsetWidth ||
-      diceAreaRef.current?.parentElement?.offsetWidth ||
-      520
-  );
-
-  const diceCount = diceDetails.length;
-  const usableWidthPx = (() => {
-    if (diceCount <= 1) {
-      return Math.min(
-        areaWidth * DAMAGE_AREA_MAX_RATIO,
-        areaWidth * DAMAGE_AREA_BASE_RATIO
-      );
+    if (
+      isDiceBoxReady &&
+      diceBox &&
+      typeof diceBox.roll === 'function' &&
+      Array.isArray(diceDetails) &&
+      diceDetails.length > 0
+    ) {
+      try {
+        const rollResult = diceBox.roll(diceDetails, options);
+        used3dAnimation = rollResult !== false;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('DiceBox roll invocation failed', error);
+        used3dAnimation = false;
+      }
     }
-    const desiredClusterWidth = Math.max(
-      areaWidth * DAMAGE_AREA_BASE_RATIO,
-      (diceCount - 1) * DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR
+
+    if (used3dAnimation) {
+      setActiveDice([]);
+      return;
+    }
+
+    if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
+      setActiveDice([]);
+      return;
+    }
+
+    const baseTime = Date.now();
+    const areaWidth = Math.max(
+      1,
+      diceAreaRef.current?.offsetWidth ||
+        diceAreaRef.current?.parentElement?.offsetWidth ||
+        520
     );
-    return Math.min(areaWidth * DAMAGE_AREA_MAX_RATIO, desiredClusterWidth);
-  })();
 
-  const slotWidthPx =
-    diceCount > 1 ? usableWidthPx / (diceCount - 1) : usableWidthPx || areaWidth;
-  const minGapPx =
-    diceCount > 1
-      ? Math.min(DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR, slotWidthPx)
-      : 0;
-  const startPx = (areaWidth - usableWidthPx) / 2;
-  const maxPx = startPx + usableWidthPx;
-  const jitterPx = Math.min(slotWidthPx * 0.25, DAMAGE_DIE_WIDTH_PX * 0.4);
-  let previousLeftPx = null;
+    const diceCount = diceDetails.length;
+    const usableWidthPx = (() => {
+      if (diceCount <= 1) {
+        return Math.min(
+          areaWidth * DAMAGE_AREA_MAX_RATIO,
+          areaWidth * DAMAGE_AREA_BASE_RATIO
+        );
+      }
+      const desiredClusterWidth = Math.max(
+        areaWidth * DAMAGE_AREA_BASE_RATIO,
+        (diceCount - 1) * DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR
+      );
+      return Math.min(areaWidth * DAMAGE_AREA_MAX_RATIO, desiredClusterWidth);
+    })();
 
-  const nextDice = diceDetails.map((detail, index) => {
-    const fraction = diceCount === 1 ? 0.5 : index / (diceCount - 1 || 1);
-    const baseLeftPx = startPx + fraction * usableWidthPx;
-    const rawOffsetPx = jitterPx
-      ? (Math.random() - 0.5) * 2 * jitterPx
-      : 0;
-    const remainingDice = diceCount - index - 1;
-    const minAllowedPx = startPx + index * minGapPx;
-    const maxAllowedPx = maxPx - remainingDice * minGapPx;
+    const slotWidthPx =
+      diceCount > 1
+        ? usableWidthPx / (diceCount - 1)
+        : usableWidthPx || areaWidth;
+    const minGapPx =
+      diceCount > 1
+        ? Math.min(DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR, slotWidthPx)
+        : 0;
+    const startPx = (areaWidth - usableWidthPx) / 2;
+    const maxPx = startPx + usableWidthPx;
+    const jitterPx = Math.min(slotWidthPx * 0.25, DAMAGE_DIE_WIDTH_PX * 0.4);
+    let previousLeftPx = null;
 
-    let leftPx = baseLeftPx + rawOffsetPx;
-    if (Number.isFinite(minAllowedPx)) {
-      leftPx = Math.max(leftPx, minAllowedPx);
-    }
-    if (Number.isFinite(maxAllowedPx)) {
-      leftPx = Math.min(leftPx, maxAllowedPx);
-    }
-    if (previousLeftPx !== null && leftPx - previousLeftPx < minGapPx) {
-      leftPx = Math.min(maxAllowedPx, previousLeftPx + minGapPx);
-    }
+    const nextDice = diceDetails.map((detail, index) => {
+      const fraction = diceCount === 1 ? 0.5 : index / (diceCount - 1 || 1);
+      const baseLeftPx = startPx + fraction * usableWidthPx;
+      const rawOffsetPx = jitterPx
+        ? (Math.random() - 0.5) * 2 * jitterPx
+        : 0;
+      const remainingDice = diceCount - index - 1;
+      const minAllowedPx = startPx + index * minGapPx;
+      const maxAllowedPx = maxPx - remainingDice * minGapPx;
 
-    previousLeftPx = leftPx;
-    const left = (leftPx / areaWidth) * 100;
-    const dropDistance = 60 + Math.random() * 70;
-    const delay = index * 0.05;
-    const rollDuration = 0.85 + Math.random() * 0.45;
-    const spinEnd = (Math.random() - 0.5) * 60;
-    const spinStart = spinEnd + (Math.random() - 0.5) * 200;
-    const spinMid = (spinStart + spinEnd) / 2;
-    return {
-      id: `${baseTime}-${index}`,
-      value:
-        typeof detail?.value === 'number'
-          ? detail.value
-          : Number(detail?.value) || 0,
-      sides: detail?.sides || 0,
-      type: detail?.type || '',
-      category: detail?.category || 'base',
-      left,
-      dropDistance,
-      delay,
-      rollDuration,
-      spinStart,
-      spinMid,
-      spinEnd,
-    };
-  });
+      let leftPx = baseLeftPx + rawOffsetPx;
+      if (Number.isFinite(minAllowedPx)) {
+        leftPx = Math.max(leftPx, minAllowedPx);
+      }
+      if (Number.isFinite(maxAllowedPx)) {
+        leftPx = Math.min(leftPx, maxAllowedPx);
+      }
+      if (previousLeftPx !== null && leftPx - previousLeftPx < minGapPx) {
+        leftPx = Math.min(maxAllowedPx, previousLeftPx + minGapPx);
+      }
 
-  setActiveDice(nextDice);
-}, [diceAreaRef]);
+      previousLeftPx = leftPx;
+      const left = (leftPx / areaWidth) * 100;
+      const dropDistance = 60 + Math.random() * 70;
+      const delay = index * 0.05;
+      const rollDuration = 0.85 + Math.random() * 0.45;
+      const spinEnd = (Math.random() - 0.5) * 60;
+      const spinStart = spinEnd + (Math.random() - 0.5) * 200;
+      const spinMid = (spinStart + spinEnd) / 2;
+      return {
+        id: `${baseTime}-${index}`,
+        value:
+          typeof detail?.value === 'number'
+            ? detail.value
+            : Number(detail?.value) || 0,
+        sides: detail?.sides || 0,
+        type: detail?.type || '',
+        category: detail?.category || 'base',
+        left,
+        dropDistance,
+        delay,
+        rollDuration,
+        spinStart,
+        spinMid,
+        spinEnd,
+      };
+    });
+
+    setActiveDice(nextDice);
+  },
+  [diceAreaRef, isDiceBoxReady]
+);
 
 const updateDamageValueWithAnimation = (
   newValue,
@@ -1140,7 +1177,13 @@ const updateDamageValueWithAnimation = (
   setPulseClass('');
   setDamageValue(newValue);
   const details = Array.isArray(extra?.diceRolls) ? extra.diceRolls : [];
-  triggerDiceAnimation(details);
+  triggerDiceAnimation(details, {
+    expression: extra.expression,
+    diceColor: form?.diceColor,
+    rollValues: extra.rollValues,
+    modifierValues: extra.modifierValues,
+    total: newValue,
+  });
   setLastRollTimestamp(Date.now());
   manualCriticalRef.current = false;
   if (newValue !== undefined) {
@@ -1296,31 +1339,40 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
             aria-hidden="true"
             ref={diceAreaRef}
           >
-            {activeDice.map((die) => {
-              const normalizedType = normalizeDamageTypeForClass(die.type);
-              const typeClass = normalizedType ? `damage-${normalizedType}` : '';
-              const categoryClass = die.category
-                ? `damage-die--${die.category}`
-                : '';
-              const shapeClass = getDieShapeClass(die.sides);
-              return (
-                <div
-                  key={die.id}
-                  className={`damage-die ${shapeClass} ${categoryClass}`}
-                  style={{
-                    left: `${die.left}%`,
-                    '--drop-delay': `${die.delay}s`,
-                    '--drop-distance': `${die.dropDistance}px`,
-                    '--drop-duration': `${die.rollDuration}s`,
-                    '--drop-spin-start': `${die.spinStart}deg`,
-                    '--drop-spin-mid': `${die.spinMid}deg`,
-                    '--drop-spin-end': `${die.spinEnd}deg`,
-                  }}
-                >
-                  <DamageDieMesh die={die} typeClass={typeClass} />
-                </div>
-              );
-            })}
+            <DiceBoxCanvas
+              ref={diceBoxControllerRef}
+              diceColor={form?.diceColor}
+              onReadyChange={handleDiceBoxReadyChange}
+            />
+            <div className="damage-roller__dice-fallback">
+              {activeDice.map((die) => {
+                const normalizedType = normalizeDamageTypeForClass(die.type);
+                const typeClass = normalizedType
+                  ? `damage-${normalizedType}`
+                  : '';
+                const categoryClass = die.category
+                  ? `damage-die--${die.category}`
+                  : '';
+                const shapeClass = getDieShapeClass(die.sides);
+                return (
+                  <div
+                    key={die.id}
+                    className={`damage-die ${shapeClass} ${categoryClass}`}
+                    style={{
+                      left: `${die.left}%`,
+                      '--drop-delay': `${die.delay}s`,
+                      '--drop-distance': `${die.dropDistance}px`,
+                      '--drop-duration': `${die.rollDuration}s`,
+                      '--drop-spin-start': `${die.spinStart}deg`,
+                      '--drop-spin-mid': `${die.spinMid}deg`,
+                      '--drop-spin-end': `${die.spinEnd}deg`,
+                    }}
+                  >
+                    <DamageDieMesh die={die} typeClass={typeClass} />
+                  </div>
+                );
+              })}
+            </div>
           </div>
           <div className="damage-roller__total">
             <span className="damage-roller__total-label">Total</span>

--- a/client/src/components/Zombies/common/DiceBoxCanvas.js
+++ b/client/src/components/Zombies/common/DiceBoxCanvas.js
@@ -1,0 +1,246 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+const DICE_BOX_ASSET_PATH =
+  'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1/dist/assets/';
+const DEFAULT_DICE_COLOR = '#3366ff';
+
+const diceBoxModuleCache = {
+  promise: null,
+};
+
+const normalizeColor = (value) => {
+  if (typeof value !== 'string') {
+    return DEFAULT_DICE_COLOR;
+  }
+
+  const trimmed = value.trim();
+  if (/^#([0-9a-fA-F]{6})$/.test(trimmed)) {
+    return `#${trimmed.slice(1).toLowerCase()}`;
+  }
+
+  return DEFAULT_DICE_COLOR;
+};
+
+const buildDiceNotation = (diceDetails) => {
+  if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
+    return '';
+  }
+
+  const groups = new Map();
+  diceDetails.forEach((die) => {
+    const sides = Number.isFinite(die?.sides)
+      ? Math.max(0, Math.round(die.sides))
+      : 0;
+    if (sides > 0) {
+      groups.set(sides, (groups.get(sides) || 0) + 1);
+    }
+  });
+
+  if (!groups.size) {
+    return '';
+  }
+
+  return Array.from(groups.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([sides, count]) => `${count}d${sides}`)
+    .join(' + ');
+};
+
+const loadDiceBoxModule = async () => {
+  if (diceBoxModuleCache.promise) {
+    return diceBoxModuleCache.promise;
+  }
+
+  diceBoxModuleCache.promise = import(
+    /* webpackIgnore: true */ 'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1/dist/dice-box.esm.min.js'
+  );
+
+  return diceBoxModuleCache.promise;
+};
+
+const DiceBoxCanvas = forwardRef(
+  (
+    {
+      className = '',
+      style = {},
+      diceColor,
+      onReadyChange = () => {},
+      assetPath = DICE_BOX_ASSET_PATH,
+    },
+    ref
+  ) => {
+    const containerRef = useRef(null);
+    const diceBoxRef = useRef(null);
+    const [isReady, setIsReady] = useState(false);
+
+    const normalizedColor = useMemo(
+      () => normalizeColor(diceColor),
+      [diceColor]
+    );
+
+    useEffect(() => {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return undefined;
+      }
+
+      if (!('WebGLRenderingContext' in window)) {
+        onReadyChange(false);
+        return undefined;
+      }
+
+      let cancelled = false;
+
+      const init = async () => {
+        try {
+          const module = await loadDiceBoxModule();
+          if (cancelled) {
+            return;
+          }
+
+          const DiceBoxCtor = module?.DiceBox || module?.default;
+          if (typeof DiceBoxCtor !== 'function') {
+            throw new Error('DiceBox constructor not available');
+          }
+
+          const target = containerRef.current;
+          if (!target) {
+            return;
+          }
+
+          const diceBoxInstance = new DiceBoxCtor(target, {
+            assetPath,
+            theme: 'default',
+            scale: 9,
+            throwForce: 6,
+            enableShadows: true,
+            gravity: 9.81,
+          });
+
+          diceBoxRef.current = diceBoxInstance;
+
+          if (typeof diceBoxInstance.init === 'function') {
+            await diceBoxInstance.init();
+          }
+
+          if (cancelled) {
+            diceBoxInstance.destroy?.();
+            diceBoxRef.current = null;
+            return;
+          }
+
+          setIsReady(true);
+          onReadyChange(true);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to initialize DiceBox', error);
+          onReadyChange(false);
+        }
+      };
+
+      init();
+
+      return () => {
+        cancelled = true;
+        setIsReady(false);
+        onReadyChange(false);
+        if (diceBoxRef.current) {
+          diceBoxRef.current.destroy?.();
+          diceBoxRef.current = null;
+        }
+      };
+    }, [assetPath, onReadyChange]);
+
+    useEffect(() => {
+      if (!containerRef.current) {
+        return;
+      }
+      containerRef.current.style.setProperty(
+        '--damage-dice-primary-color',
+        normalizedColor
+      );
+    }, [normalizedColor]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        roll(diceDetails = [], options = {}) {
+          if (!diceBoxRef.current || !isReady) {
+            return false;
+          }
+
+          const diceBoxInstance = diceBoxRef.current;
+          const expression =
+            (typeof options.expression === 'string'
+              ? options.expression.trim()
+              : '') || buildDiceNotation(diceDetails);
+
+          if (!expression) {
+            return false;
+          }
+
+          try {
+            const colorOverride = normalizeColor(
+              options.diceColor || normalizedColor
+            );
+
+            if (
+              typeof diceBoxInstance.updateColorset === 'function' &&
+              colorOverride
+            ) {
+              diceBoxInstance.updateColorset({
+                dice: colorOverride,
+                label: '#ffffff',
+                outline: '#000000',
+              });
+            }
+
+            const result = diceBoxInstance.roll(expression);
+            if (result && typeof result.then === 'function') {
+              result.catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error('DiceBox roll promise rejected', error);
+              });
+            }
+            return true;
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('DiceBox roll failed', error);
+            return false;
+          }
+        },
+        isReady() {
+          return isReady;
+        },
+        clear() {
+          if (
+            diceBoxRef.current &&
+            typeof diceBoxRef.current.clear === 'function'
+          ) {
+            diceBoxRef.current.clear();
+          }
+        },
+      }),
+      [isReady, normalizedColor]
+    );
+
+    return (
+      <div
+        ref={containerRef}
+        className={`damage-roller__dice-box ${className}`.trim()}
+        style={style}
+        aria-hidden="true"
+      />
+    );
+  }
+);
+
+DiceBoxCanvas.displayName = 'DiceBoxCanvas';
+
+export default DiceBoxCanvas;


### PR DESCRIPTION
## Summary
- add a DiceBoxCanvas wrapper that lazily loads the 3D DiceBox module and exposes a roll API for damage animations
- update the player turn damage roller to invoke the DiceBox animation while falling back to the existing 2D dice when needed
- tweak damage roller styling so the DiceBox canvas and legacy dice can share the same layout without interfering with input

## Testing
- CI=true npm --prefix client test -- --watch=false *(fails: CampaignMapBoard pointer interactions, ZombiesDM AI generation, WeaponList, ItemList suites)*

------
https://chatgpt.com/codex/tasks/task_e_68f280556418832eadf2170543e7b605