### PR TITLE
Enable dice wasm under CSP and serve assets

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -15,6 +15,8 @@ let diceBoxInstance = null;
 let diceBoxReady = false;
 let diceBoxFailed = false;
 let diceBoxDisabled = false;
+let workerSupportState = 'unknown';
+let workerSupportLogged = false;
 let hostElement = null;
 let rollQueue = Promise.resolve();
 let generatedHostId = 0;
@@ -118,6 +120,91 @@ const markDiceBoxFailure = ({ fatal = false } = {}) => {
   if (!fatal) {
     scheduleRetry();
   }
+};
+
+const assessWorkerSupport = () => {
+  if (workerSupportState !== 'unknown') {
+    return workerSupportState;
+  }
+
+  if (typeof window === 'undefined') {
+    workerSupportState = 'unsupported';
+    return workerSupportState;
+  }
+
+  if (typeof Worker !== 'function') {
+    workerSupportState = 'unsupported';
+    return workerSupportState;
+  }
+
+  if (typeof Blob !== 'function') {
+    workerSupportState = 'unsupported';
+    return workerSupportState;
+  }
+
+  if (typeof URL !== 'function' && (typeof URL !== 'object' || URL === null)) {
+    workerSupportState = 'unsupported';
+    return workerSupportState;
+  }
+
+  if (typeof URL.createObjectURL !== 'function' || typeof URL.revokeObjectURL !== 'function') {
+    workerSupportState = 'unsupported';
+    return workerSupportState;
+  }
+
+  try {
+    const blob = new Blob(['self.onmessage = function () {}']);
+    const url = URL.createObjectURL(blob);
+    try {
+      const testWorker = new Worker(url);
+      testWorker.terminate();
+      workerSupportState = 'available';
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  } catch (error) {
+    workerSupportState = isSecurityPolicyViolation(error) ? 'blocked' : 'unsupported';
+  }
+
+  if (!workerSupportLogged && workerSupportState !== 'available') {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      const message =
+        workerSupportState === 'blocked'
+          ? 'Dice box disabled: Web Worker creation is blocked by the current Content Security Policy.'
+          : 'Dice box disabled: Web Workers are not supported in this environment.';
+      console.warn(message);
+    }
+    workerSupportLogged = true;
+  }
+
+  return workerSupportState;
+};
+
+const isSecurityPolicyViolation = (error) => {
+  if (!error) {
+    return false;
+  }
+
+  const { name, message } =
+    typeof error === 'object' && error !== null
+      ? { name: error.name, message: error.message }
+      : { name: null, message: String(error) };
+
+  if (name && typeof name === 'string' && name.toLowerCase().includes('security')) {
+    return true;
+  }
+
+  if (typeof message !== 'string') {
+    return false;
+  }
+
+  const normalized = message.toLowerCase();
+
+  return (
+    normalized.includes('content security policy') ||
+    normalized.includes('refused to create a worker') ||
+    normalized.includes('blocked a frame with origin')
+  );
 };
 
 const resolveHostReference = () => {
@@ -443,6 +530,17 @@ async function ensureDiceBox() {
     scheduleRetry();
     return null;
   }
+
+  const workerState = assessWorkerSupport();
+  if (workerState === 'blocked') {
+    markDiceBoxFailure({ fatal: true });
+    return null;
+  }
+
+  if (workerState === 'unsupported') {
+    markDiceBoxFailure({ fatal: true });
+    return null;
+  }
   if (!diceBoxPromise) {
     const initGeneration = diceBoxGeneration;
     const pending = (async () => {
@@ -493,7 +591,13 @@ async function ensureDiceBox() {
         // eslint-disable-next-line no-console
         if (diceBoxGeneration === initGeneration) {
           console.error('Dice box initialization failed', error);
-          markDiceBoxFailure();
+          const fatal =
+            isSecurityPolicyViolation(error) ||
+            (workerSupportState === 'blocked' &&
+              typeof error?.message === 'string' &&
+              error.message.toLowerCase().includes('timed out')) ||
+            workerSupportState === 'unsupported';
+          markDiceBoxFailure({ fatal });
         }
         return null;
       }

--- a/server/server.js
+++ b/server/server.js
@@ -54,6 +54,9 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", 'blob:', "'unsafe-eval'", "'wasm-unsafe-eval'"],
+        workerSrc: ["'self'", 'blob:'],
+        childSrc: ["'self'", 'blob:'],
         connectSrc,
         imgSrc: ["'self'", 'https:', 'data:', 'blob:'],
         mediaSrc: ["'self'", 'https:', 'data:', 'blob:'],
@@ -92,12 +95,24 @@ const authLimiter = rateLimit({
 app.use(['/login', '/logout', '/users/verify'], authLimiter);
 app.use(routes);
 
+const buildDir = path.join(__dirname, '../client/build');
+const publicAssetsDir = path.join(__dirname, '../client/public/assets');
+
+const staticOptions = {
+  setHeaders(res, filePath) {
+    if (filePath.endsWith('.wasm')) {
+      res.setHeader('Content-Type', 'application/wasm');
+    }
+  },
+};
+
 // Adjusted to serve static files from the correct build directory
-app.use(express.static(path.join(__dirname, '../client/build')));
+app.use(express.static(buildDir, staticOptions));
+app.use('/assets', express.static(publicAssetsDir, staticOptions));
 
 app.get('*', (req, res) => {
   // Adjusted path for sending index.html
-  res.sendFile(path.join(__dirname, '../client/build/index.html'));
+  res.sendFile(path.join(buildDir, 'index.html'));
 });
 
 // Centralized error-handling middleware


### PR DESCRIPTION
## Summary
- allow the dice box WebAssembly bootstrap by permitting unsafe-eval/wasm-unsafe-eval in the CSP script sources
- serve dice-box static assets from the build output (and fallback public assets) while forcing .wasm files to the correct MIME type

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5638fbd14832ea72fb6f874f2177d