### PR TITLE
Fix undefined usingDiceBoxStub flag

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -14,6 +14,7 @@ let hostElement = null;
 let rollQueue = Promise.resolve();
 let generatedHostId = 0;
 let diceBoxScriptPromise = null;
+let usingDiceBoxStub = false;
 
 const availabilityListeners = new Set();
 


### PR DESCRIPTION
## Summary
- declare the usingDiceBoxStub flag so the dice box manager script tracks stub usage without lint errors

## Testing
- npm run lint *(fails: missing npm script)*

------
https://chatgpt.com/codex/tasks/task_e_68f5066e0808832e8a2f499bbfb2d233