### PR TITLE
Add weapon mastery popover to weapon attacks

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -666,6 +666,20 @@ body.docked-modal--resizing {
   margin-bottom: 0.25rem;
 }
 
+.weapon-mastery {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.weapon-mastery__name {
+  font-weight: 600;
+}
+
+.weapon-mastery__description {
+  font-size: 0.95rem;
+}
+
 .attack-card__actions {
   margin-top: auto;
   display: flex;
@@ -676,6 +690,15 @@ body.docked-modal--resizing {
 .attack-card__roll {
   font-size: 1.25rem;
   color: rgba(255, 255, 255, 0.85);
+}
+
+.attack-card__mastery {
+  color: #f4d35e;
+}
+
+.attack-card__mastery:hover,
+.attack-card__mastery:focus {
+  color: #ffd86b;
 }
 
 .attack-card__roll:hover,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -14,6 +14,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
+import weaponMasteryDefinitions from '../../../data/weaponMasteries';
 import { rollSkill } from './Skills';
 
 // Dice rolling helper used by calculateDamage and component actions
@@ -550,6 +551,21 @@ const [isFumble, setIsFumble] = useState(false);
           : 'Definition not available.';
         return { label, description };
       });
+  };
+
+  const getWeaponMasteryDetails = (weapon) => {
+    if (!weapon || typeof weapon !== 'object') return null;
+    const rawMastery = typeof weapon.mastery === 'string' ? weapon.mastery.trim() : '';
+    if (!rawMastery) return null;
+    const key = rawMastery.toLowerCase();
+    const detail = weaponMasteryDefinitions[key];
+    if (detail) {
+      return { ...detail };
+    }
+    return {
+      label: formatWeaponLabel(rawMastery),
+      description: 'Definition not available.',
+    };
   };
 
   const totalLevel = useMemo(
@@ -1186,11 +1202,13 @@ useEffect(() => {
                   const weaponTypeLabel = getWeaponTypeLabel(weapon);
                   const propertyDetails = getWeaponPropertyDetails(weapon);
                   const propertyLabels = propertyDetails.map(({ label }) => label);
+                  const popoverId = `weapon-properties-${slot}`;
+                  const masteryDetail = getWeaponMasteryDetails(weapon);
+                  const masteryPopoverId = `weapon-mastery-${slot}`;
                   const propertiesDisplay =
                     propertyLabels.length > 0
                       ? propertyLabels.join(', ')
                       : 'None';
-                  const popoverId = `weapon-properties-${slot}`;
                   const versatileDice = getVersatileDamageDice(weapon);
                   const isVersatile = Boolean(versatileDice);
                   const handSelection = getHandSelectionForWeapon(slot, weapon);
@@ -1220,6 +1238,22 @@ useEffect(() => {
                       </Popover.Body>
                     </Popover>
                   );
+
+                  const masteryPopover = masteryDetail
+                    ? (
+                        <Popover id={masteryPopoverId}>
+                          <Popover.Header as="h3">Weapon Mastery</Popover.Header>
+                          <Popover.Body>
+                            <div className="weapon-mastery">
+                              <div className="weapon-mastery__name">{masteryDetail.label}</div>
+                              <div className="weapon-mastery__description">
+                                {masteryDetail.description}
+                              </div>
+                            </div>
+                          </Popover.Body>
+                        </Popover>
+                      )
+                    : null;
 
                   return (
                     <div
@@ -1330,6 +1364,23 @@ useEffect(() => {
                         </div>
                       </div>
                       <div className="attack-card__actions">
+                        {masteryDetail && masteryPopover && (
+                          <OverlayTrigger
+                            trigger="click"
+                            placement="auto"
+                            overlay={masteryPopover}
+                            rootClose
+                          >
+                            <Button
+                              type="button"
+                              variant="link"
+                              className="attack-card__roll attack-card__mastery"
+                              aria-label={`View ${masteryDetail.label} mastery description`}
+                            >
+                              <i className="fa-solid fa-crown" aria-hidden="true"></i>
+                            </Button>
+                          </OverlayTrigger>
+                        )}
                         <Button
                           onClick={() => {
                             handleWeaponAttackRoll(slot, weapon);

--- a/client/src/components/Zombies/attributes/inventoryNormalization.js
+++ b/client/src/components/Zombies/attributes/inventoryNormalization.js
@@ -52,6 +52,7 @@ export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
           cost,
           type,
           attackBonus,
+          mastery,
         ] = weapon;
         if (!name) return null;
         const normalized = {
@@ -64,6 +65,7 @@ export const normalizeWeapons = (weapons, { includeUnowned = false } = {}) => {
         };
         if (type !== undefined) normalized.type = type;
         if (attackBonus !== undefined) normalized.attackBonus = attackBonus;
+        if (mastery !== undefined) normalized.mastery = mastery;
         if (owned !== undefined) normalized.owned = owned;
         return normalized;
       }

--- a/client/src/data/weaponMasteries.js
+++ b/client/src/data/weaponMasteries.js
@@ -1,0 +1,44 @@
+const weaponMasteries = {
+  cleave: {
+    label: 'Cleave',
+    description:
+      "If you hit a creature with a melee attack roll using this weapon, you can make a melee attack roll with the weapon against a second creature within 5 feet of the original target and within your reach. On a hit, the second creature takes the weapon's damage, but don't add your ability modifier to the damage roll. You can make this extra attack only once per turn.",
+  },
+  graze: {
+    label: 'Graze',
+    description:
+      'If your attack roll with this weapon misses a creature, you can still deal damage to that creature equal to the ability modifier you used to make the attack roll. You can deal this extra damage only once per turn.',
+  },
+  nick: {
+    label: 'Nick',
+    description:
+      'When you make the extra attack of the Light property with this weapon, you can make it as part of the Attack action instead of as a Bonus Action. You can still make this extra attack only once per turn.',
+  },
+  push: {
+    label: 'Push',
+    description:
+      'If you hit a creature with this weapon, you can push the creature up to 10 feet away from you if it fails a Strength saving throw (DC equals 8 + your proficiency bonus + the ability modifier you used for the attack roll). You can use this property only once per turn.',
+  },
+  sap: {
+    label: 'Sap',
+    description:
+      'If you hit a creature with this weapon and deal damage to it, the creature has disadvantage on the next attack roll it makes before the start of your next turn.',
+  },
+  slow: {
+    label: 'Slow',
+    description:
+      'If you hit a creature with this weapon, the creature’s Speed is reduced by 10 feet until the start of your next turn.',
+  },
+  topple: {
+    label: 'Topple',
+    description:
+      'If you hit a creature with this weapon, you can force the creature to make a Strength saving throw (DC equals 8 + your proficiency bonus + the ability modifier you used for the attack roll). On a failed save, the creature has the Prone condition. You can use this property only once per turn.',
+  },
+  vex: {
+    label: 'Vex',
+    description:
+      'If you hit a creature with this weapon and deal damage to the creature, you have Advantage on the next attack roll you make against that creature before the end of your next turn.',
+  },
+};
+
+export default weaponMasteries;

--- a/server/data/weapons.js
+++ b/server/data/weapons.js
@@ -12,6 +12,7 @@ const weapons = {
     properties: ["light"],
     weight: 2,
     cost: "1 sp",
+    mastery: "slow",
     proficient: false,
   },
   dagger: {
@@ -21,6 +22,7 @@ const weapons = {
     properties: ["finesse", "light", "thrown (20/60)"],
     weight: 1,
     cost: "2 gp",
+    mastery: "vex",
     proficient: false,
   },
   greatclub: {
@@ -30,6 +32,7 @@ const weapons = {
     properties: ["two-handed"],
     weight: 10,
     cost: "2 sp",
+    mastery: "topple",
     proficient: false,
   },
   handaxe: {
@@ -39,6 +42,7 @@ const weapons = {
     properties: ["light", "thrown (20/60)"],
     weight: 2,
     cost: "5 gp",
+    mastery: "vex",
     proficient: false,
   },
   javelin: {
@@ -48,6 +52,7 @@ const weapons = {
     properties: ["thrown (30/120)"],
     weight: 2,
     cost: "5 sp",
+    mastery: "nick",
     proficient: false,
   },
   "light-hammer": {
@@ -57,6 +62,7 @@ const weapons = {
     properties: ["light", "thrown (20/60)"],
     weight: 2,
     cost: "2 gp",
+    mastery: "nick",
     proficient: false,
   },
   mace: {
@@ -66,6 +72,7 @@ const weapons = {
     properties: [],
     weight: 4,
     cost: "5 gp",
+    mastery: "sap",
     proficient: false,
   },
   quarterstaff: {
@@ -75,6 +82,7 @@ const weapons = {
     properties: ["versatile (1d8)"],
     weight: 4,
     cost: "2 sp",
+    mastery: "topple",
     proficient: false,
   },
   sickle: {
@@ -84,6 +92,7 @@ const weapons = {
     properties: ["light"],
     weight: 2,
     cost: "1 gp",
+    mastery: "graze",
     proficient: false,
   },
   spear: {
@@ -93,6 +102,7 @@ const weapons = {
     properties: ["thrown (20/60)", "versatile (1d8)"],
     weight: 3,
     cost: "1 gp",
+    mastery: "nick",
     proficient: false,
   },
   "light-crossbow": {
@@ -102,6 +112,7 @@ const weapons = {
     properties: ["ammunition (80/320)", "loading", "two-handed"],
     weight: 5,
     cost: "25 gp",
+    mastery: "slow",
     proficient: false,
   },
   dart: {
@@ -111,6 +122,7 @@ const weapons = {
     properties: ["finesse", "thrown (20/60)"],
     weight: 0.25,
     cost: "5 cp",
+    mastery: "vex",
     proficient: false,
   },
   shortbow: {
@@ -120,6 +132,7 @@ const weapons = {
     properties: ["ammunition (80/320)", "two-handed"],
     weight: 2,
     cost: "25 gp",
+    mastery: "vex",
     proficient: false,
   },
   sling: {
@@ -129,6 +142,7 @@ const weapons = {
     properties: ["ammunition (30/120)"],
     weight: 0,
     cost: "1 sp",
+    mastery: "vex",
     proficient: false,
   },
   battleaxe: {
@@ -138,6 +152,7 @@ const weapons = {
     properties: ["versatile (1d10)"],
     weight: 4,
     cost: "10 gp",
+    mastery: "cleave",
     proficient: false,
   },
   flail: {
@@ -147,6 +162,7 @@ const weapons = {
     properties: [],
     weight: 2,
     cost: "10 gp",
+    mastery: "topple",
     proficient: false,
   },
   glaive: {
@@ -156,6 +172,7 @@ const weapons = {
     properties: ["heavy", "reach", "two-handed"],
     weight: 6,
     cost: "20 gp",
+    mastery: "cleave",
     proficient: false,
   },
   greataxe: {
@@ -165,6 +182,7 @@ const weapons = {
     properties: ["heavy", "two-handed"],
     weight: 7,
     cost: "30 gp",
+    mastery: "cleave",
     proficient: false,
   },
   greatsword: {
@@ -174,6 +192,7 @@ const weapons = {
     properties: ["heavy", "two-handed"],
     weight: 6,
     cost: "50 gp",
+    mastery: "cleave",
     proficient: false,
   },
   halberd: {
@@ -183,6 +202,7 @@ const weapons = {
     properties: ["heavy", "reach", "two-handed"],
     weight: 6,
     cost: "20 gp",
+    mastery: "cleave",
     proficient: false,
   },
   lance: {
@@ -192,6 +212,7 @@ const weapons = {
     properties: ["reach", "special"],
     weight: 6,
     cost: "10 gp",
+    mastery: "topple",
     proficient: false,
   },
   longsword: {
@@ -201,6 +222,7 @@ const weapons = {
     properties: ["versatile (1d10)"],
     weight: 3,
     cost: "15 gp",
+    mastery: "push",
     proficient: false,
   },
   maul: {
@@ -210,6 +232,7 @@ const weapons = {
     properties: ["heavy", "two-handed"],
     weight: 10,
     cost: "10 gp",
+    mastery: "cleave",
     proficient: false,
   },
   morningstar: {
@@ -219,6 +242,7 @@ const weapons = {
     properties: [],
     weight: 4,
     cost: "15 gp",
+    mastery: "sap",
     proficient: false,
   },
   pike: {
@@ -228,6 +252,7 @@ const weapons = {
     properties: ["heavy", "reach", "two-handed"],
     weight: 18,
     cost: "5 gp",
+    mastery: "push",
     proficient: false,
   },
   rapier: {
@@ -237,6 +262,7 @@ const weapons = {
     properties: ["finesse"],
     weight: 2,
     cost: "25 gp",
+    mastery: "vex",
     proficient: false,
   },
   scimitar: {
@@ -246,6 +272,7 @@ const weapons = {
     properties: ["finesse", "light"],
     weight: 3,
     cost: "25 gp",
+    mastery: "vex",
     proficient: false,
   },
   shortsword: {
@@ -255,6 +282,7 @@ const weapons = {
     properties: ["finesse", "light"],
     weight: 2,
     cost: "10 gp",
+    mastery: "vex",
     proficient: false,
   },
   trident: {
@@ -264,6 +292,7 @@ const weapons = {
     properties: ["thrown (20/60)", "versatile (1d8)"],
     weight: 4,
     cost: "5 gp",
+    mastery: "nick",
     proficient: false,
   },
   "war-pick": {
@@ -273,6 +302,7 @@ const weapons = {
     properties: [],
     weight: 2,
     cost: "5 gp",
+    mastery: "push",
     proficient: false,
   },
   warhammer: {
@@ -282,6 +312,7 @@ const weapons = {
     properties: ["versatile (1d10)"],
     weight: 2,
     cost: "15 gp",
+    mastery: "push",
     proficient: false,
   },
   whip: {
@@ -291,6 +322,7 @@ const weapons = {
     properties: ["finesse", "reach"],
     weight: 3,
     cost: "2 gp",
+    mastery: "vex",
     proficient: false,
   },
   blowgun: {
@@ -300,6 +332,7 @@ const weapons = {
     properties: ["ammunition (25/100)", "loading"],
     weight: 1,
     cost: "10 gp",
+    mastery: "slow",
     proficient: false,
   },
   "hand-crossbow": {
@@ -309,6 +342,7 @@ const weapons = {
     properties: ["ammunition (30/120)", "light", "loading"],
     weight: 3,
     cost: "75 gp",
+    mastery: "vex",
     proficient: false,
   },
   "heavy-crossbow": {
@@ -318,6 +352,7 @@ const weapons = {
     properties: ["ammunition (100/400)", "heavy", "loading", "two-handed"],
     weight: 18,
     cost: "50 gp",
+    mastery: "slow",
     proficient: false,
   },
   longbow: {
@@ -327,6 +362,7 @@ const weapons = {
     properties: ["ammunition (150/600)", "heavy", "two-handed"],
     weight: 2,
     cost: "50 gp",
+    mastery: "vex",
     proficient: false,
   },
   net: {
@@ -336,6 +372,7 @@ const weapons = {
     properties: ["thrown (5/15)", "special"],
     weight: 3,
     cost: "1 gp",
+    mastery: "slow",
     proficient: false,
   },
 };

--- a/types/weapon.d.ts
+++ b/types/weapon.d.ts
@@ -28,6 +28,10 @@ export interface Weapon {
    */
   cost: number;
   /**
+   * Weapon mastery key, such as "cleave" or "vex".
+   */
+  mastery?: string;
+  /**
    * Additional attack bonus provided by the weapon.
    */
   attackBonus?: number;


### PR DESCRIPTION
## Summary
- add weapon mastery metadata to the server weapon catalog and shared weapon type
- expose mastery descriptions in the client via a new dataset and crown popover on attack cards
- update styling and normalization so mastery data is preserved across inventory flows

## Testing
- npm test -- --watchAll=false *(fails: known ZombiesCharacterSheet test warnings and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68f43197fa7483239bf40210df7f87d8