### PR TITLE
Integrate dice-box roller into character sheet damage display

### DIFF
--- a/client/src/dice-box.css
+++ b/client/src/dice-box.css
@@ -1,35 +1,19 @@
-html,
-body {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  overflow: hidden;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  position: relative;
-}
-
-#dice-box {
-  position: relative;
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
-  background-image: url(/public/assets/woodgrain2.jpg);
-  background-size: cover;
-}
-
-#dice-box canvas {
-  width: 100%;
-  height: 100%;
-}
-
-#roll {
+.damage-dice-canvas__box {
   position: absolute;
-  top: 5px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1;
-  cursor: pointer;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-image: url('/assets/woodgrain2.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  pointer-events: none;
+}
+
+.damage-dice-canvas__box canvas,
+.damage-dice-canvas__box > div {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.scss';
+import './dice-box.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -1,8 +1,6 @@
-const DICE_BOX_SCRIPT_ID = 'dice-box-library-script';
-const DICE_BOX_SCRIPT_URL = '/assets/dice-box/dice-box.umd.js';
-const ASSET_PATH = '/assets/dice-box/public/assets/dice-box/';
+const ASSET_PATH = '/assets/dice-box/';
 
-let scriptPromise = null;
+let modulePromise = null;
 let diceBoxPromise = null;
 let diceBoxInstance = null;
 let diceBoxReady = false;
@@ -37,46 +35,25 @@ const setAvailability = (ready) => {
   notifyAvailability(ready);
 };
 
-const loadScript = () => {
-  if (scriptPromise) {
-    return scriptPromise;
+const getDiceBoxConstructor = () => {
+  if (modulePromise) {
+    return modulePromise;
   }
 
-  if (typeof document === 'undefined') {
-    scriptPromise = Promise.resolve();
-    return scriptPromise;
-  }
+  modulePromise = import(/* webpackChunkName: "dice-box" */ '@3d-dice/dice-box')
+    .then((module) => {
+      const DiceBoxCtor = module?.default || module?.DiceBox || module;
+      if (typeof DiceBoxCtor !== 'function') {
+        throw new Error('Dice Box module did not export a constructor');
+      }
+      return DiceBoxCtor;
+    })
+    .catch((error) => {
+      modulePromise = null;
+      throw error;
+    });
 
-  const existing = document.getElementById(DICE_BOX_SCRIPT_ID);
-  if (existing) {
-    scriptPromise = existing.getAttribute('data-loaded') === 'true'
-      ? Promise.resolve()
-      : new Promise((resolve, reject) => {
-          existing.addEventListener('load', resolve, { once: true });
-          existing.addEventListener('error', reject, { once: true });
-        });
-    return scriptPromise;
-  }
-
-  scriptPromise = new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.id = DICE_BOX_SCRIPT_ID;
-    script.async = true;
-    script.src = DICE_BOX_SCRIPT_URL;
-    script.onload = () => {
-      script.setAttribute('data-loaded', 'true');
-      resolve();
-    };
-    script.onerror = (event) => {
-      reject(new Error(`Failed to load dice box script: ${event?.message || 'unknown error'}`));
-    };
-    document.head.appendChild(script);
-  }).catch((error) => {
-    scriptPromise = null;
-    throw error;
-  });
-
-  return scriptPromise;
+  return modulePromise;
 };
 
 const resetInstance = () => {
@@ -105,14 +82,12 @@ const ensureDiceBox = async () => {
   if (!diceBoxPromise) {
     diceBoxPromise = (async () => {
       try {
-        await loadScript();
-        const { DiceBox } = window;
-        if (typeof DiceBox !== 'function') {
-          diceBoxFailed = true;
-          setAvailability(false);
-          return null;
-        }
-        const instance = new DiceBox(hostElement, {
+        const DiceBox = await getDiceBoxConstructor();
+        const target =
+          hostElement && typeof hostElement === 'object' && 'current' in hostElement
+            ? hostElement.current
+            : hostElement;
+        const instance = new DiceBox(target || hostElement, {
           assetPath: ASSET_PATH,
           theme: 'default',
           scale: 6,


### PR DESCRIPTION
## Summary
- load the 3d dice box library through a dynamic import that uses the local public assets and tracks readiness state
- scope the dice box styling to the damage roller container and ensure it is loaded with the app

## Testing
- npm test -- --watchAll=false *(fails: existing ZombiesCharacterSheet tests emit act warnings and time out while waiting for UI state)*

------
https://chatgpt.com/codex/tasks/task_e_68f4f7000630832ebd22f691306e19ff