### PR TITLE
Reduce damage dice roller canvas footprint

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1843,7 +1843,14 @@ $rotateX: -$angle;
 
 .damage-roller__dice-area {
   position: absolute;
-  inset: 0;
+  top: 24px;
+  left: 50%;
+  width: clamp(140px, 36vw, 220px);
+  height: clamp(140px, 36vw, 220px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateX(-50%);
   overflow: visible;
   pointer-events: none;
   z-index: 1;
@@ -1854,6 +1861,8 @@ $rotateX: -$angle;
 .damage-dice-canvas {
   position: absolute;
   inset: 0;
+  width: 100%;
+  height: 100%;
   pointer-events: none;
   transform-style: preserve-3d;
   overflow: visible;


### PR DESCRIPTION
## Summary
- adjust the damage dice canvas overlay to use a smaller centered footprint
- ensure the dice canvas fills the resized container

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f50e39035c832ea61b66435d574992