### PR TITLE
Roll multi-color damage dice simultaneously

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1146,84 +1146,6 @@ const manualCriticalRef = useRef(false);
         return staticResult ? { ...staticResult, rollValues: undefined } : null;
       }
 
-      const rollPlan = (() => {
-        if (!Array.isArray(requests) || requests.length === 0) {
-          return [];
-        }
-
-        const groups = [];
-        let currentGroup = null;
-
-        requests.forEach((request, index) => {
-          const rawCount = Number(request?.count);
-          const rawSides = Number(request?.sides);
-          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
-          const sides =
-            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
-
-          if (!count || !sides) {
-            currentGroup = null;
-            return;
-          }
-
-          const detail = Array.isArray(requestDetails) ? requestDetails[index] : null;
-          const color = detail?.color || null;
-
-          if (!currentGroup || currentGroup.color !== color) {
-            currentGroup = { color, items: [] };
-            groups.push(currentGroup);
-          }
-
-          currentGroup.items.push({ count, sides, requestIndex: index });
-        });
-
-        return groups.filter((group) => group.items.length > 0);
-      })();
-
-      const executeRollPlan = async () => {
-        const collected = Array.from({ length: requests.length }, () => null);
-
-        if (!Array.isArray(rollPlan) || rollPlan.length === 0) {
-          const themeHasChanged = diceFaceColor !== diceBoxThemeRef.current;
-          if (themeHasChanged) {
-            setDiceBoxThemeColor(diceFaceColor);
-            diceBoxThemeRef.current = diceFaceColor;
-            await waitForNextAnimationFrame();
-          }
-          return collected;
-        }
-
-        // eslint-disable-next-line no-await-in-loop
-        for (const group of rollPlan) {
-          if (!group || !Array.isArray(group.items) || group.items.length === 0) {
-            continue;
-          }
-
-          const targetColor = group.color || diceFaceColor;
-          if (targetColor !== diceBoxThemeRef.current) {
-            setDiceBoxThemeColor(targetColor);
-            diceBoxThemeRef.current = targetColor;
-            await waitForNextAnimationFrame();
-          }
-
-          const groupRequests = group.items.map(({ count, sides }) => ({
-            count: Math.max(1, Math.round(count || 0)),
-            sides: Math.max(1, Math.round(sides || 0)),
-          }));
-
-          const { rolls } = await rollDiceWithBox(groupRequests);
-          group.items.forEach(({ requestIndex }, idx) => {
-            if (typeof requestIndex !== 'number' || requestIndex < 0) {
-              return;
-            }
-            const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-            collected[requestIndex] = raw;
-          });
-        }
-
-        return collected;
-      };
-
       try {
         const themeHasChanged = rollThemeColor !== diceBoxThemeRef.current;
         if (themeHasChanged) {
@@ -1233,8 +1155,7 @@ const manualCriticalRef = useRef(false);
         }
 
         const collected = Array.from({ length: requests.length }, () => null);
-        const rollRequests = [];
-        const rollIndexMap = [];
+        const colorAwareRequests = [];
 
         requests.forEach((request, index) => {
           const rawCount = Number(request?.count);
@@ -1248,16 +1169,30 @@ const manualCriticalRef = useRef(false);
             return;
           }
 
-          rollRequests.push({ count, sides });
-          rollIndexMap.push(index);
+          const detail = Array.isArray(requestDetails) ? requestDetails[index] : null;
+          const color = detail?.color || null;
+
+          colorAwareRequests.push({ count, sides, color, requestIndex: index });
         });
 
-        if (rollRequests.length > 0) {
-          const { rolls } = await rollDiceWithBox(rollRequests);
-          rollIndexMap.forEach((originalIndex, idx) => {
+        if (colorAwareRequests.length > 0) {
+          const { rolls } = await rollDiceWithBox(
+            colorAwareRequests.map(({ count, sides, color }) => ({ count, sides, color })),
+            { baseColor: rollThemeColor },
+          );
+
+          colorAwareRequests.forEach(({ requestIndex }, idx) => {
+            if (typeof requestIndex !== 'number' || requestIndex < 0) {
+              return;
+            }
+
             const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-            collected[originalIndex] = raw;
+            collected[requestIndex] = raw;
           });
+        }
+
+        if (!Array.isArray(collected)) {
+          collected = Array.from({ length: requests.length }, () => null);
         }
 
         let requestIndex = 0;

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -871,7 +871,7 @@ export const warmupDiceBox = () => {
   });
 };
 
-export const rollDiceWithBox = (requests) => {
+export const rollDiceWithBox = (requests, options = {}) => {
   if (!Array.isArray(requests) || requests.length === 0) {
     return Promise.resolve({
       rolls: [],
@@ -882,7 +882,28 @@ export const rollDiceWithBox = (requests) => {
 
   const executeRoll = async () => {
     const instance = await ensureDiceBox();
-    const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
+    const normalizedRequests = requests.map((request = {}) => {
+      const rawCount = Number(request?.count);
+      const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+      const rawSides = Number(request?.sides);
+      const sides = Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+      const color = normalizeThemeColor(request?.color) || null;
+      return { count, sides, color };
+    });
+
+    const filteredRequests = normalizedRequests.filter(
+      ({ count, sides }) => count > 0 && Number.isInteger(count) && sides,
+    );
+
+    const fallback = filteredRequests.map(({ count, sides }) => fallbackRoll(count, sides));
+
+    if (filteredRequests.length === 0) {
+      return {
+        rolls: fallback,
+        rawResults: null,
+        usedFallback: true,
+      };
+    }
 
     if (!instance) {
       return {
@@ -893,7 +914,11 @@ export const rollDiceWithBox = (requests) => {
     }
 
     return new Promise((resolve) => {
-      const notations = requests.map(({ count, sides }) => `${count}d${sides}`);
+      const baseThemeColor = normalizeThemeColor(options?.baseColor) || null;
+      const notations = filteredRequests.map(({ count, sides }) => `${count}d${sides}`);
+      const supportsAdd = typeof instance.add === 'function' && typeof instance.roll === 'function';
+      const useColorOverrides =
+        supportsAdd && filteredRequests.some(({ color }) => typeof color === 'string' && color);
 
       try {
         if (typeof instance.clear === 'function') {
@@ -919,7 +944,7 @@ export const rollDiceWithBox = (requests) => {
       const cleanup = setRollHandlers(
         instance,
         (rawResults) => {
-          const parsed = parseDiceBoxResults(rawResults, requests);
+          const parsed = parseDiceBoxResults(rawResults, filteredRequests);
           if (parsed) {
             resolve({ rolls: parsed, rawResults, usedFallback: false });
             return;
@@ -928,11 +953,45 @@ export const rollDiceWithBox = (requests) => {
         },
         () => {
           finalize(fallback, true, { failure: true });
-        }
+        },
       );
 
       try {
-        instance.roll(notations);
+        let restoreColor = baseThemeColor || null;
+
+        if (useColorOverrides) {
+          if (restoreColor) {
+            applyThemeColorToInstance(instance, restoreColor);
+          } else {
+            const applied = applyThemeColorToInstance(instance, baseThemeColor)
+              ? baseThemeColor
+              : activeThemeColor;
+            restoreColor = applied || null;
+          }
+
+          filteredRequests.forEach(({ count, sides, color }) => {
+            const notation = `${count}d${sides}`;
+            if (color) {
+              applyThemeColorToInstance(instance, color);
+            } else if (restoreColor) {
+              applyThemeColorToInstance(instance, restoreColor);
+            }
+
+            try {
+              instance.add(notation);
+            } catch (error) {
+              throw error;
+            }
+          });
+
+        }
+
+        if (useColorOverrides) {
+          applyThemeColorToInstance(instance, restoreColor || baseThemeColor || null);
+          instance.roll();
+        } else {
+          instance.roll(notations);
+        }
       } catch (error) {
         cleanup();
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- collect color-aware damage roll requests so simultaneous rolls still map back to the original expression
- extend dice box manager to queue mixed-color dice in a single roll using per-die theme overrides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5ad81b7988323b2e51d0ab627de9d