### PR TITLE
Fix dice box initialization timing

### DIFF
--- a/client/src/components/Zombies/attributes/useDiceBox.js
+++ b/client/src/components/Zombies/attributes/useDiceBox.js
@@ -234,6 +234,12 @@ const useDiceBox = ({ color } = {}) => {
         return;
       }
 
+      const { width, height } = target.getBoundingClientRect();
+      if ((width === 0 || height === 0) && !cancelled) {
+        frame = requestAnimationFrame(initialize);
+        return;
+      }
+
       try {
         const module = await loadDiceBoxModule();
         const DiceBoxCtor = module?.DiceBox || module?.default;
@@ -256,6 +262,13 @@ const useDiceBox = ({ color } = {}) => {
         for (const assetPath of assetCandidates) {
           try {
             diceBoxInstance = await createDiceBoxInstance(DiceBoxCtor, target, assetPath);
+            if (typeof diceBoxInstance?.resize === 'function') {
+              try {
+                diceBoxInstance.resize();
+              } catch (resizeError) {
+                console.warn('DiceBox resize after init failed', resizeError);
+              }
+            }
             break;
           } catch (error) {
             console.warn('DiceBox init failed for asset path', assetPath, error);


### PR DESCRIPTION
## Summary
- wait for the dice container to have a measurable size before creating the DiceBox instance
- trigger a resize pass immediately after DiceBox initialization to ensure the canvas fills the stage

## Testing
- npm --prefix client test -- --watchAll=false *(fails: manual stop after observing no tests running)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c7766348832e9182e529bcae1b7b