### PR TITLE
Allow configuring DiceBox module and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Example gif is listed below:
 
 Run `npm run build` to generate the production build of the client. The `npm start` script runs this build step before launching the server so deployments always serve the latest assets from `client/build`.
 
+### Dice Box assets
+
+The 3D dice roller can operate fully offline once you mirror the Dice Box module
+and textures. See [`docs/dice-box.md`](docs/dice-box.md) for instructions on
+downloading and configuring the assets locally.
+
 ## Database Indexes
 
 The server ensures critical MongoDB indexes at startup so common lookups stay performant:

--- a/client/src/components/Zombies/common/DiceBoxCanvas.js
+++ b/client/src/components/Zombies/common/DiceBoxCanvas.js
@@ -7,12 +7,108 @@ import React, {
   useState,
 } from 'react';
 
-const DICE_BOX_ASSET_PATH =
+const DEFAULT_DICE_BOX_MODULE_URL =
+  'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1/dist/dice-box.esm.min.js';
+const DEFAULT_DICE_BOX_ASSET_PATH =
   'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1/dist/assets/';
 const DEFAULT_DICE_COLOR = '#3366ff';
 
 const diceBoxModuleCache = {
   promise: null,
+};
+
+const readRuntimeString = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : '';
+};
+
+const sanitizeAssetPath = (value) => {
+  const runtimeValue = readRuntimeString(value);
+  if (!runtimeValue) {
+    return '';
+  }
+
+  return runtimeValue.endsWith('/') ? runtimeValue : `${runtimeValue}/`;
+};
+
+const resolveDefaultAssetPath = () => {
+  const envValue = sanitizeAssetPath(process.env.REACT_APP_DICE_BOX_ASSET_PATH);
+  if (envValue) {
+    return envValue;
+  }
+
+  if (typeof window !== 'undefined') {
+    const windowValue = sanitizeAssetPath(window.__DICE_BOX_ASSET_PATH__);
+    if (windowValue) {
+      return windowValue;
+    }
+  }
+
+  return DEFAULT_DICE_BOX_ASSET_PATH;
+};
+
+const resolveConfiguredModuleUrls = () => {
+  const urls = [];
+  const envValue = readRuntimeString(process.env.REACT_APP_DICE_BOX_MODULE_URL);
+  if (envValue) {
+    urls.push(envValue);
+  }
+
+  if (typeof window !== 'undefined') {
+    const windowValue = readRuntimeString(window.__DICE_BOX_MODULE_URL__);
+    if (windowValue) {
+      urls.push(windowValue);
+    }
+  }
+
+  return urls;
+};
+
+const resolveGlobalDiceBoxCtor = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const ctor = window.DiceBox || window.diceBox || null;
+  return typeof ctor === 'function' ? ctor : null;
+};
+
+const loadExternalModule = async (url) =>
+  import(/* webpackIgnore: true */ url);
+
+const loadDiceBoxModuleFromSources = async () => {
+  const globalCtor = resolveGlobalDiceBoxCtor();
+  if (globalCtor) {
+    return { DiceBox: globalCtor, default: globalCtor };
+  }
+
+  const urls = [
+    ...new Set([...resolveConfiguredModuleUrls(), DEFAULT_DICE_BOX_MODULE_URL]),
+  ];
+
+  for (const url of urls) {
+    try {
+      const module = await loadExternalModule(url);
+      if (module) {
+        return module;
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to load DiceBox module from ${url}`, error);
+    }
+  }
+
+  const attemptedSources = urls
+    .map((url) => `- ${url}`)
+    .join('\n');
+
+  throw new Error(
+    `Unable to load DiceBox module from the available sources.\nAttempted sources:\n${attemptedSources}`
+  );
 };
 
 const normalizeColor = (value) => {
@@ -76,8 +172,11 @@ const loadDiceBoxModule = async () => {
     return diceBoxModuleCache.promise;
   }
 
-  diceBoxModuleCache.promise = import(
-    /* webpackIgnore: true */ 'https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1/dist/dice-box.esm.min.js'
+  diceBoxModuleCache.promise = loadDiceBoxModuleFromSources().catch(
+    (error) => {
+      diceBoxModuleCache.promise = null;
+      throw error;
+    }
   );
 
   return diceBoxModuleCache.promise;
@@ -90,7 +189,7 @@ const DiceBoxCanvas = forwardRef(
       style = {},
       diceColor,
       onReadyChange = () => {},
-      assetPath = DICE_BOX_ASSET_PATH,
+      assetPath,
       onRollComplete,
     },
     ref
@@ -107,6 +206,15 @@ const DiceBoxCanvas = forwardRef(
       () => normalizeColor(diceColor),
       [diceColor]
     );
+
+    const resolvedAssetPath = useMemo(() => {
+      const sanitizedPropPath = sanitizeAssetPath(assetPath);
+      if (sanitizedPropPath) {
+        return sanitizedPropPath;
+      }
+
+      return resolveDefaultAssetPath();
+    }, [assetPath]);
 
     useEffect(() => {
       if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -139,7 +247,7 @@ const DiceBoxCanvas = forwardRef(
 
           const selector = `#${elementId}`;
           const baseOptions = {
-            assetPath,
+            assetPath: resolvedAssetPath,
             theme: 'default',
             scale: 9,
             throwForce: 6,
@@ -226,7 +334,7 @@ const DiceBoxCanvas = forwardRef(
           diceBoxRef.current = null;
         }
       };
-    }, [assetPath, elementId, onReadyChange]);
+    }, [elementId, onReadyChange, resolvedAssetPath]);
 
     useEffect(() => {
       if (!containerRef.current) {

--- a/docs/dice-box.md
+++ b/docs/dice-box.md
@@ -1,0 +1,42 @@
+# Dice Box Integration
+
+The 3D dice animations rely on the [`@3d-dice/dice-box`](https://www.npmjs.com/package/@3d-dice/dice-box)
+project. The application tries to load the ESM build from jsDelivr, but you can
+override both the module URL and asset path when hosting the files yourself.
+
+## Runtime configuration
+
+`DiceBoxCanvas` checks the following values (in order) when choosing a module
+source and asset path:
+
+1. `REACT_APP_DICE_BOX_MODULE_URL` / `REACT_APP_DICE_BOX_ASSET_PATH`
+   environment variables (evaluated at build time by CRA).
+2. `window.__DICE_BOX_MODULE_URL__` / `window.__DICE_BOX_ASSET_PATH__`
+   values assigned before React mounts.
+3. The jsDelivr defaults (`https://cdn.jsdelivr.net/npm/@3d-dice/dice-box@1/...`).
+
+If you load the UMD bundle manually (for example by adding
+`<script src="/assets/dice-box/dice-box.umd.min.js"></script>` to
+`public/index.html`), `DiceBoxCanvas` will detect the global `window.DiceBox`
+constructor and skip the dynamic import entirely.
+
+## Self-hosting helper script
+
+The `scripts` folder contains `download-dice-box-assets.mjs`, a small utility
+that downloads the published assets and places them under
+`client/public/assets/dice-box`. Run it whenever you bump the Dice Box version:
+
+```bash
+node scripts/download-dice-box-assets.mjs
+```
+
+After the assets are available locally you can point the runtime at them by
+setting
+
+```bash
+REACT_APP_DICE_BOX_MODULE_URL=/assets/dice-box/dice-box.esm.min.js
+REACT_APP_DICE_BOX_ASSET_PATH=/assets/dice-box/
+```
+
+The same values can be assigned through `window.__DICE_BOX_MODULE_URL__` and
+`window.__DICE_BOX_ASSET_PATH__` if you prefer not to rebuild the client.

--- a/scripts/download-dice-box-assets.mjs
+++ b/scripts/download-dice-box-assets.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const VERSION = process.env.DICE_BOX_VERSION || process.argv[2] || '1.0.5';
+const REGISTRY =
+  process.env.DICE_BOX_REGISTRY || process.argv[3] || 'https://registry.npmjs.org/';
+
+const CLIENT_PUBLIC_DIR = path.join(__dirname, '..', 'client', 'public');
+const TARGET_DIR = path.join(CLIENT_PUBLIC_DIR, 'assets', 'dice-box');
+
+const ensureDir = async (dirPath) => {
+  await mkdir(dirPath, { recursive: true });
+};
+
+const runCommand = (command, args, options = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, options);
+    let stdout = '';
+
+    if (child.stdout) {
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+    }
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+  });
+
+const copyDirectory = async (source, destination) => {
+  await ensureDir(destination);
+  const entries = await readdir(source, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const sourcePath = path.join(source, entry.name);
+      const destinationPath = path.join(destination, entry.name);
+      if (entry.isDirectory()) {
+        await copyDirectory(sourcePath, destinationPath);
+      } else if (entry.isFile()) {
+        const data = await readFile(sourcePath);
+        await ensureDir(path.dirname(destinationPath));
+        await writeFile(destinationPath, data);
+      }
+    })
+  );
+};
+
+const main = async () => {
+  await ensureDir(CLIENT_PUBLIC_DIR);
+  await rm(TARGET_DIR, { recursive: true, force: true });
+  await ensureDir(TARGET_DIR);
+
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'dice-box-'));
+  const packArgs = [
+    'pack',
+    `@3d-dice/dice-box@${VERSION}`,
+    '--registry',
+    REGISTRY.replace(/\/$/, ''),
+  ];
+
+  console.info(`Downloading @3d-dice/dice-box@${VERSION} from ${REGISTRY}`);
+  const tarballName = await runCommand('npm', packArgs, {
+    cwd: tempRoot,
+    stdio: ['ignore', 'pipe', 'inherit'],
+    shell: false,
+  });
+
+  const tarballPath = path.join(tempRoot, tarballName);
+  const extractDir = path.join(tempRoot, 'package');
+  await ensureDir(extractDir);
+
+  console.info(`Extracting ${tarballName}`);
+  await runCommand('tar', ['-xzf', tarballPath, '-C', extractDir, '--strip-components=1'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: false,
+  });
+
+  const distDir = path.join(extractDir, 'dist');
+  try {
+    await stat(distDir);
+  } catch (error) {
+    throw new Error(`dist directory not found inside ${tarballName}`);
+  }
+
+  console.info('Copying Dice Box distribution assets');
+  await copyDirectory(path.join(distDir, 'assets'), path.join(TARGET_DIR, 'assets'));
+
+  const bundleFiles = ['dice-box.esm.min.js', 'dice-box.umd.min.js', 'dice-box.min.js'];
+  await Promise.all(
+    bundleFiles.map(async (fileName) => {
+      const sourcePath = path.join(distDir, fileName);
+      const data = await readFile(sourcePath);
+      await writeFile(path.join(TARGET_DIR, fileName), data);
+    })
+  );
+
+  console.info(`Dice Box assets synced to ${TARGET_DIR}`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- allow the DiceBox canvas to resolve module and asset paths from environment variables or runtime globals before falling back to the CDN
- add documentation and a helper script for mirroring the Dice Box bundles and textures locally
- document the new Dice Box assets workflow in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2a7928e48832eaf9a1452d408d030