### PR TITLE
Prefer CDN dice-box assets before local fallback

### DIFF
--- a/client/src/components/Zombies/attributes/useDiceBox.js
+++ b/client/src/components/Zombies/attributes/useDiceBox.js
@@ -89,7 +89,10 @@ const useDiceBox = ({ color } = {}) => {
 
         const publicUrl = typeof process !== 'undefined' ? process.env?.PUBLIC_URL : undefined;
         const localAssetPath = `${publicUrl || ''}/dice-box`;
-        const assetCandidates = [localAssetPath, CDN_ASSET_PATH].filter(Boolean);
+        const normalizedLocalAssetPath = localAssetPath
+          ? `${localAssetPath.replace(/\/$/, '')}/`
+          : null;
+        const assetCandidates = [CDN_ASSET_PATH, normalizedLocalAssetPath].filter(Boolean);
 
         let lastError;
 


### PR DESCRIPTION
## Summary
- prioritize loading 3D dice assets from the CDN to avoid stalled initialization when local assets are missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3b3dbb8c8832eae84965c9f3f96f8