### PR TITLE
Fix repeated dice theme updates compounding physics config

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -157,8 +157,7 @@ const createDiceBoxConfig = (overrides = null) => ({
   ...(overrides && typeof overrides === 'object' ? overrides : {}),
 });
 
-const buildThemeConfig = (color) =>
-  createDiceBoxConfig(color ? { themeColor: color } : null);
+const buildThemeConfig = (color) => (color ? { themeColor: color } : {});
 
 const applyThemeColorToInstance = (instance, color) => {
   if (!instance || typeof instance.updateConfig !== 'function') {


### PR DESCRIPTION
## Summary
- prevent dice theme updates from reapplying the full dice box configuration so physics values stay stable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f540312600832e867b68e38eab3b94