### PR TITLE
Overlay damage controls on dice area

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1860,6 +1860,37 @@ $rotateX: -$angle;
   max-height: var(--damage-dice-area-size, 320px);
 }
 
+.damage-roller__dice-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.damage-roller__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.damage-roller__overlay > * {
+  pointer-events: auto;
+}
+
+.damage-roller__overlay-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .damage-dice-canvas {
   position: absolute;
   inset: 0;

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1442,54 +1442,14 @@ const damageAmountStyle = {
             isFumble ? 'critical-failure' : ''
           }`}
         >
-          <div className="damage-roller__total">
-            <span className="damage-roller__total-label">Total</span>
-            <span
-              id="damageValue"
-              className={`damage-roller__total-value ${
-                typeof damageValue === 'string' ? 'spell-cast-label' : ''
-              }`}
-              role="button"
-              tabIndex={0}
-              aria-pressed={isCritical}
-              aria-label={
-                isCritical
-                  ? 'Critical damage roll enabled. Click to roll normally.'
-                  : 'Click to enable a critical damage roll on your next roll.'
-              }
-              title={
-                isCritical
-                  ? 'Critical roll ready. Click to roll normally.'
-                  : 'Click to make your next damage roll critical.'
-              }
-              onClick={handleDamageClick}
-              onKeyDown={handleDamageKeyDown}
-            >
-              {damageValue}
-            </span>
-          </div>
           <div className="attack-roll-controls damage-roller__controls">
-            <div className="attack-roll-controls__button">
-              {/* Attack Button */}
-              <button
-                onClick={handleShowAttack}
-                style={{
-                  width: '64px',
-                  height: '64px',
-                  backgroundImage: `url(${sword})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                  border: 'none',
-                  transition: 'transform 0.2s ease',
-                  cursor: 'pointer',
-                  backgroundColor: 'transparent',
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
-                onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
-                title="Attack"
-              />
-            </div>
-            <div className="attack-roll-controls__die">
+            <div
+              className="damage-roller__dice-wrapper"
+              style={{
+                width: `${resolvedDiceSize}px`,
+                height: `${resolvedDiceSize}px`,
+              }}
+            >
               <div
                 className="damage-roller__dice-area"
                 aria-hidden="true"
@@ -1499,6 +1459,54 @@ const damageAmountStyle = {
                 }}
               >
                 <DamageDiceCanvas dice={preparedDice} />
+              </div>
+              <div className="damage-roller__overlay">
+                <div className="damage-roller__total">
+                  <span className="damage-roller__total-label">Total</span>
+                  <span
+                    id="damageValue"
+                    className={`damage-roller__total-value ${
+                      typeof damageValue === 'string' ? 'spell-cast-label' : ''
+                    }`}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isCritical}
+                    aria-label={
+                      isCritical
+                        ? 'Critical damage roll enabled. Click to roll normally.'
+                        : 'Click to enable a critical damage roll on your next roll.'
+                    }
+                    title={
+                      isCritical
+                        ? 'Critical roll ready. Click to roll normally.'
+                        : 'Click to make your next damage roll critical.'
+                    }
+                    onClick={handleDamageClick}
+                    onKeyDown={handleDamageKeyDown}
+                  >
+                    {damageValue}
+                  </span>
+                </div>
+                <div className="damage-roller__overlay-button">
+                  {/* Attack Button */}
+                  <button
+                    onClick={handleShowAttack}
+                    style={{
+                      width: '64px',
+                      height: '64px',
+                      backgroundImage: `url(${sword})`,
+                      backgroundSize: 'cover',
+                      backgroundPosition: 'center',
+                      border: 'none',
+                      transition: 'transform 0.2s ease',
+                      cursor: 'pointer',
+                      backgroundColor: 'transparent',
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.1)')}
+                    onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+                    title="Attack"
+                  />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- overlay the damage total and attack trigger directly on the dice roll display
- add supporting layout styles so the dice area acts as the visual backdrop for the controls

## Testing
- npm start *(fails: Module not found: Error: Can't resolve '@3d-dice/dice-box')*

------
https://chatgpt.com/codex/tasks/task_e_68f517e74348832eb93a730d8f9a4eb4