### PR TITLE
Ensure skill rolls use the player's dice color

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1410,7 +1410,9 @@ const manualCriticalRef = useRef(false);
   const handleWeaponAttackRoll = async (slot, weapon) => {
     const rawBonus = Number(getAttackBonus(slot, weapon));
     const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
-    const { result, d20 } = await rollSkillWithDiceBox(bonus);
+    const { result, d20 } = await rollSkillWithDiceBox(bonus, {
+      diceColor: diceFaceColor,
+    });
     const weaponLabel = getWeaponDisplayName(slot, weapon);
     const segments = [`${d20} (d20)`];
     if (bonus) {

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -8,7 +8,15 @@ import proficiencyBonus from '../../../utils/proficiencyBonus';
 import SkillInfoModal from './SkillInfoModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import DockControls from '../components/DockControls';
-import { rollDiceWithBox } from '../../../utils/diceBoxManager';
+import {
+  rollDiceWithBox,
+  setDiceBoxThemeColor,
+} from '../../../utils/diceBoxManager';
+import {
+  DEFAULT_DICE_COLOR,
+  normalizeDiceColor,
+  applyDiceFaceColor,
+} from '../../../utils/diceColors';
 
 const EMPTY_OBJECT = Object.freeze({});
 
@@ -36,6 +44,19 @@ const normalizeD20Value = (value) => {
   return rounded;
 };
 
+const waitForNextAnimationFrame = () =>
+  new Promise((resolve) => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.requestAnimationFrame !== 'function'
+    ) {
+      resolve();
+      return;
+    }
+
+    window.requestAnimationFrame(() => resolve());
+  });
+
 export function rollSkill(bonus = 0, d20Override = null) {
   const normalizedOverride = normalizeD20Value(d20Override);
   const d20 =
@@ -51,7 +72,14 @@ export function rollSkill(bonus = 0, d20Override = null) {
   return { result, d20 };
 }
 
-export async function rollSkillWithDiceBox(bonus = 0) {
+export async function rollSkillWithDiceBox(bonus = 0, options = {}) {
+  const { diceColor = null } = options || {};
+  const normalizedColor = normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR;
+
+  applyDiceFaceColor(normalizedColor);
+  setDiceBoxThemeColor(normalizedColor);
+  await waitForNextAnimationFrame();
+
   try {
     const { rolls } = await rollDiceWithBox([{ count: 1, sides: 20 }]);
     const firstGroup = Array.isArray(rolls) ? rolls[0] : undefined;
@@ -88,6 +116,10 @@ export default function Skills({
 }) {
   const params = useParams();
   const safeForm = form ?? {};
+  const diceFaceColor = useMemo(
+    () => normalizeDiceColor(safeForm?.diceColor) || DEFAULT_DICE_COLOR,
+    [safeForm?.diceColor],
+  );
   const formSkills = safeForm.skills ?? EMPTY_OBJECT;
   const formProficiencyPoints = safeForm.proficiencyPoints || 0;
   const formExpertisePoints = safeForm.expertisePoints || 0;
@@ -357,7 +389,9 @@ export default function Skills({
       handleCloseSkill?.();
     }
 
-    const { result, d20 } = await rollSkillWithDiceBox(bonus);
+    const { result, d20 } = await rollSkillWithDiceBox(bonus, {
+      diceColor: diceFaceColor,
+    });
     const breakdownParts = [`${d20} (d20)`];
 
     const segments = [

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -26,10 +26,13 @@ jest.mock('../../../utils/diceBoxManager', () => ({
   setDiceBoxThemeColor: jest.fn(),
 }));
 
-const { rollDiceWithBox } = require('../../../utils/diceBoxManager');
+const { rollDiceWithBox, setDiceBoxThemeColor } = require(
+  '../../../utils/diceBoxManager'
+);
 
 const createProps = (overrides = {}) => ({
   form: {
+    diceColor: '#123456',
     skills: {},
     race: {},
     background: {},
@@ -59,6 +62,7 @@ describe('Skills modal docking props', () => {
   beforeEach(() => {
     capturedModalProps = null;
     rollDiceWithBox.mockClear();
+    setDiceBoxThemeColor.mockClear();
   });
 
   it('applies docked layout when docked', () => {
@@ -86,6 +90,7 @@ describe('Skills modal docking props', () => {
 describe('skill rolling behavior', () => {
   beforeEach(() => {
     rollDiceWithBox.mockClear();
+    setDiceBoxThemeColor.mockClear();
   });
 
   it('closes the modal after rolling when undocked', async () => {
@@ -138,5 +143,17 @@ describe('skill rolling behavior', () => {
     } finally {
       dispatchSpy.mockRestore();
     }
+  });
+  it('applies the player dice color before rolling', async () => {
+    rollDiceWithBox.mockResolvedValueOnce({ rolls: [[8]] });
+
+    render(<Skills {...createProps()} />);
+
+    const rollButton = await screen.findByRole('button', { name: /roll acrobatics/i });
+    await userEvent.click(rollButton);
+
+    await waitFor(() => {
+      expect(setDiceBoxThemeColor).toHaveBeenCalledWith('#123456');
+    });
   });
 });

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -5,6 +5,10 @@ import STATS from "../statSchema";
 import StatBreakdownModal from "./StatBreakdownModal";
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import { rollSkillWithDiceBox } from './Skills';
+import {
+  DEFAULT_DICE_COLOR,
+  normalizeDiceColor,
+} from '../../../utils/diceColors';
 
 const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
@@ -40,6 +44,11 @@ export default function Stats({
     wis: form.wis || 0,
     cha: form.cha || 0,
   });
+
+  const diceFaceColor = useMemo(
+    () => normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR,
+    [form?.diceColor],
+  );
 
   const [showBreakdown, setShowBreakdown] = useState(false);
   const [selectedStat, setSelectedStat] = useState(null);
@@ -153,7 +162,9 @@ export default function Stats({
         handleCloseStats?.();
       }
 
-      const { result, d20 } = await rollSkillWithDiceBox(statMod);
+      const { result, d20 } = await rollSkillWithDiceBox(statMod, {
+        diceColor: diceFaceColor,
+      });
       const breakdownParts = [`${d20} (d20)`];
       const modifierSegment = formatAdjustmentSegment(
         statMod,
@@ -186,7 +197,7 @@ export default function Stats({
       );
 
     },
-    [handleCloseStats, isDocked, statMods]
+    [diceFaceColor, handleCloseStats, isDocked, statMods]
   );
 
   const dialogClassName = useMemo(() => {

--- a/client/src/components/Zombies/attributes/Stats.test.js
+++ b/client/src/components/Zombies/attributes/Stats.test.js
@@ -1,7 +1,22 @@
 import React from 'react';
 import { render, screen, within, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+jest.mock('../../../utils/diceBoxManager', () => ({
+  rollDiceWithBox: jest.fn(() => Promise.resolve({ rolls: [[16]] })),
+  setDiceBoxThemeColor: jest.fn(),
+}));
+
 import Stats from './Stats';
+
+const { rollDiceWithBox, setDiceBoxThemeColor } = require(
+  '../../../utils/diceBoxManager'
+);
+
+beforeEach(() => {
+  rollDiceWithBox.mockReset();
+  rollDiceWithBox.mockImplementation(() => Promise.resolve({ rolls: [[16]] }));
+  setDiceBoxThemeColor.mockReset();
+});
 
 test('clicking view shows description and breakdown', async () => {
   const form = {
@@ -172,6 +187,10 @@ test('rolling a stat dispatches a roll event and closes the modal when undocked'
       await userEvent.click(
         within(strengthCard).getByRole('button', { name: /Roll Strength check/i })
       );
+    });
+
+    await waitFor(() => {
+      expect(rollDiceWithBox).toHaveBeenCalled();
     });
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- ensure `rollSkillWithDiceBox` applies the provided dice color before requesting a roll and waits for the theme update
- supply the player's dice color to skill rolls from stats, weapon attack rolls, and skills UI
- extend unit tests to cover the dice color behaviour and stub dice box interactions for deterministic results

## Testing
- CI=true npm test -- Skills.test.js
- CI=true npm test -- Stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f6924444288323b49bc249c4346192