### PR TITLE
Fix syntax error in PlayerTurnActions dice roll processing

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1234,35 +1234,17 @@ const manualCriticalRef = useRef(false);
             collected[index] = null;
             return;
           }
-        } else {
-          const rollRequests = [];
-          const rollIndexMap = [];
 
-          requests.forEach((request, index) => {
-            const rawCount = Number(request?.count);
-            const rawSides = Number(request?.sides);
-            const count = Number.isFinite(rawCount)
-              ? Math.max(0, Math.floor(rawCount))
-              : 0;
-            const sides =
-              Number.isFinite(rawSides) && rawSides > 0 ? Math.round(rawSides) : null;
+          rollRequests.push({ count, sides });
+          rollIndexMap.push(index);
+        });
 
-            if (!count || !sides) {
-              collected[index] = null;
-              return;
-            }
-
-            rollRequests.push({ count, sides });
-            rollIndexMap.push(index);
+        if (rollRequests.length > 0) {
+          const { rolls } = await rollDiceWithBox(rollRequests);
+          rollIndexMap.forEach((originalIndex, idx) => {
+            const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
+            collected[originalIndex] = raw;
           });
-
-          if (rollRequests.length > 0) {
-            const { rolls } = await rollDiceWithBox(rollRequests);
-            rollIndexMap.forEach((originalIndex, idx) => {
-              const raw = Array.isArray(rolls) ? rolls[idx] : undefined;
-              collected[originalIndex] = raw;
-            });
-          }
         }
 
         let requestIndex = 0;


### PR DESCRIPTION
## Summary
- remove the stray else block in PlayerTurnActions that duplicated dice roll collection logic
- keep roll request aggregation within the forEach so dice box rolling works as expected

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve '@3d-dice/dice-box')*

------
https://chatgpt.com/codex/tasks/task_e_68f6800d64a8832e9b2ffc657fbd0200