### PR TITLE
Warm up dice box during app initialization

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,6 +15,7 @@ import WeaponDetail from "./components/Weapons/WeaponDetail";
 import ArmorList from "./components/Armor/ArmorList";
 import ArmorDetail from "./components/Armor/ArmorDetail";
 import ItemList from "./components/Items/ItemList";
+import { warmupDiceBox } from './utils/diceBoxManager';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import "./App.scss";
@@ -23,6 +24,10 @@ import "./App.scss";
 function App() {
   const [user, setUser] = useState(null);
   const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    warmupDiceBox();
+  }, []);
 
   useEffect(() => {
     apiFetch('/me')

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -19,6 +19,7 @@ let rollQueue = Promise.resolve();
 let generatedHostId = 0;
 let pendingThemeColor = null;
 let activeThemeColor = null;
+let warmupPromise = null;
 
 const availabilityListeners = new Set();
 
@@ -477,6 +478,37 @@ export const subscribeToDiceBoxAvailability = (listener) => {
 };
 
 export const isDiceBoxReady = () => diceBoxReady;
+
+export const warmupDiceBox = () => {
+  if (diceBoxInstance) {
+    return Promise.resolve(diceBoxInstance);
+  }
+
+  if (diceBoxPromise) {
+    return diceBoxPromise.catch(() => null);
+  }
+
+  if (warmupPromise) {
+    return warmupPromise;
+  }
+
+  const pending = getDiceBoxConstructor()
+    .then(() => null)
+    .catch((error) => {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Dice box warmup failed', error);
+      }
+      return null;
+    });
+
+  warmupPromise = pending;
+
+  return pending.finally(() => {
+    if (warmupPromise === pending) {
+      warmupPromise = null;
+    }
+  });
+};
 
 export const rollDiceWithBox = (requests) => {
   if (!Array.isArray(requests) || requests.length === 0) {


### PR DESCRIPTION
## Summary
- add a warmup helper in the dice box manager to preload the dice box module and cache warmup attempts
- invoke the dice box warmup when the application mounts so dice initialization can begin before visiting the character sheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f54926f978832e83861d052dc76ddc