### PR TITLE
Improve damage type color resolution for dice rolls

### DIFF
--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -198,9 +198,10 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
       .map((die, index) => {
         const sides = toFiniteSides(die.sides);
         const value = toNumericValue(die.value);
+        const color = die.typeColor || resolvedColor;
         const style = {
           ...createDieStyle({ ...die, sides }, index, reduceMotion),
-          ...createDiceCategoryStyles(resolvedColor, die.category),
+          ...createDiceCategoryStyles(color, die.category),
         };
         const classes = [
           'damage-die',

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -28,6 +28,7 @@ import {
   applyDiceFaceColor,
   DEFAULT_DICE_COLOR,
   normalizeDiceColor,
+  resolveDamageTypeColor,
 } from '../../../utils/diceColors';
 
 // Dice rolling helper used by calculateDamage and component actions
@@ -54,6 +55,16 @@ function formatDamageRolls(rolls) {
 
 
 const DEFAULT_DAMAGE_TYPE_KEY = '__default__';
+
+const DAMAGE_TYPE_CLASS_TOKEN_IGNORE = new Set([
+  '',
+  'and',
+  'bonus',
+  'damage',
+  'damages',
+  'extra',
+  'plus',
+]);
 
 const parseDamageBreakdownSegments = (breakdown, normalizer) => {
   if (typeof breakdown !== 'string' || !breakdown.trim()) {
@@ -867,7 +878,21 @@ const manualCriticalRef = useRef(false);
     
   const normalizeDamageTypeForClass = (type) => {
     const trimmed = (type || '').trim();
-    return trimmed ? trimmed.toLowerCase().replace(/\s+/g, '-') : '';
+    if (!trimmed) {
+      return '';
+    }
+
+    const tokens = trimmed
+      .toLowerCase()
+      .split(/[^a-z]+/)
+      .map((token) => token.trim())
+      .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
+
+    if (tokens.length === 0) {
+      return '';
+    }
+
+    return tokens.join('-');
   };
 
   const formatDamageSegments = (damage, ability) =>
@@ -1298,9 +1323,11 @@ const preparedDice = useMemo(
   () =>
     activeDice.map((die) => {
       const normalizedType = normalizeDamageTypeForClass(die.type);
+      const typeColor = resolveDamageTypeColor(normalizedType);
       return {
         ...die,
         typeClass: normalizedType ? `damage-${normalizedType}` : '',
+        typeColor,
       };
     }),
   [activeDice],

--- a/client/src/utils/diceColors.js
+++ b/client/src/utils/diceColors.js
@@ -1,3 +1,5 @@
+import damageTypeColors from './damageTypeColors';
+
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 export const DEFAULT_DICE_COLOR = '#000000';
 export const DICE_FACE_OPACITY = 0.85;
@@ -77,6 +79,90 @@ const CATEGORY_COLOR_RULES = {
   },
 };
 
+const DAMAGE_TYPE_LOOKUP = Object.entries(damageTypeColors || {}).reduce(
+  (acc, [key, value]) => {
+    if (!key) {
+      return acc;
+    }
+
+    const normalizedKey = String(key).trim().toLowerCase();
+    if (!normalizedKey) {
+      return acc;
+    }
+
+    const normalizedColor = normalizeDiceColor(value);
+    if (!normalizedColor) {
+      return acc;
+    }
+
+    acc[normalizedKey] = normalizedColor;
+    return acc;
+  },
+  {},
+);
+
+const DAMAGE_TYPE_TOKEN_IGNORE_LIST = new Set([
+  'and',
+  'bonus',
+  'damage',
+  'damages',
+  'extra',
+  'plus',
+]);
+
+const DAMAGE_TYPE_ALIASES = {
+  acid: 'acid',
+  acidic: 'acid',
+  chill: 'cold',
+  cold: 'cold',
+  fire: 'fire',
+  flaming: 'fire',
+  force: 'force',
+  lightning: 'lightning',
+  necrotic: 'necrotic',
+  poison: 'poison',
+  poisonous: 'poison',
+  psychic: 'psychic',
+  radiant: 'radiant',
+  thunder: 'thunder',
+};
+
+export const resolveDamageTypeColor = (normalizedType) => {
+  if (typeof normalizedType !== 'string') {
+    return null;
+  }
+  const trimmed = normalizedType.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  const directMatch = DAMAGE_TYPE_LOOKUP[trimmed];
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const hyphenated = trimmed.replace(/\s+/g, '-');
+  const hyphenMatch = DAMAGE_TYPE_LOOKUP[hyphenated];
+  if (hyphenMatch) {
+    return hyphenMatch;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  for (const token of tokens) {
+    if (DAMAGE_TYPE_TOKEN_IGNORE_LIST.has(token)) {
+      continue;
+    }
+
+    const alias = DAMAGE_TYPE_ALIASES[token] || token;
+    const color = DAMAGE_TYPE_LOOKUP[alias];
+    if (color) {
+      return color;
+    }
+  }
+
+  return null;
+};
+
 export const createDiceCategoryStyles = (color, category = 'base') => {
   const normalized = normalizeDiceColor(color) || DEFAULT_DICE_COLOR;
   const rule = CATEGORY_COLOR_RULES[category] || CATEGORY_COLOR_RULES.base;
@@ -108,5 +194,6 @@ export default {
   normalizeDiceColor,
   hexToRgba,
   createDiceCategoryStyles,
+  resolveDamageTypeColor,
   applyDiceFaceColor,
 };


### PR DESCRIPTION
## Summary
- derive dice damage-type colors from the shared damageTypeColors palette and normalize variant labels
- strip filler words when generating CSS classes so special-damage dice inherit the correct themed styles

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js *(fails with RangeError: Maximum call stack size exceeded in source-map quick-sort)*

------
https://chatgpt.com/codex/tasks/task_e_68f57044189c832e9fa8c6b29166dead