### PR TITLE
Ensure dice rolls match logs and apply selected dice color

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -13,6 +13,10 @@ import {
 } from 'react-icons/gi';
 import apiFetch from '../../utils/apiFetch';
 import { rollDiceWithBox } from '../../utils/diceBoxManager';
+import {
+  applyDiceFaceColor,
+  normalizeDiceColor,
+} from '../../utils/diceColors';
 import { STATS } from '../Zombies/statSchema';
 import { SKILLS } from '../Zombies/skillSchema';
 
@@ -193,35 +197,6 @@ const buildItemOwnershipMap = (initialItems) => {
 
 const HEALING_DICE_REGEX = /(\d+)d(\d+)/gi;
 const HEALING_MODIFIER_REGEX = /([+-]\s*\d+)/gi;
-const HEX_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
-const DEFAULT_DICE_COLOR = '#000000';
-const DICE_FACE_OPACITY = 0.85;
-
-const normalizeDiceColor = (value) => {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return HEX_COLOR_PATTERN.test(trimmed) ? trimmed : null;
-};
-
-const hexToRgba = (hex, opacity = DICE_FACE_OPACITY) => {
-  const normalized = normalizeDiceColor(hex) || DEFAULT_DICE_COLOR;
-  const r = parseInt(normalized.slice(1, 3), 16);
-  const g = parseInt(normalized.slice(3, 5), 16);
-  const b = parseInt(normalized.slice(5, 7), 16);
-  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
-};
-
-const applyDiceFaceColor = (color) => {
-  if (typeof document === 'undefined') {
-    return;
-  }
-
-  const rgbaColor = hexToRgba(color);
-  document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
-};
 
 const sanitizeHealingString = (healing) => {
   if (typeof healing !== 'string') {

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -5,18 +5,11 @@ import { useNavigate, useParams } from "react-router-dom";
 import CampaignModals from "../components/CampaignModals";
 import useCampaignActions from "../hooks/useCampaignActions";
 import DockControls from '../components/DockControls';
-
-const HEX_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
-const DEFAULT_DICE_COLOR = '#000000';
-
-const normalizeDiceColor = (value) => {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return HEX_COLOR_PATTERN.test(trimmed) ? trimmed : null;
-};
+import {
+  applyDiceFaceColor,
+  DEFAULT_DICE_COLOR,
+  normalizeDiceColor,
+} from '../../../utils/diceColors';
 
 export default function Help({
   form,
@@ -68,23 +61,9 @@ export default function Help({
   const initialColor = normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR;
   const [newColor, setNewColor] = useState(initialColor);
 
-  const applyDiceFaceColor = useCallback((color) => {
-    if (typeof document === 'undefined') {
-      return;
-    }
-
-    const normalized = normalizeDiceColor(color) || DEFAULT_DICE_COLOR;
-    const r = parseInt(normalized.slice(1, 3), 16);
-    const g = parseInt(normalized.slice(3, 5), 16);
-    const b = parseInt(normalized.slice(5, 7), 16);
-    const opacity = 0.85;
-    const rgbaColor = `rgba(${r}, ${g}, ${b}, ${opacity})`;
-    document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
-  }, []);
-
   useEffect(() => {
     applyDiceFaceColor(newColor);
-  }, [applyDiceFaceColor, newColor]);
+  }, [newColor]);
 
   useEffect(() => {
     const normalized = normalizeDiceColor(form?.diceColor);

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -17,6 +17,16 @@ import weaponPropertyDefinitions from '../../../data/weaponProperties';
 import { rollSkillWithDiceBox } from './Skills';
 import DamageDiceCanvas from './DamageDiceCanvas';
 import { rollDiceWithBox } from '../../../utils/diceBoxManager';
+import {
+  collectRollValues,
+  normalizeRollValue,
+  sanitizeRollGroup,
+} from '../../../utils/diceResults';
+import {
+  applyDiceFaceColor,
+  DEFAULT_DICE_COLOR,
+  normalizeDiceColor,
+} from '../../../utils/diceColors';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -844,16 +854,41 @@ const manualCriticalRef = useRef(false);
       try {
         const { rolls } = await rollDiceWithBox(requests);
         let requestIndex = 0;
+        const appliedRollGroups = [];
         const applyRolls = (count, sides) => {
           const current = Array.isArray(rolls) ? rolls[requestIndex] : undefined;
           requestIndex += 1;
-          if (Array.isArray(current) && current.length === count) {
-            return current.map((value) => {
-              const parsed = Number(value);
-              return Number.isFinite(parsed) ? parsed : 0;
-            });
+          const normalizedGroup = sanitizeRollGroup(current, count, sides);
+          if (normalizedGroup) {
+            appliedRollGroups.push(normalizedGroup);
+            return normalizedGroup;
           }
-          return rollDice(count, sides);
+          const fallbackRolls = rollDice(count, sides);
+          const resolvedSides =
+            Number.isFinite(sides) && sides > 1 ? Math.floor(sides) : 6;
+          let numericFallback;
+          if (Array.isArray(fallbackRolls)) {
+            numericFallback = fallbackRolls
+              .map((value) => normalizeRollValue(value))
+              .filter((value) => value !== null);
+            if (numericFallback.length > count) {
+              numericFallback = numericFallback.slice(0, count);
+            }
+            while (numericFallback.length < count) {
+              numericFallback.push(
+                Math.max(
+                  1,
+                  Math.floor(Math.random() * resolvedSides) + 1,
+                ),
+              );
+            }
+          } else {
+            numericFallback = Array.from({ length: count }, () =>
+              Math.max(1, Math.floor(Math.random() * resolvedSides) + 1),
+            );
+          }
+          appliedRollGroups.push(numericFallback);
+          return numericFallback;
         };
 
         const finalResult = calculateDamage(
@@ -865,14 +900,8 @@ const manualCriticalRef = useRef(false);
           levelsAbove,
         );
 
-        const rollValues = Array.isArray(rolls)
-          ? rolls
-              .flat()
-              .map((value) => {
-                const parsed = Number(value);
-                return Number.isFinite(parsed) ? parsed : 0;
-              })
-          : undefined;
+        const appliedValues = collectRollValues(appliedRollGroups);
+        const rollValues = appliedValues.length > 0 ? appliedValues : undefined;
 
         return finalResult ? { ...finalResult, rollValues } : null;
       } catch (error) {
@@ -1083,6 +1112,15 @@ const [damageLog, setDamageLog] = useState([]);
 const [showLog, setShowLog] = useState(false);
 const [activeDice, setActiveDice] = useState([]);
 const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
+
+useEffect(() => {
+  const normalized = normalizeDiceColor(form?.diceColor);
+  if (normalized) {
+    applyDiceFaceColor(normalized);
+    return;
+  }
+  applyDiceFaceColor(DEFAULT_DICE_COLOR);
+}, [form?.diceColor]);
 
 const triggerDiceAnimation = useCallback((diceDetails = []) => {
   if (!Array.isArray(diceDetails) || diceDetails.length === 0) {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -15,6 +15,11 @@ import PlayerTurnActions, {
   calculateDamage,
 } from "../attributes/PlayerTurnActions";
 import { rollDiceWithBox } from '../../../utils/diceBoxManager';
+import {
+  collectRollValues,
+  normalizeRollValue,
+  sanitizeRollGroup,
+} from '../../../utils/diceResults';
 import Help from "../attributes/Help";
 import { SKILLS } from "../skillSchema";
 import {
@@ -2889,18 +2894,30 @@ export default function ZombiesCharacterSheet() {
       try {
         const { rolls } = await rollDiceWithBox(requests);
         let requestIndex = 0;
+        const appliedRollGroups = [];
         const applyRolls = (count, sides) => {
           const current = Array.isArray(rolls) ? rolls[requestIndex] : undefined;
           requestIndex += 1;
-          if (Array.isArray(current) && current.length === count) {
-            return current.map((value) => {
-              const parsed = Number(value);
-              return Number.isFinite(parsed) ? parsed : 0;
-            });
+          const normalizedGroup = sanitizeRollGroup(current, count, sides);
+          if (normalizedGroup) {
+            appliedRollGroups.push(normalizedGroup);
+            return normalizedGroup;
           }
-          return Array.from({ length: count }, () =>
-            Math.max(1, Math.floor(Math.random() * sides) + 1)
+          const resolvedSides =
+            Number.isFinite(sides) && sides > 1 ? Math.floor(sides) : 6;
+          const fallbackRolls = Array.from({ length: count }, () =>
+            Math.max(1, Math.floor(Math.random() * resolvedSides) + 1)
           );
+          const normalizedFallback = fallbackRolls
+            .map((value) => normalizeRollValue(value))
+            .filter((value) => value !== null);
+          while (normalizedFallback.length < count) {
+            normalizedFallback.push(
+              Math.max(1, Math.floor(Math.random() * resolvedSides) + 1),
+            );
+          }
+          appliedRollGroups.push(normalizedFallback);
+          return normalizedFallback;
         };
 
         const finalResult = calculateDamage(
@@ -2912,14 +2929,8 @@ export default function ZombiesCharacterSheet() {
           levelsAbove,
         );
 
-        const rollValues = Array.isArray(rolls)
-          ? rolls
-              .flat()
-              .map((value) => {
-                const parsed = Number(value);
-                return Number.isFinite(parsed) ? parsed : 0;
-              })
-          : undefined;
+        const appliedValues = collectRollValues(appliedRollGroups);
+        const rollValues = appliedValues.length > 0 ? appliedValues : undefined;
 
         return finalResult ? { ...finalResult, rollValues } : null;
       } catch (error) {

--- a/client/src/utils/diceColors.js
+++ b/client/src/utils/diceColors.js
@@ -1,0 +1,35 @@
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+export const DEFAULT_DICE_COLOR = '#000000';
+export const DICE_FACE_OPACITY = 0.85;
+
+export const normalizeDiceColor = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return HEX_COLOR_PATTERN.test(trimmed) ? trimmed.toLowerCase() : null;
+};
+
+export const hexToRgba = (hex, opacity = DICE_FACE_OPACITY) => {
+  const normalized = normalizeDiceColor(hex) || DEFAULT_DICE_COLOR;
+  const r = parseInt(normalized.slice(1, 3), 16);
+  const g = parseInt(normalized.slice(3, 5), 16);
+  const b = parseInt(normalized.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};
+
+export const applyDiceFaceColor = (color, opacity = DICE_FACE_OPACITY) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const rgbaColor = hexToRgba(color, opacity);
+  document.documentElement.style.setProperty('--dice-face-color', rgbaColor);
+};
+
+export default {
+  DEFAULT_DICE_COLOR,
+  DICE_FACE_OPACITY,
+  normalizeDiceColor,
+  hexToRgba,
+  applyDiceFaceColor,
+};

--- a/client/src/utils/diceResults.js
+++ b/client/src/utils/diceResults.js
@@ -1,0 +1,81 @@
+const MIN_ROLL_VALUE = 1;
+
+export const normalizeRollValue = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  const rounded = Math.round(parsed);
+  return Number.isFinite(rounded) ? Math.max(MIN_ROLL_VALUE, rounded) : null;
+};
+
+export const sanitizeRollGroup = (values, count, sides) => {
+  const totalDice = Number(count);
+  if (!Number.isFinite(totalDice) || totalDice <= 0) {
+    return null;
+  }
+
+  const collection = Array.isArray(values) ? values : [values];
+  if (!Array.isArray(collection) || collection.length === 0) {
+    return null;
+  }
+
+  const upperBound = Number.isFinite(sides) && sides > 0 ? Math.round(sides) : null;
+  const numericValues = collection
+    .map((entry) => normalizeRollValue(entry))
+    .filter((entry) => entry !== null);
+
+  if (numericValues.length === 0) {
+    return null;
+  }
+
+  const selected = [];
+  if (upperBound !== null) {
+    numericValues.forEach((value) => {
+      if (selected.length >= totalDice) {
+        return;
+      }
+      if (value >= MIN_ROLL_VALUE && value <= upperBound) {
+        selected.push(value);
+      }
+    });
+  }
+
+  if (selected.length < totalDice) {
+    numericValues.forEach((value) => {
+      if (selected.length >= totalDice) {
+        return;
+      }
+      selected.push(value);
+    });
+  }
+
+  return selected.length >= totalDice ? selected.slice(0, totalDice) : null;
+};
+
+export const collectRollValues = (groups) => {
+  if (!Array.isArray(groups) || groups.length === 0) {
+    return [];
+  }
+
+  const results = [];
+  groups.forEach((group) => {
+    if (!Array.isArray(group)) {
+      return;
+    }
+    group.forEach((value) => {
+      const normalized = normalizeRollValue(value);
+      if (normalized !== null) {
+        results.push(normalized);
+      }
+    });
+  });
+
+  return results;
+};
+
+export default {
+  normalizeRollValue,
+  sanitizeRollGroup,
+  collectRollValues,
+};


### PR DESCRIPTION
## Summary
- centralize dice color helpers and apply the selected color theme when the player view loads
- sanitize 3D dice roll results before they are used so damage and spell logs match the dice that were thrown
- reuse the shared dice color helper in the help modal and healing rolls for consistency

## Testing
- npm test -- --runTestsByPath src/components/Zombies/attributes/PlayerTurnActions.test.js
- npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js *(fails: existing act warnings and an unmet query in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68f52bd527b4832ea9b4ec2c509d0c60