### PR TITLE
Prevent manual level-1 character HP double counting

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -701,7 +701,9 @@ function bigMaff() {
   );
 
   if (startingHealth !== null) {
-    updateForm({ health: startingHealth, tempHealth: startingHealth });
+    const baseHitDie = Number(normalizedOcc.Health);
+    const baseHealth = Number.isFinite(baseHitDie) ? baseHitDie : startingHealth;
+    updateForm({ health: baseHealth, tempHealth: startingHealth });
   } else {
     const conModValue = Math.floor(((Number(randomCon) || 0) - 10) / 2);
     const baseHitDie = Number(normalizedOcc.Health) || 0;
@@ -722,7 +724,8 @@ function bigMaff() {
     );
 
     if (startingHealth !== null) {
-      baseCharacter.health = startingHealth;
+      const baseHitDie = Number(primaryOccupation?.Health);
+      baseCharacter.health = Number.isFinite(baseHitDie) ? baseHitDie : startingHealth;
       baseCharacter.tempHealth = startingHealth;
     }
 


### PR DESCRIPTION
## Summary
- ensure manual character creation stores the hit die as base health so the shared calculator only adds the Constitution modifier once
- persist the derived starting HP in tempHealth when creating or saving a manual character

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/utils/characterMetrics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f5113aa5808323bf88c1ce42482d4e