### PR TITLE
Add dice theme selection support

### DIFF
--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'; // Import useState and React
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button, Alert } from 'react-bootstrap'; // Adjust as per your actual UI library
+import { Modal, Card, Table, Button, Alert, Form } from 'react-bootstrap'; // Adjust as per your actual UI library
 import { useNavigate, useParams } from "react-router-dom";
 import CampaignModals from "../components/CampaignModals";
 import useCampaignActions from "../hooks/useCampaignActions";
@@ -10,7 +10,35 @@ import {
   DEFAULT_DICE_COLOR,
   normalizeDiceColor,
 } from '../../../utils/diceColors';
-import { setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
+import { setDiceBoxTheme, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
+
+const DICE_THEME_OPTIONS = [
+  { value: 'default', label: 'Default' },
+  { value: 'rust', label: 'Rust' },
+  { value: 'diceOfRolling', label: 'Dice of Rolling' },
+  { value: 'gemstone', label: 'Gemstone' },
+  { value: 'wooden', label: 'Wooden' },
+  { value: 'smooth', label: 'Smooth' },
+  { value: 'rock', label: 'Rock' },
+  { value: 'blueGreenMetal', label: 'Blue Green Metal' },
+];
+
+const DEFAULT_DICE_THEME = DICE_THEME_OPTIONS[0].value;
+
+const normalizeDiceTheme = (value) => {
+  if (typeof value !== 'string') {
+    return DEFAULT_DICE_THEME;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_DICE_THEME;
+  }
+
+  const lower = trimmed.toLowerCase();
+  const match = DICE_THEME_OPTIONS.find((option) => option.value.toLowerCase() === lower);
+  return match ? match.value : DEFAULT_DICE_THEME;
+};
 
 export default function Help({
   form,
@@ -61,11 +89,17 @@ export default function Help({
   //-------------------------------------------Help Module--------------------------------------------------------------------
   const initialColor = normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR;
   const [newColor, setNewColor] = useState(initialColor);
+  const [newTheme, setNewTheme] = useState(() => normalizeDiceTheme(form?.diceTheme));
+  const themeOptions = useMemo(() => DICE_THEME_OPTIONS, []);
 
   useEffect(() => {
     applyDiceFaceColor(newColor);
     setDiceBoxThemeColor(newColor);
   }, [newColor]);
+
+  useEffect(() => {
+    setDiceBoxTheme(newTheme);
+  }, [newTheme]);
 
   useEffect(() => {
     const normalized = normalizeDiceColor(form?.diceColor);
@@ -76,10 +110,22 @@ export default function Help({
     }
   }, [form?.diceColor]);
 
+  useEffect(() => {
+    const normalizedTheme = normalizeDiceTheme(form?.diceTheme);
+    setNewTheme((prev) => (prev === normalizedTheme ? prev : normalizedTheme));
+  }, [form?.diceTheme]);
+
   const handleColorChange = (event) => {
     const selectedColor = event?.target?.value;
     if (typeof selectedColor === 'string') {
       setNewColor(selectedColor);
+    }
+  };
+
+  const handleThemeChange = (event) => {
+    const selectedTheme = event?.target?.value;
+    if (typeof selectedTheme === 'string') {
+      setNewTheme(normalizeDiceTheme(selectedTheme));
     }
   };
 
@@ -89,13 +135,15 @@ export default function Help({
       return;
     }
 
+    const normalizedTheme = normalizeDiceTheme(newTheme);
+
     try {
       const response = await apiFetch(`/characters/update-dice-color/${params.id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ diceColor: normalizedColor }),
+        body: JSON.stringify({ diceColor: normalizedColor, diceTheme: normalizedTheme }),
       });
 
       if (!response.ok) {
@@ -110,10 +158,15 @@ export default function Help({
       }
 
       const nextColor = normalizeDiceColor(payload?.diceColor) || normalizedColor;
+      let nextTheme = normalizedTheme;
+      if (payload && Object.prototype.hasOwnProperty.call(payload, 'diceTheme')) {
+        nextTheme = normalizeDiceTheme(payload?.diceTheme);
+      }
       setNewColor(nextColor);
+      setNewTheme((prev) => (prev === nextTheme ? prev : nextTheme));
 
       if (typeof onDiceColorChange === 'function') {
-        onDiceColorChange(nextColor);
+        onDiceColorChange(nextColor, nextTheme);
       }
     } catch (error) {
       // Swallow fetch errors silently for now.
@@ -189,7 +242,7 @@ export default function Help({
             )}
             <div className="table-container">
               <Table striped bordered hover size="sm" className="custom-table">
-                <thead>
+                <tbody>
                   <tr>
                     <td className="center-td">
                       <strong className="text-light">Change Dice Color:</strong>
@@ -202,17 +255,34 @@ export default function Help({
                         onChange={handleColorChange}
                       />
                     </td>
-                    <td className="center-td">
+                    <td className="center-td" rowSpan={2}>
                       <Button
                         onClick={diceColorUpdate}
                         className="action-btn save-btn fa-solid fa-floppy-disk"
+                        aria-label="Save dice preferences"
                       ></Button>
                     </td>
                   </tr>
-                </thead>
-                <tbody>
                   <tr>
-                    <td className="center-td" colSpan="3">
+                    <td className="center-td">
+                      <strong className="text-light">Change Theme:</strong>
+                    </td>
+                    <td className="center-td">
+                      <Form.Select
+                        aria-label="Select dice theme"
+                        value={newTheme}
+                        onChange={handleThemeChange}
+                      >
+                        {themeOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="center-td" colSpan={3}>
                       <Button onClick={handleLogout} className="action-btn close-btn">
                         Logout
                       </Button>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -3648,15 +3648,17 @@ export default function ZombiesCharacterSheet() {
   }, [form?.occupation, form?.race?.name]);
 
   const updateLocalDiceColor = useCallback(
-    (incomingCharacterId, nextColor) => {
+    (incomingCharacterId, nextColor, nextTheme = null) => {
       const normalizedCharacterId =
         typeof incomingCharacterId === 'string' && incomingCharacterId.trim() !== ''
           ? incomingCharacterId.trim()
           : null;
       const normalizedColor =
         typeof nextColor === 'string' && nextColor.trim() !== '' ? nextColor.trim() : null;
+      const normalizedTheme =
+        typeof nextTheme === 'string' && nextTheme.trim() !== '' ? nextTheme.trim() : null;
 
-      if (!normalizedCharacterId || !normalizedColor) {
+      if (!normalizedCharacterId || (!normalizedColor && !normalizedTheme)) {
         return;
       }
 
@@ -3692,12 +3694,27 @@ export default function ZombiesCharacterSheet() {
             typeof value.diceColor === 'string' && value.diceColor.trim() !== ''
               ? value.diceColor.trim()
               : null;
+          const existingTheme =
+            typeof value.diceTheme === 'string' && value.diceTheme.trim() !== ''
+              ? value.diceTheme.trim()
+              : null;
 
-          if (existingColor === normalizedColor) {
+          const colorChanged = Boolean(normalizedColor) && existingColor !== normalizedColor;
+          const themeChanged = Boolean(normalizedTheme) && existingTheme !== normalizedTheme;
+
+          if (!colorChanged && !themeChanged) {
             return;
           }
 
-          next[key] = { ...value, diceColor: normalizedColor };
+          const nextEntry = { ...value };
+          if (colorChanged && normalizedColor) {
+            nextEntry.diceColor = normalizedColor;
+          }
+          if (themeChanged && normalizedTheme) {
+            nextEntry.diceTheme = normalizedTheme;
+          }
+
+          next[key] = nextEntry;
           didUpdate = true;
         });
 
@@ -3725,11 +3742,26 @@ export default function ZombiesCharacterSheet() {
           return prev;
         }
 
-        if (typeof prev.diceColor === 'string' && prev.diceColor.trim() === normalizedColor) {
+        const colorMatches =
+          !normalizedColor ||
+          (typeof prev.diceColor === 'string' && prev.diceColor.trim() === normalizedColor);
+        const themeMatches =
+          !normalizedTheme ||
+          (typeof prev.diceTheme === 'string' && prev.diceTheme.trim() === normalizedTheme);
+
+        if (colorMatches && themeMatches) {
           return prev;
         }
 
-        return { ...prev, diceColor: normalizedColor };
+        const nextForm = { ...prev };
+        if (!colorMatches && normalizedColor) {
+          nextForm.diceColor = normalizedColor;
+        }
+        if (!themeMatches && normalizedTheme) {
+          nextForm.diceTheme = normalizedTheme;
+        }
+
+        return nextForm;
       });
     },
     [setCampaignCharacters, setForm]
@@ -4181,6 +4213,7 @@ export default function ZombiesCharacterSheet() {
       }
 
       const hasDiceColorUpdate = Object.prototype.hasOwnProperty.call(update, 'diceColor');
+      const hasDiceThemeUpdate = Object.prototype.hasOwnProperty.call(update, 'diceTheme');
       const hasFigurineUrlUpdate = Object.prototype.hasOwnProperty.call(
         update,
         'figurineImageUrl'
@@ -4190,18 +4223,33 @@ export default function ZombiesCharacterSheet() {
         'figurineImagePublicId'
       );
 
-      if (!hasDiceColorUpdate && !hasFigurineUrlUpdate && !hasFigurineIdUpdate) {
+      if (
+        !hasDiceColorUpdate &&
+        !hasDiceThemeUpdate &&
+        !hasFigurineUrlUpdate &&
+        !hasFigurineIdUpdate
+      ) {
         return;
       }
 
+      let normalizedDiceColor = null;
       if (hasDiceColorUpdate) {
-        const normalizedDiceColor =
+        normalizedDiceColor =
           typeof update.diceColor === 'string' && update.diceColor.trim() !== ''
             ? update.diceColor.trim()
             : null;
-        if (normalizedDiceColor) {
-          updateLocalDiceColor(normalizedCharacterId, normalizedDiceColor);
-        }
+      }
+
+      let normalizedDiceTheme = null;
+      if (hasDiceThemeUpdate) {
+        normalizedDiceTheme =
+          typeof update.diceTheme === 'string' && update.diceTheme.trim() !== ''
+            ? update.diceTheme.trim()
+            : null;
+      }
+
+      if (normalizedDiceColor || normalizedDiceTheme) {
+        updateLocalDiceColor(normalizedCharacterId, normalizedDiceColor, normalizedDiceTheme);
       }
 
       if (hasFigurineUrlUpdate || hasFigurineIdUpdate) {
@@ -4238,12 +4286,12 @@ export default function ZombiesCharacterSheet() {
   }, [campaignId, applyMapPayload, updateLocalDiceColor, updateLocalFigurineImage]);
 
   const handleDiceColorChange = useCallback(
-    (nextColor) => {
+    (nextColor, nextTheme = null) => {
       const currentId = resolvedCharacterIdRef.current;
       if (!currentId) {
         return;
       }
-      updateLocalDiceColor(currentId, nextColor);
+      updateLocalDiceColor(currentId, nextColor, nextTheme);
     },
     [updateLocalDiceColor]
   );

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -2,9 +2,22 @@ const ASSET_PATH = `${
   (typeof process !== 'undefined' && process.env && process.env.PUBLIC_URL) || ''
 }/assets/dice-box/`;
 
+export const DICE_BOX_THEMES = Object.freeze([
+  'default',
+  'rust',
+  'diceOfRolling',
+  'gemstone',
+  'wooden',
+  'smooth',
+  'rock',
+  'blueGreenMetal',
+]);
+
+export const DEFAULT_DICE_THEME = DICE_BOX_THEMES[0];
+
 const BASE_CONFIG = Object.freeze({
   assetPath: ASSET_PATH,
-  theme: 'default',
+  theme: DEFAULT_DICE_THEME,
   scale: 6,
   offscreen: false,
   spinForce: 24,
@@ -24,6 +37,8 @@ let rollQueue = Promise.resolve();
 let generatedHostId = 0;
 let pendingThemeColor = null;
 let activeThemeColor = null;
+let pendingThemeName = null;
+let activeThemeName = DEFAULT_DICE_THEME;
 let warmupPromise = null;
 let retryTimeoutId = null;
 let diceBoxGeneration = 0;
@@ -356,6 +371,7 @@ const resetInstance = () => {
   diceBoxPromise = null;
   diceBoxReady = false;
   activeThemeColor = null;
+  activeThemeName = DEFAULT_DICE_THEME;
   clearScheduledRetry();
   clearScheduledResolution();
 };
@@ -372,6 +388,21 @@ const normalizeThemeColor = (value) => {
   }
 
   return `#${match[1].toLowerCase()}`;
+};
+
+const normalizeThemeName = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lower = trimmed.toLowerCase();
+  const match = DICE_BOX_THEMES.find((theme) => theme.toLowerCase() === lower);
+  return match || null;
 };
 
 const createDiceBoxConfig = (overrides = null) => ({
@@ -409,6 +440,38 @@ const applyPendingThemeColor = (instance) => {
 
   if (applyThemeColorToInstance(instance, pendingThemeColor)) {
     pendingThemeColor = null;
+  }
+};
+
+const applyThemeNameToInstance = (instance, themeName) => {
+  if (!instance || typeof instance.updateConfig !== 'function') {
+    return false;
+  }
+
+  if (themeName === activeThemeName) {
+    return true;
+  }
+
+  try {
+    instance.updateConfig({ theme: themeName });
+    activeThemeName = themeName || DEFAULT_DICE_THEME;
+    return true;
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('Dice box theme update failed', error);
+    }
+  }
+
+  return false;
+};
+
+const applyPendingThemeName = (instance) => {
+  if (!instance || !pendingThemeName) {
+    return;
+  }
+
+  if (applyThemeNameToInstance(instance, pendingThemeName)) {
+    pendingThemeName = null;
   }
 };
 
@@ -556,8 +619,20 @@ async function ensureDiceBox() {
           throw new Error('Dice box target was not available');
         }
 
+        const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
+        const normalizedActiveTheme = normalizeThemeName(activeThemeName);
+        const resolvedThemeName = normalizedPendingTheme || normalizedActiveTheme || DEFAULT_DICE_THEME;
+
+        const overrides = {};
+        if (pendingThemeColor) {
+          overrides.themeColor = pendingThemeColor;
+        }
+        if (resolvedThemeName) {
+          overrides.theme = resolvedThemeName;
+        }
+
         const options = createDiceBoxConfig(
-          pendingThemeColor ? { themeColor: pendingThemeColor } : null,
+          Object.keys(overrides).length > 0 ? overrides : null,
         );
 
         let instance = null;
@@ -584,6 +659,8 @@ async function ensureDiceBox() {
         diceBoxInstance = instance;
         diceBoxFailed = false;
         diceBoxDisabled = false;
+        activeThemeName = resolvedThemeName || DEFAULT_DICE_THEME;
+        applyPendingThemeName(instance);
         applyPendingThemeColor(instance);
         refreshDiceBoxResolution(instance);
         clearScheduledRetry();
@@ -968,6 +1045,29 @@ export const setDiceBoxThemeColor = (color) => {
   }
 };
 
+export const setDiceBoxTheme = (themeName) => {
+  const normalized =
+    themeName === null || themeName === undefined
+      ? DEFAULT_DICE_THEME
+      : normalizeThemeName(themeName);
+
+  if (!normalized) {
+    pendingThemeName = null;
+    return;
+  }
+
+  if (normalized === activeThemeName) {
+    pendingThemeName = null;
+    return;
+  }
+
+  pendingThemeName = normalized;
+
+  if (diceBoxInstance) {
+    applyPendingThemeName(diceBoxInstance);
+  }
+};
+
 export default {
   registerDiceBoxContainer,
   subscribeToDiceBoxAvailability,
@@ -975,4 +1075,5 @@ export default {
   hasDiceBoxFailed,
   rollDiceWithBox,
   setDiceBoxThemeColor,
+  setDiceBoxTheme,
 };

--- a/server/__tests__/characters.test.js
+++ b/server/__tests__/characters.test.js
@@ -16,7 +16,7 @@ jest.mock('../utils/socket', () => ({
 const charactersRouter = require('../routes');
 const classes = require('../data/classes');
 const { EQUIPMENT_SLOT_KEYS } = require('../constants/equipmentSlots');
-const { emitMapUpdate, emitCombatUpdate } = require('../utils/socket');
+const { emitMapUpdate, emitCombatUpdate, emitCharacterMetadataUpdate } = require('../utils/socket');
 const { ObjectId } = require('mongodb');
 
 const app = express();
@@ -649,6 +649,49 @@ describe('Character routes', () => {
       .put('/characters/update-dice-color/507f1f77bcf86cd799439011')
       .send({ diceColor: 5 });
     expect(res.status).toBe(400);
+  });
+
+  test('update dice color invalid theme', async () => {
+    dbo.mockResolvedValue({});
+    const res = await request(app)
+      .put('/characters/update-dice-color/507f1f77bcf86cd799439011')
+      .send({ diceColor: '#ffffff', diceTheme: 'invalid-theme' });
+    expect(res.status).toBe(400);
+  });
+
+  test('update dice color with theme success', async () => {
+    const characterId = new ObjectId('507f1f77bcf86cd799439011');
+    const campaignId = 'campaign-123';
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOneAndUpdate: async () => ({
+          value: {
+            _id: characterId,
+            campaign: campaignId,
+            diceColor: '#ffffff',
+            diceTheme: 'rust',
+          },
+        }),
+      }),
+    });
+
+    const res = await request(app)
+      .put(`/characters/update-dice-color/${characterId.toHexString()}`)
+      .send({ diceColor: '#ffffff', diceTheme: 'rust' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      campaignId,
+      characterId: characterId.toHexString(),
+      diceColor: '#ffffff',
+      diceTheme: 'rust',
+    });
+    expect(emitCharacterMetadataUpdate).toHaveBeenCalledWith(campaignId, {
+      campaignId,
+      characterId: characterId.toHexString(),
+      diceColor: '#ffffff',
+      diceTheme: 'rust',
+    });
   });
 
   test('update feats success', async () => {

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -24,6 +24,17 @@ const {
   normalizeCampaignMapState,
 } = require('../../utils/campaignMaps');
 
+const SUPPORTED_DICE_THEMES = new Set([
+  'default',
+  'rust',
+  'diceOfRolling',
+  'gemstone',
+  'wooden',
+  'smooth',
+  'rock',
+  'blueGreenMetal',
+]);
+
 const countFeatProficiencies = (feat = []) => {
   const profs = new Set();
   if (Array.isArray(feat)) {
@@ -575,7 +586,22 @@ module.exports = (router) => {
 
   // This section will update dice color.
   characterRouter.route('/update-dice-color/:id').put(
-    [body('diceColor').isString().withMessage('diceColor must be a string').trim()],
+    [
+      body('diceColor').isString().withMessage('diceColor must be a string').trim(),
+      body('diceTheme')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('diceTheme must be a string')
+        .bail()
+        .trim()
+        .custom((value) => {
+          if (value === '') {
+            return true;
+          }
+          return SUPPORTED_DICE_THEMES.has(value);
+        })
+        .withMessage('diceTheme must be one of the supported dice themes'),
+    ],
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
@@ -583,13 +609,23 @@ module.exports = (router) => {
       }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
-      const { diceColor } = matchedData(req, { locations: ['body'] });
+      const { diceColor, diceTheme } = matchedData(req, { locations: ['body'] });
       try {
+        const updateOperation = {
+          $set: { diceColor },
+        };
+
+        if (typeof diceTheme === 'string') {
+          if (diceTheme === '') {
+            updateOperation.$unset = { diceTheme: '' };
+          } else {
+            updateOperation.$set.diceTheme = diceTheme;
+          }
+        }
+
         const updateResult = await db_connect.collection('Characters').findOneAndUpdate(
           id,
-          {
-            $set: { diceColor },
-          },
+          updateOperation,
           { returnDocument: 'after' }
         );
 
@@ -608,14 +644,24 @@ module.exports = (router) => {
         const characterId =
           updatedCharacter._id && typeof updatedCharacter._id.toString === 'function'
             ? updatedCharacter._id.toString()
-            : typeof updatedCharacter.characterId === 'string'
+          : typeof updatedCharacter.characterId === 'string'
               ? updatedCharacter.characterId
               : null;
+
+        const storedDiceColor =
+          typeof updatedCharacter.diceColor === 'string' && updatedCharacter.diceColor.trim() !== ''
+            ? updatedCharacter.diceColor.trim()
+            : diceColor;
+        const storedDiceTheme =
+          typeof updatedCharacter.diceTheme === 'string' && updatedCharacter.diceTheme.trim() !== ''
+            ? updatedCharacter.diceTheme.trim()
+            : null;
 
         const payload = {
           campaignId,
           characterId,
-          diceColor,
+          diceColor: storedDiceColor,
+          diceTheme: storedDiceTheme,
         };
 
         if (campaignId && characterId) {

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -278,6 +278,15 @@ const emitCharacterMetadataUpdate = (campaignId, payload) => {
     outgoingPayload.diceColor = outgoingPayload.diceColor.trim();
   }
 
+  if (
+    typeof outgoingPayload.diceTheme === 'string' &&
+    outgoingPayload.diceTheme.trim() !== ''
+  ) {
+    outgoingPayload.diceTheme = outgoingPayload.diceTheme.trim();
+  } else if (Object.prototype.hasOwnProperty.call(outgoingPayload, 'diceTheme')) {
+    outgoingPayload.diceTheme = null;
+  }
+
   outgoingPayload.campaignId = normalizedId;
 
   io.to(getCampaignRoom(normalizedId)).emit('campaign:characters:update', outgoingPayload);


### PR DESCRIPTION
## Summary
- add a dice theme selector to the help modal and persist the choice alongside the color
- extend the dice box manager to handle applying theme names in addition to colors
- update the character metadata endpoint and tests to accept and broadcast dice themes

## Testing
- npm --prefix server test -- --runTestsByPath __tests__/characters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f6b11694108323b8f07456871c6798