### PR TITLE
Fix dice color switching for mixed damage rolls

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1232,32 +1232,43 @@ const manualCriticalRef = useRef(false);
           await waitForNextAnimationFrame();
         }
 
-        const collected = Array.from({ length: requests.length }, () => null);
-        const rollRequests = [];
-        const rollIndexMap = [];
+        let collected;
+        if (Array.isArray(rollPlan) && rollPlan.length > 0) {
+          collected = await executeRollPlan();
+        } else {
+          const fallbackCollected = Array.from({ length: requests.length }, () => null);
+          const rollRequests = [];
+          const rollIndexMap = [];
 
-        requests.forEach((request, index) => {
-          const rawCount = Number(request?.count);
-          const rawSides = Number(request?.sides);
-          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
-          const sides =
-            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+          requests.forEach((request, index) => {
+            const rawCount = Number(request?.count);
+            const rawSides = Number(request?.sides);
+            const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+            const sides =
+              Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
 
-          if (!count || !sides) {
-            collected[index] = null;
-            return;
+            if (!count || !sides) {
+              fallbackCollected[index] = null;
+              return;
+            }
+
+            rollRequests.push({ count, sides });
+            rollIndexMap.push(index);
+          });
+
+          if (rollRequests.length > 0) {
+            const { rolls } = await rollDiceWithBox(rollRequests);
+            rollIndexMap.forEach((originalIndex, idx) => {
+              const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
+              fallbackCollected[originalIndex] = raw;
+            });
           }
 
-          rollRequests.push({ count, sides });
-          rollIndexMap.push(index);
-        });
+          collected = fallbackCollected;
+        }
 
-        if (rollRequests.length > 0) {
-          const { rolls } = await rollDiceWithBox(rollRequests);
-          rollIndexMap.forEach((originalIndex, idx) => {
-            const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-            collected[originalIndex] = raw;
-          });
+        if (!Array.isArray(collected)) {
+          collected = Array.from({ length: requests.length }, () => null);
         }
 
         let requestIndex = 0;


### PR DESCRIPTION
## Summary
- execute grouped dice roll plan when a damage expression includes multiple damage type colors
- retain batched roll behavior for single-color rolls while normalizing collected results for downstream logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5ad81b7988323b2e51d0ab627de9d