### PR TITLE
Fix dice overlay colors for mixed damage types

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -129,6 +129,51 @@ const groupDiceRollsByType = (diceRolls, normalizer) => {
   return results;
 };
 
+const normalizeDamageTypeForClass = (type) => {
+  const trimmed = (type || '').trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const tokens = trimmed
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .map((token) => token.trim())
+    .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
+
+  if (tokens.length === 0) {
+    return '';
+  }
+
+  return tokens.join('-');
+};
+
+const classifyDamageTypeColor = (typeValue) => {
+  const normalizedType = normalizeDamageTypeForClass(typeValue || '');
+  if (!normalizedType) {
+    return { normalizedType: '', color: null, isColorless: true, isMixed: false };
+  }
+
+  const tokens = normalizedType.split('-').filter(Boolean);
+  const isMixed = tokens.length > 1;
+  if (isMixed) {
+    return {
+      normalizedType,
+      color: null,
+      isColorless: true,
+      isMixed: true,
+    };
+  }
+
+  const color = resolveDamageTypeColor(normalizedType) || null;
+  return {
+    normalizedType,
+    color,
+    isColorless: !color,
+    isMixed: false,
+  };
+};
+
 const WEAPON_SLOT_KEYS = ['mainHand', 'offHand', 'ranged'];
 const HAND_SELECTIONS = {
   ONE_HANDED: 'one-handed',
@@ -892,25 +937,6 @@ const manualCriticalRef = useRef(false);
     abilityForWeapon(weapon, slot) +
     Number(weapon?.attackBonus ?? weapon?.bonus ?? 0);
     
-  const normalizeDamageTypeForClass = (type) => {
-    const trimmed = (type || '').trim();
-    if (!trimmed) {
-      return '';
-    }
-
-    const tokens = trimmed
-      .toLowerCase()
-      .split(/[^a-z]+/)
-      .map((token) => token.trim())
-      .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
-
-    if (tokens.length === 0) {
-      return '';
-    }
-
-    return tokens.join('-');
-  };
-
   const formatDamageSegments = (damage, ability) =>
     damage
       .split(/\s+\+\s+/)
@@ -1006,31 +1032,7 @@ const manualCriticalRef = useRef(false);
         ? validation.diceRolls
         : [];
 
-      const classifyTypeColor = (typeValue) => {
-        const normalizedType = normalizeDamageTypeForClass(typeValue || '');
-        if (!normalizedType) {
-          return { normalizedType: '', color: null, isColorless: true, isMixed: false };
-        }
-
-        const tokens = normalizedType.split('-').filter(Boolean);
-        const isMixed = tokens.length > 1;
-        if (isMixed) {
-          return {
-            normalizedType,
-            color: null,
-            isColorless: true,
-            isMixed: true,
-          };
-        }
-
-        const color = resolveDamageTypeColor(normalizedType) || null;
-        return {
-          normalizedType,
-          color,
-          isColorless: !color,
-          isMixed: false,
-        };
-      };
+      const classifyTypeColor = classifyDamageTypeColor;
 
       const requestDetails = (() => {
         if (!Array.isArray(requests) || requests.length === 0) {
@@ -1593,12 +1595,11 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
 const preparedDice = useMemo(
   () =>
     activeDice.map((die) => {
-      const normalizedType = normalizeDamageTypeForClass(die.type);
-      const typeColor = resolveDamageTypeColor(normalizedType);
+      const { normalizedType, color } = classifyDamageTypeColor(die.type);
       return {
         ...die,
         typeClass: normalizedType ? `damage-${normalizedType}` : '',
-        typeColor,
+        typeColor: color,
       };
     }),
   [activeDice],


### PR DESCRIPTION
## Summary
- centralize damage type normalization and color classification
- ensure dice that include non-special damage keep the default color instead of the special damage hue

## Testing
- npm test -- PlayerTurnActions.test.js *(fails: jest exits early with repeated `doQuickSort` stack frames in source-map-support)*

------
https://chatgpt.com/codex/tasks/task_e_68f647f13670832e84b5a057fcaf996d