### PR TITLE
Close stat and skills modals on roll

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -342,17 +342,22 @@ export default function Skills({
     const skillLabel = skill?.label || skill?.name || skillKey;
     const armorPenalty = skill?.armorPenalty || 0;
     const penalty = armorPenalty ? armorPenalty * totalCheckPenalty : 0;
+    const proficiencyValue = profBonus * (expertise ? 2 : proficient ? 1 : 0);
     const bonus =
       modMap[ability] +
-      profBonus * (expertise ? 2 : proficient ? 1 : 0) +
+      proficiencyValue +
       penalty +
       itemTotals[skillKey] +
       featTotals[skillKey] +
       raceTotals[skillKey];
-    const { result, d20 } = await rollSkillWithDiceBox(bonus);
     const abilityLabel =
       ABILITY_LABELS[ability] || ability?.toUpperCase?.() || ability || 'Ability';
-    const proficiencyValue = profBonus * (expertise ? 2 : proficient ? 1 : 0);
+
+    if (!isDocked) {
+      handleCloseSkill?.();
+    }
+
+    const { result, d20 } = await rollSkillWithDiceBox(bonus);
     const breakdownParts = [`${d20} (d20)`];
 
     const segments = [
@@ -393,10 +398,6 @@ export default function Skills({
         },
       })
     );
-
-    if (!isDocked) {
-      handleCloseSkill?.();
-    }
   };
 
   const handleView = (skill) => {

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Skills from './Skills';
 
 let capturedModalProps;
@@ -19,6 +20,12 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({ id: 'test-id' }),
 }));
+
+jest.mock('../../../utils/diceBoxManager', () => ({
+  rollDiceWithBox: jest.fn().mockResolvedValue({ rolls: [[12]] }),
+}));
+
+const { rollDiceWithBox } = require('../../../utils/diceBoxManager');
 
 const createProps = (overrides = {}) => ({
   form: {
@@ -50,6 +57,7 @@ const createProps = (overrides = {}) => ({
 describe('Skills modal docking props', () => {
   beforeEach(() => {
     capturedModalProps = null;
+    rollDiceWithBox.mockClear();
   });
 
   it('applies docked layout when docked', () => {
@@ -71,5 +79,63 @@ describe('Skills modal docking props', () => {
     expect(capturedModalProps.centered).toBe(true);
     expect(capturedModalProps.backdrop).toBe(true);
     expect(capturedModalProps.enforceFocus).toBe(true);
+  });
+});
+
+describe('skill rolling behavior', () => {
+  beforeEach(() => {
+    rollDiceWithBox.mockClear();
+  });
+
+  it('closes the modal after rolling when undocked', async () => {
+    const handleCloseSkill = jest.fn();
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    rollDiceWithBox.mockResolvedValueOnce({ rolls: [[17]] });
+
+    render(<Skills {...createProps({ handleCloseSkill })} />);
+
+    try {
+      const rollButton = await screen.findByRole('button', { name: /roll acrobatics/i });
+      await userEvent.click(rollButton);
+
+      expect(handleCloseSkill).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        const rollEventCall = dispatchSpy.mock.calls.find(
+          ([event]) => event?.type === 'damage-roll'
+        );
+        expect(rollEventCall).toBeDefined();
+      });
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+
+  it('keeps the modal open after rolling when docked', async () => {
+    const handleCloseSkill = jest.fn();
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    rollDiceWithBox.mockResolvedValueOnce({ rolls: [[9]] });
+
+    render(
+      <Skills
+        {...createProps({ handleCloseSkill, isDocked: true, dockedSide: 'left' })}
+      />
+    );
+
+    try {
+      const rollButton = await screen.findByRole('button', { name: /roll acrobatics/i });
+      await userEvent.click(rollButton);
+
+      expect(handleCloseSkill).not.toHaveBeenCalled();
+
+      await waitFor(() => {
+        const rollEventCall = dispatchSpy.mock.calls.find(
+          ([event]) => event?.type === 'damage-roll'
+        );
+        expect(rollEventCall).toBeDefined();
+      });
+    } finally {
+      dispatchSpy.mockRestore();
+    }
   });
 });

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -146,9 +146,14 @@ export default function Stats({
   const handleRoll = useCallback(
     async (statKey) => {
       const statMod = statMods[statKey] ?? 0;
-      const { result, d20 } = await rollSkillWithDiceBox(statMod);
       const statInfo = STATS.find((stat) => stat.key === statKey);
       const statLabel = statInfo?.label || statKey.toUpperCase();
+
+      if (!isDocked) {
+        handleCloseStats?.();
+      }
+
+      const { result, d20 } = await rollSkillWithDiceBox(statMod);
       const breakdownParts = [`${d20} (d20)`];
       const modifierSegment = formatAdjustmentSegment(
         statMod,
@@ -180,9 +185,6 @@ export default function Stats({
         })
       );
 
-      if (!isDocked) {
-        handleCloseStats?.();
-      }
     },
     [handleCloseStats, isDocked, statMods]
   );


### PR DESCRIPTION
## Summary
- close the stats modal as soon as a roll is triggered when it is not docked
- close the skills modal when rolling unless it is docked and keep roll event behaviour intact
- cover the skills modal roll behaviour with new tests for docked and undocked modes

## Testing
- CI=true npm test -- Stats.test.js
- CI=true npm test -- Skills.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f51f0fcb38832e8b6517659014c971