### PR TITLE
Adjust dice theme when mixed colors

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1559,22 +1559,15 @@ const showOverlayDice = useMemo(() => {
   }
 
   const uniqueColors = new Set();
-  let hasColorless = false;
 
   preparedDice.forEach((die) => {
-    const color = die?.typeColor;
-    if (color) {
-      uniqueColors.add(color);
-    } else {
-      hasColorless = true;
+    const normalizedColor = normalizeDiceColor(die?.typeColor);
+    if (normalizedColor) {
+      uniqueColors.add(normalizedColor);
     }
   });
 
-  if (uniqueColors.size === 0) {
-    return false;
-  }
-
-  return uniqueColors.size > 1 || hasColorless;
+  return uniqueColors.size > 1;
 }, [preparedDice]);
 
 const updateDamageValueWithAnimation = (


### PR DESCRIPTION
## Summary
- prevent the dice box theme from switching to an elemental tint when any colorless dice are present in the roll

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f584253038832e9a5f696bcd273b53