### PR TITLE
Define roll plan for grouped dice requests

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1095,6 +1095,40 @@ const manualCriticalRef = useRef(false);
         return staticResult ? { ...staticResult, rollValues: undefined } : null;
       }
 
+      const rollPlan = (() => {
+        if (!Array.isArray(requests) || requests.length === 0) {
+          return [];
+        }
+
+        const groups = [];
+        let currentGroup = null;
+
+        requests.forEach((request, index) => {
+          const rawCount = Number(request?.count);
+          const rawSides = Number(request?.sides);
+          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+          const sides =
+            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+
+          if (!count || !sides) {
+            currentGroup = null;
+            return;
+          }
+
+          const detail = Array.isArray(requestDetails) ? requestDetails[index] : null;
+          const color = detail?.color || null;
+
+          if (!currentGroup || currentGroup.color !== color) {
+            currentGroup = { color, items: [] };
+            groups.push(currentGroup);
+          }
+
+          currentGroup.items.push({ count, sides, requestIndex: index });
+        });
+
+        return groups.filter((group) => group.items.length > 0);
+      })();
+
       const executeRollPlan = async () => {
         const collected = Array.from({ length: requests.length }, () => null);
 


### PR DESCRIPTION
## Summary
- derive a grouped roll plan from incoming dice roll requests
- ensure grouped requests carry their associated color metadata for themed rolls

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f5830fc080832e912d07963767fa18