### PR TITLE
Set physical damage dice color to black

### DIFF
--- a/client/src/utils/damageTypeColors.js
+++ b/client/src/utils/damageTypeColors.js
@@ -9,6 +9,9 @@ const damageTypeColors = {
   necrotic: '#90cf80',
   radiant: '#FFFF99',
   psychic: '#BA55D3',
+  slashing: '#000000',
+  piercing: '#000000',
+  bludgeoning: '#000000',
 };
 
 export default damageTypeColors;

--- a/client/src/utils/diceColors.test.js
+++ b/client/src/utils/diceColors.test.js
@@ -1,0 +1,15 @@
+import { resolveDamageTypeColor } from './diceColors';
+
+describe('resolveDamageTypeColor', () => {
+  it('returns black for slashing damage types', () => {
+    expect(resolveDamageTypeColor('slashing')).toBe('#000000');
+  });
+
+  it('returns black for piercing damage regardless of casing', () => {
+    expect(resolveDamageTypeColor('Piercing')).toBe('#000000');
+  });
+
+  it('returns black for bludgeoning damage phrases', () => {
+    expect(resolveDamageTypeColor('bludgeoning damage')).toBe('#000000');
+  });
+});


### PR DESCRIPTION
## Summary
- map the slashing, piercing, and bludgeoning damage types to the default black dice color
- add unit tests covering the physical damage types in resolveDamageTypeColor

## Testing
- CI=true npm test -- --runTestsByPath src/utils/diceColors.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f5aaff04748323a55bc5c1f6f1f808