### PR TITLE
Fix stat and skill rolls to use dice box

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -14,7 +14,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { normalizeWeapons } from './inventoryNormalization';
 import weaponPropertyDefinitions from '../../../data/weaponProperties';
-import { rollSkill } from './Skills';
+import { rollSkillWithDiceBox } from './Skills';
 import DamageDiceCanvas from './DamageDiceCanvas';
 import { rollDiceWithBox } from '../../../utils/diceBoxManager';
 
@@ -911,10 +911,10 @@ const manualCriticalRef = useRef(false);
     [abilityForWeapon, getDamageStringForHandSelection, isCritical, rollDamageExpression],
   );
 
-  const handleWeaponAttackRoll = (slot, weapon) => {
+  const handleWeaponAttackRoll = async (slot, weapon) => {
     const rawBonus = Number(getAttackBonus(slot, weapon));
     const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
-    const { result, d20 } = rollSkill(bonus);
+    const { result, d20 } = await rollSkillWithDiceBox(bonus);
     const weaponLabel = getWeaponDisplayName(slot, weapon);
     const segments = [`${d20} (d20)`];
     if (bonus) {

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -8,6 +8,7 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import SkillInfoModal from './SkillInfoModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import DockControls from '../components/DockControls';
+import { rollDiceWithBox } from '../../../utils/diceBoxManager';
 
 const EMPTY_OBJECT = Object.freeze({});
 
@@ -26,8 +27,21 @@ const formatAdjustmentSegment = (value, label) => {
   return `${sign} ${Math.abs(value)} ${label}`;
 };
 
-export function rollSkill(bonus = 0) {
-  const d20 = Math.floor(Math.random() * 20) + 1;
+const normalizeD20Value = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  const rounded = Math.round(parsed);
+  if (rounded < 1) return 1;
+  if (rounded > 20) return 20;
+  return rounded;
+};
+
+export function rollSkill(bonus = 0, d20Override = null) {
+  const normalizedOverride = normalizeD20Value(d20Override);
+  const d20 =
+    normalizedOverride !== null
+      ? normalizedOverride
+      : Math.floor(Math.random() * 20) + 1;
   if (d20 === 20) {
     window.dispatchEvent(new CustomEvent('critical-hit', { detail: 'critical' }));
   } else if (d20 === 1) {
@@ -35,6 +49,23 @@ export function rollSkill(bonus = 0) {
   }
   const result = d20 + bonus;
   return { result, d20 };
+}
+
+export async function rollSkillWithDiceBox(bonus = 0) {
+  try {
+    const { rolls } = await rollDiceWithBox([{ count: 1, sides: 20 }]);
+    const firstGroup = Array.isArray(rolls) ? rolls[0] : undefined;
+    const firstValue = Array.isArray(firstGroup) ? firstGroup[0] : firstGroup;
+    const override = normalizeD20Value(firstValue);
+    if (override !== null) {
+      return { ...rollSkill(bonus, override), usedDiceBox: true };
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Skill roll using dice box failed', error);
+  }
+
+  return { ...rollSkill(bonus), usedDiceBox: false };
 }
 
 export default function Skills({
@@ -306,7 +337,7 @@ export default function Skills({
     updateSkill(skill, updated);
   };
 
-  const handleRoll = (skillKey, ability, proficient, expertise) => {
+  const handleRoll = async (skillKey, ability, proficient, expertise) => {
     const skill = SKILLS.find((s) => s.key === skillKey);
     const skillLabel = skill?.label || skill?.name || skillKey;
     const armorPenalty = skill?.armorPenalty || 0;
@@ -318,7 +349,7 @@ export default function Skills({
       itemTotals[skillKey] +
       featTotals[skillKey] +
       raceTotals[skillKey];
-    const { result, d20 } = rollSkill(bonus);
+    const { result, d20 } = await rollSkillWithDiceBox(bonus);
     const abilityLabel =
       ABILITY_LABELS[ability] || ability?.toUpperCase?.() || ability || 'Ability';
     const proficiencyValue = profBonus * (expertise ? 2 : proficient ? 1 : 0);

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -4,7 +4,7 @@ import DockControls from '../components/DockControls';
 import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
-import { rollSkill } from './Skills';
+import { rollSkillWithDiceBox } from './Skills';
 
 const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
@@ -144,9 +144,9 @@ export default function Stats({
   };
 
   const handleRoll = useCallback(
-    (statKey) => {
+    async (statKey) => {
       const statMod = statMods[statKey] ?? 0;
-      const { result, d20 } = rollSkill(statMod);
+      const { result, d20 } = await rollSkillWithDiceBox(statMod);
       const statInfo = STATS.find((stat) => stat.key === statKey);
       const statLabel = statInfo?.label || statKey.toUpperCase();
       const breakdownParts = [`${d20} (d20)`];

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within, act } from '@testing-library/react';
+import { render, screen, within, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Stats from './Stats';
 
@@ -174,6 +174,10 @@ test('rolling a stat dispatches a roll event and closes the modal when undocked'
       );
     });
 
+    await waitFor(() => {
+      expect(handleCloseStats).toHaveBeenCalled();
+    });
+
     const rollEventCall = dispatchSpy.mock.calls.find(
       ([event]) => event?.type === 'damage-roll'
     );
@@ -194,7 +198,6 @@ test('rolling a stat dispatches a roll event and closes the modal when undocked'
         }),
       ],
     });
-    expect(handleCloseStats).toHaveBeenCalled();
   } finally {
     randomSpy.mockRestore();
     dispatchSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add a dice box-backed skill rolling helper with a safe fallback
- update stat, skill, and weapon attack rolls to use the new helper
- adjust the stat rolling test to accommodate the asynchronous roll

## Testing
- CI=true npm --prefix client test -- Stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f51b432f28832ebac95c3be8cd99a1