### PR TITLE
Fix missing DiceSandboxRenderer import in damage dice canvas

### DIFF
--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { getPolyhedronGeometry } from '../../../utils/dieGeometry';
+import DiceSandboxRenderer from '../../../utils/diceSandbox';
 
 const LIGHT_DIRECTION = normalizeVector([0.42, 0.86, 0.52]);
 const GRAVITY = 9.8;


### PR DESCRIPTION
## Summary
- import `DiceSandboxRenderer` into the damage dice canvas so the component can instantiate the renderer

## Testing
- npm run lint -- --max-warnings=0 *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f3e20284e4832e8edcf90a323e2f9d