### PR TITLE
Fix dice box asset path to restore 3D dice display

### DIFF
--- a/client/src/components/Zombies/attributes/useDiceBox.js
+++ b/client/src/components/Zombies/attributes/useDiceBox.js
@@ -89,7 +89,10 @@ const useDiceBox = ({ color } = {}) => {
 
         const publicUrl = typeof process !== 'undefined' ? process.env?.PUBLIC_URL : undefined;
         const localAssetPath = `${publicUrl || ''}/dice-box`;
-        const assetCandidates = [localAssetPath, CDN_ASSET_PATH].filter(Boolean);
+        const normalizedLocalAssetPath = localAssetPath
+          ? `${localAssetPath.replace(/\/$/, '')}/`
+          : null;
+        const assetCandidates = [normalizedLocalAssetPath, CDN_ASSET_PATH].filter(Boolean);
 
         let lastError;
 


### PR DESCRIPTION
## Summary
- normalize the local dice-box asset path so it always includes a trailing slash
- ensure the 3D dice loader can fall back to the CDN assets successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3b3dbb8c8832eae84965c9f3f96f8