### PR TITLE
Sync multi-color damage dice rolls

### DIFF
--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -161,7 +161,12 @@ const createDieStyle = (die, index, reduceMotion) => {
   };
 };
 
-const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
+const DamageDiceCanvas = ({
+  dice = [],
+  diceColor,
+  instanceKey = null,
+  forceOverlay = false,
+}) => {
   const resolvedColor = useMemo(
     () => normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR,
     [diceColor],
@@ -170,7 +175,7 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
   const diceBoxRef = useRef(null);
   const [diceBoxReady, setDiceBoxReady] = useState(false);
   const registrationKey = instanceKey ?? '__default__';
-  const overlayEnabled = !diceBoxReady;
+  const overlayEnabled = forceOverlay || !diceBoxReady;
 
   useEffect(() => {
     const reference = diceBoxRef.current || '#damage-dice-box';
@@ -246,7 +251,7 @@ const DamageDiceCanvas = ({ dice = [], diceColor, instanceKey = null }) => {
         ref={diceBoxRef}
         className={`damage-dice-canvas__box ${
           diceBoxReady ? 'damage-dice-canvas__box--ready' : ''
-        }`}
+        } ${forceOverlay ? 'damage-dice-canvas__box--hidden' : ''}`.trim()}
       />
       {overlayEnabled ? diceElements : null}
     </div>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1208,84 +1208,6 @@ const manualCriticalRef = useRef(false);
         return staticResult ? { ...staticResult, rollValues: undefined } : null;
       }
 
-      const rollPlan = (() => {
-        if (!Array.isArray(requests) || requests.length === 0) {
-          return [];
-        }
-
-        const groups = [];
-        let currentGroup = null;
-
-        requests.forEach((request, index) => {
-          const rawCount = Number(request?.count);
-          const rawSides = Number(request?.sides);
-          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
-          const sides =
-            Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
-
-          if (!count || !sides) {
-            currentGroup = null;
-            return;
-          }
-
-          const detail = Array.isArray(requestDetails) ? requestDetails[index] : null;
-          const color = detail?.color || null;
-
-          if (!currentGroup || currentGroup.color !== color) {
-            currentGroup = { color, items: [] };
-            groups.push(currentGroup);
-          }
-
-          currentGroup.items.push({ count, sides, requestIndex: index });
-        });
-
-        return groups.filter((group) => group.items.length > 0);
-      })();
-
-      const executeRollPlan = async () => {
-        const collected = Array.from({ length: requests.length }, () => null);
-
-        if (!Array.isArray(rollPlan) || rollPlan.length === 0) {
-          const themeHasChanged = diceFaceColor !== diceBoxThemeRef.current;
-          if (themeHasChanged) {
-            setDiceBoxThemeColor(diceFaceColor);
-            diceBoxThemeRef.current = diceFaceColor;
-            await waitForNextAnimationFrame();
-          }
-          return collected;
-        }
-
-        // eslint-disable-next-line no-await-in-loop
-        for (const group of rollPlan) {
-          if (!group || !Array.isArray(group.items) || group.items.length === 0) {
-            continue;
-          }
-
-          const targetColor = group.color || diceFaceColor;
-          if (targetColor !== diceBoxThemeRef.current) {
-            setDiceBoxThemeColor(targetColor);
-            diceBoxThemeRef.current = targetColor;
-            await waitForNextAnimationFrame();
-          }
-
-          const groupRequests = group.items.map(({ count, sides }) => ({
-            count: Math.max(1, Math.round(count || 0)),
-            sides: Math.max(1, Math.round(sides || 0)),
-          }));
-
-          const { rolls } = await rollDiceWithBox(groupRequests);
-          group.items.forEach(({ requestIndex }, idx) => {
-            if (typeof requestIndex !== 'number' || requestIndex < 0) {
-              return;
-            }
-            const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-            collected[requestIndex] = raw;
-          });
-        }
-
-        return collected;
-      };
-
       try {
         const themeHasChanged = rollThemeColor !== diceBoxThemeRef.current;
         if (themeHasChanged) {
@@ -1294,14 +1216,17 @@ const manualCriticalRef = useRef(false);
           await waitForNextAnimationFrame();
         }
 
-        const collected = Array.from({ length: requests.length }, () => null);
+        let collected = Array.from({ length: requests.length }, () => null);
+
         const rollRequests = [];
         const rollIndexMap = [];
 
         requests.forEach((request, index) => {
           const rawCount = Number(request?.count);
           const rawSides = Number(request?.sides);
-          const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+          const count = Number.isFinite(rawCount)
+            ? Math.max(0, Math.floor(rawCount))
+            : 0;
           const sides =
             Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
 
@@ -1644,15 +1569,26 @@ const sortedSpells = useMemo(() => {
     const classifications = diceDetails.map((detail) =>
       classifyDamageTypeColor(detail?.type),
     );
-    const hasColoredDice = classifications.some(
-      (classification) => classification?.color && !classification.isMixed,
-    );
-    const hasColorlessDice = classifications.some(
-      (classification) => !classification?.color || classification.isMixed,
-    );
+    const uniqueColors = new Set();
+    let hasColorlessDice = false;
+
+    classifications.forEach((classification) => {
+      if (!classification) {
+        hasColorlessDice = true;
+        return;
+      }
+
+      if (classification.color && !classification.isMixed) {
+        uniqueColors.add(classification.color);
+      } else {
+        hasColorlessDice = true;
+      }
+    });
+
+    const hasColoredDice = uniqueColors.size > 0;
     const useDefaultForColorless = hasColoredDice && hasColorlessDice;
 
-    setHasMixedDamageColors(useDefaultForColorless);
+    setHasMixedDamageColors(uniqueColors.size > 1 || useDefaultForColorless);
     setOverlayColorlessColor(useDefaultForColorless ? DEFAULT_DICE_COLOR : null);
 
     const timestamp = Date.now();
@@ -2058,6 +1994,7 @@ const damageAmountStyle = {
                 <DamageDiceCanvas
                   dice={preparedDice}
                   diceColor={diceFaceColor}
+                  forceOverlay={hasMixedDamageColors}
                   instanceKey={characterId}
                 />
               </div>

--- a/client/src/dice-box.css
+++ b/client/src/dice-box.css
@@ -11,6 +11,10 @@
   pointer-events: none;
 }
 
+.damage-dice-canvas__box--hidden {
+  opacity: 0;
+}
+
 .damage-dice-canvas__box canvas,
 .damage-dice-canvas__box > div {
   width: 100%;


### PR DESCRIPTION
## Summary
- roll all requested damage dice in a single dice-box call while keeping collected results aligned
- flag rolls with multiple colors to drive an overlay animation that shows all colored dice together
- allow the damage dice canvas to force its overlay and mute the physical dice box when mixed colors appear

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f67a64ed5c832eb309fa61bf4753e6