### PR TITLE
Integrate dice box roller into damage flow

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1859,6 +1859,25 @@ $rotateX: -$angle;
   overflow: visible;
 }
 
+.damage-dice-canvas__box {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  overflow: hidden;
+}
+
+.damage-dice-canvas__box canvas,
+.damage-dice-canvas__box > div {
+  width: 100%;
+  height: 100%;
+}
+
+.damage-dice-canvas__box--ready {
+  opacity: 1;
+}
+
 .damage-roller__total {
   position: relative;
   z-index: 2;

--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -1,4 +1,8 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  registerDiceBoxContainer,
+  subscribeToDiceBoxAvailability,
+} from '../../../utils/diceBoxManager';
 
 const DIE_SIZE_BY_SIDES = new Map([
   [4, 44],
@@ -153,6 +157,23 @@ const createDieStyle = (die, index, reduceMotion) => {
 
 const DamageDiceCanvas = ({ dice = [] }) => {
   const reduceMotion = usePrefersReducedMotion();
+  const diceBoxRef = useRef(null);
+  const [diceBoxReady, setDiceBoxReady] = useState(false);
+
+  useEffect(() => {
+    const element = diceBoxRef.current;
+    if (!element) return () => {};
+
+    const unregister = registerDiceBoxContainer(element);
+    const unsubscribe = subscribeToDiceBoxAvailability((ready) => {
+      setDiceBoxReady(Boolean(ready));
+    });
+
+    return () => {
+      unregister?.();
+      unsubscribe?.();
+    };
+  }, []);
 
   const diceElements = useMemo(() => {
     if (!Array.isArray(dice) || dice.length === 0) {
@@ -201,7 +222,13 @@ const DamageDiceCanvas = ({ dice = [] }) => {
 
   return (
     <div className="damage-dice-canvas" aria-hidden="true">
-      {diceElements}
+      <div
+        ref={diceBoxRef}
+        className={`damage-dice-canvas__box ${
+          diceBoxReady ? 'damage-dice-canvas__box--ready' : ''
+        }`}
+      />
+      {!diceBoxReady && diceElements}
     </div>
   );
 };

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -16,6 +16,7 @@ import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkill } from './Skills';
 import DamageDiceCanvas from './DamageDiceCanvas';
+import { rollDiceWithBox } from '../../../utils/diceBoxManager';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -799,19 +800,116 @@ const manualCriticalRef = useRef(false);
     return 'Attack';
   };
 
-  const handleWeaponAttack = (slot, weapon) => {
-    const ability = abilityForWeapon(weapon, slot);
-    const damageString = getDamageStringForHandSelection(slot, weapon);
-    if (typeof damageString !== 'string' || !damageString.trim()) return;
-    const result = calculateDamage(damageString, ability, isCritical);
-    if (!result) return;
-    updateDamageValueWithAnimation(
-      result.total,
-      result.breakdown,
-      weapon.name,
-      { diceRolls: result.diceRolls }
-    );
-  };
+  const rollDamageExpression = useCallback(
+    async ({
+      damageString,
+      ability = 0,
+      crit = false,
+      extraDice,
+      levelsAbove = 0,
+    }) => {
+      if (typeof damageString !== 'string') return null;
+      const trimmed = damageString.trim();
+      if (!trimmed) return null;
+
+      const requests = [];
+      const validation = calculateDamage(
+        trimmed,
+        ability,
+        crit,
+        (count, sides) => {
+          requests.push({ count, sides });
+          return Array(count).fill(1);
+        },
+        extraDice,
+        levelsAbove,
+      );
+
+      if (!validation) {
+        return null;
+      }
+
+      if (requests.length === 0) {
+        const staticResult = calculateDamage(
+          trimmed,
+          ability,
+          crit,
+          rollDice,
+          extraDice,
+          levelsAbove,
+        );
+        return staticResult ? { ...staticResult, rollValues: undefined } : null;
+      }
+
+      try {
+        const { rolls } = await rollDiceWithBox(requests);
+        let requestIndex = 0;
+        const applyRolls = (count, sides) => {
+          const current = Array.isArray(rolls) ? rolls[requestIndex] : undefined;
+          requestIndex += 1;
+          if (Array.isArray(current) && current.length === count) {
+            return current.map((value) => {
+              const parsed = Number(value);
+              return Number.isFinite(parsed) ? parsed : 0;
+            });
+          }
+          return rollDice(count, sides);
+        };
+
+        const finalResult = calculateDamage(
+          trimmed,
+          ability,
+          crit,
+          applyRolls,
+          extraDice,
+          levelsAbove,
+        );
+
+        const rollValues = Array.isArray(rolls)
+          ? rolls
+              .flat()
+              .map((value) => {
+                const parsed = Number(value);
+                return Number.isFinite(parsed) ? parsed : 0;
+              })
+          : undefined;
+
+        return finalResult ? { ...finalResult, rollValues } : null;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Damage roll failed', error);
+        const fallbackResult = calculateDamage(
+          trimmed,
+          ability,
+          crit,
+          rollDice,
+          extraDice,
+          levelsAbove,
+        );
+        return fallbackResult ? { ...fallbackResult, rollValues: undefined } : null;
+      }
+    },
+    [rollDiceWithBox],
+  );
+
+  const handleWeaponAttack = useCallback(
+    async (slot, weapon) => {
+      const ability = abilityForWeapon(weapon, slot);
+      const damageString = getDamageStringForHandSelection(slot, weapon);
+      if (typeof damageString !== 'string' || !damageString.trim()) return;
+      const result = await rollDamageExpression({
+        damageString,
+        ability,
+        crit: isCritical,
+      });
+      if (!result) return;
+      updateDamageValueWithAnimation(result.total, result.breakdown, weapon.name, {
+        diceRolls: result.diceRolls,
+        rollValues: result.rollValues,
+      });
+    },
+    [abilityForWeapon, getDamageStringForHandSelection, isCritical, rollDamageExpression],
+  );
 
   const handleWeaponAttackRoll = (slot, weapon) => {
     const rawBonus = Number(getAttackBonus(slot, weapon));
@@ -845,27 +943,30 @@ const manualCriticalRef = useRef(false);
     );
   };
 
-  const handleBreathWeaponAttack = () => {
+  const handleBreathWeaponAttack = useCallback(async () => {
     if (!breathWeaponDetails) return;
-    const result = calculateDamage(breathWeaponDetails.damageString, 0, false);
+    const result = await rollDamageExpression({
+      damageString: breathWeaponDetails.damageString,
+      ability: 0,
+      crit: false,
+    });
     if (!result) return;
-    updateDamageValueWithAnimation(
-      result.total,
-      result.breakdown,
-      'Breath Weapon',
-      { diceRolls: result.diceRolls }
-    );
-  };
+    updateDamageValueWithAnimation(result.total, result.breakdown, 'Breath Weapon', {
+      diceRolls: result.diceRolls,
+      rollValues: result.rollValues,
+    });
+  }, [breathWeaponDetails, rollDamageExpression]);
 
 const [showUpcast, setShowUpcast] = useState(false);
 const [pendingSpell, setPendingSpell] = useState(null);
 
-  const applyUpcast = (spell, level, crit, slotType) => {
-    const diff = level - (spell.level || 0);
-    let extra;
-    if (diff > 0 && spell.higherLevels) {
-      const incMatch = spell.higherLevels.match(/(\d+)d(\d+)/);
-      if (incMatch) {
+  const applyUpcast = useCallback(
+    async (spell, level, crit, slotType) => {
+      const diff = level - (spell.level || 0);
+      let extra;
+      if (diff > 0 && spell.higherLevels) {
+        const incMatch = spell.higherLevels.match(/(\d+)d(\d+)/);
+        if (incMatch) {
         extra = {
           count: parseInt(incMatch[1], 10),
           sides: parseInt(incMatch[2], 10),
@@ -877,14 +978,25 @@ const [pendingSpell, setPendingSpell] = useState(null);
       else if (totalLevel >= 11 && spell.scaling[11]) spell.damage = spell.scaling[11];
       else if (totalLevel >= 5 && spell.scaling[5]) spell.damage = spell.scaling[5];
     }
-    const value = calculateDamage(
-      spell.damage,
-      0,
-      crit || isCritical,
-      rollDice,
-      extra,
-      diff > 0 ? diff : 0
-    );
+    const rollParams = {
+      damageString: spell.damage,
+      ability: 0,
+      crit: crit || isCritical,
+      extraDice: extra,
+      levelsAbove: diff > 0 ? diff : 0,
+    };
+
+    const value = onCastSpell
+      ? calculateDamage(
+          rollParams.damageString,
+          rollParams.ability,
+          rollParams.crit,
+          rollDice,
+          rollParams.extraDice,
+          rollParams.levelsAbove,
+        )
+      : await rollDamageExpression(rollParams);
+
     if (!value) return;
     if (onCastSpell) {
       onCastSpell({
@@ -899,8 +1011,9 @@ const [pendingSpell, setPendingSpell] = useState(null);
     }
     updateDamageValueWithAnimation(value.total, value.breakdown, spell.name, {
       diceRolls: value.diceRolls,
+      rollValues: value.rollValues,
     });
-  };
+  }, [isCritical, onCastSpell, rollDamageExpression, totalLevel]);
 
   const handleSpellsButtonClick = (spell, crit = false) => {
     if (!spell?.damage) return;
@@ -1658,9 +1771,9 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
         onHide={() => setShowUpcast(false)}
         baseLevel={pendingSpell?.spell?.level}
         slots={availableSlots}
-        onSelect={(lvl, type) => {
+        onSelect={async (lvl, type) => {
           if (pendingSpell) {
-            applyUpcast(pendingSpell.spell, lvl, pendingSpell.crit, type);
+            await applyUpcast(pendingSpell.spell, lvl, pendingSpell.crit, type);
             setPendingSpell(null);
           }
           setShowUpcast(false);

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -1,0 +1,346 @@
+const DICE_BOX_SCRIPT_ID = 'dice-box-library-script';
+const DICE_BOX_SCRIPT_URL = '/assets/dice-box/dice-box.umd.js';
+const ASSET_PATH = '/assets/dice-box/public/assets/dice-box/';
+
+let scriptPromise = null;
+let diceBoxPromise = null;
+let diceBoxInstance = null;
+let diceBoxReady = false;
+let diceBoxFailed = false;
+let hostElement = null;
+let rollQueue = Promise.resolve();
+
+const availabilityListeners = new Set();
+
+const fallbackRoll = (count, sides) =>
+  Array.from({ length: count }, () => Math.floor(Math.random() * sides) + 1);
+
+const safeNumber = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const notifyAvailability = (ready) => {
+  availabilityListeners.forEach((listener) => {
+    try {
+      listener(ready);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Dice box listener error', error);
+    }
+  });
+};
+
+const setAvailability = (ready) => {
+  diceBoxReady = ready;
+  notifyAvailability(ready);
+};
+
+const loadScript = () => {
+  if (scriptPromise) {
+    return scriptPromise;
+  }
+
+  if (typeof document === 'undefined') {
+    scriptPromise = Promise.resolve();
+    return scriptPromise;
+  }
+
+  const existing = document.getElementById(DICE_BOX_SCRIPT_ID);
+  if (existing) {
+    scriptPromise = existing.getAttribute('data-loaded') === 'true'
+      ? Promise.resolve()
+      : new Promise((resolve, reject) => {
+          existing.addEventListener('load', resolve, { once: true });
+          existing.addEventListener('error', reject, { once: true });
+        });
+    return scriptPromise;
+  }
+
+  scriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = DICE_BOX_SCRIPT_ID;
+    script.async = true;
+    script.src = DICE_BOX_SCRIPT_URL;
+    script.onload = () => {
+      script.setAttribute('data-loaded', 'true');
+      resolve();
+    };
+    script.onerror = (event) => {
+      reject(new Error(`Failed to load dice box script: ${event?.message || 'unknown error'}`));
+    };
+    document.head.appendChild(script);
+  }).catch((error) => {
+    scriptPromise = null;
+    throw error;
+  });
+
+  return scriptPromise;
+};
+
+const resetInstance = () => {
+  diceBoxInstance = null;
+  diceBoxPromise = null;
+  diceBoxReady = false;
+};
+
+const ensureDiceBox = async () => {
+  if (diceBoxInstance) {
+    return diceBoxInstance;
+  }
+  if (diceBoxFailed) {
+    return null;
+  }
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test') {
+    diceBoxFailed = true;
+    return null;
+  }
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+  if (!hostElement) {
+    return null;
+  }
+  if (!diceBoxPromise) {
+    diceBoxPromise = (async () => {
+      try {
+        await loadScript();
+        const { DiceBox } = window;
+        if (typeof DiceBox !== 'function') {
+          diceBoxFailed = true;
+          setAvailability(false);
+          return null;
+        }
+        const instance = new DiceBox(hostElement, {
+          assetPath: ASSET_PATH,
+          theme: 'default',
+          scale: 6,
+          offscreen: false,
+        });
+        await instance.init();
+        diceBoxInstance = instance;
+        diceBoxFailed = false;
+        setAvailability(true);
+        return instance;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Dice box initialization failed', error);
+        diceBoxFailed = true;
+        setAvailability(false);
+        return null;
+      }
+    })();
+  }
+  return diceBoxPromise;
+};
+
+const parseDiceBoxResults = (rawResults, requests) => {
+  if (!Array.isArray(rawResults) || rawResults.length === 0) {
+    return null;
+  }
+
+  const extracted = [];
+
+  const pushValues = (values) => {
+    if (!Array.isArray(values) || values.length === 0) {
+      return;
+    }
+    const numbers = values
+      .map((value) => {
+        if (Array.isArray(value)) {
+          return value
+            .map((nested) => safeNumber(nested?.value ?? nested?.result ?? nested))
+            .filter((num) => num !== null);
+        }
+        if (value && typeof value === 'object') {
+          const num =
+            safeNumber(value.value) ?? safeNumber(value.result) ?? safeNumber(value.total);
+          return num !== null ? [num] : [];
+        }
+        const num = safeNumber(value);
+        return num !== null ? [num] : [];
+      })
+      .flat();
+    if (numbers.length > 0) {
+      extracted.push(numbers);
+    }
+  };
+
+  const traverse = (node) => {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      node.forEach(traverse);
+      return;
+    }
+    if (typeof node !== 'object') return;
+
+    if (Array.isArray(node.results)) {
+      pushValues(node.results);
+    }
+    if (Array.isArray(node.rolls)) {
+      node.rolls.forEach((roll) => {
+        if (Array.isArray(roll.results)) {
+          pushValues(roll.results);
+        } else if (Array.isArray(roll.values)) {
+          pushValues(roll.values);
+        } else if (typeof roll.value === 'number') {
+          pushValues([roll.value]);
+        }
+      });
+    }
+    if (Array.isArray(node.values)) {
+      pushValues(node.values);
+    }
+  };
+
+  rawResults.forEach(traverse);
+
+  if (extracted.length === requests.length) {
+    return extracted.map((values, index) => {
+      const expected = requests[index]?.count;
+      if (typeof expected === 'number' && expected > 0 && values.length !== expected) {
+        return values.slice(0, expected);
+      }
+      return values;
+    });
+  }
+
+  return null;
+};
+
+const setRollHandlers = (instance, onComplete, onError) => {
+  if (!instance) return () => {};
+
+  const cleanup = () => {
+    instance.onRollComplete = null;
+    if ('onRollError' in instance) {
+      instance.onRollError = null;
+    }
+  };
+
+  instance.onRollComplete = (results) => {
+    cleanup();
+    onComplete(results);
+  };
+
+  if ('onRollError' in instance) {
+    instance.onRollError = (error) => {
+      cleanup();
+      onError(error);
+    };
+  }
+
+  return cleanup;
+};
+
+export const registerDiceBoxContainer = (element) => {
+  hostElement = element || null;
+  resetInstance();
+  diceBoxFailed = false;
+  if (!hostElement) {
+    setAvailability(false);
+    return () => {};
+  }
+
+  ensureDiceBox();
+
+  return () => {
+    if (hostElement === element) {
+      hostElement = null;
+      resetInstance();
+      setAvailability(false);
+    }
+  };
+};
+
+export const subscribeToDiceBoxAvailability = (listener) => {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+  availabilityListeners.add(listener);
+  listener(diceBoxReady);
+  return () => {
+    availabilityListeners.delete(listener);
+  };
+};
+
+export const isDiceBoxReady = () => diceBoxReady;
+
+export const rollDiceWithBox = (requests) => {
+  if (!Array.isArray(requests) || requests.length === 0) {
+    return Promise.resolve({
+      rolls: [],
+      rawResults: null,
+      usedFallback: true,
+    });
+  }
+
+  const executeRoll = async () => {
+    const instance = await ensureDiceBox();
+    const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
+
+    if (!instance) {
+      return {
+        rolls: fallback,
+        rawResults: null,
+        usedFallback: true,
+      };
+    }
+
+    return new Promise((resolve) => {
+      const notations = requests.map(({ count, sides }) => `${count}d${sides}`);
+
+      try {
+        if (typeof instance.clear === 'function') {
+          instance.clear();
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Dice box clear failed', error);
+      }
+
+      const finalize = (rawResults, usedFallback = false) => {
+        resolve({
+          rolls: usedFallback ? fallback : rawResults,
+          rawResults: usedFallback ? null : rawResults,
+          usedFallback,
+        });
+      };
+
+      const cleanup = setRollHandlers(
+        instance,
+        (rawResults) => {
+          const parsed = parseDiceBoxResults(rawResults, requests);
+          if (parsed) {
+            resolve({ rolls: parsed, rawResults, usedFallback: false });
+            return;
+          }
+          resolve({ rolls: fallback, rawResults, usedFallback: true });
+        },
+        () => {
+          finalize(fallback, true);
+        }
+      );
+
+      try {
+        instance.roll(notations);
+      } catch (error) {
+        cleanup();
+        // eslint-disable-next-line no-console
+        console.error('Dice box roll failed', error);
+        finalize(fallback, true);
+      }
+    });
+  };
+
+  rollQueue = rollQueue.then(executeRoll, executeRoll);
+  return rollQueue;
+};
+
+export default {
+  registerDiceBoxContainer,
+  subscribeToDiceBoxAvailability,
+  isDiceBoxReady,
+  rollDiceWithBox,
+};


### PR DESCRIPTION
## Summary
- load the dice box asset bundle through a new client-side manager with graceful fallbacks
- update the player turn actions damage workflows to consume dice box rolls when available while preserving existing behavior elsewhere
- embed the dice box viewport in the damage display with new styling hooks

## Testing
- npm --prefix client test -- PlayerTurnActions.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68f4ef42f034832e9407f44356c5b2ac