### PR TITLE
Add canvas-driven 3D dice animation to damage roller

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1851,6 +1851,47 @@ $rotateX: -$angle;
   transform-style: preserve-3d;
 }
 
+.damage-dice-canvas {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  pointer-events: none;
+}
+
+.damage-dice-canvas__surface {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: transparent;
+  mix-blend-mode: normal;
+}
+
+.damage-dice-canvas__labels {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-family: 'Courier New', monospace;
+}
+
+.damage-dice-label {
+  position: absolute;
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 4px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #ffffff;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.75);
+  transform: translate(-9999px, -9999px);
+  transition: opacity 0.18s ease;
+  pointer-events: none;
+}
+
 .damage-roller__total {
   position: relative;
   z-index: 2;

--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -1,0 +1,539 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { getPolyhedronGeometry } from '../../../utils/dieGeometry';
+
+const LIGHT_DIRECTION = normalizeVector([0.42, 0.86, 0.52]);
+const GRAVITY = 9.8;
+const SETTLE_VELOCITY_THRESHOLD = 0.35;
+const SETTLE_ANGULAR_THRESHOLD = 0.4;
+const BASE_PLANE_Y = 0;
+const BOUNDS_X = 6.5;
+const BOUNDS_Z = 4.5;
+const FRICTION = 0.86;
+const RESTITUTION = 0.45;
+const AIR_RESISTANCE = 0.985;
+const LABEL_OPACITY_FALLOFF = 0.6;
+
+function normalizeVector(vector) {
+  if (!Array.isArray(vector)) return [0, 0, 1];
+  const length = Math.hypot(...vector);
+  if (!Number.isFinite(length) || length <= 1e-6) {
+    return [0, 0, 1];
+  }
+  return vector.map((value) => value / length);
+}
+
+function subtract(a, b) {
+  return a.map((value, index) => value - (b[index] || 0));
+}
+
+function dot(a, b) {
+  return a.reduce((sum, value, index) => sum + value * (b[index] || 0), 0);
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function projectToScreen(point, camera, viewport) {
+  const relative = subtract(point, camera.position);
+  const x = dot(relative, camera.right);
+  const y = dot(relative, camera.up);
+  const z = dot(relative, camera.forward);
+
+  const depth = z + camera.distance;
+  const perspective = camera.focalLength / Math.max(camera.near, depth);
+
+  return {
+    x: viewport.width / 2 + x * perspective * camera.scale,
+    y: viewport.height * 0.58 - y * perspective * camera.scale,
+    depth,
+  };
+}
+
+function parseColor(input, fallback) {
+  if (typeof input !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return fallback;
+  }
+
+  const hexMatch = trimmed.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hexMatch) {
+    const hex = hexMatch[1];
+    const normalized = hex.length === 3
+      ? hex
+          .split('')
+          .map((char) => `${char}${char}`)
+          .join('')
+      : hex;
+    return [
+      parseInt(normalized.slice(0, 2), 16),
+      parseInt(normalized.slice(2, 4), 16),
+      parseInt(normalized.slice(4, 6), 16),
+    ];
+  }
+
+  const rgbMatch = trimmed.match(/^rgba?\(([^)]+)\)$/i);
+  if (rgbMatch) {
+    const parts = rgbMatch[1]
+      .split(',')
+      .slice(0, 3)
+      .map((value) => Number(value.trim()));
+    if (parts.every((value) => Number.isFinite(value))) {
+      return parts;
+    }
+  }
+
+  return fallback;
+}
+
+function colorToString([r, g, b]) {
+  return `rgb(${Math.round(clamp(r, 0, 255))}, ${Math.round(clamp(g, 0, 255))}, ${Math.round(
+    clamp(b, 0, 255),
+  )})`;
+}
+
+function blendColor(color, intensity, highlight) {
+  const ratio = clamp(intensity, 0, 1);
+  return color.map((value, index) => value * (0.25 + ratio * 0.75) + highlight[index] * ratio * 0.15);
+}
+
+function rotateVertex(vertex, rotation) {
+  const cosX = Math.cos(rotation.x);
+  const sinX = Math.sin(rotation.x);
+  const cosY = Math.cos(rotation.y);
+  const sinY = Math.sin(rotation.y);
+  const cosZ = Math.cos(rotation.z);
+  const sinZ = Math.sin(rotation.z);
+
+  let [x, y, z] = vertex;
+
+  // X rotation
+  let ty = y * cosX - z * sinX;
+  let tz = y * sinX + z * cosX;
+  y = ty;
+  z = tz;
+
+  // Y rotation
+  let tx = x * cosY + z * sinY;
+  tz = -x * sinY + z * cosY;
+  x = tx;
+  z = tz;
+
+  // Z rotation
+  tx = x * cosZ - y * sinZ;
+  ty = x * sinZ + y * cosZ;
+
+  return [tx, ty, z];
+}
+
+function computeCamera(viewport) {
+  const distance = 9.5;
+  const position = [0, 5.4, 11.5];
+  const target = [0, 0.8, 0];
+  const forward = normalizeVector(subtract(target, position));
+  const worldUp = [0, 1, 0];
+  let right = cross(forward, worldUp);
+  if (Math.hypot(...right) < 1e-6) {
+    right = [1, 0, 0];
+  }
+  right = normalizeVector(right);
+  const up = normalizeVector(cross(right, forward));
+
+  const aspect = viewport.width / Math.max(1, viewport.height);
+  const focalLength = 2.6;
+
+  return {
+    position,
+    target,
+    forward,
+    right,
+    up,
+    distance,
+    focalLength,
+    near: 0.8,
+    scale: clamp(0.9 * Math.min(1.2, aspect + 0.2), 0.85, 1.35),
+  };
+}
+
+function createDieState(die, index, total, colorPalette) {
+  const geometry = getPolyhedronGeometry(die.sides);
+  const scale = geometry.scale || 1;
+  const vertices = geometry.vertices || [];
+  const faces = geometry.faces || [];
+
+  const spread = total > 1 ? (index / Math.max(1, total - 1)) * 2 - 1 : 0;
+  const position = [spread * 2.8, 2.8 + Math.random() * 1.2, (Math.random() - 0.5) * 1.6];
+  const velocity = [
+    (Math.random() - 0.5) * 1.5,
+    -2.4 - Math.random() * 1.2,
+    (Math.random() - 0.5) * 1.2,
+  ];
+  const rotation = {
+    x: Math.random() * Math.PI * 2,
+    y: Math.random() * Math.PI * 2,
+    z: Math.random() * Math.PI * 2,
+  };
+  const angularVelocity = {
+    x: (Math.random() - 0.5) * 8,
+    y: (Math.random() - 0.5) * 8,
+    z: (Math.random() - 0.5) * 8,
+  };
+
+  const baseColor = colorPalette.getColor(die.category);
+  const highlight = colorPalette.getHighlight(die.category);
+
+  return {
+    id: die.id,
+    value: die.value,
+    sides: die.sides,
+    typeClass: die.typeClass,
+    position,
+    velocity,
+    rotation,
+    angularVelocity,
+    scale,
+    vertices,
+    faces,
+    settled: false,
+    baseColor,
+    highlight,
+    labelPosition: { x: 0, y: 0, visible: false },
+  };
+}
+
+class ColorPalette {
+  constructor(root) {
+    const computed = getComputedStyle(root || document.documentElement);
+    this.base = parseColor(
+      computed.getPropertyValue('--dice-face-color'),
+      [31, 70, 204],
+    );
+    this.critical = parseColor('#f2c100', [242, 193, 0]);
+    this.criticalBonus = parseColor('#ff8a33', [255, 138, 51]);
+    this.bonus = parseColor('#30b86f', [48, 184, 111]);
+    this.highlight = parseColor('#ffffff', [255, 255, 255]);
+  }
+
+  getColor(category) {
+    switch (category) {
+      case 'critical':
+        return this.critical;
+      case 'critical-bonus':
+        return this.criticalBonus;
+      case 'bonus':
+        return this.bonus;
+      default:
+        return this.base;
+    }
+  }
+
+  getHighlight(category) {
+    if (category === 'critical' || category === 'critical-bonus') {
+      return this.highlight;
+    }
+    return this.base;
+  }
+}
+
+class DiceRenderer {
+  constructor(canvas, options = {}) {
+    this.canvas = canvas;
+    this.ctx = canvas?.getContext('2d', { alpha: true });
+    this.dice = [];
+    this.pixelRatio = window.devicePixelRatio || 1;
+    this.frameRequest = null;
+    this.lastTimestamp = 0;
+    this.active = false;
+    this.colorPalette = new ColorPalette(options.root);
+    this.labelElements = options.labelElements || (() => null);
+    this.camera = computeCamera({ width: canvas?.clientWidth || 300, height: canvas?.clientHeight || 300 });
+
+    this.handleResize = this.handleResize.bind(this);
+    window.addEventListener('resize', this.handleResize);
+    this.handleResize();
+  }
+
+  handleResize() {
+    if (!this.canvas) return;
+    const { clientWidth, clientHeight } = this.canvas;
+    const width = Math.max(10, clientWidth);
+    const height = Math.max(10, clientHeight);
+    const ratio = this.pixelRatio;
+    this.canvas.width = Math.floor(width * ratio);
+    this.canvas.height = Math.floor(height * ratio);
+    if (this.ctx) {
+      this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+      this.ctx.scale(ratio, ratio);
+    }
+    this.viewport = { width, height };
+    this.camera = computeCamera(this.viewport);
+  }
+
+  dispose() {
+    window.removeEventListener('resize', this.handleResize);
+    if (this.frameRequest) cancelAnimationFrame(this.frameRequest);
+    this.frameRequest = null;
+    this.active = false;
+  }
+
+  setLabelElements(resolver) {
+    this.labelElements = typeof resolver === 'function' ? resolver : () => null;
+  }
+
+  setDice(dice) {
+    if (!Array.isArray(dice) || !dice.length) {
+      this.dice = [];
+      this.clear();
+      this.updateLabels([]);
+      return;
+    }
+
+    this.dice = dice.map((die, index) =>
+      createDieState(die, index, dice.length, this.colorPalette),
+    );
+    this.start();
+  }
+
+  start() {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+    this.lastTimestamp = performance.now();
+    const loop = (timestamp) => {
+      if (!this.active) return;
+      const delta = Math.min(0.032, (timestamp - this.lastTimestamp) / 1000 || 0.016);
+      this.lastTimestamp = timestamp;
+      this.update(delta);
+      this.frameRequest = requestAnimationFrame(loop);
+    };
+    this.frameRequest = requestAnimationFrame(loop);
+  }
+
+  clear() {
+    if (this.ctx) {
+      this.ctx.clearRect(0, 0, this.viewport.width, this.viewport.height);
+    }
+  }
+
+  update(delta) {
+    if (!this.ctx) return;
+
+    this.clear();
+
+    const facesToRender = [];
+
+    let activeDice = 0;
+    this.dice.forEach((die) => {
+      this.integrateDie(die, delta);
+      if (!die.vertices || die.vertices.length === 0 || !die.faces || die.faces.length === 0) {
+        return;
+      }
+      activeDice += 1;
+      const transformed = die.vertices.map((vertex) => {
+        const rotated = rotateVertex(vertex, die.rotation);
+        return [
+          rotated[0] * die.scale + die.position[0],
+          rotated[1] * die.scale + die.position[1],
+          rotated[2] * die.scale + die.position[2],
+        ];
+      });
+
+      const faceColor = die.baseColor;
+      const highlightColor = die.highlight;
+
+      die.faces.forEach((face) => {
+        if (!Array.isArray(face) || face.length < 3) return;
+        const vertices = face.map((index) => transformed[index]);
+        const v0 = vertices[0];
+        const v1 = vertices[1];
+        const v2 = vertices[2];
+        const normal = normalizeVector(cross(subtract(v1, v0), subtract(v2, v0)));
+        const intensity = Math.max(0, dot(normal, LIGHT_DIRECTION));
+        const fill = colorToString(blendColor(faceColor, intensity, highlightColor));
+        const projected = vertices.map((point) => projectToScreen(point, this.camera, this.viewport));
+        const averageDepth = projected.reduce((sum, p) => sum + p.depth, 0) / projected.length;
+        const path = projected.map(({ x, y }) => [x, y]);
+        facesToRender.push({ path, fill, depth: averageDepth });
+      });
+
+      const center = transformed.reduce(
+        (acc, vertex) => [acc[0] + vertex[0], acc[1] + vertex[1], acc[2] + vertex[2]],
+        [0, 0, 0],
+      ).map((value) => value / transformed.length);
+      const projectedCenter = projectToScreen(center, this.camera, this.viewport);
+
+      const labelElement = this.labelElements(die.id);
+      if (labelElement) {
+        const clampedX = clamp(projectedCenter.x, 20, this.viewport.width - 20);
+        const clampedY = clamp(projectedCenter.y, 20, this.viewport.height - 18);
+        labelElement.style.transform = `translate(${clampedX}px, ${clampedY}px)`;
+        const visibility = die.settled ? 1 : clamp(1 - Math.abs(die.velocity[1]) * LABEL_OPACITY_FALLOFF, 0, 1);
+        labelElement.style.opacity = visibility.toFixed(3);
+      }
+
+      const shadow = projectToScreen(
+        [die.position[0], BASE_PLANE_Y + 0.1, die.position[2]],
+        this.camera,
+        this.viewport,
+      );
+      const shadowSize = 26 * clamp(1.1 - die.position[1] * 0.15, 0.4, 1.1);
+      facesToRender.push({
+        path: createEllipsePath(shadow.x, shadow.y, shadowSize * 1.2, shadowSize * 0.65),
+        fill: 'rgba(0, 0, 0, 0.22)',
+        depth: shadow.depth + 0.001,
+        shadow: true,
+      });
+
+    });
+
+    facesToRender
+      .sort((a, b) => b.depth - a.depth)
+      .forEach((face) => {
+        if (!Array.isArray(face.path) || face.path.length < 2) return;
+        this.ctx.beginPath();
+        this.ctx.moveTo(face.path[0][0], face.path[0][1]);
+        for (let i = 1; i < face.path.length; i += 1) {
+          this.ctx.lineTo(face.path[i][0], face.path[i][1]);
+        }
+        this.ctx.closePath();
+        this.ctx.fillStyle = face.fill;
+        this.ctx.fill();
+      });
+
+    if (activeDice === 0) {
+      this.active = false;
+    }
+  }
+
+  integrateDie(die, delta) {
+    if (die.settled) {
+      die.velocity = die.velocity.map((value) => value * 0.92);
+      return;
+    }
+
+    die.velocity[1] -= GRAVITY * delta;
+    die.position[0] += die.velocity[0] * delta;
+    die.position[1] += die.velocity[1] * delta;
+    die.position[2] += die.velocity[2] * delta;
+
+    die.rotation.x += die.angularVelocity[0] * delta;
+    die.rotation.y += die.angularVelocity[1] * delta;
+    die.rotation.z += die.angularVelocity[2] * delta;
+
+    die.angularVelocity[0] *= AIR_RESISTANCE;
+    die.angularVelocity[1] *= AIR_RESISTANCE;
+    die.angularVelocity[2] *= AIR_RESISTANCE;
+    die.velocity[0] *= FRICTION;
+    die.velocity[2] *= FRICTION;
+
+    if (die.position[1] <= BASE_PLANE_Y) {
+      die.position[1] = BASE_PLANE_Y;
+      if (Math.abs(die.velocity[1]) > 0.12) {
+        die.velocity[1] = Math.abs(die.velocity[1]) * RESTITUTION;
+      } else {
+        die.velocity[1] = 0;
+      }
+      die.angularVelocity[0] *= 0.78;
+      die.angularVelocity[1] *= 0.78;
+      die.angularVelocity[2] *= 0.78;
+    }
+
+    if (Math.abs(die.position[0]) > BOUNDS_X) {
+      die.position[0] = clamp(die.position[0], -BOUNDS_X, BOUNDS_X);
+      die.velocity[0] *= -RESTITUTION;
+    }
+
+    if (Math.abs(die.position[2]) > BOUNDS_Z) {
+      die.position[2] = clamp(die.position[2], -BOUNDS_Z, BOUNDS_Z);
+      die.velocity[2] *= -RESTITUTION;
+    }
+
+    const speed = Math.hypot(...die.velocity);
+    const angularSpeed = Math.hypot(die.angularVelocity[0], die.angularVelocity[1], die.angularVelocity[2]);
+    if (speed < SETTLE_VELOCITY_THRESHOLD && angularSpeed < SETTLE_ANGULAR_THRESHOLD && die.position[1] <= BASE_PLANE_Y + 0.05) {
+      die.settled = true;
+      die.velocity = [0, 0, 0];
+      die.angularVelocity = [0, 0, 0];
+    }
+  }
+
+}
+
+function createEllipsePath(cx, cy, rx, ry) {
+  const points = [];
+  const steps = 16;
+  for (let i = 0; i < steps; i += 1) {
+    const angle = (i / steps) * Math.PI * 2;
+    points.push([cx + Math.cos(angle) * rx, cy + Math.sin(angle) * ry]);
+  }
+  return points;
+}
+
+const registerMapEntry = (map, key, node) => {
+  if (!map) return;
+  if (node) {
+    map.set(key, node);
+  } else {
+    map.delete(key);
+  }
+};
+
+const DamageDiceCanvas = ({ dice = [] }) => {
+  const canvasRef = useRef(null);
+  const rendererRef = useRef(null);
+  const labelsRef = useRef(new Map());
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const renderer = new DiceRenderer(canvasRef.current, {
+      root: document.documentElement,
+      labelElements: (id) => labelsRef.current.get(id) || null,
+    });
+    rendererRef.current = renderer;
+    return () => renderer.dispose();
+  }, []);
+
+  useEffect(() => {
+    if (!rendererRef.current) return;
+    rendererRef.current.setLabelElements((id) => labelsRef.current.get(id) || null);
+    rendererRef.current.setDice(dice);
+  }, [dice]);
+
+  const labelItems = useMemo(
+    () =>
+      dice.map((die) => (
+        <span
+          key={die.id}
+          data-die-id={die.id}
+          className={`damage-dice-label ${die.typeClass || ''}`.trim()}
+          ref={(node) => registerMapEntry(labelsRef.current, die.id, node)}
+          style={{ opacity: 0 }}
+        >
+          {die.value}
+        </span>
+      )),
+    [dice],
+  );
+
+  return (
+    <div className="damage-dice-canvas">
+      <canvas ref={canvasRef} className="damage-dice-canvas__surface" />
+      <div className="damage-dice-canvas__labels">{labelItems}</div>
+    </div>
+  );
+};
+
+export default DamageDiceCanvas;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -15,7 +15,7 @@ import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
-import { createPolyhedronFaces } from '../../../utils/dieGeometry';
+import DamageDiceCanvas from './DamageDiceCanvas';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -33,10 +33,6 @@ function rollDice(numberOfDiceValue, sidesOfDiceValue) {
   return results;
 }
 
-const DAMAGE_DIE_WIDTH_PX = 42;
-const DAMAGE_DIE_SPREAD_FACTOR = 1.15;
-const DAMAGE_AREA_BASE_RATIO = 0.42;
-const DAMAGE_AREA_MAX_RATIO = 0.92;
 function formatDamageRolls(rolls) {
   return rolls
     .map(({ value, type }) => `${value}${type ? ` ${type}` : ''}`)
@@ -57,211 +53,6 @@ const anyDamageDiceRegex = /\d+d\d+(?:[+-]\d+)?/;
 const spellsCatalog = spellsData || {};
 
 const diceExpressionPattern = /\d+d\d+(?:\s*[+-]\s*\d+)?/gi;
-
-const FACE_DATA_CACHE = new Map();
-const IDENTITY_MATRIX_4 = [
-  1, 0, 0, 0,
-  0, 1, 0, 0,
-  0, 0, 1, 0,
-  0, 0, 0, 1,
-];
-
-const toMatrixComponent = (value) => {
-  const rounded = Math.abs(value) < 1e-6 ? 0 : value;
-  return Number(rounded.toFixed(6));
-};
-
-const matrixToCss = (matrix) =>
-  `matrix3d(${matrix.map((value) => toMatrixComponent(value)).join(',')})`;
-
-const radiansToDegrees = (radians) => (radians * 180) / Math.PI;
-
-const FACE_VALUE_OVERRIDES = {
-  4: [1, 2, 3, 4],
-  6: [1, 6, 2, 5, 3, 4],
-  8: [1, 7, 3, 5, 8, 2, 4, 6],
-  10: [1, 7, 9, 3, 5, 10, 8, 2, 4, 6],
-  12: [1, 12, 6, 7, 2, 11, 5, 8, 3, 10, 4, 9],
-  20: [1, 7, 13, 19, 5, 11, 17, 3, 9, 15, 20, 14, 8, 2, 18, 12, 6, 4, 10, 16],
-};
-
-const getFaceValueSequence = (sides) => {
-  const normalized = Math.max(2, Math.round(Number(sides) || 0));
-  const override = FACE_VALUE_OVERRIDES[normalized];
-  if (Array.isArray(override) && override.length === normalized) {
-    return override;
-  }
-  return Array.from({ length: normalized }, (_, index) => index + 1);
-};
-
-const computeFaceAlignment = (face) => {
-  if (!face) {
-    return null;
-  }
-
-  const [tx, ty, tz] = face.tangent || [1, 0, 0];
-  const [bx, by, bz] = face.bitangent || [0, 1, 0];
-  const [nx, ny, nz] = face.normal || [0, 0, 1];
-
-  const matrix = [
-    [tx, ty, tz],
-    [bx, by, bz],
-    [nx, ny, nz],
-  ];
-
-  const sy = Math.hypot(matrix[2][1], matrix[2][2]);
-
-  let ax;
-  let ay;
-  let az;
-
-  if (sy > 1e-6) {
-    ax = Math.atan2(matrix[2][1], matrix[2][2]);
-    ay = Math.atan2(-matrix[2][0], sy);
-    az = Math.atan2(matrix[1][0], matrix[0][0]);
-  } else {
-    ax = Math.atan2(-matrix[1][2], matrix[1][1]);
-    ay = Math.atan2(-matrix[2][0], sy);
-    az = 0;
-  }
-
-  return {
-    x: radiansToDegrees(ax),
-    y: radiansToDegrees(ay),
-    z: radiansToDegrees(az),
-  };
-};
-
-function getFaceDataForSides(sides) {
-  const normalized = Math.max(2, Math.round(Number(sides) || 0));
-  if (FACE_DATA_CACHE.has(normalized)) {
-    return FACE_DATA_CACHE.get(normalized);
-  }
-
-  const geometry = createPolyhedronFaces(normalized, 18);
-  if (!Array.isArray(geometry)) {
-    FACE_DATA_CACHE.set(normalized, null);
-    return null;
-  }
-
-  const valueSequence = getFaceValueSequence(normalized);
-  const faces = geometry.map((face, index) => {
-    const matrixValues =
-      Array.isArray(face.matrix) && face.matrix.length === 16
-        ? face.matrix
-        : IDENTITY_MATRIX_4;
-    return {
-      id: index + 1,
-      value: valueSequence[index % valueSequence.length],
-      matrix: matrixToCss(matrixValues),
-      clipPath: face.clipPath,
-      tangent: face.tangent,
-      bitangent: face.bitangent,
-      normal: face.normal,
-      alignment: computeFaceAlignment(face),
-    };
-  });
-
-  FACE_DATA_CACHE.set(normalized, faces);
-  return faces;
-}
-
-function DamageDieMesh({ die, typeClass }) {
-  const finalValue =
-    typeof die?.value === 'number' ? die.value : Number(die?.value) || 0;
-  const [displayValue, setDisplayValue] = useState(finalValue);
-  const faceData = useMemo(() => getFaceDataForSides(die?.sides), [die?.sides]);
-  const fallbackSides = Number.isFinite(die?.sides)
-    ? Math.max(2, Math.round(die.sides))
-    : 20;
-
-  useEffect(() => {
-    const sides = fallbackSides;
-    const delayMs = Number.isFinite(die?.delay)
-      ? Math.max(0, die.delay * 1000)
-      : 0;
-    const durationMs = Number.isFinite(die?.rollDuration)
-      ? Math.max(350, die.rollDuration * 1000)
-      : 900;
-
-    let scrambleIntervalId = null;
-    let scrambleTimeoutId = null;
-    let startTimeoutId = null;
-
-    const startScramble = () => {
-      if (sides < 2 || durationMs <= 0) {
-        setDisplayValue(finalValue);
-        return;
-      }
-
-      const intervalMs = Math.max(65, Math.min(160, durationMs / 6));
-      scrambleIntervalId = setInterval(() => {
-        setDisplayValue(Math.floor(Math.random() * sides) + 1);
-      }, intervalMs);
-
-      scrambleTimeoutId = setTimeout(() => {
-        if (scrambleIntervalId) clearInterval(scrambleIntervalId);
-        setDisplayValue(finalValue);
-      }, durationMs);
-    };
-
-    startTimeoutId = setTimeout(startScramble, delayMs);
-
-    return () => {
-      if (startTimeoutId) clearTimeout(startTimeoutId);
-      if (scrambleIntervalId) clearInterval(scrambleIntervalId);
-      if (scrambleTimeoutId) clearTimeout(scrambleTimeoutId);
-    };
-  }, [die?.id, die?.delay, die?.rollDuration, fallbackSides, finalValue]);
-
-  const activeValue = useMemo(() => {
-    if (!Array.isArray(faceData) || !faceData.length) {
-      return displayValue;
-    }
-    if (Number.isFinite(displayValue) && displayValue !== 0) {
-      return displayValue;
-    }
-    return finalValue;
-  }, [displayValue, faceData, finalValue]);
-
-  if (!Array.isArray(faceData) || faceData.length === 0) {
-    return (
-      <div className="damage-die__icon">
-        <span className="damage-die__shape" aria-hidden="true" />
-        <span className={`damage-die__value damage-die__value--front ${typeClass}`}>
-          {displayValue}
-        </span>
-        <span
-          className={`damage-die__value damage-die__value--back ${typeClass}`}
-          aria-hidden="true"
-        >
-          {displayValue}
-        </span>
-      </div>
-    );
-  }
-  return (
-    <div className="damage-die__icon" aria-hidden="true">
-      <div className="damage-die__poly">
-        {faceData.map((face) => {
-          const isActive = face.value === activeValue;
-          return (
-            <span
-              key={face.id}
-              className={`damage-die__face ${isActive ? 'damage-die__face--active' : ''}`}
-              style={{
-                transform: face.matrix,
-                clipPath: face.clipPath,
-              }}
-            >
-              <span className={`damage-die__face-label ${typeClass}`}>{face.value}</span>
-            </span>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 function extractDiceExpression(description = '') {
   diceExpressionPattern.lastIndex = 0;
@@ -1165,33 +956,6 @@ const [damageLog, setDamageLog] = useState([]);
 const [showLog, setShowLog] = useState(false);
 const [activeDice, setActiveDice] = useState([]);
 const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
-const diceAreaRef = useRef(null);
-
-const getDieShapeClass = (sides) => {
-  if (!Number.isFinite(sides)) {
-    return 'damage-die--generic';
-  }
-
-  const normalized = Math.max(0, Math.round(sides));
-
-  switch (normalized) {
-    case 4:
-      return 'damage-die--d4';
-    case 6:
-      return 'damage-die--d6';
-    case 8:
-      return 'damage-die--d8';
-    case 10:
-    case 100:
-      return 'damage-die--d10';
-    case 12:
-      return 'damage-die--d12';
-    case 20:
-      return 'damage-die--d20';
-    default:
-      return 'damage-die--generic';
-  }
-};
 
 const triggerDiceAnimation = useCallback((diceDetails = []) => {
   if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
@@ -1199,128 +963,32 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
     return;
   }
 
-  const baseTime = Date.now();
-  const areaWidth = Math.max(
-    1,
-    diceAreaRef.current?.offsetWidth ||
-      diceAreaRef.current?.parentElement?.offsetWidth ||
-      520
-  );
-
-  const diceCount = diceDetails.length;
-  const usableWidthPx = (() => {
-    if (diceCount <= 1) {
-      return Math.min(
-        areaWidth * DAMAGE_AREA_MAX_RATIO,
-        areaWidth * DAMAGE_AREA_BASE_RATIO
-      );
-    }
-    const desiredClusterWidth = Math.max(
-      areaWidth * DAMAGE_AREA_BASE_RATIO,
-      (diceCount - 1) * DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR
-    );
-    return Math.min(areaWidth * DAMAGE_AREA_MAX_RATIO, desiredClusterWidth);
-  })();
-
-  const slotWidthPx =
-    diceCount > 1 ? usableWidthPx / (diceCount - 1) : usableWidthPx || areaWidth;
-  const minGapPx =
-    diceCount > 1
-      ? Math.min(DAMAGE_DIE_WIDTH_PX * DAMAGE_DIE_SPREAD_FACTOR, slotWidthPx)
-      : 0;
-  const startPx = (areaWidth - usableWidthPx) / 2;
-  const maxPx = startPx + usableWidthPx;
-  const jitterPx = Math.min(slotWidthPx * 0.25, DAMAGE_DIE_WIDTH_PX * 0.4);
-  let previousLeftPx = null;
-
-  const nextDice = diceDetails.map((detail, index) => {
-    const fraction = diceCount === 1 ? 0.5 : index / (diceCount - 1 || 1);
-    const baseLeftPx = startPx + fraction * usableWidthPx;
-    const rawOffsetPx = jitterPx
-      ? (Math.random() - 0.5) * 2 * jitterPx
-      : 0;
-    const remainingDice = diceCount - index - 1;
-    const minAllowedPx = startPx + index * minGapPx;
-    const maxAllowedPx = maxPx - remainingDice * minGapPx;
-
-    let leftPx = baseLeftPx + rawOffsetPx;
-    if (Number.isFinite(minAllowedPx)) {
-      leftPx = Math.max(leftPx, minAllowedPx);
-    }
-    if (Number.isFinite(maxAllowedPx)) {
-      leftPx = Math.min(leftPx, maxAllowedPx);
-    }
-    if (previousLeftPx !== null && leftPx - previousLeftPx < minGapPx) {
-      leftPx = Math.min(maxAllowedPx, previousLeftPx + minGapPx);
-    }
-
-    previousLeftPx = leftPx;
-    const left = (leftPx / areaWidth) * 100;
-    const dropDistance = 60 + Math.random() * 70;
-    const delay = index * 0.05;
-    const rollDuration = 0.85 + Math.random() * 0.45;
-    const entryDirection = Math.random() < 0.5 ? -1 : 1;
-    const startX = entryDirection * (areaWidth * (0.55 + Math.random() * 0.35));
-    const midX = startX * -0.25;
-    const startY = -(120 + Math.random() * 80);
-    const midY = -(40 + Math.random() * 60);
-    const startZ = entryDirection * (30 + Math.random() * 90);
-    const midZ = (Math.random() - 0.5) * 80;
-      const normalizedValue =
-        typeof detail?.value === 'number'
-          ? Math.round(detail.value)
-          : Number(detail?.value) || 0;
-      const faces = getFaceDataForSides(detail?.sides);
-      const finalFace = Array.isArray(faces)
-        ? faces.find((face) => face.value === normalizedValue) || faces[0]
-        : null;
-      const finalAlignment = finalFace?.alignment || { x: 0, y: 0, z: 0 };
-      const spinRange = 360 + Math.random() * 360;
-      const rotXEnd = finalAlignment.x;
-      const rotYEnd = finalAlignment.y;
-      const rotZEnd = finalAlignment.z;
-      const rotXStart = rotXEnd + (Math.random() - 0.5) * spinRange;
-      const rotYStart = rotYEnd + (Math.random() - 0.5) * spinRange;
-      const rotZStart = rotZEnd + (Math.random() - 0.5) * spinRange;
-      const rotXMid =
-        (rotXStart + rotXEnd) / 2 + entryDirection * (120 + Math.random() * 80);
-      const rotYMid = (rotYStart + rotYEnd) / 2 + (Math.random() - 0.5) * 160;
-      const rotZMid = (rotZStart + rotZEnd) / 2 + (Math.random() - 0.5) * 150;
-      const settleBounce = 6 + Math.random() * 10;
-      return {
-        id: `${baseTime}-${index}`,
-        value:
-          typeof detail?.value === 'number'
-          ? detail.value
-          : Number(detail?.value) || 0,
-      sides: detail?.sides || 0,
-      type: detail?.type || '',
-      category: detail?.category || 'base',
-      left,
-      dropDistance,
-      delay,
-      rollDuration,
-      startX,
-      startY,
-      startZ,
-      midX,
-      midY,
-      midZ,
-      rotXStart,
-      rotYStart,
-      rotZStart,
-      rotXMid,
-      rotYMid,
-      rotZMid,
-      rotXEnd,
-      rotYEnd,
-      rotZEnd,
-      settleBounce,
-    };
-  });
+  const timestamp = Date.now();
+  const nextDice = diceDetails.map((detail, index) => ({
+    id: `${timestamp}-${index}`,
+    value:
+      typeof detail?.value === 'number'
+        ? detail.value
+        : Number(detail?.value) || 0,
+    sides: Number.isFinite(detail?.sides) ? Math.max(2, Math.round(detail.sides)) : 20,
+    type: detail?.type || '',
+    category: detail?.category || 'base',
+  }));
 
   setActiveDice(nextDice);
-}, [diceAreaRef]);
+}, []);
+
+const preparedDice = useMemo(
+  () =>
+    activeDice.map((die) => {
+      const normalizedType = normalizeDamageTypeForClass(die.type);
+      return {
+        ...die,
+        typeClass: normalizedType ? `damage-${normalizedType}` : '',
+      };
+    }),
+  [activeDice],
+);
 
 const updateDamageValueWithAnimation = (
   newValue,
@@ -1377,6 +1045,16 @@ useEffect(() => {
   }, 2000);
   return () => clearTimeout(timer);
 }, [lastRollTimestamp, isCritical, isFumble]);
+
+useEffect(() => {
+  if (!lastRollTimestamp) {
+    return undefined;
+  }
+  const timer = setTimeout(() => {
+    setActiveDice([]);
+  }, 2600);
+  return () => clearTimeout(timer);
+}, [lastRollTimestamp]);
 
 // Allow other components to display values in the damage circle
 useEffect(() => {
@@ -1482,49 +1160,8 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
             isFumble ? 'critical-failure' : ''
           }`}
         >
-          <div
-            className="damage-roller__dice-area"
-            aria-hidden="true"
-            ref={diceAreaRef}
-          >
-            {activeDice.map((die) => {
-              const normalizedType = normalizeDamageTypeForClass(die.type);
-              const typeClass = normalizedType ? `damage-${normalizedType}` : '';
-              const categoryClass = die.category
-                ? `damage-die--${die.category}`
-                : '';
-              const shapeClass = getDieShapeClass(die.sides);
-              return (
-                <div
-                  key={die.id}
-                  className={`damage-die ${shapeClass} ${categoryClass}`}
-                  style={{
-                    left: `${die.left}%`,
-                    '--drop-delay': `${die.delay}s`,
-                    '--drop-duration': `${die.rollDuration}s`,
-                    '--flight-start-x': `${die.startX}px`,
-                    '--flight-start-y': `${die.startY}px`,
-                    '--flight-start-z': `${die.startZ}px`,
-                    '--flight-mid-x': `${die.midX}px`,
-                    '--flight-mid-y': `${die.midY}px`,
-                    '--flight-mid-z': `${die.midZ}px`,
-                    '--flight-end-y': `${die.dropDistance}px`,
-                    '--flight-settle-bounce': `${die.settleBounce}px`,
-                    '--rot-x-start': `${die.rotXStart}deg`,
-                    '--rot-y-start': `${die.rotYStart}deg`,
-                    '--rot-z-start': `${die.rotZStart}deg`,
-                    '--rot-x-mid': `${die.rotXMid}deg`,
-                    '--rot-y-mid': `${die.rotYMid}deg`,
-                    '--rot-z-mid': `${die.rotZMid}deg`,
-                    '--rot-x-end': `${die.rotXEnd}deg`,
-                    '--rot-y-end': `${die.rotYEnd}deg`,
-                    '--rot-z-end': `${die.rotZEnd}deg`,
-                  }}
-                >
-                  <DamageDieMesh die={die} typeClass={typeClass} />
-                </div>
-              );
-            })}
+          <div className="damage-roller__dice-area" aria-hidden="true">
+            <DamageDiceCanvas dice={preparedDice} />
           </div>
           <div className="damage-roller__total">
             <span className="damage-roller__total-label">Total</span>

--- a/client/src/utils/dieGeometry.js
+++ b/client/src/utils/dieGeometry.js
@@ -164,6 +164,15 @@ const polyhedraDefinitions = {
   20: createIcosahedron,
 };
 
+const scaleBySides = {
+  4: 1.32,
+  6: 1.28,
+  8: 1.24,
+  10: 1.24,
+  12: 1.2,
+  20: 1.16,
+};
+
 const baseTriangleHeight = SQRT3 / 2;
 const baseTriangle = [
   [0, (2 * baseTriangleHeight) / 3, 0],
@@ -444,6 +453,30 @@ function mergeCoplanarFaces(faces, vertices) {
   });
 
   return merged;
+}
+
+export function getPolyhedronGeometry(sides) {
+  const normalized = Math.max(2, Math.round(Number(sides) || 0));
+  const factory = polyhedraDefinitions[normalized];
+
+  if (!factory) {
+    return { vertices: [], faces: [], scale: 1 };
+  }
+
+  const { vertices, faces: presetFaces } = factory();
+  const rawFaces = Array.isArray(presetFaces) && presetFaces.length
+    ? presetFaces
+    : generateConvexHullTriangles(vertices);
+
+  const faces = rawFaces
+    .map((face) => ensureFaceOrientation(face, vertices))
+    .map(({ indices }) => indices);
+
+  return {
+    vertices,
+    faces,
+    scale: scaleBySides[normalized] || 1.18,
+  };
 }
 
 const baseOrigin = baseTriangle[0];


### PR DESCRIPTION
## Summary
- add a dedicated DamageDiceCanvas renderer that simulates and paints animated 3D dice with canvas
- refactor the damage roller in PlayerTurnActions to feed the new renderer and simplify animation state management
- expose polyhedron geometry helpers and style the dice area for the new canvas/label overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3d6468370832e9c5c4f6aec689e92