### PR TITLE
Fix stat breakdown to avoid double counting bonuses

### DIFF
--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -93,12 +93,16 @@ export default function Stats({
   );
 
   const breakdowns = Object.keys(stats).reduce((acc, key) => {
-    const base = stats[key] - classBonus[key];
+    const statValueRaw = Number(stats[key]);
+    const statValue = Number.isNaN(statValueRaw) ? 0 : statValueRaw;
+    const cls = Number(classBonus[key] || 0);
     const race = Number(raceBonus[key] || 0);
-    const feat = totalFeatBonus[key];
-    const item = totalItemBonus[key];
-    const cls = classBonus[key];
-    const totalWithoutOverride = base + cls + race + feat + item;
+    const feat = Number(totalFeatBonus[key] || 0);
+    const item = Number(totalItemBonus[key] || 0);
+    const baseValue = statValue - (cls + race + feat + item);
+    const sanitizedBase = Number.isFinite(baseValue) ? baseValue : 0;
+    const base = Object.is(sanitizedBase, -0) ? 0 : sanitizedBase;
+    const totalWithoutOverride = statValue;
     const overrideValue = itemOverrides[key];
     const breakdown = {
       base,

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -5,7 +5,7 @@ import Stats from './Stats';
 
 test('clicking view shows description and breakdown', async () => {
   const form = {
-    str: 10,
+    str: 14,
     dex: 0,
     con: 0,
     int: 0,


### PR DESCRIPTION
## Summary
- adjust the ability score breakdown to derive the base stat from the stored value instead of double counting bonuses
- ensure breakdown totals align with the final ability score and handle missing values safely
- update the stats breakdown test fixture to reflect the final Strength value used in the assertions

## Testing
- CI=true npm test -- Stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f50d157380832399857b7ba7705b58