### PR TITLE
Roll mixed damage types in a single batch

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1146,44 +1146,10 @@ const manualCriticalRef = useRef(false);
         return staticResult ? { ...staticResult, rollValues: undefined } : null;
       }
 
-      const rollPlan = (() => {
-        if (!Array.isArray(requests) || requests.length === 0) {
-          return [];
-        }
-
-        const groups = [];
-        let currentGroup = null;
-
-        requests.forEach((request, index) => {
-          const rawCount = Number(request?.count);
-          const rawSides = Number(request?.sides);
-          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
-          const sides =
-            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
-
-          if (!count || !sides) {
-            currentGroup = null;
-            return;
-          }
-
-          const detail = Array.isArray(requestDetails) ? requestDetails[index] : null;
-          const color = detail?.color || null;
-
-          if (!currentGroup || currentGroup.color !== color) {
-            currentGroup = { color, items: [] };
-            groups.push(currentGroup);
-          }
-
-          currentGroup.items.push({ count, sides, requestIndex: index });
-        });
-
-        return groups.filter((group) => group.items.length > 0);
-      })();
-
       const executeRollPlan = async () => {
         const collected = Array.from({ length: requests.length }, () => null);
 
-        if (!Array.isArray(rollPlan) || rollPlan.length === 0) {
+        if (!Array.isArray(requests) || requests.length === 0) {
           const themeHasChanged = diceFaceColor !== diceBoxThemeRef.current;
           if (themeHasChanged) {
             setDiceBoxThemeColor(diceFaceColor);
@@ -1193,33 +1159,39 @@ const manualCriticalRef = useRef(false);
           return collected;
         }
 
-        // eslint-disable-next-line no-await-in-loop
-        for (const group of rollPlan) {
-          if (!group || !Array.isArray(group.items) || group.items.length === 0) {
-            continue;
+        const rollRequests = [];
+        const rollIndexMap = [];
+
+        requests.forEach((request, index) => {
+          const rawCount = Number(request?.count);
+          const rawSides = Number(request?.sides);
+          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+          const sides =
+            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+
+          if (!count || !sides) {
+            return;
           }
 
-          const targetColor = group.color || diceFaceColor;
-          if (targetColor !== diceBoxThemeRef.current) {
-            setDiceBoxThemeColor(targetColor);
-            diceBoxThemeRef.current = targetColor;
+          rollRequests.push({ count, sides });
+          rollIndexMap.push(index);
+        });
+
+        if (rollRequests.length === 0) {
+          const themeHasChanged = diceFaceColor !== diceBoxThemeRef.current;
+          if (themeHasChanged) {
+            setDiceBoxThemeColor(diceFaceColor);
+            diceBoxThemeRef.current = diceFaceColor;
             await waitForNextAnimationFrame();
           }
-
-          const groupRequests = group.items.map(({ count, sides }) => ({
-            count: Math.max(1, Math.round(count || 0)),
-            sides: Math.max(1, Math.round(sides || 0)),
-          }));
-
-          const { rolls } = await rollDiceWithBox(groupRequests);
-          group.items.forEach(({ requestIndex }, idx) => {
-            if (typeof requestIndex !== 'number' || requestIndex < 0) {
-              return;
-            }
-            const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-            collected[requestIndex] = raw;
-          });
+          return collected;
         }
+
+        const { rolls } = await rollDiceWithBox(rollRequests);
+        rollIndexMap.forEach((originalIndex, idx) => {
+          const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
+          collected[originalIndex] = raw;
+        });
 
         return collected;
       };
@@ -1232,40 +1204,7 @@ const manualCriticalRef = useRef(false);
           await waitForNextAnimationFrame();
         }
 
-        let collected;
-        if (Array.isArray(rollPlan) && rollPlan.length > 0) {
-          collected = await executeRollPlan();
-        } else {
-          const fallbackCollected = Array.from({ length: requests.length }, () => null);
-          const rollRequests = [];
-          const rollIndexMap = [];
-
-          requests.forEach((request, index) => {
-            const rawCount = Number(request?.count);
-            const rawSides = Number(request?.sides);
-            const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
-            const sides =
-              Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
-
-            if (!count || !sides) {
-              fallbackCollected[index] = null;
-              return;
-            }
-
-            rollRequests.push({ count, sides });
-            rollIndexMap.push(index);
-          });
-
-          if (rollRequests.length > 0) {
-            const { rolls } = await rollDiceWithBox(rollRequests);
-            rollIndexMap.forEach((originalIndex, idx) => {
-              const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-              fallbackCollected[originalIndex] = raw;
-            });
-          }
-
-          collected = fallbackCollected;
-        }
+        let collected = await executeRollPlan();
 
         if (!Array.isArray(collected)) {
           collected = Array.from({ length: requests.length }, () => null);


### PR DESCRIPTION
## Summary
- update the player turn damage roller to send all dice requests to the dice box at once instead of batching by damage type

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js *(fails: source-map quick sort recursion error)*

------
https://chatgpt.com/codex/tasks/task_e_68f5b5934f4c8323ac8de02d70de1675