### PR TITLE
Handle CSP worker violations by disabling dice box

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -120,6 +120,33 @@ const markDiceBoxFailure = ({ fatal = false } = {}) => {
   }
 };
 
+const isSecurityPolicyViolation = (error) => {
+  if (!error) {
+    return false;
+  }
+
+  const { name, message } =
+    typeof error === 'object' && error !== null
+      ? { name: error.name, message: error.message }
+      : { name: null, message: String(error) };
+
+  if (name && typeof name === 'string' && name.toLowerCase().includes('security')) {
+    return true;
+  }
+
+  if (typeof message !== 'string') {
+    return false;
+  }
+
+  const normalized = message.toLowerCase();
+
+  return (
+    normalized.includes('content security policy') ||
+    normalized.includes('refused to create a worker') ||
+    normalized.includes('blocked a frame with origin')
+  );
+};
+
 const resolveHostReference = () => {
   if (!hostElement) {
     return null;
@@ -493,7 +520,7 @@ async function ensureDiceBox() {
         // eslint-disable-next-line no-console
         if (diceBoxGeneration === initGeneration) {
           console.error('Dice box initialization failed', error);
-          markDiceBoxFailure();
+          markDiceBoxFailure({ fatal: isSecurityPolicyViolation(error) });
         }
         return null;
       }


### PR DESCRIPTION
## Summary
- detect dice box initialization failures caused by Content Security Policy worker restrictions
- mark the dice box as permanently disabled in these environments to avoid repeated retries
- allow automatic fallback dice rolling to be used when the 3D dice box cannot start

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5638fbd14832ea72fb6f874f2177d