### PR TITLE
Reorganize damage roller layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1812,12 +1812,13 @@ $rotateX: -$angle;
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
   align-items: center;
+  justify-content: flex-start;
+  gap: 18px;
   width: min(90vw, 520px);
-  min-height: clamp(220px, 45vh, 360px);
+  min-height: clamp(240px, 48vh, 380px);
   margin: 0 auto;
-  padding: 24px 24px 80px;
+  padding: 32px 24px 48px;
   color: #ffffff;
   font-weight: bold;
   font-family: 'Courier New', monospace;
@@ -1842,15 +1843,13 @@ $rotateX: -$angle;
 }
 
 .damage-roller__dice-area {
-  position: absolute;
-  top: 24px;
-  left: 50%;
+  position: relative;
   width: clamp(140px, 36vw, 220px);
   height: clamp(140px, 36vw, 220px);
   display: flex;
   align-items: center;
   justify-content: center;
-  transform: translateX(-50%);
+  margin: 0 auto;
   overflow: visible;
   pointer-events: none;
   z-index: 1;
@@ -1894,7 +1893,7 @@ $rotateX: -$angle;
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  margin-top: auto;
+  margin: 0;
   padding: 14px 26px;
   border-radius: 24px;
   transition: box-shadow 0.3s ease;
@@ -1919,6 +1918,17 @@ $rotateX: -$angle;
     transition: opacity 0.2s ease;
     z-index: -1;
   }
+}
+
+.damage-roller__controls {
+  width: 100%;
+  max-width: min(70vw, 360px);
+  margin: 0 auto;
+  gap: calc(var(--attack-die-size) * 0.2);
+}
+
+.damage-roller__controls .attack-roll-controls__button {
+  justify-content: center;
 }
 
 .damage-roller__total-label {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1273,9 +1273,6 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
             isFumble ? 'critical-failure' : ''
           }`}
         >
-          <div className="damage-roller__dice-area" aria-hidden="true">
-            <DamageDiceCanvas dice={preparedDice} />
-          </div>
           <div className="damage-roller__total">
             <span className="damage-roller__total-label">Total</span>
             <span
@@ -1301,6 +1298,33 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
             >
               {damageValue}
             </span>
+          </div>
+          <div className="attack-roll-controls damage-roller__controls">
+            <div className="attack-roll-controls__button">
+              {/* Attack Button */}
+              <button
+                onClick={handleShowAttack}
+                style={{
+                  width: '64px',
+                  height: '64px',
+                  backgroundImage: `url(${sword})`,
+                  backgroundSize: 'cover',
+                  backgroundPosition: 'center',
+                  border: 'none',
+                  transition: 'transform 0.2s ease',
+                  cursor: 'pointer',
+                  backgroundColor: 'transparent',
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
+                onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+                title="Attack"
+              />
+            </div>
+            <div className="attack-roll-controls__die">
+              <div className="damage-roller__dice-area" aria-hidden="true">
+                <DamageDiceCanvas dice={preparedDice} />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -1382,38 +1406,6 @@ const passDisabled = !canPassTurn || isPassTurnInProgress;
           </ul>
         </Modal.Body>
       </Modal>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          overflowY: 'auto',
-          paddingBottom: `${footerHeight}px`,
-        }}
-      >
-        <div className="attack-roll-controls">
-          <div className="attack-roll-controls__button">
-            {/* Attack Button */}
-            <button
-              onClick={handleShowAttack}
-              style={{
-                width: '64px',
-                height: '64px',
-                backgroundImage: `url(${sword})`,
-                backgroundSize: 'cover',
-                backgroundPosition: 'center',
-                border: 'none',
-                transition: 'transform 0.2s ease',
-                cursor: 'pointer',
-                backgroundColor: 'transparent',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
-              onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
-              title="Attack"
-            />
-          </div>
-        </div>
-      </div>
 {/* Attack Modal */}
 
       <Modal size="lg" className="dnd-modal modern-modal" centered show={showAttack} onHide={handleCloseAttack}>


### PR DESCRIPTION
## Summary
- reposition the damage total above the attack controls within the damage display
- place the sword attack trigger between the damage total and the dice roller
- update the damage roller styling to support the new vertical layout

## Testing
- npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js *(fails: existing act() warnings and unmet expectations in ZombiesCharacterSheet.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f5111f3d84832eb95f2da716a3eb10