### PR TITLE
Fix dice theme detection for mixed damage types

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1006,6 +1006,32 @@ const manualCriticalRef = useRef(false);
         ? validation.diceRolls
         : [];
 
+      const classifyTypeColor = (typeValue) => {
+        const normalizedType = normalizeDamageTypeForClass(typeValue || '');
+        if (!normalizedType) {
+          return { normalizedType: '', color: null, isColorless: true, isMixed: false };
+        }
+
+        const tokens = normalizedType.split('-').filter(Boolean);
+        const isMixed = tokens.length > 1;
+        if (isMixed) {
+          return {
+            normalizedType,
+            color: null,
+            isColorless: true,
+            isMixed: true,
+          };
+        }
+
+        const color = resolveDamageTypeColor(normalizedType) || null;
+        return {
+          normalizedType,
+          color,
+          isColorless: !color,
+          isMixed: false,
+        };
+      };
+
       const requestDetails = (() => {
         if (!Array.isArray(requests) || requests.length === 0) {
           return [];
@@ -1027,28 +1053,56 @@ const manualCriticalRef = useRef(false);
             return { count, sides, color: null };
           }
 
-          const normalizedTypes = subset.map((detail) =>
-            normalizeDamageTypeForClass(detail?.type || ''),
+          const analysis = subset.reduce(
+            (acc, detail) => {
+              const classification = classifyTypeColor(detail?.type);
+              if (classification.color && !classification.isMixed) {
+                acc.colors.add(classification.color);
+              } else {
+                acc.hasColorless = true;
+              }
+              return acc;
+            },
+            { colors: new Set(), hasColorless: false },
           );
-          const colorCandidates = normalizedTypes
-            .map((type) => (type ? resolveDamageTypeColor(type) : null))
-            .filter(Boolean);
-          const uniqueColors = Array.from(new Set(colorCandidates));
-          const hasColorless = normalizedTypes.some((type) => {
-            if (!type) {
-              return true;
-            }
-            return !resolveDamageTypeColor(type);
-          });
 
+          const uniqueColors = Array.from(analysis.colors);
           const color =
-            uniqueColors.length === 1 && !hasColorless ? uniqueColors[0] : null;
+            uniqueColors.length === 1 && !analysis.hasColorless ? uniqueColors[0] : null;
 
           return { count, sides, color };
         });
       })();
 
       const resolveRollThemeColor = () => {
+        const diceTheme = (() => {
+          if (!Array.isArray(diceRolls) || diceRolls.length === 0) {
+            return null;
+          }
+
+          const uniqueColors = new Set();
+          let hasColorless = false;
+
+          diceRolls.forEach((die) => {
+            const classification = classifyTypeColor(die?.type);
+            if (classification.color && !classification.isMixed) {
+              uniqueColors.add(classification.color);
+            } else {
+              hasColorless = true;
+            }
+          });
+
+          if (uniqueColors.size === 1 && !hasColorless) {
+            return Array.from(uniqueColors)[0];
+          }
+
+          return null;
+        })();
+
+        if (diceTheme) {
+          return diceTheme;
+        }
+
         if (!Array.isArray(requestDetails) || requestDetails.length === 0) {
           return diceFaceColor;
         }
@@ -1559,22 +1613,15 @@ const showOverlayDice = useMemo(() => {
   }
 
   const uniqueColors = new Set();
-  let hasColorless = false;
 
   preparedDice.forEach((die) => {
-    const color = die?.typeColor;
-    if (color) {
-      uniqueColors.add(color);
-    } else {
-      hasColorless = true;
+    const normalizedColor = normalizeDiceColor(die?.typeColor);
+    if (normalizedColor) {
+      uniqueColors.add(normalizedColor);
     }
   });
 
-  if (uniqueColors.size === 0) {
-    return false;
-  }
-
-  return uniqueColors.size > 1 || hasColorless;
+  return uniqueColors.size > 1;
 }, [preparedDice]);
 
 const updateDamageValueWithAnimation = (


### PR DESCRIPTION
## Summary
- add a helper to classify damage types by color versus mixed tokens
- only tint the dice-box theme when every rolled die shares the same elemental color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f584253038832e9a5f696bcd273b53