### PR TITLE
Ensure spell damage uses dice box rolls

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -986,33 +986,47 @@ const [pendingSpell, setPendingSpell] = useState(null);
       levelsAbove: diff > 0 ? diff : 0,
     };
 
-    const value = onCastSpell
-      ? calculateDamage(
-          rollParams.damageString,
-          rollParams.ability,
-          rollParams.crit,
-          rollDice,
-          rollParams.extraDice,
-          rollParams.levelsAbove,
-        )
-      : await rollDamageExpression(rollParams);
+    const value = await rollDamageExpression(rollParams);
 
     if (!value) return;
+
     if (onCastSpell) {
-      onCastSpell({
+      const payload = {
         level,
         slotType,
         damage: value.total,
         breakdown: value.breakdown,
         castingTime: spell.castingTime,
         name: spell.name,
-      });
+      };
+      if (Array.isArray(value.diceRolls) && value.diceRolls.length > 0) {
+        payload.diceRolls = value.diceRolls;
+      }
+      if (Array.isArray(value.rollValues) && value.rollValues.length > 0) {
+        payload.rollValues = value.rollValues;
+      }
+      onCastSpell(payload);
       return;
     }
-    updateDamageValueWithAnimation(value.total, value.breakdown, spell.name, {
-      diceRolls: value.diceRolls,
-      rollValues: value.rollValues,
-    });
+
+    const extraDetails = {};
+    if (Array.isArray(value.diceRolls) && value.diceRolls.length > 0) {
+      extraDetails.diceRolls = value.diceRolls;
+    }
+    if (Array.isArray(value.rollValues) && value.rollValues.length > 0) {
+      extraDetails.rollValues = value.rollValues;
+    }
+
+    if (Object.keys(extraDetails).length > 0) {
+      updateDamageValueWithAnimation(
+        value.total,
+        value.breakdown,
+        spell.name,
+        extraDetails,
+      );
+    } else {
+      updateDamageValueWithAnimation(value.total, value.breakdown, spell.name);
+    }
   }, [isCritical, onCastSpell, rollDamageExpression, totalLevel]);
 
   const handleSpellsButtonClick = (spell, crit = false) => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1,9 +1,32 @@
 import React from 'react';
 import { render, act, fireEvent, screen, within, waitFor } from '@testing-library/react';
 import PlayerTurnActions, * as PlayerTurnActionsModule from './PlayerTurnActions';
+
+jest.mock('../../../utils/diceBoxManager', () => {
+  const actual = jest.requireActual('../../../utils/diceBoxManager');
+  return {
+    ...actual,
+    registerDiceBoxContainer: jest.fn(() => () => {}),
+    subscribeToDiceBoxAvailability: jest.fn(() => () => {}),
+    isDiceBoxReady: jest.fn(() => false),
+    rollDiceWithBox: jest.fn(),
+  };
+});
+const { rollDiceWithBox } = require('../../../utils/diceBoxManager');
 import damageTypeColors from '../../../utils/damageTypeColors';
 
 const { calculateDamage } = PlayerTurnActionsModule;
+
+beforeEach(() => {
+  rollDiceWithBox.mockClear();
+  rollDiceWithBox.mockImplementation((requests = []) =>
+    Promise.resolve({
+      rolls: Array.isArray(requests)
+        ? requests.map(({ count }) => Array(count).fill(1))
+        : [],
+    })
+  );
+});
 
 describe('calculateDamage parser', () => {
   const fixedRoll = (count, sides) => Array(count).fill(1);
@@ -400,11 +423,15 @@ describe('PlayerTurnActions weapon damage display', () => {
       expect(card).not.toBeNull();
       if (!card) throw new Error('missing Longsword card');
 
-      const toHitButton = within(card).getByLabelText(/Roll to hit/i);
+    const toHitButton = within(card).getByLabelText(/Roll to hit/i);
 
-      await act(async () => {
-        fireEvent.click(toHitButton);
-      });
+    rollDiceWithBox.mockImplementationOnce(() =>
+      Promise.resolve({ rolls: [[9]] })
+    );
+
+    await act(async () => {
+      fireEvent.click(toHitButton);
+    });
 
       await waitFor(() => {
         const valueNode = document.getElementById('damageValue');
@@ -983,19 +1010,21 @@ describe('PlayerTurnActions spell casting', () => {
     });
 
     const rollButton = await screen.findByLabelText(/Roll damage/i);
-    act(() => {
+    await act(async () => {
       fireEvent.click(rollButton);
     });
 
-    expect(onCastSpell).toHaveBeenCalledWith(
-      expect.objectContaining({
-        level: spell.level,
-        slotType: undefined,
-        damage: expect.any(Number),
-        breakdown: expect.any(String),
-        castingTime: spell.castingTime,
-        name: spell.name,
-      })
+    await waitFor(() =>
+      expect(onCastSpell).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: spell.level,
+          slotType: undefined,
+          damage: expect.any(Number),
+          breakdown: expect.any(String),
+          castingTime: spell.castingTime,
+          name: spell.name,
+        })
+      )
     );
   });
 
@@ -1073,10 +1102,10 @@ describe('PlayerTurnActions spell casting', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
     const rollButton = await screen.findByLabelText(/Roll damage/i);
-    act(() => {
+    await act(async () => {
       fireEvent.click(rollButton);
     });
-    expect(state.action[0]).toBe('used');
+    await waitFor(() => expect(state.action[0]).toBe('used'));
     expect(state.bonus[0]).toBe('active');
   });
 
@@ -1114,10 +1143,10 @@ describe('PlayerTurnActions spell casting', () => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
     const rollButton = await screen.findByLabelText(/Roll damage/i);
-    act(() => {
+    await act(async () => {
       fireEvent.click(rollButton);
     });
-    expect(state.bonus[0]).toBe('used');
+    await waitFor(() => expect(state.bonus[0]).toBe('used'));
     expect(state.action[0]).toBe('active');
   });
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -14,6 +14,7 @@ import { calculateFeatPointsLeft } from '../../../utils/featUtils';
 import PlayerTurnActions, {
   calculateDamage,
 } from "../attributes/PlayerTurnActions";
+import { rollDiceWithBox } from '../../../utils/diceBoxManager';
 import Help from "../attributes/Help";
 import { SKILLS } from "../skillSchema";
 import {
@@ -2845,8 +2846,101 @@ export default function ZombiesCharacterSheet() {
     setShortRestCount((c) => c + 1);
   }, []);
 
+  const rollSpellDamage = useCallback(
+    async (damageString, extraDice, levelsAbove = 0) => {
+      if (typeof damageString !== 'string') {
+        return null;
+      }
+
+      const trimmed = damageString.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      const requests = [];
+      const validation = calculateDamage(
+        trimmed,
+        0,
+        false,
+        (count, sides) => {
+          requests.push({ count, sides });
+          return Array(count).fill(1);
+        },
+        extraDice,
+        levelsAbove,
+      );
+
+      if (!validation) {
+        return null;
+      }
+
+      if (requests.length === 0) {
+        const staticResult = calculateDamage(
+          trimmed,
+          0,
+          false,
+          undefined,
+          extraDice,
+          levelsAbove,
+        );
+        return staticResult ? { ...staticResult, rollValues: undefined } : null;
+      }
+
+      try {
+        const { rolls } = await rollDiceWithBox(requests);
+        let requestIndex = 0;
+        const applyRolls = (count, sides) => {
+          const current = Array.isArray(rolls) ? rolls[requestIndex] : undefined;
+          requestIndex += 1;
+          if (Array.isArray(current) && current.length === count) {
+            return current.map((value) => {
+              const parsed = Number(value);
+              return Number.isFinite(parsed) ? parsed : 0;
+            });
+          }
+          return Array.from({ length: count }, () =>
+            Math.max(1, Math.floor(Math.random() * sides) + 1)
+          );
+        };
+
+        const finalResult = calculateDamage(
+          trimmed,
+          0,
+          false,
+          applyRolls,
+          extraDice,
+          levelsAbove,
+        );
+
+        const rollValues = Array.isArray(rolls)
+          ? rolls
+              .flat()
+              .map((value) => {
+                const parsed = Number(value);
+                return Number.isFinite(parsed) ? parsed : 0;
+              })
+          : undefined;
+
+        return finalResult ? { ...finalResult, rollValues } : null;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Spell damage roll failed', error);
+        const fallbackResult = calculateDamage(
+          trimmed,
+          0,
+          false,
+          undefined,
+          extraDice,
+          levelsAbove,
+        );
+        return fallbackResult ? { ...fallbackResult, rollValues: undefined } : null;
+      }
+    },
+    [rollDiceWithBox],
+  );
+
   const handleCastSpell = useCallback(
-    (arg, lvl, idx) => {
+    async (arg, lvl, idx) => {
       if (arg === 'action' || arg === 'bonus') {
         consumeCircle(arg, lvl);
         if (arg === 'action' && speakWithAnimalsPendingRef.current) {
@@ -2928,6 +3022,8 @@ export default function ZombiesCharacterSheet() {
           name,
           spellName: altName,
           pendingEffectOnly,
+          diceRolls: providedDiceRolls,
+          rollValues: providedRollValues,
         } = arg;
         const spellLabel = name || altName;
         if (pendingEffectOnly) {
@@ -2941,21 +3037,46 @@ export default function ZombiesCharacterSheet() {
         if (castingTime?.includes('1 action')) consumeCircle('action');
         else if (castingTime?.includes('1 bonus action')) consumeCircle('bonus');
         let result;
+        let diceRollDetails = Array.isArray(providedDiceRolls)
+          ? providedDiceRolls
+          : undefined;
+        let rollValueDetails = Array.isArray(providedRollValues)
+          ? providedRollValues
+          : undefined;
         if (typeof damage === 'number') {
           result = { total: damage, breakdown };
         } else if (damage) {
-          const calc = calculateDamage(
-            damage,
-            0,
-            false,
-            undefined,
-            extraDice,
-            levelsAbove
-          );
-          result =
-            calc && typeof calc === 'object'
-              ? calc
-              : { total: calc };
+          if (!diceRollDetails && !rollValueDetails) {
+            const rolled = await rollSpellDamage(
+              damage,
+              extraDice,
+              levelsAbove,
+            );
+            if (rolled) {
+              result = rolled;
+              diceRollDetails = Array.isArray(rolled.diceRolls)
+                ? rolled.diceRolls
+                : undefined;
+              rollValueDetails = Array.isArray(rolled.rollValues)
+                ? rolled.rollValues
+                : undefined;
+            }
+          }
+
+          if (!result) {
+            const calc = calculateDamage(
+              damage,
+              0,
+              false,
+              undefined,
+              extraDice,
+              levelsAbove,
+            );
+            result =
+              calc && typeof calc === 'object'
+                ? calc
+                : { total: calc };
+          }
           if (!result?.breakdown && breakdown) {
             result = { ...result, breakdown };
           }
@@ -2963,11 +3084,33 @@ export default function ZombiesCharacterSheet() {
           const spellLabel = name || altName;
           result = { total: spellLabel || 'Spell Cast' };
         }
-        playerTurnActionsRef.current?.updateDamageValueWithAnimation(
-          result?.total,
-          result?.breakdown,
-          typeof result?.total === 'number' ? spellLabel : undefined
-        );
+        const hasDiceDetails =
+          (Array.isArray(diceRollDetails) && diceRollDetails.length > 0) ||
+          (Array.isArray(rollValueDetails) && rollValueDetails.length > 0);
+        const extraDetails = hasDiceDetails
+          ? {
+              ...(Array.isArray(diceRollDetails) && diceRollDetails.length > 0
+                ? { diceRolls: diceRollDetails }
+                : {}),
+              ...(Array.isArray(rollValueDetails) && rollValueDetails.length > 0
+                ? { rollValues: rollValueDetails }
+                : {}),
+            }
+          : undefined;
+        if (extraDetails) {
+          playerTurnActionsRef.current?.updateDamageValueWithAnimation(
+            result?.total,
+            result?.breakdown,
+            typeof result?.total === 'number' ? spellLabel : undefined,
+            extraDetails,
+          );
+        } else {
+          playerTurnActionsRef.current?.updateDamageValueWithAnimation(
+            result?.total,
+            result?.breakdown,
+            typeof result?.total === 'number' ? spellLabel : undefined,
+          );
+        }
         if (name === 'Haste') {
           setActiveEffects((prev) => [
             ...prev,
@@ -3006,7 +3149,7 @@ export default function ZombiesCharacterSheet() {
         return { ...prev, [key]: levelState };
       });
     },
-    [form, consumeCircle]
+    [consumeCircle, form, rollSpellDamage]
   );
 
   const availableSlots = useMemo(() => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -19,6 +19,17 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ id: '1' }),
 }));
 
+jest.mock('../../../utils/diceBoxManager', () => {
+  const actual = jest.requireActual('../../../utils/diceBoxManager');
+  return {
+    ...actual,
+    registerDiceBoxContainer: jest.fn(() => () => {}),
+    subscribeToDiceBoxAvailability: jest.fn(() => () => {}),
+    isDiceBoxReady: jest.fn(() => false),
+    rollDiceWithBox: jest.fn(),
+  };
+});
+
 const mockCharacterInfoProps = { current: null };
 jest.mock('../attributes/CharacterInfo', () => (props) => {
   mockCharacterInfoProps.current = props;
@@ -104,6 +115,7 @@ jest.mock('../attributes/Features', () => (props) => {
 });
 
 import ZombiesCharacterSheet from './ZombiesCharacterSheet';
+const { rollDiceWithBox } = require('../../../utils/diceBoxManager');
 
 const defaultApiFetchImplementation = (url) => {
   if (typeof url === 'string' && url.includes('/maps')) {
@@ -149,6 +161,14 @@ beforeEach(() => {
   mockSocketIo.mockReturnValue(socketStub);
   mockUpdateDamage.mockClear();
   mockCalcDamage.mockClear();
+  rollDiceWithBox.mockReset();
+  rollDiceWithBox.mockImplementation((requests = []) =>
+    Promise.resolve({
+      rolls: Array.isArray(requests)
+        ? requests.map(({ count }) => Array(count).fill(1))
+        : [],
+    })
+  );
   mockOnCastSpell.current = null;
   mockHandleClose.current = null;
   mockShopModalProps.current = null;
@@ -2221,14 +2241,10 @@ test('handleCastSpell outputs calculated damage', async () => {
   mockOnCastSpell.current({ level: 1, damage: '1d4', name: 'Acid Splash' });
   mockHandleClose.current();
   await waitFor(() => expect(screen.queryByTestId('spell-selector')).toBeNull());
-  expect(mockCalcDamage).toHaveBeenCalledWith(
-    '1d4',
-    0,
-    false,
-    undefined,
-    undefined,
-    undefined
-  );
+  expect(mockCalcDamage).toHaveBeenCalled();
+  expect(
+    mockCalcDamage.mock.calls.some((call) => call[0] === '1d4')
+  ).toBe(true);
   expect(mockUpdateDamage).toHaveBeenCalled();
 });
 


### PR DESCRIPTION
## Summary
- ensure PlayerTurnActions always source spell damage from the dice box and forward the resulting roll data for UI updates
- add a reusable spell damage roller inside ZombiesCharacterSheet so direct casts also trigger dice animations and carry dice details forward
- update unit tests to stub dice box utilities consistently with the new asynchronous flows

## Testing
- `npm test -- PlayerTurnActions.test.js`
- `CI=true npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js -t "handleCastSpell outputs calculated damage"`


------
https://chatgpt.com/codex/tasks/task_e_68f522eae29c832ea3168a25235c63f5