### PR TITLE
Improve damage dice coloring and remove overlay fallback

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3324,15 +3324,18 @@ h1 {
 
 /* Damage type colors */
 .damage-acid { color: #09ff09; }
+.damage-bludgeoning { color: #A67C52; }
 .damage-cold { color: #00BFFF; }
 .damage-fire { color: #FF4500; }
 .damage-lightning { color: #0026ff; }
 .damage-poison { color: #c4f74e; }
+.damage-piercing { color: #C0C0C0; }
 .damage-thunder { color: #8A2BE2; }
 .damage-force { color: #FF1493; }
 .damage-necrotic { color: #90cf80; }
 .damage-radiant { color: #FFFF99; }
 .damage-psychic { color: #BA55D3; }
+.damage-slashing { color: #B22222; }
 
 .roll-separator {
   border-top: 1px solid #ccc;

--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -161,12 +161,7 @@ const createDieStyle = (die, index, reduceMotion) => {
   };
 };
 
-const DamageDiceCanvas = ({
-  dice = [],
-  diceColor,
-  instanceKey = null,
-  showOverlayDice = false,
-}) => {
+const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
   const resolvedColor = useMemo(
     () => normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR,
     [diceColor],
@@ -175,6 +170,7 @@ const DamageDiceCanvas = ({
   const diceBoxRef = useRef(null);
   const [diceBoxReady, setDiceBoxReady] = useState(false);
   const registrationKey = instanceKey ?? '__default__';
+  const overlayEnabled = !diceBoxReady;
 
   useEffect(() => {
     const reference = diceBoxRef.current || '#damage-dice-box';
@@ -213,7 +209,7 @@ const DamageDiceCanvas = ({
           getDieShapeClass(sides),
           getCategoryClass(die.category),
           resolveDamageTypeClass(die.typeClass),
-          showOverlayDice ? 'damage-die--overlay' : '',
+          overlayEnabled ? 'damage-die--overlay' : '',
         ]
           .filter(Boolean)
           .join(' ');
@@ -241,7 +237,7 @@ const DamageDiceCanvas = ({
           </div>
         );
       });
-  }, [dice, reduceMotion, resolvedColor, showOverlayDice]);
+  }, [dice, overlayEnabled, reduceMotion, resolvedColor]);
 
   return (
     <div className="damage-dice-canvas" aria-hidden="true">
@@ -252,7 +248,7 @@ const DamageDiceCanvas = ({
           diceBoxReady ? 'damage-dice-canvas__box--ready' : ''
         }`}
       />
-      {(showOverlayDice || !diceBoxReady) && diceElements}
+      {overlayEnabled ? diceElements : null}
     </div>
   );
 };

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -28,6 +28,7 @@ import {
   applyDiceFaceColor,
   DEFAULT_DICE_COLOR,
   normalizeDiceColor,
+  resolveDamageTypeKey,
   resolveDamageTypeColor,
 } from '../../../utils/diceColors';
 
@@ -64,6 +65,18 @@ const DAMAGE_TYPE_CLASS_TOKEN_IGNORE = new Set([
   'damages',
   'extra',
   'plus',
+  'attack',
+  'attacks',
+  'die',
+  'dice',
+  'magic',
+  'magical',
+  'melee',
+  'nonmagical',
+  'ranged',
+  'silvered',
+  'versatile',
+  'weapon',
 ]);
 
 const parseDamageBreakdownSegments = (breakdown, normalizer) => {
@@ -139,13 +152,27 @@ const normalizeDamageTypeForClass = (type) => {
     .toLowerCase()
     .split(/[^a-z]+/)
     .map((token) => token.trim())
-    .filter((token) => !DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token));
+    .filter(Boolean);
 
-  if (tokens.length === 0) {
-    return '';
+  const recognized = [];
+
+  tokens.forEach((token) => {
+    if (DAMAGE_TYPE_CLASS_TOKEN_IGNORE.has(token)) {
+      return;
+    }
+
+    const key = resolveDamageTypeKey(token);
+    if (key) {
+      recognized.push(key);
+    }
+  });
+
+  if (recognized.length === 0) {
+    const fallbackKey = resolveDamageTypeKey(trimmed);
+    return fallbackKey || '';
   }
 
-  return tokens.join('-');
+  return Array.from(new Set(recognized)).join('-');
 };
 
 const classifyDamageTypeColor = (typeValue) => {
@@ -165,7 +192,7 @@ const classifyDamageTypeColor = (typeValue) => {
     };
   }
 
-  const color = resolveDamageTypeColor(normalizedType) || null;
+  const color = resolveDamageTypeColor(tokens[0]) || null;
   return {
     normalizedType,
     color,
@@ -1657,27 +1684,6 @@ const sortedSpells = useMemo(() => {
     [activeDice, overlayColorlessColor],
   );
 
-  const showOverlayDice = useMemo(() => {
-    if (hasMixedDamageColors) {
-      return false;
-    }
-
-    if (!Array.isArray(preparedDice) || preparedDice.length === 0) {
-      return false;
-    }
-
-    const uniqueColors = new Set();
-
-    preparedDice.forEach((die) => {
-      const normalizedColor = normalizeDiceColor(die?.typeColor);
-      if (normalizedColor) {
-        uniqueColors.add(normalizedColor);
-      }
-    });
-
-    return uniqueColors.size > 1;
-  }, [preparedDice, hasMixedDamageColors]);
-
 const updateDamageValueWithAnimation = (
   newValue,
   breakdown,
@@ -2053,7 +2059,6 @@ const damageAmountStyle = {
                   dice={preparedDice}
                   diceColor={diceFaceColor}
                   instanceKey={characterId}
-                  showOverlayDice={showOverlayDice}
                 />
               </div>
               <div className="damage-roller__overlay">

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -707,7 +707,8 @@ describe('PlayerTurnActions damage log', () => {
   test('damage log segments use damage type colors', async () => {
     const weapon = {
       name: 'Elemental Blade',
-      damage: '1d4 cold + 1d4 fire + 1d4 lightning',
+      damage:
+        '1d4 cold + 1d4 fire + 1d4 lightning + 1d4 bludgeoning + 1d4 piercing + 1d4 slashing',
       category: 'melee',
     };
     const orig = Math.random;
@@ -737,23 +738,28 @@ describe('PlayerTurnActions damage log', () => {
     });
     const modal = await screen.findByRole('dialog');
 
-    const cold = within(modal).getByText('3 cold');
-    expect(
-      cold.style.color === damageTypeColors.cold ||
-        cold.classList.contains('damage-cold')
-    ).toBe(true);
+    const expectedTypes = [
+      'cold',
+      'fire',
+      'lightning',
+      'bludgeoning',
+      'piercing',
+      'slashing',
+    ];
 
-    const fire = within(modal).getByText('1 fire');
-    expect(
-      fire.style.color === damageTypeColors.fire ||
-        fire.classList.contains('damage-fire')
-    ).toBe(true);
+    expectedTypes.forEach((type) => {
+      const element = modal.querySelector(`.damage-${type}`);
+      expect(element).not.toBeNull();
+      if (!element) {
+        throw new Error(`Missing damage segment for ${type}`);
+      }
 
-    const lightning = within(modal).getByText('1 lightning');
-    expect(
-      lightning.style.color === damageTypeColors.lightning ||
-        lightning.classList.contains('damage-lightning')
-    ).toBe(true);
+      expect(element.textContent.toLowerCase()).toContain(type);
+      expect(
+        element.style.color === damageTypeColors[type] ||
+          element.classList.contains(`damage-${type}`)
+      ).toBe(true);
+    });
     Math.random = orig;
   });
 

--- a/client/src/utils/damageTypeColors.js
+++ b/client/src/utils/damageTypeColors.js
@@ -1,14 +1,17 @@
 const damageTypeColors = {
   acid: '#09ff09',
+  bludgeoning: '#A67C52',
   cold: '#00BFFF',
   fire: '#FF4500',
   lightning: '#0026ff',
   poison: '#c4f74e',
+  piercing: '#C0C0C0',
   thunder: '#8A2BE2',
   force: '#FF1493',
   necrotic: '#90cf80',
   radiant: '#FFFF99',
   psychic: '#BA55D3',
+  slashing: '#B22222',
 };
 
 export default damageTypeColors;

--- a/client/src/utils/diceColors.js
+++ b/client/src/utils/diceColors.js
@@ -108,6 +108,18 @@ const DAMAGE_TYPE_TOKEN_IGNORE_LIST = new Set([
   'damages',
   'extra',
   'plus',
+  'versatile',
+  'magical',
+  'magic',
+  'nonmagical',
+  'silvered',
+  'weapon',
+  'melee',
+  'ranged',
+  'attack',
+  'attacks',
+  'die',
+  'dice',
 ]);
 
 const DAMAGE_TYPE_ALIASES = {
@@ -127,24 +139,23 @@ const DAMAGE_TYPE_ALIASES = {
   thunder: 'thunder',
 };
 
-export const resolveDamageTypeColor = (normalizedType) => {
-  if (typeof normalizedType !== 'string') {
+export const resolveDamageTypeKey = (value) => {
+  if (typeof value !== 'string') {
     return null;
   }
-  const trimmed = normalizedType.trim().toLowerCase();
+
+  const trimmed = value.trim().toLowerCase();
   if (!trimmed) {
     return null;
   }
 
-  const directMatch = DAMAGE_TYPE_LOOKUP[trimmed];
-  if (directMatch) {
-    return directMatch;
+  if (DAMAGE_TYPE_LOOKUP[trimmed]) {
+    return trimmed;
   }
 
   const hyphenated = trimmed.replace(/\s+/g, '-');
-  const hyphenMatch = DAMAGE_TYPE_LOOKUP[hyphenated];
-  if (hyphenMatch) {
-    return hyphenMatch;
+  if (DAMAGE_TYPE_LOOKUP[hyphenated]) {
+    return hyphenated;
   }
 
   const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
@@ -154,13 +165,21 @@ export const resolveDamageTypeColor = (normalizedType) => {
     }
 
     const alias = DAMAGE_TYPE_ALIASES[token] || token;
-    const color = DAMAGE_TYPE_LOOKUP[alias];
-    if (color) {
-      return color;
+    if (DAMAGE_TYPE_LOOKUP[alias]) {
+      return alias;
     }
   }
 
   return null;
+};
+
+export const resolveDamageTypeColor = (value) => {
+  const key = resolveDamageTypeKey(value);
+  if (!key) {
+    return null;
+  }
+
+  return DAMAGE_TYPE_LOOKUP[key] || null;
 };
 
 export const createDiceCategoryStyles = (color, category = 'base') => {
@@ -194,6 +213,7 @@ export default {
   normalizeDiceColor,
   hexToRgba,
   createDiceCategoryStyles,
+  resolveDamageTypeKey,
   resolveDamageTypeColor,
   applyDiceFaceColor,
 };


### PR DESCRIPTION
## Summary
- normalize weapon damage strings via a shared damage-type resolver so bludgeoning, piercing, and slashing dice pick up their palette colors
- update the player turn actions to rely on the new resolver and drop the multi-color overlay dice logic
- render the CSS damage dice overlay only when the 3D dice box is unavailable to prevent the legacy animation from showing alongside the main roll

## Testing
- CI=true npm test -- --testNamePattern="handles multi-type damage" --runTestsByPath client/src/components/Zombies/attributes/PlayerTurnActions.test.js *(fails with source-map quicksort overflow in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f657001914832ea6d2a6b38c601b90