### PR TITLE
Fix mixed-damage dice to preserve default color for non-special dice

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -129,6 +129,51 @@ const groupDiceRollsByType = (diceRolls, normalizer) => {
   return results;
 };
 
+const normalizeDamageTypeForClass = (type) => {
+  const trimmed = (type || '').trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const tokens = trimmed
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .map((token) => token.trim())
+    .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
+
+  if (tokens.length === 0) {
+    return '';
+  }
+
+  return tokens.join('-');
+};
+
+const classifyDamageTypeColor = (typeValue) => {
+  const normalizedType = normalizeDamageTypeForClass(typeValue || '');
+  if (!normalizedType) {
+    return { normalizedType: '', color: null, isColorless: true, isMixed: false };
+  }
+
+  const tokens = normalizedType.split('-').filter(Boolean);
+  const isMixed = tokens.length > 1;
+  if (isMixed) {
+    return {
+      normalizedType,
+      color: null,
+      isColorless: true,
+      isMixed: true,
+    };
+  }
+
+  const color = resolveDamageTypeColor(normalizedType) || null;
+  return {
+    normalizedType,
+    color,
+    isColorless: !color,
+    isMixed: false,
+  };
+};
+
 const WEAPON_SLOT_KEYS = ['mainHand', 'offHand', 'ranged'];
 const HAND_SELECTIONS = {
   ONE_HANDED: 'one-handed',
@@ -892,25 +937,6 @@ const manualCriticalRef = useRef(false);
     abilityForWeapon(weapon, slot) +
     Number(weapon?.attackBonus ?? weapon?.bonus ?? 0);
     
-  const normalizeDamageTypeForClass = (type) => {
-    const trimmed = (type || '').trim();
-    if (!trimmed) {
-      return '';
-    }
-
-    const tokens = trimmed
-      .toLowerCase()
-      .split(/[^a-z]+/)
-      .map((token) => token.trim())
-      .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
-
-    if (tokens.length === 0) {
-      return '';
-    }
-
-    return tokens.join('-');
-  };
-
   const formatDamageSegments = (damage, ability) =>
     damage
       .split(/\s+\+\s+/)
@@ -1006,31 +1032,35 @@ const manualCriticalRef = useRef(false);
         ? validation.diceRolls
         : [];
 
-      const classifyTypeColor = (typeValue) => {
-        const normalizedType = normalizeDamageTypeForClass(typeValue || '');
-        if (!normalizedType) {
-          return { normalizedType: '', color: null, isColorless: true, isMixed: false };
-        }
+      const classifyTypeColor = classifyDamageTypeColor;
 
-        const tokens = normalizedType.split('-').filter(Boolean);
-        const isMixed = tokens.length > 1;
-        if (isMixed) {
+      const dicePaletteAnalysis = (() => {
+        if (!Array.isArray(diceRolls) || diceRolls.length === 0) {
           return {
-            normalizedType,
-            color: null,
-            isColorless: true,
-            isMixed: true,
+            colors: new Set(),
+            hasColorless: false,
+            useDefaultForColorless: false,
           };
         }
 
-        const color = resolveDamageTypeColor(normalizedType) || null;
+        const colors = new Set();
+        let hasColorless = false;
+
+        diceRolls.forEach((die) => {
+          const classification = classifyTypeColor(die?.type);
+          if (classification.color && !classification.isMixed) {
+            colors.add(classification.color);
+          } else {
+            hasColorless = true;
+          }
+        });
+
         return {
-          normalizedType,
-          color,
-          isColorless: !color,
-          isMixed: false,
+          colors,
+          hasColorless,
+          useDefaultForColorless: colors.size > 0 && hasColorless,
         };
-      };
+      })();
 
       const requestDetails = (() => {
         if (!Array.isArray(requests) || requests.length === 0) {
@@ -1067,8 +1097,17 @@ const manualCriticalRef = useRef(false);
           );
 
           const uniqueColors = Array.from(analysis.colors);
-          const color =
-            uniqueColors.length === 1 && !analysis.hasColorless ? uniqueColors[0] : null;
+          const color = (() => {
+            if (uniqueColors.length === 1 && !analysis.hasColorless) {
+              return uniqueColors[0];
+            }
+
+            if (dicePaletteAnalysis.useDefaultForColorless && analysis.hasColorless) {
+              return DEFAULT_DICE_COLOR;
+            }
+
+            return null;
+          })();
 
           return { count, sides, color };
         });
@@ -1080,20 +1119,12 @@ const manualCriticalRef = useRef(false);
             return null;
           }
 
-          const uniqueColors = new Set();
-          let hasColorless = false;
+          if (dicePaletteAnalysis.colors.size === 1 && !dicePaletteAnalysis.hasColorless) {
+            return Array.from(dicePaletteAnalysis.colors)[0];
+          }
 
-          diceRolls.forEach((die) => {
-            const classification = classifyTypeColor(die?.type);
-            if (classification.color && !classification.isMixed) {
-              uniqueColors.add(classification.color);
-            } else {
-              hasColorless = true;
-            }
-          });
-
-          if (uniqueColors.size === 1 && !hasColorless) {
-            return Array.from(uniqueColors)[0];
+          if (dicePaletteAnalysis.useDefaultForColorless) {
+            return DEFAULT_DICE_COLOR;
           }
 
           return null;
@@ -1104,7 +1135,9 @@ const manualCriticalRef = useRef(false);
         }
 
         if (!Array.isArray(requestDetails) || requestDetails.length === 0) {
-          return diceFaceColor;
+          return dicePaletteAnalysis.useDefaultForColorless
+            ? DEFAULT_DICE_COLOR
+            : diceFaceColor;
         }
 
         const uniqueColors = new Set();
@@ -1123,7 +1156,9 @@ const manualCriticalRef = useRef(false);
           return Array.from(uniqueColors)[0];
         }
 
-        return diceFaceColor;
+        return dicePaletteAnalysis.useDefaultForColorless
+          ? DEFAULT_DICE_COLOR
+          : diceFaceColor;
       };
 
       const rollThemeColor = resolveRollThemeColor();
@@ -1562,64 +1597,86 @@ const sortedSpells = useMemo(() => {
     );
 }, [form.spells]);
 
-// -----------------------------------------Dice roller for damage-------------------------------------------------------------------
-const [damageValue, setDamageValue] = useState(0);
+  // -----------------------------------------Dice roller for damage--------------------------------------------------------------
+  const [damageValue, setDamageValue] = useState(0);
   const [damageLog, setDamageLog] = useState([]);
   const [showLog, setShowLog] = useState(false);
   const [activeDice, setActiveDice] = useState([]);
+  const [overlayColorlessColor, setOverlayColorlessColor] = useState(null);
+  const [hasMixedDamageColors, setHasMixedDamageColors] = useState(false);
   const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
 
-const triggerDiceAnimation = useCallback((diceDetails = []) => {
-  if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
-    setActiveDice([]);
-    return;
-  }
-
-  const timestamp = Date.now();
-  const nextDice = diceDetails.map((detail, index) => ({
-    id: `${timestamp}-${index}`,
-    value:
-      typeof detail?.value === 'number'
-        ? detail.value
-        : Number(detail?.value) || 0,
-    sides: Number.isFinite(detail?.sides) ? Math.max(2, Math.round(detail.sides)) : 20,
-    type: detail?.type || '',
-    category: detail?.category || 'base',
-  }));
-
-  setActiveDice(nextDice);
-}, []);
-
-const preparedDice = useMemo(
-  () =>
-    activeDice.map((die) => {
-      const normalizedType = normalizeDamageTypeForClass(die.type);
-      const typeColor = resolveDamageTypeColor(normalizedType);
-      return {
-        ...die,
-        typeClass: normalizedType ? `damage-${normalizedType}` : '',
-        typeColor,
-      };
-    }),
-  [activeDice],
-);
-
-const showOverlayDice = useMemo(() => {
-  if (!Array.isArray(preparedDice) || preparedDice.length === 0) {
-    return false;
-  }
-
-  const uniqueColors = new Set();
-
-  preparedDice.forEach((die) => {
-    const normalizedColor = normalizeDiceColor(die?.typeColor);
-    if (normalizedColor) {
-      uniqueColors.add(normalizedColor);
+  const triggerDiceAnimation = useCallback((diceDetails = []) => {
+    if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
+      setActiveDice([]);
+      setHasMixedDamageColors(false);
+      setOverlayColorlessColor(null);
+      return;
     }
-  });
 
-  return uniqueColors.size > 1;
-}, [preparedDice]);
+    const classifications = diceDetails.map((detail) =>
+      classifyDamageTypeColor(detail?.type),
+    );
+    const hasColoredDice = classifications.some(
+      (classification) => classification?.color && !classification.isMixed,
+    );
+    const hasColorlessDice = classifications.some(
+      (classification) => !classification?.color || classification.isMixed,
+    );
+    const useDefaultForColorless = hasColoredDice && hasColorlessDice;
+
+    setHasMixedDamageColors(useDefaultForColorless);
+    setOverlayColorlessColor(useDefaultForColorless ? DEFAULT_DICE_COLOR : null);
+
+    const timestamp = Date.now();
+    const nextDice = diceDetails.map((detail, index) => ({
+      id: `${timestamp}-${index}`,
+      value:
+        typeof detail?.value === 'number'
+          ? detail.value
+          : Number(detail?.value) || 0,
+      sides: Number.isFinite(detail?.sides) ? Math.max(2, Math.round(detail.sides)) : 20,
+      type: detail?.type || '',
+      category: detail?.category || 'base',
+    }));
+
+    setActiveDice(nextDice);
+  }, []);
+
+  const preparedDice = useMemo(
+    () =>
+      activeDice.map((die) => {
+        const { normalizedType, color } = classifyDamageTypeColor(die.type);
+        const resolvedColor = color || overlayColorlessColor || null;
+        return {
+          ...die,
+          typeClass: normalizedType ? `damage-${normalizedType}` : '',
+          typeColor: resolvedColor,
+        };
+      }),
+    [activeDice, overlayColorlessColor],
+  );
+
+  const showOverlayDice = useMemo(() => {
+    if (hasMixedDamageColors) {
+      return false;
+    }
+
+    if (!Array.isArray(preparedDice) || preparedDice.length === 0) {
+      return false;
+    }
+
+    const uniqueColors = new Set();
+
+    preparedDice.forEach((die) => {
+      const normalizedColor = normalizeDiceColor(die?.typeColor);
+      if (normalizedColor) {
+        uniqueColors.add(normalizedColor);
+      }
+    });
+
+    return uniqueColors.size > 1;
+  }, [preparedDice, hasMixedDamageColors]);
 
 const updateDamageValueWithAnimation = (
   newValue,


### PR DESCRIPTION
## Summary
- analyze roll results to detect when special and colorless damage mix so colorless dice fall back to the default hue
- update dice animation state to retain that fallback, hide the legacy overlay during mixed rolls, and carry the color through prepared dice
- keep roll-planning logic in sync so sequential dice-box themes respect the default color for non-special dice while still highlighting special dice

## Testing
- npm test -- PlayerTurnActions.test.js *(fails: Jest exits with repeated `doQuickSort` frames from `source-map-support`)*

------
https://chatgpt.com/codex/tasks/task_e_68f647f13670832e84b5a057fcaf996d