### PR TITLE
Avoid redundant dice theme updates

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -18,6 +18,7 @@ let hostElement = null;
 let rollQueue = Promise.resolve();
 let generatedHostId = 0;
 let pendingThemeColor = null;
+let activeThemeColor = null;
 
 const availabilityListeners = new Set();
 
@@ -136,6 +137,7 @@ const resetInstance = () => {
   diceBoxInstance = null;
   diceBoxPromise = null;
   diceBoxReady = false;
+  activeThemeColor = null;
 };
 
 const normalizeThemeColor = (value) => {
@@ -157,16 +159,20 @@ const createDiceBoxConfig = (overrides = null) => ({
   ...(overrides && typeof overrides === 'object' ? overrides : {}),
 });
 
-const buildThemeConfig = (color) =>
-  createDiceBoxConfig(color ? { themeColor: color } : null);
+const buildThemeConfig = (color) => (color ? { themeColor: color } : {});
 
 const applyThemeColorToInstance = (instance, color) => {
   if (!instance || typeof instance.updateConfig !== 'function') {
     return false;
   }
 
+  if (color === activeThemeColor) {
+    return true;
+  }
+
   try {
     instance.updateConfig(buildThemeConfig(color));
+    activeThemeColor = color || null;
     return true;
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -546,6 +552,12 @@ export const rollDiceWithBox = (requests) => {
 export const setDiceBoxThemeColor = (color) => {
   const normalized = normalizeThemeColor(color);
   if (!normalized) {
+    pendingThemeColor = null;
+    activeThemeColor = null;
+    return;
+  }
+
+  if (normalized === activeThemeColor) {
     pendingThemeColor = null;
     return;
   }


### PR DESCRIPTION
## Summary
- track the active dice theme color so updateConfig is only called when the color actually changes
- reset the active theme color when the dice box instance is torn down

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f540312600832e867b68e38eab3b94