### PR TITLE
Hide fallback die once DiceBox loads

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1755,6 +1755,70 @@ $rotateX: -$angle;
   margin: auto 0;
 }
 
+.attack-roll-controls__die .content {
+  position: relative;
+}
+
+.attack-roll-controls__dice-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.attack-roll-controls__dice-box {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.attack-roll-controls__dice-box canvas {
+  width: 100% !important;
+  height: 100% !important;
+  pointer-events: none;
+}
+
+.attack-roll-controls__sparkles {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.attack-roll-controls__fallback {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.attack-roll-controls__fallback--hidden {
+  display: none;
+}
+
+.attack-roll-controls__trigger {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.attack-roll-controls__trigger:focus-visible {
+  outline: 2px solid var(--bs-primary, #0d6efd);
+  border-radius: 50%;
+}
+
 .attack-roll-controls__spacer {
   height: var(--attack-roll-footer-height);
   flex-shrink: 0;

--- a/client/src/components/Zombies/common/D20RollerModal.js
+++ b/client/src/components/Zombies/common/D20RollerModal.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Modal } from 'react-bootstrap';
+import DiceBoxCanvas from './DiceBoxCanvas';
 
 const DEFAULT_DICE_COLOR = '#3366ff';
 const SPARKLE_DURATION_MS = 2000;
@@ -37,6 +38,8 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
   const sparkleTimeoutRef = useRef(null);
   const sparkleRepeatTimeoutRef = useRef(null);
   const previousColorRef = useRef(null);
+  const diceBoxControllerRef = useRef(null);
+  const [isDiceBoxReady, setIsDiceBoxReady] = useState(false);
 
   const shouldApplyColor = renderInline || show;
 
@@ -66,7 +69,11 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
 
   const getRandomFace = () => Math.floor(Math.random() * DICE_SIDES) + INITIAL_SIDE;
 
-  const triggerSparkles = (face, isRepeat = false) => {
+  const handleDiceBoxReadyChange = useCallback((ready) => {
+    setIsDiceBoxReady(!!ready);
+  }, []);
+
+  const triggerSparkles = useCallback((face, isRepeat = false) => {
     clearTimeout(sparkleTimeoutRef.current);
 
     if (face === 20) {
@@ -90,25 +97,116 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
         SPARKLE_REPEAT_DELAY_MS
       );
     }
-  };
+  }, []);
 
-  const rollTo = (face) => {
-    clearTimeout(rollTimeoutRef.current);
-    setActiveFace(face);
-    setRolling(false);
+  const rollTo = useCallback(
+    (face) => {
+      clearTimeout(rollTimeoutRef.current);
+      setActiveFace(face);
+      setRolling(false);
 
-    if (face === 20 || face === 1) {
-      triggerSparkles(face);
-    } else {
-      clearTimeout(sparkleTimeoutRef.current);
-      clearTimeout(sparkleRepeatTimeoutRef.current);
-      setShowCriticalSparkles(false);
-      setShowFumbleSparkles(false);
+      if (face === 20 || face === 1) {
+        triggerSparkles(face);
+      } else {
+        clearTimeout(sparkleTimeoutRef.current);
+        clearTimeout(sparkleRepeatTimeoutRef.current);
+        setShowCriticalSparkles(false);
+        setShowFumbleSparkles(false);
+      }
+    },
+    [triggerSparkles]
+  );
+
+  const extractFaceFromResult = useCallback((payload) => {
+    if (!payload) {
+      return null;
     }
-  };
+
+    const candidates = [];
+
+    if (Array.isArray(payload)) {
+      candidates.push(...payload);
+    } else {
+      candidates.push(payload);
+      if (Array.isArray(payload.dice)) {
+        candidates.push(...payload.dice);
+      }
+      if (Array.isArray(payload.rolls)) {
+        candidates.push(...payload.rolls);
+      }
+      if (Array.isArray(payload.results)) {
+        candidates.push(...payload.results);
+      }
+      if (Array.isArray(payload.values)) {
+        candidates.push(...payload.values);
+      }
+      if (Array.isArray(payload.rolledDice)) {
+        candidates.push(...payload.rolledDice);
+      }
+    }
+
+    for (const candidate of candidates) {
+      if (!candidate) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      const value = candidate.value ?? candidate.total ?? candidate.result ?? candidate.roll ?? candidate.face;
+      const numeric = Number(value);
+      if (Number.isFinite(numeric) && numeric >= INITIAL_SIDE && numeric <= DICE_SIDES) {
+        return numeric;
+      }
+    }
+
+    const fallbackValue = Number(
+      payload.value ?? payload.total ?? payload.result ?? payload.roll ?? payload.face
+    );
+    return Number.isFinite(fallbackValue) ? fallbackValue : null;
+  }, []);
+
+  const handleDiceBoxRollComplete = useCallback(
+    (payload) => {
+      const face = extractFaceFromResult(payload);
+      if (face !== null) {
+        rollTo(face);
+      }
+    },
+    [extractFaceFromResult, rollTo]
+  );
+
+  const rollWithDiceBox = useCallback(() => {
+    const diceBox = diceBoxControllerRef.current;
+    if (!isDiceBoxReady || !diceBox || typeof diceBox.roll !== 'function') {
+      return false;
+    }
+
+    try {
+      const result = diceBox.roll(
+        [
+          {
+            id: 'd20',
+            sides: DICE_SIDES,
+          },
+        ],
+        { expression: '1d20' }
+      );
+
+      return result !== false;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('DiceBox roll invocation failed', error);
+      return false;
+    }
+  }, [isDiceBoxReady]);
 
   const handleRandomizeClick = (event) => {
-    event.preventDefault();
+    event?.preventDefault?.();
+    const usedDiceBox = rollWithDiceBox();
+    if (usedDiceBox) {
+      setRolling(true);
+      return;
+    }
+
     setRolling(true);
     clearTimeout(rollTimeoutRef.current);
 
@@ -133,17 +231,38 @@ const D20RollerModal = ({ show = false, onHide = () => {}, diceColor, renderInli
   const dieContent = (
     <div className="attack-roll-controls__die">
       <div className="content">
-        {showCriticalSparkles && <div className="sparkle"></div>}
-        {showFumbleSparkles && <div className="sparkle1"></div>}
+        <div className="attack-roll-controls__dice-layer" aria-hidden="true">
+          <DiceBoxCanvas
+            ref={diceBoxControllerRef}
+            diceColor={diceColor}
+            onReadyChange={handleDiceBoxReadyChange}
+            onRollComplete={handleDiceBoxRollComplete}
+            className="attack-roll-controls__dice-box"
+          />
+        </div>
+        <div className="attack-roll-controls__sparkles" aria-hidden="true">
+          {showCriticalSparkles && <div className="sparkle"></div>}
+          {showFumbleSparkles && <div className="sparkle1"></div>}
+        </div>
         <div
-          role="button"
+          className={`attack-roll-controls__fallback ${
+            isDiceBoxReady ? 'attack-roll-controls__fallback--hidden' : ''
+          }`}
+          aria-hidden={isDiceBoxReady}
+        >
+          <div
+            className={`die ${rolling ? 'rolling' : ''}`}
+            data-face={activeFace}
+          >
+            {faceElements}
+          </div>
+        </div>
+        <button
+          type="button"
           aria-label="Roll a d20"
           onClick={handleRandomizeClick}
-          className={`die ${rolling ? 'rolling' : ''}`}
-          data-face={activeFace}
-        >
-          {faceElements}
-        </div>
+          className="attack-roll-controls__trigger"
+        ></button>
       </div>
     </div>
   );

--- a/client/src/components/Zombies/common/DiceBoxCanvas.js
+++ b/client/src/components/Zombies/common/DiceBoxCanvas.js
@@ -91,6 +91,7 @@ const DiceBoxCanvas = forwardRef(
       diceColor,
       onReadyChange = () => {},
       assetPath = DICE_BOX_ASSET_PATH,
+      onRollComplete,
     },
     ref
   ) => {
@@ -249,11 +250,41 @@ const DiceBoxCanvas = forwardRef(
             }
 
             const result = diceBoxInstance.roll(expression);
-            if (result && typeof result.then === 'function') {
-              result.catch((error) => {
-                // eslint-disable-next-line no-console
-                console.error('DiceBox roll promise rejected', error);
+            const completionHandlers = [];
+
+            if (typeof onRollComplete === 'function') {
+              completionHandlers.push(onRollComplete);
+            }
+
+            if (typeof options.onRollComplete === 'function') {
+              completionHandlers.push(options.onRollComplete);
+            }
+
+            const invokeCompletionHandlers = (payload) => {
+              completionHandlers.forEach((handler) => {
+                try {
+                  handler(payload);
+                } catch (handlerError) {
+                  // eslint-disable-next-line no-console
+                  console.error('DiceBox roll completion handler failed', handlerError);
+                }
               });
+            };
+
+            if (result && typeof result.then === 'function') {
+              result
+                .then((payload) => {
+                  if (completionHandlers.length > 0) {
+                    invokeCompletionHandlers(payload);
+                  }
+                  return payload;
+                })
+                .catch((error) => {
+                  // eslint-disable-next-line no-console
+                  console.error('DiceBox roll promise rejected', error);
+                });
+            } else if (completionHandlers.length > 0) {
+              invokeCompletionHandlers(result);
             }
             return true;
           } catch (error) {
@@ -274,7 +305,7 @@ const DiceBoxCanvas = forwardRef(
           }
         },
       }),
-      [isReady, normalizedColor]
+      [isReady, normalizedColor, onRollComplete]
     );
 
     return (


### PR DESCRIPTION
## Summary
- add an invisible button overlay so DiceBox rolls can be triggered without showing the legacy die
- move sparkle effects into their own layer and hide the fallback die once DiceBox reports ready
- adjust stacking order and focus styles so the DiceBox canvas remains visible while keeping keyboard access

## Testing
- npm test -- --watchAll=false *(fails: existing ZombiesDM tests require act(...) wrappers and hit timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68f28c0bf860832e8c0e8f359be072e9