### PR TITLE
Destroy dice box instance when switching containers

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -134,7 +134,29 @@ const getDiceBoxConstructor = () => {
   return modulePromise;
 };
 
+const destroyInstance = (instance) => {
+  if (!instance) {
+    return;
+  }
+
+  try {
+    if (typeof instance.destroy === 'function') {
+      instance.destroy();
+    } else if (typeof instance.dispose === 'function') {
+      instance.dispose();
+    }
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('Dice box destroy failed', error);
+    }
+  }
+};
+
 const resetInstance = () => {
+  if (diceBoxInstance) {
+    destroyInstance(diceBoxInstance);
+  }
+
   diceBoxInstance = null;
   diceBoxPromise = null;
   diceBoxReady = false;


### PR DESCRIPTION
## Summary
- ensure the dice box instance is destroyed whenever the host container changes
- prevent stale WebGL contexts from breaking the dice visuals after switching characters

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f54ac9ac94832e8a2f2b499936e67c