### PR TITLE
Fix dice face color initialization in player turn actions

### DIFF
--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -198,9 +198,10 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
       .map((die, index) => {
         const sides = toFiniteSides(die.sides);
         const value = toNumericValue(die.value);
+        const color = die.typeColor || resolvedColor;
         const style = {
           ...createDieStyle({ ...die, sides }, index, reduceMotion),
-          ...createDiceCategoryStyles(resolvedColor, die.category),
+          ...createDiceCategoryStyles(color, die.category),
         };
         const classes = [
           'damage-die',

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -28,6 +28,7 @@ import {
   applyDiceFaceColor,
   DEFAULT_DICE_COLOR,
   normalizeDiceColor,
+  resolveDamageTypeColor,
 } from '../../../utils/diceColors';
 
 // Dice rolling helper used by calculateDamage and component actions
@@ -54,6 +55,16 @@ function formatDamageRolls(rolls) {
 
 
 const DEFAULT_DAMAGE_TYPE_KEY = '__default__';
+
+const DAMAGE_TYPE_CLASS_TOKEN_IGNORE = new Set([
+  '',
+  'and',
+  'bonus',
+  'damage',
+  'damages',
+  'extra',
+  'plus',
+]);
 
 const parseDamageBreakdownSegments = (breakdown, normalizer) => {
   if (typeof breakdown !== 'string' || !breakdown.trim()) {
@@ -867,7 +878,21 @@ const manualCriticalRef = useRef(false);
     
   const normalizeDamageTypeForClass = (type) => {
     const trimmed = (type || '').trim();
-    return trimmed ? trimmed.toLowerCase().replace(/\s+/g, '-') : '';
+    if (!trimmed) {
+      return '';
+    }
+
+    const tokens = trimmed
+      .toLowerCase()
+      .split(/[^a-z]+/)
+      .map((token) => token.trim())
+      .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
+
+    if (tokens.length === 0) {
+      return '';
+    }
+
+    return tokens.join('-');
   };
 
   const formatDamageSegments = (damage, ability) =>
@@ -919,6 +944,16 @@ const manualCriticalRef = useRef(false);
     return 'Attack';
   };
 
+  const diceFaceColor = useMemo(
+    () => normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR,
+    [form?.diceColor],
+  );
+
+  useEffect(() => {
+    applyDiceFaceColor(diceFaceColor);
+    setDiceBoxThemeColor(diceFaceColor);
+  }, [diceFaceColor]);
+
   const rollDamageExpression = useCallback(
     async ({
       damageString,
@@ -947,6 +982,38 @@ const manualCriticalRef = useRef(false);
       if (!validation) {
         return null;
       }
+
+      const diceRolls = Array.isArray(validation?.diceRolls)
+        ? validation.diceRolls
+        : [];
+      let selectedColor = null;
+      let hasColorlessDice = false;
+      let hasConflictingColor = false;
+      diceRolls.forEach((detail) => {
+        const normalizedType = normalizeDamageTypeForClass(detail?.type || '');
+        if (!normalizedType) {
+          hasColorlessDice = true;
+          return;
+        }
+        const color = resolveDamageTypeColor(normalizedType);
+        if (!color) {
+          hasColorlessDice = true;
+          return;
+        }
+        if (!selectedColor) {
+          selectedColor = color;
+          return;
+        }
+        if (selectedColor !== color) {
+          hasConflictingColor = true;
+        }
+      });
+
+      const rollThemeColor =
+        selectedColor && !hasColorlessDice && !hasConflictingColor
+          ? selectedColor
+          : null;
+      setDiceBoxThemeColor(rollThemeColor || diceFaceColor);
 
       if (requests.length === 0) {
         const staticResult = calculateDamage(
@@ -1027,7 +1094,13 @@ const manualCriticalRef = useRef(false);
         return fallbackResult ? { ...fallbackResult, rollValues: undefined } : null;
       }
     },
-    [rollDiceWithBox],
+    [
+      diceFaceColor,
+      normalizeDamageTypeForClass,
+      resolveDamageTypeColor,
+      rollDiceWithBox,
+      setDiceBoxThemeColor,
+    ],
   );
 
   const handleWeaponAttack = useCallback(
@@ -1258,20 +1331,10 @@ const sortedSpells = useMemo(() => {
 
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const [damageValue, setDamageValue] = useState(0);
-const [damageLog, setDamageLog] = useState([]);
-const [showLog, setShowLog] = useState(false);
-const [activeDice, setActiveDice] = useState([]);
-const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
-
-const diceFaceColor = useMemo(
-  () => normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR,
-  [form?.diceColor],
-);
-
-useEffect(() => {
-  applyDiceFaceColor(diceFaceColor);
-  setDiceBoxThemeColor(diceFaceColor);
-}, [diceFaceColor]);
+  const [damageLog, setDamageLog] = useState([]);
+  const [showLog, setShowLog] = useState(false);
+  const [activeDice, setActiveDice] = useState([]);
+  const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
 
 const triggerDiceAnimation = useCallback((diceDetails = []) => {
   if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
@@ -1298,9 +1361,11 @@ const preparedDice = useMemo(
   () =>
     activeDice.map((die) => {
       const normalizedType = normalizeDamageTypeForClass(die.type);
+      const typeColor = resolveDamageTypeColor(normalizedType);
       return {
         ...die,
         typeClass: normalizedType ? `damage-${normalizedType}` : '',
+        typeColor,
       };
     }),
   [activeDice],

--- a/client/src/utils/diceColors.js
+++ b/client/src/utils/diceColors.js
@@ -1,3 +1,5 @@
+import damageTypeColors from './damageTypeColors';
+
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 export const DEFAULT_DICE_COLOR = '#000000';
 export const DICE_FACE_OPACITY = 0.85;
@@ -77,6 +79,90 @@ const CATEGORY_COLOR_RULES = {
   },
 };
 
+const DAMAGE_TYPE_LOOKUP = Object.entries(damageTypeColors || {}).reduce(
+  (acc, [key, value]) => {
+    if (!key) {
+      return acc;
+    }
+
+    const normalizedKey = String(key).trim().toLowerCase();
+    if (!normalizedKey) {
+      return acc;
+    }
+
+    const normalizedColor = normalizeDiceColor(value);
+    if (!normalizedColor) {
+      return acc;
+    }
+
+    acc[normalizedKey] = normalizedColor;
+    return acc;
+  },
+  {},
+);
+
+const DAMAGE_TYPE_TOKEN_IGNORE_LIST = new Set([
+  'and',
+  'bonus',
+  'damage',
+  'damages',
+  'extra',
+  'plus',
+]);
+
+const DAMAGE_TYPE_ALIASES = {
+  acid: 'acid',
+  acidic: 'acid',
+  chill: 'cold',
+  cold: 'cold',
+  fire: 'fire',
+  flaming: 'fire',
+  force: 'force',
+  lightning: 'lightning',
+  necrotic: 'necrotic',
+  poison: 'poison',
+  poisonous: 'poison',
+  psychic: 'psychic',
+  radiant: 'radiant',
+  thunder: 'thunder',
+};
+
+export const resolveDamageTypeColor = (normalizedType) => {
+  if (typeof normalizedType !== 'string') {
+    return null;
+  }
+  const trimmed = normalizedType.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  const directMatch = DAMAGE_TYPE_LOOKUP[trimmed];
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const hyphenated = trimmed.replace(/\s+/g, '-');
+  const hyphenMatch = DAMAGE_TYPE_LOOKUP[hyphenated];
+  if (hyphenMatch) {
+    return hyphenMatch;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  for (const token of tokens) {
+    if (DAMAGE_TYPE_TOKEN_IGNORE_LIST.has(token)) {
+      continue;
+    }
+
+    const alias = DAMAGE_TYPE_ALIASES[token] || token;
+    const color = DAMAGE_TYPE_LOOKUP[alias];
+    if (color) {
+      return color;
+    }
+  }
+
+  return null;
+};
+
 export const createDiceCategoryStyles = (color, category = 'base') => {
   const normalized = normalizeDiceColor(color) || DEFAULT_DICE_COLOR;
   const rule = CATEGORY_COLOR_RULES[category] || CATEGORY_COLOR_RULES.base;
@@ -108,5 +194,6 @@ export default {
   normalizeDiceColor,
   hexToRgba,
   createDiceCategoryStyles,
+  resolveDamageTypeColor,
   applyDiceFaceColor,
 };


### PR DESCRIPTION
## Summary
- memoize the dice face color before registering roll callbacks so it can be referenced safely
- keep the dice box theme color in sync via an effect without triggering reference errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f57044189c832e9fa8c6b29166dead