### PR TITLE
Ensure mixed damage dice roll simultaneously

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2151,6 +2151,10 @@ $rotateX: -$angle;
   will-change: transform, opacity;
 }
 
+.damage-die--overlay {
+  mix-blend-mode: normal;
+}
+
 .damage-die__icon {
   position: relative;
   width: 100%;

--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -161,7 +161,12 @@ const createDieStyle = (die, index, reduceMotion) => {
   };
 };
 
-const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
+const DamageDiceCanvas = ({
+  dice = [],
+  diceColor,
+  instanceKey = null,
+  showOverlayDice = false,
+}) => {
   const resolvedColor = useMemo(
     () => normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR,
     [diceColor],
@@ -198,15 +203,17 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
       .map((die, index) => {
         const sides = toFiniteSides(die.sides);
         const value = toNumericValue(die.value);
+        const color = die.typeColor || resolvedColor;
         const style = {
           ...createDieStyle({ ...die, sides }, index, reduceMotion),
-          ...createDiceCategoryStyles(resolvedColor, die.category),
+          ...createDiceCategoryStyles(color, die.category),
         };
         const classes = [
           'damage-die',
           getDieShapeClass(sides),
           getCategoryClass(die.category),
           resolveDamageTypeClass(die.typeClass),
+          showOverlayDice ? 'damage-die--overlay' : '',
         ]
           .filter(Boolean)
           .join(' ');
@@ -234,7 +241,7 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
           </div>
         );
       });
-  }, [dice, reduceMotion, resolvedColor]);
+  }, [dice, reduceMotion, resolvedColor, showOverlayDice]);
 
   return (
     <div className="damage-dice-canvas" aria-hidden="true">
@@ -245,7 +252,7 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
           diceBoxReady ? 'damage-dice-canvas__box--ready' : ''
         }`}
       />
-      {!diceBoxReady && diceElements}
+      {(showOverlayDice || !diceBoxReady) && diceElements}
     </div>
   );
 };

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -28,6 +28,7 @@ import {
   applyDiceFaceColor,
   DEFAULT_DICE_COLOR,
   normalizeDiceColor,
+  resolveDamageTypeColor,
 } from '../../../utils/diceColors';
 
 // Dice rolling helper used by calculateDamage and component actions
@@ -54,6 +55,16 @@ function formatDamageRolls(rolls) {
 
 
 const DEFAULT_DAMAGE_TYPE_KEY = '__default__';
+
+const DAMAGE_TYPE_CLASS_TOKEN_IGNORE = new Set([
+  '',
+  'and',
+  'bonus',
+  'damage',
+  'damages',
+  'extra',
+  'plus',
+]);
 
 const parseDamageBreakdownSegments = (breakdown, normalizer) => {
   if (typeof breakdown !== 'string' || !breakdown.trim()) {
@@ -131,6 +142,22 @@ const anyDamageDiceRegex = /\d+d\d+(?:[+-]\d+)?/;
 const spellsCatalog = spellsData || {};
 
 const diceExpressionPattern = /\d+d\d+(?:\s*[+-]\s*\d+)?/gi;
+
+const waitForNextAnimationFrame = () => {
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    return new Promise((resolve) => {
+      window.requestAnimationFrame(() => resolve());
+    });
+  }
+
+  if (typeof setTimeout === 'function') {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  return Promise.resolve();
+};
 
 function extractDiceExpression(description = '') {
   diceExpressionPattern.lastIndex = 0;
@@ -867,7 +894,21 @@ const manualCriticalRef = useRef(false);
     
   const normalizeDamageTypeForClass = (type) => {
     const trimmed = (type || '').trim();
-    return trimmed ? trimmed.toLowerCase().replace(/\s+/g, '-') : '';
+    if (!trimmed) {
+      return '';
+    }
+
+    const tokens = trimmed
+      .toLowerCase()
+      .split(/[^a-z]+/)
+      .map((token) => token.trim())
+      .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
+
+    if (tokens.length === 0) {
+      return '';
+    }
+
+    return tokens.join('-');
   };
 
   const formatDamageSegments = (damage, ability) =>
@@ -919,6 +960,19 @@ const manualCriticalRef = useRef(false);
     return 'Attack';
   };
 
+  const diceFaceColor = useMemo(
+    () => normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR,
+    [form?.diceColor],
+  );
+
+  const diceBoxThemeRef = useRef(null);
+
+  useEffect(() => {
+    applyDiceFaceColor(diceFaceColor);
+    setDiceBoxThemeColor(diceFaceColor);
+    diceBoxThemeRef.current = diceFaceColor;
+  }, [diceFaceColor]);
+
   const rollDamageExpression = useCallback(
     async ({
       damageString,
@@ -948,7 +1002,88 @@ const manualCriticalRef = useRef(false);
         return null;
       }
 
+      const diceRolls = Array.isArray(validation?.diceRolls)
+        ? validation.diceRolls
+        : [];
+
+      const requestDetails = (() => {
+        if (!Array.isArray(requests) || requests.length === 0) {
+          return [];
+        }
+
+        let placeholderIndex = 0;
+        return requests.map((request = {}) => {
+          const rawCount = Number(request?.count);
+          const rawSides = Number(request?.sides);
+          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+          const sides =
+            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+
+          const sliceEnd = placeholderIndex + count;
+          const subset = diceRolls.slice(placeholderIndex, sliceEnd);
+          placeholderIndex = sliceEnd;
+
+          if (!Array.isArray(subset) || subset.length === 0) {
+            return { count, sides, color: null };
+          }
+
+          const normalizedTypes = subset.map((detail) =>
+            normalizeDamageTypeForClass(detail?.type || ''),
+          );
+          const colorCandidates = normalizedTypes
+            .map((type) => (type ? resolveDamageTypeColor(type) : null))
+            .filter(Boolean);
+          const uniqueColors = Array.from(new Set(colorCandidates));
+          const hasColorless = normalizedTypes.some((type) => {
+            if (!type) {
+              return true;
+            }
+            return !resolveDamageTypeColor(type);
+          });
+
+          const color =
+            uniqueColors.length === 1 && !hasColorless ? uniqueColors[0] : null;
+
+          return { count, sides, color };
+        });
+      })();
+
+      const resolveRollThemeColor = () => {
+        if (!Array.isArray(requestDetails) || requestDetails.length === 0) {
+          return diceFaceColor;
+        }
+
+        const uniqueColors = new Set();
+        let hasColorless = false;
+
+        requestDetails.forEach((detail) => {
+          if (!detail || detail.count <= 0) {
+            return;
+          }
+
+          if (detail.color) {
+            uniqueColors.add(detail.color);
+          } else {
+            hasColorless = true;
+          }
+        });
+
+        if (uniqueColors.size === 1 && !hasColorless) {
+          return Array.from(uniqueColors)[0];
+        }
+
+        return diceFaceColor;
+      };
+
+      const rollThemeColor = resolveRollThemeColor();
+
       if (requests.length === 0) {
+        const themeHasChanged = rollThemeColor !== diceBoxThemeRef.current;
+        if (themeHasChanged) {
+          setDiceBoxThemeColor(rollThemeColor);
+          diceBoxThemeRef.current = rollThemeColor;
+          await waitForNextAnimationFrame();
+        }
         const staticResult = calculateDamage(
           trimmed,
           ability,
@@ -961,11 +1096,47 @@ const manualCriticalRef = useRef(false);
       }
 
       try {
-        const { rolls } = await rollDiceWithBox(requests);
+        const themeHasChanged = rollThemeColor !== diceBoxThemeRef.current;
+        if (themeHasChanged) {
+          setDiceBoxThemeColor(rollThemeColor);
+          diceBoxThemeRef.current = rollThemeColor;
+          await waitForNextAnimationFrame();
+        }
+
+        const collected = Array.from({ length: requests.length }, () => null);
+        const rollRequests = [];
+        const rollIndexMap = [];
+
+        requests.forEach((request, index) => {
+          const rawCount = Number(request?.count);
+          const rawSides = Number(request?.sides);
+          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+          const sides =
+            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+
+          if (!count || !sides) {
+            collected[index] = null;
+            return;
+          }
+
+          rollRequests.push({ count, sides });
+          rollIndexMap.push(index);
+        });
+
+        if (rollRequests.length > 0) {
+          const { rolls } = await rollDiceWithBox(rollRequests);
+          rollIndexMap.forEach((originalIndex, idx) => {
+            const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
+            collected[originalIndex] = raw;
+          });
+        }
+
         let requestIndex = 0;
         const appliedRollGroups = [];
         const applyRolls = (count, sides) => {
-          const current = Array.isArray(rolls) ? rolls[requestIndex] : undefined;
+          const current = Array.isArray(collected)
+            ? collected[requestIndex]
+            : undefined;
           requestIndex += 1;
           const normalizedGroup = sanitizeRollGroup(current, count, sides);
           if (normalizedGroup) {
@@ -1027,7 +1198,13 @@ const manualCriticalRef = useRef(false);
         return fallbackResult ? { ...fallbackResult, rollValues: undefined } : null;
       }
     },
-    [rollDiceWithBox],
+    [
+      diceFaceColor,
+      normalizeDamageTypeForClass,
+      resolveDamageTypeColor,
+      rollDiceWithBox,
+      setDiceBoxThemeColor,
+    ],
   );
 
   const handleWeaponAttack = useCallback(
@@ -1258,20 +1435,10 @@ const sortedSpells = useMemo(() => {
 
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const [damageValue, setDamageValue] = useState(0);
-const [damageLog, setDamageLog] = useState([]);
-const [showLog, setShowLog] = useState(false);
-const [activeDice, setActiveDice] = useState([]);
-const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
-
-const diceFaceColor = useMemo(
-  () => normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR,
-  [form?.diceColor],
-);
-
-useEffect(() => {
-  applyDiceFaceColor(diceFaceColor);
-  setDiceBoxThemeColor(diceFaceColor);
-}, [diceFaceColor]);
+  const [damageLog, setDamageLog] = useState([]);
+  const [showLog, setShowLog] = useState(false);
+  const [activeDice, setActiveDice] = useState([]);
+  const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
 
 const triggerDiceAnimation = useCallback((diceDetails = []) => {
   if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
@@ -1298,13 +1465,39 @@ const preparedDice = useMemo(
   () =>
     activeDice.map((die) => {
       const normalizedType = normalizeDamageTypeForClass(die.type);
+      const typeColor = resolveDamageTypeColor(normalizedType);
       return {
         ...die,
         typeClass: normalizedType ? `damage-${normalizedType}` : '',
+        typeColor,
       };
     }),
   [activeDice],
 );
+
+const showOverlayDice = useMemo(() => {
+  if (!Array.isArray(preparedDice) || preparedDice.length === 0) {
+    return false;
+  }
+
+  const uniqueColors = new Set();
+  let hasColorless = false;
+
+  preparedDice.forEach((die) => {
+    const color = die?.typeColor;
+    if (color) {
+      uniqueColors.add(color);
+    } else {
+      hasColorless = true;
+    }
+  });
+
+  if (uniqueColors.size === 0) {
+    return false;
+  }
+
+  return uniqueColors.size > 1 || hasColorless;
+}, [preparedDice]);
 
 const updateDamageValueWithAnimation = (
   newValue,
@@ -1681,6 +1874,7 @@ const damageAmountStyle = {
                   dice={preparedDice}
                   diceColor={diceFaceColor}
                   instanceKey={characterId}
+                  showOverlayDice={showOverlayDice}
                 />
               </div>
               <div className="damage-roller__overlay">

--- a/client/src/utils/diceColors.js
+++ b/client/src/utils/diceColors.js
@@ -1,3 +1,5 @@
+import damageTypeColors from './damageTypeColors';
+
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 export const DEFAULT_DICE_COLOR = '#000000';
 export const DICE_FACE_OPACITY = 0.85;
@@ -77,6 +79,90 @@ const CATEGORY_COLOR_RULES = {
   },
 };
 
+const DAMAGE_TYPE_LOOKUP = Object.entries(damageTypeColors || {}).reduce(
+  (acc, [key, value]) => {
+    if (!key) {
+      return acc;
+    }
+
+    const normalizedKey = String(key).trim().toLowerCase();
+    if (!normalizedKey) {
+      return acc;
+    }
+
+    const normalizedColor = normalizeDiceColor(value);
+    if (!normalizedColor) {
+      return acc;
+    }
+
+    acc[normalizedKey] = normalizedColor;
+    return acc;
+  },
+  {},
+);
+
+const DAMAGE_TYPE_TOKEN_IGNORE_LIST = new Set([
+  'and',
+  'bonus',
+  'damage',
+  'damages',
+  'extra',
+  'plus',
+]);
+
+const DAMAGE_TYPE_ALIASES = {
+  acid: 'acid',
+  acidic: 'acid',
+  chill: 'cold',
+  cold: 'cold',
+  fire: 'fire',
+  flaming: 'fire',
+  force: 'force',
+  lightning: 'lightning',
+  necrotic: 'necrotic',
+  poison: 'poison',
+  poisonous: 'poison',
+  psychic: 'psychic',
+  radiant: 'radiant',
+  thunder: 'thunder',
+};
+
+export const resolveDamageTypeColor = (normalizedType) => {
+  if (typeof normalizedType !== 'string') {
+    return null;
+  }
+  const trimmed = normalizedType.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  const directMatch = DAMAGE_TYPE_LOOKUP[trimmed];
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const hyphenated = trimmed.replace(/\s+/g, '-');
+  const hyphenMatch = DAMAGE_TYPE_LOOKUP[hyphenated];
+  if (hyphenMatch) {
+    return hyphenMatch;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  for (const token of tokens) {
+    if (DAMAGE_TYPE_TOKEN_IGNORE_LIST.has(token)) {
+      continue;
+    }
+
+    const alias = DAMAGE_TYPE_ALIASES[token] || token;
+    const color = DAMAGE_TYPE_LOOKUP[alias];
+    if (color) {
+      return color;
+    }
+  }
+
+  return null;
+};
+
 export const createDiceCategoryStyles = (color, category = 'base') => {
   const normalized = normalizeDiceColor(color) || DEFAULT_DICE_COLOR;
   const rule = CATEGORY_COLOR_RULES[category] || CATEGORY_COLOR_RULES.base;
@@ -108,5 +194,6 @@ export default {
   normalizeDiceColor,
   hexToRgba,
   createDiceCategoryStyles,
+  resolveDamageTypeColor,
   applyDiceFaceColor,
 };


### PR DESCRIPTION
## Summary
- compute each roll's theme color once and batch dice-box requests so all dice animate together while still honoring elemental palettes
- render the damage dice overlay whenever mixed colors are needed so special-damage dice keep their tint even when the dice box is active
- add styling for overlay dice so they layer cleanly above the 3D canvas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f57044189c832e9fa8c6b29166dead