### PR TITLE
Bundle full SRD monster data for DM tools

### DIFF
--- a/server/data/monsters.json
+++ b/server/data/monsters.json
@@ -1,697 +1,30137 @@
 {
   "results": [
-    { "index": "bandit", "name": "Bandit", "url": "/api/monsters/bandit" },
-    { "index": "bugbear", "name": "Bugbear", "url": "/api/monsters/bugbear" },
-    { "index": "cultist", "name": "Cultist", "url": "/api/monsters/cultist" },
-    { "index": "ghoul", "name": "Ghoul", "url": "/api/monsters/ghoul" },
-    { "index": "giant-spider", "name": "Giant Spider", "url": "/api/monsters/giant-spider" },
-    { "index": "giant-wolf-spider", "name": "Giant Wolf Spider", "url": "/api/monsters/giant-wolf-spider" },
-    { "index": "goblin", "name": "Goblin", "url": "/api/monsters/goblin" },
-    { "index": "hobgoblin", "name": "Hobgoblin", "url": "/api/monsters/hobgoblin" },
-    { "index": "kobold", "name": "Kobold", "url": "/api/monsters/kobold" },
-    { "index": "ogre", "name": "Ogre", "url": "/api/monsters/ogre" },
-    { "index": "orc", "name": "Orc", "url": "/api/monsters/orc" },
-    { "index": "skeleton", "name": "Skeleton", "url": "/api/monsters/skeleton" },
-    { "index": "wolf", "name": "Wolf", "url": "/api/monsters/wolf" },
-    { "index": "worg", "name": "Worg", "url": "/api/monsters/worg" },
-    { "index": "zombie", "name": "Zombie", "url": "/api/monsters/zombie" }
+    {
+      "index": "aboleth",
+      "name": "Aboleth",
+      "url": "/api/monsters/aboleth"
+    },
+    {
+      "index": "adult-black-dragon",
+      "name": "Adult Black Dragon",
+      "url": "/api/monsters/adult-black-dragon"
+    },
+    {
+      "index": "adult-blue-dragon",
+      "name": "Adult Blue Dragon",
+      "url": "/api/monsters/adult-blue-dragon"
+    },
+    {
+      "index": "adult-brass-dragon",
+      "name": "Adult Brass Dragon",
+      "url": "/api/monsters/adult-brass-dragon"
+    },
+    {
+      "index": "adult-bronze-dragon",
+      "name": "Adult Bronze Dragon",
+      "url": "/api/monsters/adult-bronze-dragon"
+    },
+    {
+      "index": "adult-copper-dragon",
+      "name": "Adult Copper Dragon",
+      "url": "/api/monsters/adult-copper-dragon"
+    },
+    {
+      "index": "adult-gold-dragon",
+      "name": "Adult Gold Dragon",
+      "url": "/api/monsters/adult-gold-dragon"
+    },
+    {
+      "index": "adult-green-dragon",
+      "name": "Adult Green Dragon",
+      "url": "/api/monsters/adult-green-dragon"
+    },
+    {
+      "index": "adult-red-dragon",
+      "name": "Adult Red Dragon",
+      "url": "/api/monsters/adult-red-dragon"
+    },
+    {
+      "index": "adult-silver-dragon",
+      "name": "Adult Silver Dragon",
+      "url": "/api/monsters/adult-silver-dragon"
+    },
+    {
+      "index": "adult-white-dragon",
+      "name": "Adult White Dragon",
+      "url": "/api/monsters/adult-white-dragon"
+    },
+    {
+      "index": "air-elemental",
+      "name": "Air Elemental",
+      "url": "/api/monsters/air-elemental"
+    },
+    {
+      "index": "allosaurus",
+      "name": "Allosaurus",
+      "url": "/api/monsters/allosaurus"
+    },
+    {
+      "index": "ancient-black-dragon",
+      "name": "Ancient Black Dragon",
+      "url": "/api/monsters/ancient-black-dragon"
+    },
+    {
+      "index": "ancient-brass-dragon",
+      "name": "Ancient Brass Dragon",
+      "url": "/api/monsters/ancient-brass-dragon"
+    },
+    {
+      "index": "ancient-bronze-dragon",
+      "name": "Ancient Bronze Dragon",
+      "url": "/api/monsters/ancient-bronze-dragon"
+    },
+    {
+      "index": "ancient-copper-dragon",
+      "name": "Ancient Copper Dragon",
+      "url": "/api/monsters/ancient-copper-dragon"
+    },
+    {
+      "index": "ancient-gold-dragon",
+      "name": "Ancient Gold Dragon",
+      "url": "/api/monsters/ancient-gold-dragon"
+    },
+    {
+      "index": "ancient-green-dragon",
+      "name": "Ancient Green Dragon",
+      "url": "/api/monsters/ancient-green-dragon"
+    },
+    {
+      "index": "ancient-red-dragon",
+      "name": "Ancient Red Dragon",
+      "url": "/api/monsters/ancient-red-dragon"
+    },
+    {
+      "index": "ancient-silver-dragon",
+      "name": "Ancient Silver Dragon",
+      "url": "/api/monsters/ancient-silver-dragon"
+    },
+    {
+      "index": "ancient-white-dragon",
+      "name": "Ancient White Dragon",
+      "url": "/api/monsters/ancient-white-dragon"
+    },
+    {
+      "index": "animated-armor",
+      "name": "Animated Armor",
+      "url": "/api/monsters/animated-armor"
+    },
+    {
+      "index": "animated-flying-sword",
+      "name": "Animated Flying Sword",
+      "url": "/api/monsters/animated-flying-sword"
+    },
+    {
+      "index": "animated-rug-of-smothering",
+      "name": "Animated Rug of Smothering",
+      "url": "/api/monsters/animated-rug-of-smothering"
+    },
+    {
+      "index": "ankheg",
+      "name": "Ankheg",
+      "url": "/api/monsters/ankheg"
+    },
+    {
+      "index": "ankylosaurus",
+      "name": "Ankylosaurus",
+      "url": "/api/monsters/ankylosaurus"
+    },
+    {
+      "index": "ape",
+      "name": "Ape",
+      "url": "/api/monsters/ape"
+    },
+    {
+      "index": "archelon",
+      "name": "Archelon",
+      "url": "/api/monsters/archelon"
+    },
+    {
+      "index": "archmage",
+      "name": "Archmage",
+      "url": "/api/monsters/archmage"
+    },
+    {
+      "index": "assassin",
+      "name": "Assassin",
+      "url": "/api/monsters/assassin"
+    },
+    {
+      "index": "awakened-shrub",
+      "name": "Awakened Shrub",
+      "url": "/api/monsters/awakened-shrub"
+    },
+    {
+      "index": "awakened-tree",
+      "name": "Awakened Tree",
+      "url": "/api/monsters/awakened-tree"
+    },
+    {
+      "index": "axe-beak",
+      "name": "Axe Beak",
+      "url": "/api/monsters/axe-beak"
+    },
+    {
+      "index": "azer-sentinel",
+      "name": "Azer Sentinel",
+      "url": "/api/monsters/azer-sentinel"
+    },
+    {
+      "index": "baboon",
+      "name": "Baboon",
+      "url": "/api/monsters/baboon"
+    },
+    {
+      "index": "badger",
+      "name": "Badger",
+      "url": "/api/monsters/badger"
+    },
+    {
+      "index": "balor",
+      "name": "Balor",
+      "url": "/api/monsters/balor"
+    },
+    {
+      "index": "bandit",
+      "name": "Bandit",
+      "url": "/api/monsters/bandit"
+    },
+    {
+      "index": "bandit-captain",
+      "name": "Bandit Captain",
+      "url": "/api/monsters/bandit-captain"
+    },
+    {
+      "index": "barbed-devil",
+      "name": "Barbed Devil",
+      "url": "/api/monsters/barbed-devil"
+    },
+    {
+      "index": "basilisk",
+      "name": "Basilisk",
+      "url": "/api/monsters/basilisk"
+    },
+    {
+      "index": "bat",
+      "name": "Bat",
+      "url": "/api/monsters/bat"
+    },
+    {
+      "index": "bearded-devil",
+      "name": "Bearded Devil",
+      "url": "/api/monsters/bearded-devil"
+    },
+    {
+      "index": "behir",
+      "name": "Behir",
+      "url": "/api/monsters/behir"
+    },
+    {
+      "index": "berserker",
+      "name": "Berserker",
+      "url": "/api/monsters/berserker"
+    },
+    {
+      "index": "black-bear",
+      "name": "Black Bear",
+      "url": "/api/monsters/black-bear"
+    },
+    {
+      "index": "black-dragon-wyrmling",
+      "name": "Black Dragon Wyrmling",
+      "url": "/api/monsters/black-dragon-wyrmling"
+    },
+    {
+      "index": "black-pudding",
+      "name": "Black Pudding",
+      "url": "/api/monsters/black-pudding"
+    },
+    {
+      "index": "blink-dog",
+      "name": "Blink Dog",
+      "url": "/api/monsters/blink-dog"
+    },
+    {
+      "index": "blood-hawk",
+      "name": "Blood Hawk",
+      "url": "/api/monsters/blood-hawk"
+    },
+    {
+      "index": "blue-dragon-wyrmling",
+      "name": "Blue Dragon Wyrmling",
+      "url": "/api/monsters/blue-dragon-wyrmling"
+    },
+    {
+      "index": "boar",
+      "name": "Boar",
+      "url": "/api/monsters/boar"
+    },
+    {
+      "index": "brass-dragon-wyrmling",
+      "name": "Brass Dragon Wyrmling",
+      "url": "/api/monsters/brass-dragon-wyrmling"
+    },
+    {
+      "index": "bronze-dragon-wyrmling",
+      "name": "Bronze Dragon Wyrmling",
+      "url": "/api/monsters/bronze-dragon-wyrmling"
+    },
+    {
+      "index": "brown-bear",
+      "name": "Brown Bear",
+      "url": "/api/monsters/brown-bear"
+    },
+    {
+      "index": "bugbear-stalker",
+      "name": "Bugbear Stalker",
+      "url": "/api/monsters/bugbear-stalker"
+    },
+    {
+      "index": "bugbear-warrior",
+      "name": "Bugbear Warrior",
+      "url": "/api/monsters/bugbear-warrior"
+    },
+    {
+      "index": "bulette",
+      "name": "Bulette",
+      "url": "/api/monsters/bulette"
+    },
+    {
+      "index": "camel",
+      "name": "Camel",
+      "url": "/api/monsters/camel"
+    },
+    {
+      "index": "cat",
+      "name": "Cat",
+      "url": "/api/monsters/cat"
+    },
+    {
+      "index": "centaur-trooper",
+      "name": "Centaur Trooper",
+      "url": "/api/monsters/centaur-trooper"
+    },
+    {
+      "index": "chain-devil",
+      "name": "Chain Devil",
+      "url": "/api/monsters/chain-devil"
+    },
+    {
+      "index": "chimera",
+      "name": "Chimera",
+      "url": "/api/monsters/chimera"
+    },
+    {
+      "index": "chuul",
+      "name": "Chuul",
+      "url": "/api/monsters/chuul"
+    },
+    {
+      "index": "clay-golem",
+      "name": "Clay Golem",
+      "url": "/api/monsters/clay-golem"
+    },
+    {
+      "index": "cloaker",
+      "name": "Cloaker",
+      "url": "/api/monsters/cloaker"
+    },
+    {
+      "index": "cloud-giant",
+      "name": "Cloud Giant",
+      "url": "/api/monsters/cloud-giant"
+    },
+    {
+      "index": "cockatrice",
+      "name": "Cockatrice",
+      "url": "/api/monsters/cockatrice"
+    },
+    {
+      "index": "commoner",
+      "name": "Commoner",
+      "url": "/api/monsters/commoner"
+    },
+    {
+      "index": "constrictor-snake",
+      "name": "Constrictor Snake",
+      "url": "/api/monsters/constrictor-snake"
+    },
+    {
+      "index": "copper-dragon-wyrmling",
+      "name": "Copper Dragon Wyrmling",
+      "url": "/api/monsters/copper-dragon-wyrmling"
+    },
+    {
+      "index": "couatl",
+      "name": "Couatl",
+      "url": "/api/monsters/couatl"
+    },
+    {
+      "index": "crab",
+      "name": "Crab",
+      "url": "/api/monsters/crab"
+    },
+    {
+      "index": "crocodile",
+      "name": "Crocodile",
+      "url": "/api/monsters/crocodile"
+    },
+    {
+      "index": "cultist",
+      "name": "Cultist",
+      "url": "/api/monsters/cultist"
+    },
+    {
+      "index": "cultist-fanatic",
+      "name": "Cultist Fanatic",
+      "url": "/api/monsters/cultist-fanatic"
+    },
+    {
+      "index": "darkmantle",
+      "name": "Darkmantle",
+      "url": "/api/monsters/darkmantle"
+    },
+    {
+      "index": "death-dog",
+      "name": "Death Dog",
+      "url": "/api/monsters/death-dog"
+    },
+    {
+      "index": "deer",
+      "name": "Deer",
+      "url": "/api/monsters/deer"
+    },
+    {
+      "index": "deva",
+      "name": "Deva",
+      "url": "/api/monsters/deva"
+    },
+    {
+      "index": "dire-wolf",
+      "name": "Dire Wolf",
+      "url": "/api/monsters/dire-wolf"
+    },
+    {
+      "index": "djinni",
+      "name": "Djinni",
+      "url": "/api/monsters/djinni"
+    },
+    {
+      "index": "doppelganger",
+      "name": "Doppelganger",
+      "url": "/api/monsters/doppelganger"
+    },
+    {
+      "index": "draft-horse",
+      "name": "Draft Horse",
+      "url": "/api/monsters/draft-horse"
+    },
+    {
+      "index": "dragon-turtle",
+      "name": "Dragon Turtle",
+      "url": "/api/monsters/dragon-turtle"
+    },
+    {
+      "index": "dretch",
+      "name": "Dretch",
+      "url": "/api/monsters/dretch"
+    },
+    {
+      "index": "drider",
+      "name": "Drider",
+      "url": "/api/monsters/drider"
+    },
+    {
+      "index": "druid",
+      "name": "Druid",
+      "url": "/api/monsters/druid"
+    },
+    {
+      "index": "dryad",
+      "name": "Dryad",
+      "url": "/api/monsters/dryad"
+    },
+    {
+      "index": "dust-mephit",
+      "name": "Dust Mephit",
+      "url": "/api/monsters/dust-mephit"
+    },
+    {
+      "index": "eagle",
+      "name": "Eagle",
+      "url": "/api/monsters/eagle"
+    },
+    {
+      "index": "earth-elemental",
+      "name": "Earth Elemental",
+      "url": "/api/monsters/earth-elemental"
+    },
+    {
+      "index": "efreeti",
+      "name": "Efreeti",
+      "url": "/api/monsters/efreeti"
+    },
+    {
+      "index": "elephant",
+      "name": "Elephant",
+      "url": "/api/monsters/elephant"
+    },
+    {
+      "index": "elk",
+      "name": "Elk",
+      "url": "/api/monsters/elk"
+    },
+    {
+      "index": "erinyes",
+      "name": "Erinyes",
+      "url": "/api/monsters/erinyes"
+    },
+    {
+      "index": "ettercap",
+      "name": "Ettercap",
+      "url": "/api/monsters/ettercap"
+    },
+    {
+      "index": "ettin",
+      "name": "Ettin",
+      "url": "/api/monsters/ettin"
+    },
+    {
+      "index": "fire-elemental",
+      "name": "Fire Elemental",
+      "url": "/api/monsters/fire-elemental"
+    },
+    {
+      "index": "fire-giant",
+      "name": "Fire Giant",
+      "url": "/api/monsters/fire-giant"
+    },
+    {
+      "index": "flesh-golem",
+      "name": "Flesh Golem",
+      "url": "/api/monsters/flesh-golem"
+    },
+    {
+      "index": "flying-snake",
+      "name": "Flying Snake",
+      "url": "/api/monsters/flying-snake"
+    },
+    {
+      "index": "frog",
+      "name": "Frog",
+      "url": "/api/monsters/frog"
+    },
+    {
+      "index": "frost-giant",
+      "name": "Frost Giant",
+      "url": "/api/monsters/frost-giant"
+    },
+    {
+      "index": "gargoyle",
+      "name": "Gargoyle",
+      "url": "/api/monsters/gargoyle"
+    },
+    {
+      "index": "gelatinous-cube",
+      "name": "Gelatinous Cube",
+      "url": "/api/monsters/gelatinous-cube"
+    },
+    {
+      "index": "ghast",
+      "name": "Ghast",
+      "url": "/api/monsters/ghast"
+    },
+    {
+      "index": "ghost",
+      "name": "Ghost",
+      "url": "/api/monsters/ghost"
+    },
+    {
+      "index": "ghoul",
+      "name": "Ghoul",
+      "url": "/api/monsters/ghoul"
+    },
+    {
+      "index": "giant-ape",
+      "name": "Giant Ape",
+      "url": "/api/monsters/giant-ape"
+    },
+    {
+      "index": "giant-badger",
+      "name": "Giant Badger",
+      "url": "/api/monsters/giant-badger"
+    },
+    {
+      "index": "giant-bat",
+      "name": "Giant Bat",
+      "url": "/api/monsters/giant-bat"
+    },
+    {
+      "index": "giant-boar",
+      "name": "Giant Boar",
+      "url": "/api/monsters/giant-boar"
+    },
+    {
+      "index": "giant-centipede",
+      "name": "Giant Centipede",
+      "url": "/api/monsters/giant-centipede"
+    },
+    {
+      "index": "giant-constrictor-snake",
+      "name": "Giant Constrictor Snake",
+      "url": "/api/monsters/giant-constrictor-snake"
+    },
+    {
+      "index": "giant-crocodile",
+      "name": "Giant Crocodile",
+      "url": "/api/monsters/giant-crocodile"
+    },
+    {
+      "index": "giant-elk",
+      "name": "Giant Elk",
+      "url": "/api/monsters/giant-elk"
+    },
+    {
+      "index": "giant-fire-beetle",
+      "name": "Giant Fire Beetle",
+      "url": "/api/monsters/giant-fire-beetle"
+    },
+    {
+      "index": "giant-frog",
+      "name": "Giant Frog",
+      "url": "/api/monsters/giant-frog"
+    },
+    {
+      "index": "giant-goat",
+      "name": "Giant Goat",
+      "url": "/api/monsters/giant-goat"
+    },
+    {
+      "index": "giant-hyena",
+      "name": "Giant Hyena",
+      "url": "/api/monsters/giant-hyena"
+    },
+    {
+      "index": "giant-lizard",
+      "name": "Giant Lizard",
+      "url": "/api/monsters/giant-lizard"
+    },
+    {
+      "index": "giant-octopus",
+      "name": "Giant Octopus",
+      "url": "/api/monsters/giant-octopus"
+    },
+    {
+      "index": "giant-owl",
+      "name": "Giant Owl",
+      "url": "/api/monsters/giant-owl"
+    },
+    {
+      "index": "giant-rat",
+      "name": "Giant Rat",
+      "url": "/api/monsters/giant-rat"
+    },
+    {
+      "index": "giant-scorpion",
+      "name": "Giant Scorpion",
+      "url": "/api/monsters/giant-scorpion"
+    },
+    {
+      "index": "giant-seahorse",
+      "name": "Giant Seahorse",
+      "url": "/api/monsters/giant-seahorse"
+    },
+    {
+      "index": "giant-shark",
+      "name": "Giant Shark",
+      "url": "/api/monsters/giant-shark"
+    },
+    {
+      "index": "giant-spider",
+      "name": "Giant Spider",
+      "url": "/api/monsters/giant-spider"
+    },
+    {
+      "index": "giant-toad",
+      "name": "Giant Toad",
+      "url": "/api/monsters/giant-toad"
+    },
+    {
+      "index": "giant-venomous-snake",
+      "name": "Giant Venomous Snake",
+      "url": "/api/monsters/giant-venomous-snake"
+    },
+    {
+      "index": "giant-vulture",
+      "name": "Giant Vulture",
+      "url": "/api/monsters/giant-vulture"
+    },
+    {
+      "index": "giant-wasp",
+      "name": "Giant Wasp",
+      "url": "/api/monsters/giant-wasp"
+    },
+    {
+      "index": "giant-weasel",
+      "name": "Giant Weasel",
+      "url": "/api/monsters/giant-weasel"
+    },
+    {
+      "index": "giant-wolf-spider",
+      "name": "Giant Wolf Spider",
+      "url": "/api/monsters/giant-wolf-spider"
+    },
+    {
+      "index": "gibbering-mouther",
+      "name": "Gibbering Mouther",
+      "url": "/api/monsters/gibbering-mouther"
+    },
+    {
+      "index": "glabrezu",
+      "name": "Glabrezu",
+      "url": "/api/monsters/glabrezu"
+    },
+    {
+      "index": "gladiator",
+      "name": "Gladiator",
+      "url": "/api/monsters/gladiator"
+    },
+    {
+      "index": "gnoll-warrior",
+      "name": "Gnoll Warrior",
+      "url": "/api/monsters/gnoll-warrior"
+    },
+    {
+      "index": "goat",
+      "name": "Goat",
+      "url": "/api/monsters/goat"
+    },
+    {
+      "index": "goblin-boss",
+      "name": "Goblin Boss",
+      "url": "/api/monsters/goblin-boss"
+    },
+    {
+      "index": "goblin-minion",
+      "name": "Goblin Minion",
+      "url": "/api/monsters/goblin-minion"
+    },
+    {
+      "index": "goblin-warrior",
+      "name": "Goblin Warrior",
+      "url": "/api/monsters/goblin-warrior"
+    },
+    {
+      "index": "gold-dragon-wyrmling",
+      "name": "Gold Dragon Wyrmling",
+      "url": "/api/monsters/gold-dragon-wyrmling"
+    },
+    {
+      "index": "gorgon",
+      "name": "Gorgon",
+      "url": "/api/monsters/gorgon"
+    },
+    {
+      "index": "gray-ooze",
+      "name": "Gray Ooze",
+      "url": "/api/monsters/gray-ooze"
+    },
+    {
+      "index": "green-dragon-wyrmling",
+      "name": "Green Dragon Wyrmling",
+      "url": "/api/monsters/green-dragon-wyrmling"
+    },
+    {
+      "index": "green-hag",
+      "name": "Green Hag",
+      "url": "/api/monsters/green-hag"
+    },
+    {
+      "index": "grick",
+      "name": "Grick",
+      "url": "/api/monsters/grick"
+    },
+    {
+      "index": "griffon",
+      "name": "Griffon",
+      "url": "/api/monsters/griffon"
+    },
+    {
+      "index": "grimlock",
+      "name": "Grimlock",
+      "url": "/api/monsters/grimlock"
+    },
+    {
+      "index": "guard",
+      "name": "Guard",
+      "url": "/api/monsters/guard"
+    },
+    {
+      "index": "guard-captain",
+      "name": "Guard Captain",
+      "url": "/api/monsters/guard-captain"
+    },
+    {
+      "index": "guardian-naga",
+      "name": "Guardian Naga",
+      "url": "/api/monsters/guardian-naga"
+    },
+    {
+      "index": "half-dragon",
+      "name": "Half-Dragon",
+      "url": "/api/monsters/half-dragon"
+    },
+    {
+      "index": "harpy",
+      "name": "Harpy",
+      "url": "/api/monsters/harpy"
+    },
+    {
+      "index": "hawk",
+      "name": "Hawk",
+      "url": "/api/monsters/hawk"
+    },
+    {
+      "index": "hell-hound",
+      "name": "Hell Hound",
+      "url": "/api/monsters/hell-hound"
+    },
+    {
+      "index": "hezrou",
+      "name": "Hezrou",
+      "url": "/api/monsters/hezrou"
+    },
+    {
+      "index": "hill-giant",
+      "name": "Hill Giant",
+      "url": "/api/monsters/hill-giant"
+    },
+    {
+      "index": "hippogriff",
+      "name": "Hippogriff",
+      "url": "/api/monsters/hippogriff"
+    },
+    {
+      "index": "hippopotamus",
+      "name": "Hippopotamus",
+      "url": "/api/monsters/hippopotamus"
+    },
+    {
+      "index": "hobgoblin-captain",
+      "name": "Hobgoblin Captain",
+      "url": "/api/monsters/hobgoblin-captain"
+    },
+    {
+      "index": "hobgoblin-warrior",
+      "name": "Hobgoblin Warrior",
+      "url": "/api/monsters/hobgoblin-warrior"
+    },
+    {
+      "index": "homunculus",
+      "name": "Homunculus",
+      "url": "/api/monsters/homunculus"
+    },
+    {
+      "index": "horned-devil",
+      "name": "Horned Devil",
+      "url": "/api/monsters/horned-devil"
+    },
+    {
+      "index": "hunter-shark",
+      "name": "Hunter Shark",
+      "url": "/api/monsters/hunter-shark"
+    },
+    {
+      "index": "hydra",
+      "name": "Hydra",
+      "url": "/api/monsters/hydra"
+    },
+    {
+      "index": "hyena",
+      "name": "Hyena",
+      "url": "/api/monsters/hyena"
+    },
+    {
+      "index": "ice-devil",
+      "name": "Ice Devil",
+      "url": "/api/monsters/ice-devil"
+    },
+    {
+      "index": "ice-mephit",
+      "name": "Ice Mephit",
+      "url": "/api/monsters/ice-mephit"
+    },
+    {
+      "index": "imp",
+      "name": "Imp",
+      "url": "/api/monsters/imp"
+    },
+    {
+      "index": "incubus",
+      "name": "Incubus",
+      "url": "/api/monsters/incubus"
+    },
+    {
+      "index": "invisible-stalker",
+      "name": "Invisible Stalker",
+      "url": "/api/monsters/invisible-stalker"
+    },
+    {
+      "index": "iron-golem",
+      "name": "Iron Golem",
+      "url": "/api/monsters/iron-golem"
+    },
+    {
+      "index": "jackal",
+      "name": "Jackal",
+      "url": "/api/monsters/jackal"
+    },
+    {
+      "index": "killer-whale",
+      "name": "Killer Whale",
+      "url": "/api/monsters/killer-whale"
+    },
+    {
+      "index": "knight",
+      "name": "Knight",
+      "url": "/api/monsters/knight"
+    },
+    {
+      "index": "kobold-warrior",
+      "name": "Kobold Warrior",
+      "url": "/api/monsters/kobold-warrior"
+    },
+    {
+      "index": "kraken",
+      "name": "Kraken",
+      "url": "/api/monsters/kraken"
+    },
+    {
+      "index": "lamia",
+      "name": "Lamia",
+      "url": "/api/monsters/lamia"
+    },
+    {
+      "index": "lemure",
+      "name": "Lemure",
+      "url": "/api/monsters/lemure"
+    },
+    {
+      "index": "lich",
+      "name": "Lich",
+      "url": "/api/monsters/lich"
+    },
+    {
+      "index": "lizard",
+      "name": "Lizard",
+      "url": "/api/monsters/lizard"
+    },
+    {
+      "index": "mage",
+      "name": "Mage",
+      "url": "/api/monsters/mage"
+    },
+    {
+      "index": "magma-mephit",
+      "name": "Magma Mephit",
+      "url": "/api/monsters/magma-mephit"
+    },
+    {
+      "index": "magmin",
+      "name": "Magmin",
+      "url": "/api/monsters/magmin"
+    },
+    {
+      "index": "mammoth",
+      "name": "Mammoth",
+      "url": "/api/monsters/mammoth"
+    },
+    {
+      "index": "manticore",
+      "name": "Manticore",
+      "url": "/api/monsters/manticore"
+    },
+    {
+      "index": "marilith",
+      "name": "Marilith",
+      "url": "/api/monsters/marilith"
+    },
+    {
+      "index": "mastiff",
+      "name": "Mastiff",
+      "url": "/api/monsters/mastiff"
+    },
+    {
+      "index": "medusa",
+      "name": "Medusa",
+      "url": "/api/monsters/medusa"
+    },
+    {
+      "index": "merfolk-skirmisher",
+      "name": "Merfolk Skirmisher",
+      "url": "/api/monsters/merfolk-skirmisher"
+    },
+    {
+      "index": "merrow",
+      "name": "Merrow",
+      "url": "/api/monsters/merrow"
+    },
+    {
+      "index": "mimic",
+      "name": "Mimic",
+      "url": "/api/monsters/mimic"
+    },
+    {
+      "index": "minotaur-skeleton",
+      "name": "Minotaur Skeleton",
+      "url": "/api/monsters/minotaur-skeleton"
+    },
+    {
+      "index": "minotaur-of-baphomet",
+      "name": "Minotaur of Baphomet",
+      "url": "/api/monsters/minotaur-of-baphomet"
+    },
+    {
+      "index": "mule",
+      "name": "Mule",
+      "url": "/api/monsters/mule"
+    },
+    {
+      "index": "mummy",
+      "name": "Mummy",
+      "url": "/api/monsters/mummy"
+    },
+    {
+      "index": "mummy-lord",
+      "name": "Mummy Lord",
+      "url": "/api/monsters/mummy-lord"
+    },
+    {
+      "index": "nalfeshnee",
+      "name": "Nalfeshnee",
+      "url": "/api/monsters/nalfeshnee"
+    },
+    {
+      "index": "night-hag",
+      "name": "Night Hag",
+      "url": "/api/monsters/night-hag"
+    },
+    {
+      "index": "nightmare",
+      "name": "Nightmare",
+      "url": "/api/monsters/nightmare"
+    },
+    {
+      "index": "noble",
+      "name": "Noble",
+      "url": "/api/monsters/noble"
+    },
+    {
+      "index": "ochre-jelly",
+      "name": "Ochre Jelly",
+      "url": "/api/monsters/ochre-jelly"
+    },
+    {
+      "index": "octopus",
+      "name": "Octopus",
+      "url": "/api/monsters/octopus"
+    },
+    {
+      "index": "ogre",
+      "name": "Ogre",
+      "url": "/api/monsters/ogre"
+    },
+    {
+      "index": "ogre-zombie",
+      "name": "Ogre Zombie",
+      "url": "/api/monsters/ogre-zombie"
+    },
+    {
+      "index": "oni",
+      "name": "Oni",
+      "url": "/api/monsters/oni"
+    },
+    {
+      "index": "otyugh",
+      "name": "Otyugh",
+      "url": "/api/monsters/otyugh"
+    },
+    {
+      "index": "owl",
+      "name": "Owl",
+      "url": "/api/monsters/owl"
+    },
+    {
+      "index": "owlbear",
+      "name": "Owlbear",
+      "url": "/api/monsters/owlbear"
+    },
+    {
+      "index": "panther",
+      "name": "Panther",
+      "url": "/api/monsters/panther"
+    },
+    {
+      "index": "pegasus",
+      "name": "Pegasus",
+      "url": "/api/monsters/pegasus"
+    },
+    {
+      "index": "phase-spider",
+      "name": "Phase Spider",
+      "url": "/api/monsters/phase-spider"
+    },
+    {
+      "index": "piranha",
+      "name": "Piranha",
+      "url": "/api/monsters/piranha"
+    },
+    {
+      "index": "pirate",
+      "name": "Pirate",
+      "url": "/api/monsters/pirate"
+    },
+    {
+      "index": "pirate-captain",
+      "name": "Pirate Captain",
+      "url": "/api/monsters/pirate-captain"
+    },
+    {
+      "index": "pit-fiend",
+      "name": "Pit Fiend",
+      "url": "/api/monsters/pit-fiend"
+    },
+    {
+      "index": "planetar",
+      "name": "Planetar",
+      "url": "/api/monsters/planetar"
+    },
+    {
+      "index": "plesiosaurus",
+      "name": "Plesiosaurus",
+      "url": "/api/monsters/plesiosaurus"
+    },
+    {
+      "index": "polar-bear",
+      "name": "Polar Bear",
+      "url": "/api/monsters/polar-bear"
+    },
+    {
+      "index": "pony",
+      "name": "Pony",
+      "url": "/api/monsters/pony"
+    },
+    {
+      "index": "priest",
+      "name": "Priest",
+      "url": "/api/monsters/priest"
+    },
+    {
+      "index": "priest-acolyte",
+      "name": "Priest Acolyte",
+      "url": "/api/monsters/priest-acolyte"
+    },
+    {
+      "index": "pseudodragon",
+      "name": "Pseudodragon",
+      "url": "/api/monsters/pseudodragon"
+    },
+    {
+      "index": "pteranodon",
+      "name": "Pteranodon",
+      "url": "/api/monsters/pteranodon"
+    },
+    {
+      "index": "purple-worm",
+      "name": "Purple Worm",
+      "url": "/api/monsters/purple-worm"
+    },
+    {
+      "index": "quasit",
+      "name": "Quasit",
+      "url": "/api/monsters/quasit"
+    },
+    {
+      "index": "rakshasa",
+      "name": "Rakshasa",
+      "url": "/api/monsters/rakshasa"
+    },
+    {
+      "index": "rat",
+      "name": "Rat",
+      "url": "/api/monsters/rat"
+    },
+    {
+      "index": "raven",
+      "name": "Raven",
+      "url": "/api/monsters/raven"
+    },
+    {
+      "index": "red-dragon-wyrmling",
+      "name": "Red Dragon Wyrmling",
+      "url": "/api/monsters/red-dragon-wyrmling"
+    },
+    {
+      "index": "reef-shark",
+      "name": "Reef Shark",
+      "url": "/api/monsters/reef-shark"
+    },
+    {
+      "index": "remorhaz",
+      "name": "Remorhaz",
+      "url": "/api/monsters/remorhaz"
+    },
+    {
+      "index": "rhinoceros",
+      "name": "Rhinoceros",
+      "url": "/api/monsters/rhinoceros"
+    },
+    {
+      "index": "riding-horse",
+      "name": "Riding Horse",
+      "url": "/api/monsters/riding-horse"
+    },
+    {
+      "index": "roc",
+      "name": "Roc",
+      "url": "/api/monsters/roc"
+    },
+    {
+      "index": "roper",
+      "name": "Roper",
+      "url": "/api/monsters/roper"
+    },
+    {
+      "index": "rust-monster",
+      "name": "Rust Monster",
+      "url": "/api/monsters/rust-monster"
+    },
+    {
+      "index": "saber-toothed-tiger",
+      "name": "Saber-Toothed Tiger",
+      "url": "/api/monsters/saber-toothed-tiger"
+    },
+    {
+      "index": "sahuagin-warrior",
+      "name": "Sahuagin Warrior",
+      "url": "/api/monsters/sahuagin-warrior"
+    },
+    {
+      "index": "salamander",
+      "name": "Salamander",
+      "url": "/api/monsters/salamander"
+    },
+    {
+      "index": "satyr",
+      "name": "Satyr",
+      "url": "/api/monsters/satyr"
+    },
+    {
+      "index": "scorpion",
+      "name": "Scorpion",
+      "url": "/api/monsters/scorpion"
+    },
+    {
+      "index": "scout",
+      "name": "Scout",
+      "url": "/api/monsters/scout"
+    },
+    {
+      "index": "sea-hag",
+      "name": "Sea Hag",
+      "url": "/api/monsters/sea-hag"
+    },
+    {
+      "index": "seahorse",
+      "name": "Seahorse",
+      "url": "/api/monsters/seahorse"
+    },
+    {
+      "index": "shadow",
+      "name": "Shadow",
+      "url": "/api/monsters/shadow"
+    },
+    {
+      "index": "shambling-mound",
+      "name": "Shambling Mound",
+      "url": "/api/monsters/shambling-mound"
+    },
+    {
+      "index": "shield-guardian",
+      "name": "Shield Guardian",
+      "url": "/api/monsters/shield-guardian"
+    },
+    {
+      "index": "shrieker-fungus",
+      "name": "Shrieker Fungus",
+      "url": "/api/monsters/shrieker-fungus"
+    },
+    {
+      "index": "silver-dragon-wyrmling",
+      "name": "Silver Dragon Wyrmling",
+      "url": "/api/monsters/silver-dragon-wyrmling"
+    },
+    {
+      "index": "skeleton",
+      "name": "Skeleton",
+      "url": "/api/monsters/skeleton"
+    },
+    {
+      "index": "solar",
+      "name": "Solar",
+      "url": "/api/monsters/solar"
+    },
+    {
+      "index": "specter",
+      "name": "Specter",
+      "url": "/api/monsters/specter"
+    },
+    {
+      "index": "sphinx-of-lore",
+      "name": "Sphinx of Lore",
+      "url": "/api/monsters/sphinx-of-lore"
+    },
+    {
+      "index": "sphinx-of-valor",
+      "name": "Sphinx of Valor",
+      "url": "/api/monsters/sphinx-of-valor"
+    },
+    {
+      "index": "sphinx-of-wonder",
+      "name": "Sphinx of Wonder",
+      "url": "/api/monsters/sphinx-of-wonder"
+    },
+    {
+      "index": "spider",
+      "name": "Spider",
+      "url": "/api/monsters/spider"
+    },
+    {
+      "index": "spirit-naga",
+      "name": "Spirit Naga",
+      "url": "/api/monsters/spirit-naga"
+    },
+    {
+      "index": "sprite",
+      "name": "Sprite",
+      "url": "/api/monsters/sprite"
+    },
+    {
+      "index": "spy",
+      "name": "Spy",
+      "url": "/api/monsters/spy"
+    },
+    {
+      "index": "steam-mephit",
+      "name": "Steam Mephit",
+      "url": "/api/monsters/steam-mephit"
+    },
+    {
+      "index": "stirge",
+      "name": "Stirge",
+      "url": "/api/monsters/stirge"
+    },
+    {
+      "index": "stone-giant",
+      "name": "Stone Giant",
+      "url": "/api/monsters/stone-giant"
+    },
+    {
+      "index": "stone-golem",
+      "name": "Stone Golem",
+      "url": "/api/monsters/stone-golem"
+    },
+    {
+      "index": "storm-giant",
+      "name": "Storm Giant",
+      "url": "/api/monsters/storm-giant"
+    },
+    {
+      "index": "succubus",
+      "name": "Succubus",
+      "url": "/api/monsters/succubus"
+    },
+    {
+      "index": "swarm-of-bats",
+      "name": "Swarm of Bats",
+      "url": "/api/monsters/swarm-of-bats"
+    },
+    {
+      "index": "swarm-of-crawling-claws",
+      "name": "Swarm of Crawling Claws",
+      "url": "/api/monsters/swarm-of-crawling-claws"
+    },
+    {
+      "index": "swarm-of-insects",
+      "name": "Swarm of Insects",
+      "url": "/api/monsters/swarm-of-insects"
+    },
+    {
+      "index": "swarm-of-piranhas",
+      "name": "Swarm of Piranhas",
+      "url": "/api/monsters/swarm-of-piranhas"
+    },
+    {
+      "index": "swarm-of-rats",
+      "name": "Swarm of Rats",
+      "url": "/api/monsters/swarm-of-rats"
+    },
+    {
+      "index": "swarm-of-ravens",
+      "name": "Swarm of Ravens",
+      "url": "/api/monsters/swarm-of-ravens"
+    },
+    {
+      "index": "swarm-of-venomous-snakes",
+      "name": "Swarm of Venomous Snakes",
+      "url": "/api/monsters/swarm-of-venomous-snakes"
+    },
+    {
+      "index": "tarrasque",
+      "name": "Tarrasque",
+      "url": "/api/monsters/tarrasque"
+    },
+    {
+      "index": "tiger",
+      "name": "Tiger",
+      "url": "/api/monsters/tiger"
+    },
+    {
+      "index": "tough",
+      "name": "Tough",
+      "url": "/api/monsters/tough"
+    },
+    {
+      "index": "tough-boss",
+      "name": "Tough Boss",
+      "url": "/api/monsters/tough-boss"
+    },
+    {
+      "index": "treant",
+      "name": "Treant",
+      "url": "/api/monsters/treant"
+    },
+    {
+      "index": "triceratops",
+      "name": "Triceratops",
+      "url": "/api/monsters/triceratops"
+    },
+    {
+      "index": "troll",
+      "name": "Troll",
+      "url": "/api/monsters/troll"
+    },
+    {
+      "index": "troll-limb",
+      "name": "Troll Limb",
+      "url": "/api/monsters/troll-limb"
+    },
+    {
+      "index": "tyrannosaurus-rex",
+      "name": "Tyrannosaurus Rex",
+      "url": "/api/monsters/tyrannosaurus-rex"
+    },
+    {
+      "index": "unicorn",
+      "name": "Unicorn",
+      "url": "/api/monsters/unicorn"
+    },
+    {
+      "index": "vampire",
+      "name": "Vampire",
+      "url": "/api/monsters/vampire"
+    },
+    {
+      "index": "vampire-familiar",
+      "name": "Vampire Familiar",
+      "url": "/api/monsters/vampire-familiar"
+    },
+    {
+      "index": "vampire-spawn",
+      "name": "Vampire Spawn",
+      "url": "/api/monsters/vampire-spawn"
+    },
+    {
+      "index": "venomous-snake",
+      "name": "Venomous Snake",
+      "url": "/api/monsters/venomous-snake"
+    },
+    {
+      "index": "violet-fungus",
+      "name": "Violet Fungus",
+      "url": "/api/monsters/violet-fungus"
+    },
+    {
+      "index": "vrock",
+      "name": "Vrock",
+      "url": "/api/monsters/vrock"
+    },
+    {
+      "index": "vulture",
+      "name": "Vulture",
+      "url": "/api/monsters/vulture"
+    },
+    {
+      "index": "warhorse",
+      "name": "Warhorse",
+      "url": "/api/monsters/warhorse"
+    },
+    {
+      "index": "warhorse-skeleton",
+      "name": "Warhorse Skeleton",
+      "url": "/api/monsters/warhorse-skeleton"
+    },
+    {
+      "index": "warrior-infantry",
+      "name": "Warrior Infantry",
+      "url": "/api/monsters/warrior-infantry"
+    },
+    {
+      "index": "warrior-veteran",
+      "name": "Warrior Veteran",
+      "url": "/api/monsters/warrior-veteran"
+    },
+    {
+      "index": "water-elemental",
+      "name": "Water Elemental",
+      "url": "/api/monsters/water-elemental"
+    },
+    {
+      "index": "weasel",
+      "name": "Weasel",
+      "url": "/api/monsters/weasel"
+    },
+    {
+      "index": "werebear",
+      "name": "Werebear",
+      "url": "/api/monsters/werebear"
+    },
+    {
+      "index": "wereboar",
+      "name": "Wereboar",
+      "url": "/api/monsters/wereboar"
+    },
+    {
+      "index": "wererat",
+      "name": "Wererat",
+      "url": "/api/monsters/wererat"
+    },
+    {
+      "index": "weretiger",
+      "name": "Weretiger",
+      "url": "/api/monsters/weretiger"
+    },
+    {
+      "index": "werewolf",
+      "name": "Werewolf",
+      "url": "/api/monsters/werewolf"
+    },
+    {
+      "index": "white-dragon-wyrmling",
+      "name": "White Dragon Wyrmling",
+      "url": "/api/monsters/white-dragon-wyrmling"
+    },
+    {
+      "index": "wight",
+      "name": "Wight",
+      "url": "/api/monsters/wight"
+    },
+    {
+      "index": "will-o-wisp",
+      "name": "Will-o’-Wisp",
+      "url": "/api/monsters/will-o-wisp"
+    },
+    {
+      "index": "wolf",
+      "name": "Wolf",
+      "url": "/api/monsters/wolf"
+    },
+    {
+      "index": "worg",
+      "name": "Worg",
+      "url": "/api/monsters/worg"
+    },
+    {
+      "index": "wyvern",
+      "name": "Wyvern",
+      "url": "/api/monsters/wyvern"
+    },
+    {
+      "index": "xorn",
+      "name": "Xorn",
+      "url": "/api/monsters/xorn"
+    },
+    {
+      "index": "young-black-dragon",
+      "name": "Young Black Dragon",
+      "url": "/api/monsters/young-black-dragon"
+    },
+    {
+      "index": "young-blue-dragon",
+      "name": "Young Blue Dragon",
+      "url": "/api/monsters/young-blue-dragon"
+    },
+    {
+      "index": "young-brass-dragon",
+      "name": "Young Brass Dragon",
+      "url": "/api/monsters/young-brass-dragon"
+    },
+    {
+      "index": "young-bronze-dragon",
+      "name": "Young Bronze Dragon",
+      "url": "/api/monsters/young-bronze-dragon"
+    },
+    {
+      "index": "young-copper-dragon",
+      "name": "Young Copper Dragon",
+      "url": "/api/monsters/young-copper-dragon"
+    },
+    {
+      "index": "young-gold-dragon",
+      "name": "Young Gold Dragon",
+      "url": "/api/monsters/young-gold-dragon"
+    },
+    {
+      "index": "young-green-dragon",
+      "name": "Young Green Dragon",
+      "url": "/api/monsters/young-green-dragon"
+    },
+    {
+      "index": "young-red-dragon",
+      "name": "Young Red Dragon",
+      "url": "/api/monsters/young-red-dragon"
+    },
+    {
+      "index": "young-silver-dragon",
+      "name": "Young Silver Dragon",
+      "url": "/api/monsters/young-silver-dragon"
+    },
+    {
+      "index": "young-white-dragon",
+      "name": "Young White Dragon",
+      "url": "/api/monsters/young-white-dragon"
+    },
+    {
+      "index": "zombie",
+      "name": "Zombie",
+      "url": "/api/monsters/zombie"
+    }
   ],
   "monsters": {
+    "aboleth": {
+      "index": "aboleth",
+      "name": "Aboleth",
+      "size": "Large",
+      "type": "aberration",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 150,
+      "hit_dice": "20d10 + 40",
+      "speed": {
+        "walk": "10 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 21,
+      "dexterity": 9,
+      "constitution": 15,
+      "intelligence": 18,
+      "wisdom": 15,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "CON",
+          "value": 6
+        },
+        {
+          "name": "INT",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "history": 12,
+        "perception": 10
+      },
+      "senses": {
+        "passive_perception": 20,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Deep Speech; telepathy 120 ft.",
+      "challenge_rating": 10.0,
+      "xp": 5900,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The aboleth can breathe air and water."
+        },
+        {
+          "name": "Eldritch Restoration",
+          "desc": "If destroyed, the aboleth gains a new body in 5d10 days, reviving with all its Hit Points in the Far Realm or another location chosen by the GM."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the aboleth fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Mucus Cloud",
+          "desc": "While underwater, the aboleth is surrounded by mucus. Constitution Saving Throw: DC 14, each creature in a 5-foot Emanation originating from the aboleth at the end of the aboleth’s turn. Failure: The target is cursed. Until the curse ends, the target’s skin becomes slimy, the target can breathe air and water, and it can’t regain Hit Points unless it is underwater. While the cursed creature is outside a body of water, the creature takes 6 (1d12) Acid damage at the end of every 10 minutes unless moisture is applied to its skin before those minutes have passed.",
+          "damage": [
+            {
+              "damage_dice": "1d12",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "1d12",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Probing Telepathy",
+          "desc": "If a creature the aboleth can see communicates telepathically with the aboleth, the aboleth learns the creature’s greatest desires."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The aboleth makes two Tentacle attacks and uses either Consume Memories or Dominate Mind if available."
+        },
+        {
+          "name": "Tentacle",
+          "desc": "Melee Attack Roll: +9, reach 15 ft. Hit: 12 (2d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of four tentacles.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d6+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Consume Memories",
+          "desc": "Intelligence Saving Throw: DC 16, one creature within 30 feet that is Charmed or Grappled by the aboleth. Failure: 10 (3d6) Psychic damage. Success: Half damage. Failure or Success: The aboleth gains the target’s memories if the target is a Humanoid and is reduced to 0 Hit Points by this action.",
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Dominate Mind (2/Day)",
+          "desc": "Wisdom Saving Throw: DC 16, one creature the aboleth can see within 30 feet. Failure: The target has the Charmed condition until the aboleth dies or is on a different plane of existence from the target. While Charmed, the target acts as an ally to the aboleth and is under its control while within 60 feet of it. In addition, the aboleth and the target can communicate telepathically with each other over any distance. The target repeats the save whenever it takes damage as well as after every 24 hours it spends at least 1 mile away from the aboleth, ending the effect on itself on a success."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the aboleth can expend a use to take one of the following actions. The aboleth regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Lash",
+          "desc": "The aboleth makes one Tentacle attack."
+        },
+        {
+          "name": "Psychic Drain",
+          "desc": "If the aboleth has at least one creature Charmed or Grappled, it uses Consume Memories and regains 5 (1d10) Hit Points."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "air-elemental": {
+      "index": "air-elemental",
+      "name": "Air Elemental",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 15,
+      "hit_points": 90,
+      "hit_dice": "12d10 + 24",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "90 ft. (hover)"
+      },
+      "strength": 14,
+      "dexterity": 20,
+      "constitution": 14,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Primordial (Auran)",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Lightning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Poison",
+        "Thunder"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained",
+        "Unconscious"
+      ],
+      "special_abilities": [
+        {
+          "name": "Air Form",
+          "desc": "The elemental can enter a creature’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The elemental makes two Thunderous Slam attacks."
+        },
+        {
+          "name": "Thunderous Slam",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Thunder damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "thunder"
+          }
+        },
+        {
+          "name": "Whirlwind (Recharge 4-6)",
+          "desc": "Strength Saving Throw: DC 13, one Medium or smaller creature in the elemental’s space. Failure: 24 (4d10 + 2) Thunder damage, and the target is pushed up to 20 feet straight away from the elemental and has the Prone condition. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "4d10+2",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "4d10+2",
+          "damage_type": {
+            "name": "thunder"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "animated-armor": {
+      "index": "animated-armor",
+      "name": "Animated Armor",
+      "size": "Medium",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 18,
+      "hit_points": 33,
+      "hit_dice": "6d8 + 6",
+      "speed": {
+        "walk": "25 ft."
+      },
+      "strength": 14,
+      "dexterity": 11,
+      "constitution": 13,
+      "intelligence": 1,
+      "wisdom": 3,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison",
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Deafened"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The armor makes two Slam attacks."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "animated-flying-sword": {
+      "index": "animated-flying-sword",
+      "name": "Animated Flying Sword",
+      "size": "Small",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 17,
+      "hit_points": 14,
+      "hit_dice": "4d6",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "50 ft. (hover)"
+      },
+      "strength": 12,
+      "dexterity": 15,
+      "constitution": 11,
+      "intelligence": 1,
+      "wisdom": 5,
+      "charisma": 1,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison",
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Deafened"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Slash",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "animated-rug-of-smothering": {
+      "index": "animated-rug-of-smothering",
+      "name": "Animated Rug of Smothering",
+      "size": "Large",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 27,
+      "hit_dice": "5d10",
+      "speed": {
+        "walk": "10 ft."
+      },
+      "strength": 17,
+      "dexterity": 14,
+      "constitution": 10,
+      "intelligence": 1,
+      "wisdom": 3,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison",
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Deafened"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Smother",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the rug can give it the Grappled condition (escape DC 13) instead of dealing damage. Until the grapple ends, the target has the Blinded and Restrained conditions, is suffocating, and takes 10 (2d6 + 3) Bludgeoning damage at the start of each of its turns. The rug can smother only one creature at a time. While grappling the target, the rug can’t take this action, the rug halves the damage it takes (round down), and the target takes the same amount of damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ankheg": {
+      "index": "ankheg",
+      "name": "Ankheg",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "30 ft.",
+        "burrow": "10 ft."
+      },
+      "strength": 17,
+      "dexterity": 11,
+      "constitution": 14,
+      "intelligence": 1,
+      "wisdom": 13,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "tremorsense": "60 ft.",
+        "summary": "Darkvision 60 ft., Tremorsense 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Tunneler",
+          "desc": "The ankheg can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the ankheg), reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 3 (1d6) Acid damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13).",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Spray (Recharge 6)",
+          "desc": "Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-foot-wide Line. Failure: 14 (4d6) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "4d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "assassin": {
+      "index": "assassin",
+      "name": "Assassin",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 16,
+      "hit_points": 97,
+      "hit_dice": "15d8 + 30",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 18,
+      "constitution": 14,
+      "intelligence": 16,
+      "wisdom": 11,
+      "charisma": 10,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "INT",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "acrobatics": 7,
+        "perception": 6,
+        "stealth": 10
+      },
+      "senses": {
+        "passive_perception": 16,
+        "cant_cr": "8",
+        "xp": "3",
+        "summary": "Languages Common, Thieves’ Cant CR 8 (XP 3,900; PB +3)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Poison"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Evasion",
+          "desc": "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the save and only half damage if it fails. It can’t use this trait if it has the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The assassin makes three attacks, using Shortsword or Light Crossbow in any combination."
+        },
+        {
+          "name": "Shortsword",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 7 (1d6 + 4) Piercing damage plus 17 (5d6) Poison damage, and the target has the Poisoned condition until the start of the assassin’s next turn.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Light Crossbow",
+          "desc": "Ranged Attack Roll: +7, range 80/320 ft. Hit: 8 (1d8 + 4) Piercing damage plus 21 (6d6) Poison damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Cunning Action",
+          "desc": "The assassin takes the Dash, Disengage, or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "awakened-shrub": {
+      "index": "awakened-shrub",
+      "name": "Awakened Shrub",
+      "size": "Small",
+      "type": "plant",
+      "alignment": "Neutral",
+      "armor_class": 9,
+      "hit_points": 10,
+      "hit_dice": "3d6",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 3,
+      "dexterity": 8,
+      "constitution": 11,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": [
+        "Piercing"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rake",
+          "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Slashing damage.",
+          "attack_bonus": 1
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "awakened-tree": {
+      "index": "awakened-tree",
+      "name": "Awakened Tree",
+      "size": "Huge",
+      "type": "plant",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 59,
+      "hit_dice": "7d12 + 14",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 19,
+      "dexterity": 6,
+      "constitution": 15,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (3d6 + 4) Bludgeoning damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "axe-beak": {
+      "index": "axe-beak",
+      "name": "Axe Beak",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 19,
+      "hit_dice": "3d10 + 3",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 14,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Beak",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "azer-sentinel": {
+      "index": "azer-sentinel",
+      "name": "Azer Sentinel",
+      "size": "Medium",
+      "type": "elemental",
+      "alignment": "Lawful Neutral",
+      "armor_class": 17,
+      "hit_points": 39,
+      "hit_dice": "6d8 + 12",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 12,
+      "constitution": 15,
+      "intelligence": 12,
+      "wisdom": 13,
+      "charisma": 10,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned Senses Passive Perception 11 Languages Primordial (Ignan)"
+      ],
+      "special_abilities": [
+        {
+          "name": "Fire Aura",
+          "desc": "At the end of each of the azer’s turns, each creature of the azer’s choice in a 5-foot Emanation originating from the azer takes 5 (1d10) Fire damage unless the azer has the Incapacitated condition."
+        },
+        {
+          "name": "Illumination",
+          "desc": "The azer sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Burning Hammer",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 3 (1d6) Fire damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "balor": {
+      "index": "balor",
+      "name": "Balor",
+      "size": "Huge",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 19,
+      "hit_points": 287,
+      "hit_dice": "23d12 + 138",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 26,
+      "dexterity": 15,
+      "constitution": 22,
+      "intelligence": 20,
+      "wisdom": 16,
+      "charisma": 22,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 12
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "perception": 9
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 19.0,
+      "xp": 22000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Frightened",
+        "Poisoned Senses Truesight 120 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Death Throes",
+          "desc": "The balor explodes when it dies. Dexterity Saving Throw: DC 20, each creature in a 30-foot Emanation originating from the balor. Failure: 31 (9d6) Fire damage plus 31 (9d6) Force damage. Success: Half damage. Failure or Success: If the balor dies outside the Abyss, it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss.",
+          "damage": [
+            {
+              "damage_dice": "9d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "9d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Fire Aura",
+          "desc": "At the end of each of the balor’s turns, each creature in a 5-foot Emanation originating from the balor takes 13 (3d8) Fire damage."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "desc": "If the balor fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The balor has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The balor makes one Flame Whip attack and one Lightning Blade attack."
+        },
+        {
+          "name": "Flame Whip",
+          "desc": "Melee Attack Roll: +14, reach 30 ft. Hit: 18 (3d6 + 8) Force damage plus 17 (5d6) Fire damage. If the target is a Huge or smaller creature, the balor pulls the target up to 25 feet straight toward itself, and the target has the Prone condition.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "3d6+8",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "3d6+8",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Lightning Blade",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 21 (3d8 + 8) Force damage plus 22 (4d10) Lightning damage, and the target can’t take Reactions until the start of the balor’s next turn.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "3d8+8",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "3d8+8",
+          "damage_type": {
+            "name": "force"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Teleport",
+          "desc": "The balor teleports itself or a willing demon within 10 feet of itself up to 60 feet to an unoccupied space the balor can see."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
     "bandit": {
       "index": "bandit",
       "name": "Bandit",
       "size": "Medium",
-      "type": "humanoid",
-      "subtype": "any race",
-      "alignment": "any non-lawful alignment",
-      "armor_class": [
-        { "type": "leather armor", "value": 12 }
-      ],
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 12,
       "hit_points": 11,
-      "hit_dice": "2d8",
-      "speed": { "walk": "30 ft." },
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 11,
       "dexterity": 12,
       "constitution": 12,
       "intelligence": 10,
       "wisdom": 10,
       "charisma": 10,
-      "skills": { "athletics": 3 },
-      "senses": { "passive_perception": 10 },
-      "languages": "Common",
-      "challenge_rating": 0.125,
-      "xp": 25,
-      "proficiency_bonus": 2,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "cant_cr": "1",
+        "xp": "25",
+        "summary": "Languages Common, Thieves’ Cant CR 1/8 (XP 25; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
       "actions": [
         {
           "name": "Scimitar",
-          "type": "melee",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
           "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
           "damage_dice": "1d6+1",
-          "damage_type": { "name": "slashing" },
-          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+          "damage_type": {
+            "name": "slashing"
+          }
         },
         {
           "name": "Light Crossbow",
-          "type": "ranged",
+          "desc": "Ranged Attack Roll: +3, range 80/320 ft. Hit: 5 (1d8 + 1) Piercing damage.",
           "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d8+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
           "damage_dice": "1d8+1",
-          "damage_type": { "name": "piercing" },
-          "desc": "Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+          "damage_type": {
+            "name": "piercing"
+          }
         }
-      ]
-    },
-    "bugbear": {
-      "index": "bugbear",
-      "name": "Bugbear",
-      "size": "Medium",
-      "type": "humanoid",
-      "subtype": "goblinoid",
-      "alignment": "chaotic evil",
-      "armor_class": [
-        { "type": "hide armor", "value": 16 }
       ],
-      "hit_points": 27,
-      "hit_dice": "5d8",
-      "speed": { "walk": "30 ft." },
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "bandit-captain": {
+      "index": "bandit-captain",
+      "name": "Bandit Captain",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 15,
+      "hit_points": 52,
+      "hit_dice": "8d8 + 16",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 16,
+      "constitution": 14,
+      "intelligence": 14,
+      "wisdom": 11,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 4
+        },
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "athletics": 4,
+        "deception": 4
+      },
+      "senses": {
+        "passive_perception": 10,
+        "cant_cr": "2",
+        "xp": "450",
+        "summary": "Languages Common, Thieves’ Cant CR 2 (XP 450; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The bandit makes two attacks, using Scimitar and Pistol in any combination."
+        },
+        {
+          "name": "Scimitar",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Pistol",
+          "desc": "Ranged Attack Roll: +5, range 30/90 ft. Hit: 8 (1d10 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The bandit is hit by a melee attack roll while holding a weapon. Response: The bandit adds 2 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "barbed-devil": {
+      "index": "barbed-devil",
+      "name": "Barbed Devil",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 15,
+      "hit_points": 110,
+      "hit_dice": "13d8 + 52",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 17,
+      "constitution": 18,
+      "intelligence": 12,
+      "wisdom": 14,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 6
+        },
+        {
+          "name": "CON",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 5
+        },
+        {
+          "name": "CHA",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "deception": 5,
+        "insight": 5,
+        "perception": 8
+      },
+      "senses": {
+        "passive_perception": 18,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Barbed Hide",
+          "desc": "At the start of each of its turns, the devil deals 5 (1d10) Piercing damage to any creature it is grappling or any creature grappling it."
+        },
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The devil makes one Claws attack and one Tail attack, or it makes two Hurl Flame attacks."
+        },
+        {
+          "name": "Claws",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from both claws.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tail",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (2d10 + 3) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d10+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Hurl Flame",
+          "desc": "Ranged Attack Roll: +5, range 150 ft. Hit: 17 (5d6) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "5d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "5d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "basilisk": {
+      "index": "basilisk",
+      "name": "Basilisk",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 15,
+      "hit_points": 52,
+      "hit_dice": "8d8 + 16",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 16,
+      "dexterity": 8,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 8,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Petrifying Gaze (Recharge 4-6)",
+          "desc": "Constitution Saving Throw: DC 12, each creature in a 30-foot Cone. If the basilisk sees its reflection in the Cone, the basilisk must make this save. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "bearded-devil": {
+      "index": "bearded-devil",
+      "name": "Bearded Devil",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 13,
+      "hit_points": 58,
+      "hit_dice": "9d8 + 18",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 15,
+      "constitution": 15,
+      "intelligence": 9,
+      "wisdom": 11,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 5
+        },
+        {
+          "name": "CON",
+          "value": 4
+        },
+        {
+          "name": "CHA",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Frightened",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The devil makes one Beard attack and one Infernal Glaive attack."
+        },
+        {
+          "name": "Beard",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the target has the Poisoned condition until the start of the devil’s next turn. Until this poison ends, the target can’t regain Hit Points.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Infernal Glaive",
+          "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage. If the target is a creature and doesn’t already have an infernal wound, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target receives an infernal wound. While wounded, the target loses 5 (1d10) Hit Points at the start of each of its turns. The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 12 Wisdom (Medicine) check.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "behir": {
+      "index": "behir",
+      "name": "Behir",
+      "size": "Huge",
+      "type": "monstrosity",
+      "alignment": "Neutral Evil",
+      "armor_class": 17,
+      "hit_points": 168,
+      "hit_dice": "16d12 + 64",
+      "speed": {
+        "walk": "50 ft.",
+        "climb": "50 ft."
+      },
+      "strength": 23,
+      "dexterity": 16,
+      "constitution": 18,
+      "intelligence": 7,
+      "wisdom": 14,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "90 ft.",
+        "summary": "Darkvision 90 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The behir makes one Bite attack and uses Constrict."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 19 (2d12 + 6) Piercing damage plus 11 (2d10) Lightning damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d12+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Constrict",
+          "desc": "Strength Saving Throw: DC 18, one Large or smaller creature the behir can see within 5 feet. Failure: 28 (5d8 + 6) Bludgeoning damage. The target has the Grappled condition (escape DC 16), and it has the Restrained condition until the grapple ends.",
+          "damage": [
+            {
+              "damage_dice": "5d8+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "5d8+6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 16, each creature in a 90-foot-long, 5-footwide Line. Failure: 66 (12d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "12d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Swallow",
+          "desc": "Dexterity Saving Throw: DC 18, one Large or smaller creature Grappled by the behir (the behir can have only one creature swallowed at a time). Failure: The behir swallows the target, which is no longer Grappled. While swallowed, a creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the behir, and takes 21 (6d6) Acid damage at the start of each of the behir’s turns. If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls in a space within 10 feet of the behir and has the Prone condition. If the behir dies, a swallowed creature is no longer Restrained and can escape from the corpse by using 15 feet of movement, exiting Prone.",
+          "damage": [
+            {
+              "damage_dice": "6d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "6d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "berserker": {
+      "index": "berserker",
+      "name": "Berserker",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 67,
+      "hit_dice": "9d8 + 27",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 12,
+      "constitution": 17,
+      "intelligence": 9,
+      "wisdom": 11,
+      "charisma": 9,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Bloodied Frenzy",
+          "desc": "While Bloodied, the berserker has Advantage on attack rolls and saving throws."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Greataxe",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 9 (1d12 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d12+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d12+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "black-dragon-wyrmling": {
+      "index": "black-dragon-wyrmling",
+      "name": "Black Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 17,
+      "hit_points": 33,
+      "hit_dice": "6d8 + 6",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 14,
+      "constitution": 13,
+      "intelligence": 10,
+      "wisdom": 11,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage plus 2 (1d4) Acid damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 11, each creature in a 15-foot-long, 5-footwide Line. Failure: 22 (5d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "5d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "5d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "young-black-dragon": {
+      "index": "young-black-dragon",
+      "name": "Young Black Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 18,
+      "hit_points": 127,
+      "hit_dice": "15d10 + 45",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 19,
+      "dexterity": 14,
+      "constitution": 17,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "perception": 6,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 16,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 7.0,
+      "xp": 2900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 3 (1d6) Acid damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 14, each creature in a 30-foot-long, 5-footwide Line. Failure: 49 (14d6) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "14d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "14d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "adult-black-dragon": {
+      "index": "adult-black-dragon",
+      "name": "Adult Black Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 19,
+      "hit_points": 195,
+      "hit_dice": "17d12 + 85",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 23,
+      "dexterity": 14,
+      "constitution": 21,
+      "intelligence": 14,
+      "wisdom": 13,
+      "charisma": 19,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "perception": 11,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 21,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 14.0,
+      "xp": 11500,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 3 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Acid damage.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "2d6+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-footwide Line. Failure: 54 (12d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "12d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks): At Will: Acid Arrow (level 3 version), Detect Magic, Fear 1/Day Each: Speak with Dead, Vitriolic Sphere"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns. Cloud of Insects. Dexterity Saving Throw: DC 17, one creature the dragon can see within 120 feet. Failure: 22 (4d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "4d10",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "4d10",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Frightful Presence",
+          "desc": "The dragon uses Spellcasting to cast Fear. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "ancient-black-dragon": {
+      "index": "ancient-black-dragon",
+      "name": "Ancient Black Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 22,
+      "hit_points": 367,
+      "hit_dice": "21d20 + 147",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 27,
+      "dexterity": 14,
+      "constitution": 25,
+      "intelligence": 16,
+      "wisdom": 15,
+      "charisma": 22,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "perception": 16,
+        "stealth": 9
+      },
+      "senses": {
+        "passive_perception": 26,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 21.0,
+      "xp": 33000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 4 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 9 (2d8) Acid damage.",
+          "attack_bonus": 15,
+          "damage": [
+            {
+              "damage_dice": "2d8+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 22, each creature in a 90-foot-long, 10-footwide Line. Failure: 67 (15d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "15d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "15d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks): At Will: Acid Arrow (level 4 version), Detect Magic, Fear 1/Day Each: Create Undead, Speak with Dead, Vitriolic Sphere (level 5 version)"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns. Cloud of Insects. Dexterity Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 33 (6d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "6d10",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "6d10",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Frightful Presence",
+          "desc": "The dragon uses Spellcasting to cast Fear. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "black-pudding": {
+      "index": "black-pudding",
+      "name": "Black Pudding",
+      "size": "Large",
+      "type": "ooze",
+      "alignment": "Unaligned",
+      "armor_class": 7,
+      "hit_points": 68,
+      "hit_dice": "8d10 + 24",
+      "speed": {
+        "walk": "20 ft.",
+        "climb": "20 ft."
+      },
+      "strength": 16,
+      "dexterity": 5,
+      "constitution": 16,
+      "intelligence": 1,
+      "wisdom": 6,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid",
+        "Cold",
+        "Lightning",
+        "Slashing"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Deafened",
+        "Exhaustion",
+        "Frightened",
+        "Grappled",
+        "Prone",
+        "Restrained"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amorphous",
+          "desc": "The pudding can move through a space as narrow as 1 inch without expending extra movement to do so."
+        },
+        {
+          "name": "Corrosive Form",
+          "desc": "A creature that hits the pudding with a melee attack roll takes 4 (1d8) Acid damage. Nonmagical ammunition is destroyed immediately after hitting the pudding and dealing any damage. Any nonmagical weapon takes a cumulative -1 penalty to attack rolls immediately after dealing damage to the pudding and coming into contact with it. The weapon is destroyed if the penalty reaches -5. The penalty can be removed by casting the Mending spell on the weapon. In 1 minute, the pudding can eat through 2 feet of nonmagical wood or metal."
+        },
+        {
+          "name": "Spider Climb",
+          "desc": "The pudding can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Dissolving Pseudopod",
+          "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 17 (4d6 + 3) Acid damage. Nonmagical armor worn by the target takes a -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "4d6+3",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "4d6+3",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Split",
+          "desc": "Trigger: While the pudding is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The pudding splits into two new Black Puddings. Each new pudding is one size smaller than the original pudding and acts on its Initiative. The original pudding’s Hit Points are divided evenly between the new puddings (round down)."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "blink-dog": {
+      "index": "blink-dog",
+      "name": "Blink Dog",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Lawful Good",
+      "armor_class": 13,
+      "hit_points": 22,
+      "hit_dice": "4d8 + 4",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 12,
+      "dexterity": 17,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 13,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Blink Dog; understands Elvish and Sylvan but can’t speak them",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Teleport (Recharge 4-6)",
+          "desc": "The dog teleports up to 40 feet to an unoccupied space it can see."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "blue-dragon-wyrmling": {
+      "index": "blue-dragon-wyrmling",
+      "name": "Blue Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 65,
+      "hit_dice": "10d8 + 20",
+      "speed": {
+        "walk": "30 ft.",
+        "burrow": "15 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 17,
+      "dexterity": 10,
+      "constitution": 15,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage plus 3 (1d6) Lightning damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-footwide Line. Failure: 21 (6d6) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "6d6",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "6d6",
+          "damage_type": {
+            "name": "lightning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "young-blue-dragon": {
+      "index": "young-blue-dragon",
+      "name": "Young Blue Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 152,
+      "hit_dice": "16d10 + 64",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "20 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 21,
+      "dexterity": 10,
+      "constitution": 19,
+      "intelligence": 14,
+      "wisdom": 13,
+      "charisma": 17,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "perception": 9,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 19,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 12 (2d6 + 5) Slashing damage plus 5 (1d10) Lightning damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d6+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 16, each creature in a 60-foot-long, 5-footwide Line. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "10d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "10d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "adult-blue-dragon": {
+      "index": "adult-blue-dragon",
+      "name": "Adult Blue Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 16,
+      "hit_points": 161,
+      "hit_dice": "17d10 + 68",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 16,
+      "constitution": 18,
+      "intelligence": 13,
+      "wisdom": 14,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 8
+        },
+        {
+          "name": "INT",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        },
+        {
+          "name": "CHA",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "perception": 17,
+        "stealth": 7,
+        "deception": 7,
+        "insight": 6
+      },
+      "senses": {
+        "passive_perception": 12,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Lightning",
+        "Lightning",
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The devil makes two Claw attacks and one Infernal Sting attack."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Infernal Sting",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 15 (2d10 + 4) Piercing damage plus 18 (4d8) Poison damage, and the target has the Poisoned condition until the start of the devil’s next turn. While Poisoned, the target can’t regain Hit Points.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Cloaked Flight",
+          "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Sonic Boom",
+          "desc": "The dragon uses Spellcasting to cast Shatter (level 3 version). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Tail Swipe",
+          "desc": "The dragon makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "brass-dragon-wyrmling": {
+      "index": "brass-dragon-wyrmling",
+      "name": "Brass Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 15,
+      "hit_points": 22,
+      "hit_dice": "4d8 + 4",
+      "speed": {
+        "walk": "30 ft.",
+        "burrow": "15 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 15,
+      "dexterity": 10,
+      "constitution": 13,
+      "intelligence": 10,
+      "wisdom": 11,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d10+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-footwide Line. Failure: 14 (4d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "4d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Sleep Breath",
+          "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "young-brass-dragon": {
+      "index": "young-brass-dragon",
+      "name": "Young Brass Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 17,
+      "hit_points": 110,
+      "hit_dice": "13d10 + 39",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "20 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 19,
+      "dexterity": 10,
+      "constitution": 17,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "perception": 6,
+        "persuasion": 5,
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 16,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace two attacks with a use of Sleep Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-footwide Line. Failure: 38 (11d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "11d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "11d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Sleep Breath",
+          "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "adult-brass-dragon": {
+      "index": "adult-brass-dragon",
+      "name": "Adult Brass Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 18,
+      "hit_points": 172,
+      "hit_dice": "15d12 + 75",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "30 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 23,
+      "dexterity": 10,
+      "constitution": 21,
+      "intelligence": 14,
+      "wisdom": 13,
+      "charisma": 17,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "history": 7,
+        "perception": 11,
+        "persuasion": 8,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 21,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 13.0,
+      "xp": 10000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Fire damage.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "2d10+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-footwide Line. Failure: 45 (10d8) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "10d8",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "10d8",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Sleep Breath",
+          "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16): At Will: Detect Magic, Minor Illusion, Scorching Ray, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals 1/Day Each: Detect Thoughts, Control Weather"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Blazing Light",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Scorching Ray",
+          "desc": ""
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        },
+        {
+          "name": "Scorching Sands",
+          "desc": "Dexterity Saving Throw: DC 16, one creature the dragon can see within 120 feet. Failure: 27 (6d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "6d8",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "6d8",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "ancient-brass-dragon": {
+      "index": "ancient-brass-dragon",
+      "name": "Ancient Brass Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 20,
+      "hit_points": 332,
+      "hit_dice": "19d20 + 133",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 27,
+      "dexterity": 10,
+      "constitution": 25,
+      "intelligence": 16,
+      "wisdom": 15,
+      "charisma": 22,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 8
+        }
+      ],
+      "skills": {
+        "history": 9,
+        "perception": 14,
+        "persuasion": 12
+      },
+      "senses": {
+        "passive_perception": 24,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 20.0,
+      "xp": 25000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray (level 3 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +14, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 7 (2d6) Fire damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "2d10+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 21, each creature in a 90-foot-long, 5-footwide Line. Failure: 58 (13d8) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "13d8",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "13d8",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Sleep Breath",
+          "desc": "Constitution Saving Throw: DC 21, each creature in a 90-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20): At Will: Detect Magic, Minor Illusion, Scorching Ray (level 3 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals 1/Day Each: Control Weather, Detect Thoughts"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Blazing Light",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Scorching Ray (level 3 version)",
+          "desc": ""
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        },
+        {
+          "name": "Scorching Sands",
+          "desc": "Dexterity Saving Throw: DC 20, one creature the dragon can see within 120 feet. Failure: 36 (8d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "8d8",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "8d8",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "bronze-dragon-wyrmling": {
+      "index": "bronze-dragon-wyrmling",
+      "name": "Bronze Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 15,
+      "hit_points": 39,
+      "hit_dice": "6d8 + 12",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 10,
+      "constitution": 15,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 12, each creature in a 40-foot-long, 5-footwide Line. Failure: 16 (3d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "3d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "3d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Repulsion Breath",
+          "desc": "Strength Saving Throw: DC 12, each creature in a 30-foot Cone. Failure: The target is pushed up to 30 feet straight away from the dragon and has the Prone condition."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "young-bronze-dragon": {
+      "index": "young-bronze-dragon",
+      "name": "Young Bronze Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 17,
+      "hit_points": 142,
+      "hit_dice": "15d10 + 60",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 21,
+      "dexterity": 10,
+      "constitution": 19,
+      "intelligence": 14,
+      "wisdom": 13,
+      "charisma": 17,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "insight": 4,
+        "perception": 7,
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 17,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Repulsion Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 15, each creature in a 60-foot-long, 5-footwide Line. Failure: 49 (9d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "9d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "9d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Repulsion Breath",
+          "desc": "Strength Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: The target is pushed up to 40 feet straight away from the dragon and has the Prone condition."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "adult-bronze-dragon": {
+      "index": "adult-bronze-dragon",
+      "name": "Adult Bronze Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 18,
+      "hit_points": 212,
+      "hit_dice": "17d12 + 102",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 25,
+      "dexterity": 10,
+      "constitution": 23,
+      "intelligence": 16,
+      "wisdom": 15,
+      "charisma": 20,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "insight": 7,
+        "perception": 12,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 22,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 15.0,
+      "xp": 13000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "2d8+7",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+7",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-footwide Line. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "10d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "10d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Repulsion Breath",
+          "desc": "Strength Saving Throw: DC 19, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the Prone condition."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +10 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy 1/Day Each: Detect Thoughts, Water Breathing"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Guiding Light",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Guiding Bolt (level 2 version)",
+          "desc": ""
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        },
+        {
+          "name": "Thunderclap",
+          "desc": "Constitution Saving Throw: DC 17, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 10 (3d6) Thunder damage, and the target has the Deafened condition until the end of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "thunder"
+          }
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "ancient-bronze-dragon": {
+      "index": "ancient-bronze-dragon",
+      "name": "Ancient Bronze Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 22,
+      "hit_points": 444,
+      "hit_dice": "24d20 + 192",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 29,
+      "dexterity": 10,
+      "constitution": 27,
+      "intelligence": 18,
+      "wisdom": 17,
+      "charisma": 25,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "insight": 10,
+        "perception": 17,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 27,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 22.0,
+      "xp": 41000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 9 (2d8) Lightning damage.",
+          "attack_bonus": 16,
+          "damage": [
+            {
+              "damage_dice": "2d8+9",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+9",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 82 (15d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "15d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "15d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Repulsion Breath",
+          "desc": "Strength Saving Throw: DC 23, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the Prone condition."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22, +14 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy 1/Day Each: Detect Thoughts, Control Water, Scrying, Water Breathing"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Guiding Light",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Guiding Bolt (level 2 version)",
+          "desc": ""
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        },
+        {
+          "name": "Thunderclap",
+          "desc": "Constitution Saving Throw: DC 22, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 13 (3d8) Thunder damage, and the target has the Deafened condition until the end of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "3d8",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "3d8",
+          "damage_type": {
+            "name": "thunder"
+          }
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "bugbear-stalker": {
+      "index": "bugbear-stalker",
+      "name": "Bugbear Stalker",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Chaotic Evil",
+      "armor_class": 15,
+      "hit_points": 65,
+      "hit_dice": "10d8 + 20",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 14,
+      "constitution": 14,
+      "intelligence": 11,
+      "wisdom": 12,
+      "charisma": 11,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "stealth": 6,
+        "survival": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Abduct",
+          "desc": "The bugbear needn’t spend extra movement to move a creature it is grappling."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The bugbear makes two Javelin or Morningstar attacks."
+        },
+        {
+          "name": "Javelin",
+          "desc": "Melee or Ranged Attack Roll: +5, reach 10 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "3d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Morningstar",
+          "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Quick Grapple",
+          "desc": "Dexterity Saving Throw: DC 13, one Medium or smaller creature the bugbear can see within 10 feet. Failure: The target has the Grappled condition (escape DC 13)."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
+    },
+    "bugbear-warrior": {
+      "index": "bugbear-warrior",
+      "name": "Bugbear Warrior",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Chaotic Evil",
+      "armor_class": 14,
+      "hit_points": 33,
+      "hit_dice": "6d8 + 6",
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 15,
       "dexterity": 14,
       "constitution": 13,
       "intelligence": 8,
       "wisdom": 11,
       "charisma": 9,
-      "skills": { "stealth": 6 },
-      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
+      "saving_throws": [],
+      "skills": {
+        "stealth": 6,
+        "survival": 2
+      },
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
       "languages": "Common, Goblin",
-      "challenge_rating": 1,
+      "challenge_rating": 1.0,
       "xp": 200,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
       "special_abilities": [
         {
-          "name": "Brute",
-          "desc": "A melee weapon deals one extra die of its damage when the bugbear hits with it (included in the attack)."
-        },
-        {
-          "name": "Surprise Attack",
-          "desc": "If the bugbear surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 7 (2d6) damage from the attack."
+          "name": "Abduct",
+          "desc": "The bugbear needn’t spend extra movement to move a creature it is grappling."
         }
       ],
       "actions": [
         {
-          "name": "Morningstar",
+          "name": "Grab",
+          "desc": "Melee Attack Roll: +4, reach 10 ft. Hit: 9 (2d6 + 2) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
           "attack_bonus": 4,
-          "damage_dice": "2d8+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 11 (2d8 + 2) piercing damage."
+          "damage": [
+            {
+              "damage_dice": "2d6+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
         },
         {
-          "name": "Javelin",
+          "name": "Light Hammer",
+          "desc": "Melee or Ranged Attack Roll: +4 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. or range 20/60 ft. Hit: 9 (3d4 + 2) Bludgeoning damage.",
           "attack_bonus": 4,
-          "damage_dice": "2d6+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 9 (2d6 + 2) piercing damage in melee or 7 (2d4 + 2) piercing damage at range."
+          "damage": [
+            {
+              "damage_dice": "3d4+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d4+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
         }
-      ]
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
+    },
+    "bulette": {
+      "index": "bulette",
+      "name": "Bulette",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 17,
+      "hit_points": 94,
+      "hit_dice": "9d10 + 45",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "40 ft."
+      },
+      "strength": 19,
+      "dexterity": 11,
+      "constitution": 21,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "60 ft.",
+        "tremorsense": "120 ft.",
+        "summary": "Darkvision 60 ft., Tremorsense 120 ft."
+      },
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The bulette makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d12+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Deadly Leap",
+          "desc": "The bulette spends 5 feet of movement to jump to a space within 15 feet that contains one or more Large or smaller creatures. Dexterity Saving Throw: DC 15, each creature in the bulette’s destina- tion space. Failure: 19 (3d12) Bludgeoning damage, and the target has the Prone condition. Success: Half damage, and the target is pushed 5 feet straight away from the bulette.",
+          "damage": [
+            {
+              "damage_dice": "3d12",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d12",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Leap",
+          "desc": "The bulette jumps up to 30 feet by spending 10 feet of movement."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "centaur-trooper": {
+      "index": "centaur-trooper",
+      "name": "Centaur Trooper",
+      "size": "Large",
+      "type": "fey",
+      "alignment": "Neutral Good",
+      "armor_class": 16,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 14,
+      "intelligence": 9,
+      "wisdom": 13,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "athletics": 6,
+        "perception": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The centaur makes two attacks, using Pike or Longbow in any combination."
+        },
+        {
+          "name": "Pike",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Longbow",
+          "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Trampling Charge (Recharge 5-6)",
+          "desc": "The centaur moves up to its Speed without provoking Opportunity Attacks and can move through the spaces of Medium or smaller creatures. Each creature whose space the centaur enters is targeted once by the following effect. Strength Saving Throw: DC 14. Failure: 7 (1d6 + 4) Bludgeoning damage, and the target has the Prone condition.",
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "chain-devil": {
+      "index": "chain-devil",
+      "name": "Chain Devil",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 15,
+      "hit_points": 85,
+      "hit_dice": "10d8 + 40",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 18,
+      "intelligence": 11,
+      "wisdom": 12,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Cold",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The devil makes two Chain attacks and uses Conjure Infernal Chain."
+        },
+        {
+          "name": "Chain",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two chains, and it has the Restrained condition until the grapple ends.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Conjure Infernal Chain",
+          "desc": "The devil conjures a fiery chain to bind a creature. Dexterity Saving Throw: DC 15, one creature the devil can see within 60 feet. Failure: 9 (2d4 + 4) Fire damage, and the target has the Restrained condition until the end of the devil’s next turn, at which point the chain disappears. If the target is Large or smaller, the devil moves the target up to 30 feet straight toward itself. Success: The chain disappears.",
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Unnerving Gaze",
+          "desc": "Trigger: A creature the devil can see starts its turn within 30 feet of the devil and can see the devil. Response-Wisdom Saving Throw: DC 15, the triggering creature. Failure: The target has the Frightened condition until the end of its turn. Success: The target is immune to this devil’s Unnerving Gaze for 24 hours."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "chimera": {
+      "index": "chimera",
+      "name": "Chimera",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 14,
+      "hit_points": 114,
+      "hit_dice": "12d10 + 48",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 19,
+      "dexterity": 11,
+      "constitution": 19,
+      "intelligence": 3,
+      "wisdom": 14,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "perception": 8
+      },
+      "senses": {
+        "passive_perception": 18,
+        "darkvision": "60 ft.",
+        "t_speak_cr": "6",
+        "xp": "2",
+        "summary": "Darkvision 60 ft.; Languages Understands Draconic but can’t speak CR 6 (XP 2,300; PB +3)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The chimera makes one Ram attack, one Bite attack, and one Claw attack. It can replace the Claw attack with a use of Fire Breath if available."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage, or 18 (4d6 + 4) Piercing damage if the chimera had Advantage on the attack roll.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 7 (1d6 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 10 (1d12 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d12+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d12+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 15, each creature in a 15-foot Cone. Failure: 31 (7d8) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "7d8",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "7d8",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "chuul": {
+      "index": "chuul",
+      "name": "Chuul",
+      "size": "Large",
+      "type": "aberration",
+      "alignment": "Chaotic Evil",
+      "armor_class": 16,
+      "hit_points": 76,
+      "hit_dice": "9d10 + 27",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 10,
+      "constitution": 16,
+      "intelligence": 5,
+      "wisdom": 11,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "t_speak_cr": "4",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Understands Deep Speech but can’t speak CR 4 (XP 1,100; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The chuul can breathe air and water."
+        },
+        {
+          "name": "Sense Magic",
+          "desc": "The chuul senses magic within 120 feet of itself. This trait otherwise works like the Detect Magic spell but isn’t itself magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The chuul makes two Pincer attacks and uses Paralyzing Tentacles."
+        },
+        {
+          "name": "Pincer",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two pincers.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Paralyzing Tentacles",
+          "desc": "Constitution Saving Throw: DC 13, one creature Grappled by the chuul. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. While Poisoned, the target has the Paralyzed condition."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "clay-golem": {
+      "index": "clay-golem",
+      "name": "Clay Golem",
+      "size": "Large",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 123,
+      "hit_dice": "13d10 + 52",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 20,
+      "dexterity": 9,
+      "constitution": 18,
+      "intelligence": 3,
+      "wisdom": 8,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Acid",
+        "Poison",
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion"
+      ],
+      "special_abilities": [
+        {
+          "name": "Acid Absorption",
+          "desc": "Whenever the golem is subjected to Acid damage, it takes no damage and instead regains a number of Hit Points equal to the Acid damage dealt."
+        },
+        {
+          "name": "Berserk",
+          "desc": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it continues to be berserk until it is destroyed or it is no longer Bloodied."
+        },
+        {
+          "name": "Immutable Form",
+          "desc": "The golem can’t shape-shift."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The golem makes two Slam attacks, or it makes three Slam attacks if it used Hasten this turn."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 10 (1d10 + 5) Bludgeoning damage plus 6 (1d12) Acid damage, and the target’s Hit Point maximum decreases by an amount equal to the Acid damage taken.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "1d10+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d10+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Hasten (Recharge 5-6)",
+          "desc": "The golem takes the Dash and Disengage actions."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "cloaker": {
+      "index": "cloaker",
+      "name": "Cloaker",
+      "size": "Large",
+      "type": "aberration",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 14,
+      "hit_points": 91,
+      "hit_dice": "14d10 + 14",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 17,
+      "dexterity": 15,
+      "constitution": 12,
+      "intelligence": 13,
+      "wisdom": 14,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Deep Speech, Undercommon",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Frightened"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Light Sensitivity",
+          "desc": "While in Bright Light, the cloaker has Disadvantage on attack rolls."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The cloaker makes one Attach attack and two Tail attacks."
+        },
+        {
+          "name": "Attach",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (3d6 + 3) Piercing damage. If the target is a Large or smaller creature, the cloaker attaches to it. While the cloaker is attached, the target has the Blinded condition, and the cloaker can’t make Attach attacks against other tar- gets. In addition, the cloaker halves the damage it takes (round down), and the target takes the same amount of damage. The cloaker can detach itself by spending 5 feet of movement. The target or a creature within 5 feet of it can take an action to try to detach the cloaker, doing so by succeeding on a DC 14 Strength (Athletics) check.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tail",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Moan",
+          "desc": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Emanation originating from the cloaker. Failure: The target has the Frightened condition until the end of the cloaker’s next turn. Success: The target is immune to this cloaker’s Moan for the next 24 hours."
+        },
+        {
+          "name": "Phantasms (Recharge after a Short or Long Rest)",
+          "desc": "The cloaker casts the Mirror Image spell, requiring no spell components and using Wisdom as the spellcasting ability. The spell ends early if the cloaker starts or ends its turn in Bright Light."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "cloud-giant": {
+      "index": "cloud-giant",
+      "name": "Cloud Giant",
+      "size": "Huge",
+      "type": "giant",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 200,
+      "hit_dice": "16d12 + 96",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "20 ft. (hover)"
+      },
+      "strength": 27,
+      "dexterity": 10,
+      "constitution": 22,
+      "intelligence": 12,
+      "wisdom": 16,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 10
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "insight": 7,
+        "perception": 11
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The giant makes two attacks, using Thunderous Mace or Thundercloud in any combination. It can replace one attack with a use of Spellcasting to cast Fog Cloud."
+        },
+        {
+          "name": "Thunderous Mace",
+          "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 21 (3d8 + 8) Bludgeoning damage plus 7 (2d6) Thunder damage.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "3d8+8",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d8+8",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Thundercloud",
+          "desc": "Ranged Attack Roll: +12, range 240 ft. Hit: 18 (3d6 + 8) Thunder damage, and the target has the Incapacitated condition until the end of its next turn.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "3d6+8",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "3d6+8",
+          "damage_type": {
+            "name": "thunder"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The giant casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15): At Will: Detect Magic, Fog Cloud, Light 1/Day Each: Control Weather, Gaseous Form, Telekinesis"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Misty Step",
+          "desc": "The giant casts the Misty Step spell, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "cockatrice": {
+      "index": "cockatrice",
+      "name": "Cockatrice",
+      "size": "Small",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 22,
+      "hit_dice": "5d6 + 5",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 6,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 13,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Petrified"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Petrifying Bite",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 11. First Failure: The target has the Restrained condition. The target repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition, instead of the Restrained condition, for 24 hours.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d4+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "commoner": {
+      "index": "commoner",
+      "name": "Commoner",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 10,
+      "hit_points": 4,
+      "hit_dice": "1d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 10,
+      "constitution": 10,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "Common",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Training",
+          "desc": "The commoner has proficiency in one skill of the GM’s choice and has Advantage whenever it makes an ability check using that skill."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Club",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "copper-dragon-wyrmling": {
+      "index": "copper-dragon-wyrmling",
+      "name": "Copper Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 16,
+      "hit_points": 22,
+      "hit_dice": "4d8 + 4",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 15,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 14,
+      "wisdom": 11,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d10+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-footwide Line. Failure: 18 (4d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "4d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Slowing Breath",
+          "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "young-copper-dragon": {
+      "index": "young-copper-dragon",
+      "name": "Young Copper Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 17,
+      "hit_points": 119,
+      "hit_dice": "14d10 + 42",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 19,
+      "dexterity": 12,
+      "constitution": 17,
+      "intelligence": 16,
+      "wisdom": 13,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "deception": 5,
+        "perception": 7,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 17,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 7.0,
+      "xp": 2900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Slowing Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-footwide Line. Failure: 40 (9d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "9d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "9d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Slowing Breath",
+          "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "adult-copper-dragon": {
+      "index": "adult-copper-dragon",
+      "name": "Adult Copper Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 18,
+      "hit_points": 184,
+      "hit_dice": "16d12 + 80",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 23,
+      "dexterity": 12,
+      "constitution": 21,
+      "intelligence": 18,
+      "wisdom": 15,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "deception": 9,
+        "perception": 12,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 22,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 14.0,
+      "xp": 11500,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 4 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Acid damage.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "2d10+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 18, each creature in an 60-foot-long, 5-footwide Line. Failure: 54 (12d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "12d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Slowing Breath",
+          "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Magic, Mind Spike (level 4 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Greater Restoration, Major Image"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Giggling Magic",
+          "desc": "Charisma Saving Throw: DC 17, one creature the dragon can see within 90 feet. Failure: 24 (7d6) Psychic damage. Until the end of its next turn, the target rolls 1d6 whenever it makes an ability check or attack roll and subtracts the number rolled from the D20 Test. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "7d6",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "7d6",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Mind Jolt",
+          "desc": "The dragon uses Spellcasting to cast Mind Spike (level 4 version). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "ancient-copper-dragon": {
+      "index": "ancient-copper-dragon",
+      "name": "Ancient Copper Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Chaotic Good",
+      "armor_class": 21,
+      "hit_points": 367,
+      "hit_dice": "21d20 + 147",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 27,
+      "dexterity": 12,
+      "constitution": 25,
+      "intelligence": 20,
+      "wisdom": 17,
+      "charisma": 22,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "deception": 13,
+        "perception": 17,
+        "stealth": 8
+      },
+      "senses": {
+        "passive_perception": 27,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 21.0,
+      "xp": 33000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 5 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 9 (2d8) Acid damage.",
+          "attack_bonus": 15,
+          "damage": [
+            {
+              "damage_dice": "2d10+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 22, each creature in an 90-foot-long, 10-footwide Line. Failure: 63 (14d8) Acid damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "14d8",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "14d8",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Slowing Breath",
+          "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21): At Will: Detect Magic, Mind Spike (level 5 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Greater Restoration, Major Image, Project Image"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Giggling Magic",
+          "desc": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 31 (9d6) Psychic damage. Until the end of its next turn, the target rolls 1d8 whenever it makes an ability check or attack roll and subtracts the number rolled from the D20 Test. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "9d6",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "9d6",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Mind Jolt",
+          "desc": "The dragon uses Spellcasting to cast Mind Spike (level 5 version). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "couatl": {
+      "index": "couatl",
+      "name": "Couatl",
+      "size": "Medium",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 19,
+      "hit_points": 60,
+      "hit_dice": "8d8 + 24",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "90 ft."
+      },
+      "strength": 16,
+      "dexterity": 20,
+      "constitution": 17,
+      "intelligence": 18,
+      "wisdom": 20,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 15,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "All; telepathy 120 ft.",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Psychic",
+        "Radiant"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Shielded Mind",
+          "desc": "The couatl’s thoughts can’t be read by any means, and other creatures can communicate with it telepathically only if it allows them."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (1d12 + 5) Piercing damage, and the target has the Poisoned condition until the end of the couatl’s next turn.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d12+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d12+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Constrict",
+          "desc": "Strength Saving Throw: DC 15, one Medium or smaller creature the couatl can see within 5 feet. Failure: 8 (1d6 + 5) Bludgeoning damage. The target has the Grappled condition (escape DC 13), and it has the Restrained condition until the grapple ends.",
+          "damage": [
+            {
+              "damage_dice": "1d6+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The couatl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save DC 15): At Will: Detect Evil and Good, Detect Magic, Detect Thoughts, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Create Food and Water, Dream, Greater Restoration, Scrying, Sleep"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Divine Aid (2/Day)",
+          "desc": "The couatl casts Bless, Lesser Restoration, or Sanctuary, requiring no spell components and using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-crawling-claws": {
+      "index": "swarm-of-crawling-claws",
+      "name": "Swarm of Crawling Claws",
+      "size": "Medium",
+      "type": "swarm of tiny undead",
+      "alignment": "Neutral Evil",
+      "armor_class": 12,
+      "hit_points": 49,
+      "hit_dice": "11d8",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 14,
+      "constitution": 11,
+      "intelligence": 5,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "blindsight": "30 ft.",
+        "t_speak_cr": "3",
+        "xp": "700",
+        "summary": "Blindsight 30 ft.; Languages Understands Common but can’t speak CR 3 (XP 700; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened",
+        "Grappled",
+        "Incapacitated",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained",
+        "Stunned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny creature. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        }
+      ],
+      "actions": null,
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
     "cultist": {
       "index": "cultist",
       "name": "Cultist",
       "size": "Medium",
-      "type": "humanoid",
-      "subtype": "any race",
-      "alignment": "any non-good alignment",
-      "armor_class": [
-        { "type": "leather armor", "value": 12 }
-      ],
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 12,
       "hit_points": 9,
       "hit_dice": "2d8",
-      "speed": { "walk": "30 ft." },
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 11,
       "dexterity": 12,
       "constitution": 10,
       "intelligence": 10,
       "wisdom": 11,
       "charisma": 10,
-      "skills": { "deception": 2, "religion": 2 },
-      "senses": { "passive_perception": 10 },
-      "languages": "Common",
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "deception": 2,
+        "religion": 2
+      },
+      "senses": null,
+      "languages": "",
       "challenge_rating": 0.125,
       "xp": 25,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
       "actions": [
         {
-          "name": "Scimitar",
+          "name": "Ritual Sickle",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 1 Necrotic damage.",
           "attack_bonus": 3,
-          "damage_dice": "1d6+1",
-          "damage_type": { "name": "slashing" },
-          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+          "damage": [
+            {
+              "damage_dice": "1d4+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+1",
+          "damage_type": {
+            "name": "slashing"
+          }
         }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "cultist-fanatic": {
+      "index": "cultist-fanatic",
+      "name": "Cultist Fanatic",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 44,
+      "hit_dice": "8d8 + 8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 14,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "deception": 3,
+        "persuasion": 3,
+        "religion": 2
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Pact Blade",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 7 (2d6) Necrotic damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks): At Will: Light, Thaumaturgy 2/Day: Command 1/Day: Hold Person"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Spiritual Weapon (2/Day)",
+          "desc": "The cultist casts the Spiritual Weapon spell, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "darkmantle": {
+      "index": "darkmantle",
+      "name": "Darkmantle",
+      "size": "Small",
+      "type": "aberration",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 22,
+      "hit_dice": "5d6 + 5",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 10,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Crush",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage, and the darkmantle attaches to the target. If the target is a Medium or smaller creature and the darkmantle had Advantage on the attack roll, it covers the target, which has the Blinded condition and is suffocating while the darkmantle is attached in this way. While attached to a target, the darkmantle can attack only the target but has Advantage on its attack rolls. Its Speed becomes 0, it can’t benefit from any bonus to its Speed, and it moves with the target. A creature can take an action to try to detach the darkmantle from itself, doing so with a successful DC 13 Strength (Athletics) check. On its turn, the darkmantle can detach itself by using 5 feet of movement.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Darkness Aura (1/Day)",
+          "desc": "Magical Darkness fills a 15-foot Emanation originating from the darkmantle. This effect lasts while the darkmantle maintains Concentration on it, up to 10 minutes. Darkvision can’t penetrate this area, and no light can illuminate it."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "death-dog": {
+      "index": "death-dog",
+      "name": "Death Dog",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Neutral Evil",
+      "armor_class": 12,
+      "hit_points": 39,
+      "hit_dice": "6d8 + 12",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 15,
+      "dexterity": 14,
+      "constitution": 14,
+      "intelligence": 3,
+      "wisdom": 13,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Frightened",
+        "Stunned",
+        "Unconscious"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The death dog makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 12. First Failure: The target has the Poisoned condition. While Poisoned, the target’s Hit Point max- imum doesn’t return to normal when finishing a Long Rest, and it repeats the save every 24 hours that elapse, ending the effect on itself on a success. Subsequent Failures: The Poisoned target’s Hit Point maximum decreases by 5 (1d10).",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "deva": {
+      "index": "deva",
+      "name": "Deva",
+      "size": "Medium",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 17,
+      "hit_points": 229,
+      "hit_dice": "27d8 + 108",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "90 ft. (hover)"
+      },
+      "strength": 18,
+      "dexterity": 18,
+      "constitution": 18,
+      "intelligence": 17,
+      "wisdom": 20,
+      "charisma": 20,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 9
+        },
+        {
+          "name": "CHA",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "insight": 9,
+        "perception": 9
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 10.0,
+      "xp": 5900,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Radiant"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened Senses Darkvision 120 ft."
+      ],
+      "condition_immunities": [
+        "Passive Perception 19 Languages All"
       ],
       "special_abilities": [
         {
-          "name": "Dark Devotion",
-          "desc": "The cultist has advantage on saving throws against being charmed or frightened."
+          "name": "Exalted Restoration",
+          "desc": "If the deva dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The deva has Advantage on saving throws against spells and other magical effects."
         }
-      ]
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The deva makes two Holy Mace attacks."
+        },
+        {
+          "name": "Holy Mace",
+          "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 18 (4d8) Radiant damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The deva casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Evil and Good, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Commune, Raise Dead"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Divine Aid (2/Day)",
+          "desc": "The deva casts Cure Wounds, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "angel"
+    },
+    "djinni": {
+      "index": "djinni",
+      "name": "Djinni",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 218,
+      "hit_dice": "19d10 + 114",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "90 ft. (hover)"
+      },
+      "strength": 21,
+      "dexterity": 15,
+      "constitution": 22,
+      "intelligence": 15,
+      "wisdom": 16,
+      "charisma": 20,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Primordial (Auran)",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning",
+        "Thunder"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Elemental Restoration",
+          "desc": "If the djinni dies outside the Elemental Plane of Air, its body dissolves into mist, and it gains a new body in 1d4 days, reviving with all its Hit Points somewhere on the Plane of Air."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The djinni has Advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Wishes",
+          "desc": "The djinni has a 30 percent chance of knowing the Wish spell. If the djinni knows it, the djinni can cast it only on behalf of a non-genie creature who communicates a wish in a way the djinni can understand. If the djinni casts the spell for the creature, the djinni suffers none of the spell’s stress. Once the djinni has cast it three times, the djinni can’t do so again for 365 days."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The djinni makes three attacks, using Storm Blade or Storm Bolt in any combination."
+        },
+        {
+          "name": "Storm Blade",
+          "desc": "Melee Attack Roll: +9, reach 5 feet. Hit: 12 (2d6 + 5) Slashing damage plus 7 (2d6) Lightning damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d6+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Storm Bolt",
+          "desc": "Ranged Attack Roll: +9, range 120 feet. Hit: 13 (3d8) Thunder damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "3d8",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "3d8",
+          "damage_type": {
+            "name": "thunder"
+          }
+        },
+        {
+          "name": "Create Whirlwind",
+          "desc": "The djinni conjures a whirlwind at a point it can see within 120 feet. The whirlwind fills a 20-foot-radius, 60-foot-high Cylinder centered on that point. The whirlwind lasts until the djinni’s Concentration on it ends. The djinni can move the whirlwind up to 20 feet at the start of each of its turns. Whenever the whirlwind enters a creature’s space or a creature enters the whirlwind, that creature is subjected to the following effect. Strength Saving Throw: DC 17 (a creature makes this save only once per turn, and the djinni is unaffected). Failure: While in the whirlwind, the target has the Restrained condition and moves with the whirlwind. At the start of each of its turns, the Restrained target takes 21 (6d6) Thunder damage. At the end of each of its turns, the target repeats the save, ending the effect on itself on a success.",
+          "damage": [
+            {
+              "damage_dice": "6d6",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "6d6",
+          "damage_type": {
+            "name": "thunder"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The djinni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Evil and Good, Detect Magic 2/Day Each: Create Food and Water (can create wine instead of water), Tongues, Wind Walk 1/Day Each: Creation, Gaseous Form, Invisibility, Major Image, Plane Shift"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "genie"
+    },
+    "doppelganger": {
+      "index": "doppelganger",
+      "name": "Doppelganger",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 52,
+      "hit_dice": "8d8 + 16",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 18,
+      "constitution": 14,
+      "intelligence": 11,
+      "wisdom": 12,
+      "charisma": 14,
+      "saving_throws": [],
+      "skills": {
+        "deception": 6,
+        "insight": 3
+      },
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "languages_common_plus_three_other_languages_cr": "3",
+        "xp": "700",
+        "summary": "Darkvision 60 ft.; Languages Common plus three other languages CR 3 (XP 700; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Charmed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The doppelganger makes two Slam attacks and uses Unsettling Visage if available."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +6 (with Advantage during the first round of each combat), reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Read Thoughts",
+          "desc": "The doppelganger casts Detect Thoughts, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 12)."
+        },
+        {
+          "name": "Unsettling Visage (Recharge 6)",
+          "desc": "Wisdom Saving Throw: DC 12, each creature in a 15-foot Emanation originating from the doppelganger that can see the doppelganger. Failure: The target has the Frightened condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The doppelganger shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "dragon-turtle": {
+      "index": "dragon-turtle",
+      "name": "Dragon Turtle",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Neutral",
+      "armor_class": 20,
+      "hit_points": 356,
+      "hit_dice": "23d20 + 115",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "50 ft."
+      },
+      "strength": 25,
+      "dexterity": 10,
+      "constitution": 20,
+      "intelligence": 10,
+      "wisdom": 12,
+      "charisma": 12,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 11
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Draconic, Primordial (Aquan)",
+      "challenge_rating": 17.0,
+      "xp": 18000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Fire"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Bite attacks. It can replace one attack with a Tail attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +13, reach 15 ft. Hit: 23 (3d10 + 7) Piercing damage plus 7 (2d6) Fire damage. Being underwater doesn’t grant Resistance to this Fire damage.",
+          "attack_bonus": 13,
+          "damage": [
+            {
+              "damage_dice": "3d10+7",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d10+7",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tail",
+          "desc": "Melee Attack Roll: +13, reach 15 ft. Hit: 18 (2d10 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+          "attack_bonus": 13,
+          "damage": [
+            {
+              "damage_dice": "2d10+7",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+7",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Steam Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage. Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage.",
+          "damage": [
+            {
+              "damage_dice": "16d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "16d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "dretch": {
+      "index": "dretch",
+      "name": "Dretch",
+      "size": "Small",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 11,
+      "hit_points": 18,
+      "hit_dice": "4d6 + 4",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 12,
+      "dexterity": 11,
+      "constitution": 12,
+      "intelligence": 5,
+      "wisdom": 8,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Abyssal; telepathy 60 ft. (works only with creatures that understand Abyssal)",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fetid Cloud (1/Day)",
+          "desc": "Constitution Saving Throw: DC 11, each creature in a 10-foot Emanation originating from the dretch. Failure: The target has the Poisoned condition until the end of its next turn. While Poisoned, the creature can take either an action or a Bonus Action on its turn, not both, and it can’t take Reactions."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "drider": {
+      "index": "drider",
+      "name": "Drider",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 19,
+      "hit_points": 123,
+      "hit_dice": "13d10 + 52",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 19,
+      "constitution": 18,
+      "intelligence": 13,
+      "wisdom": 16,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6,
+        "stealth": 10
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Elvish, Undercommon",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The drider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "desc": "While in sunlight, the drider has Disadvantage on ability checks and attack rolls."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The drider ignores movement restrictions caused by webs, and the drider knows the location of any other creature in contact with the same web."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The drider makes three attacks, using Foreleg or Poison Burst in any combination."
+        },
+        {
+          "name": "Foreleg",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Poison Burst",
+          "desc": "Ranged Attack Roll: +6, range 120 ft. Hit: 13 (3d6 + 3) Poison damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d6+3",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "3d6+3",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "druid": {
+      "index": "druid",
+      "name": "Druid",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 44,
+      "hit_dice": "8d8 + 8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 12,
+      "wisdom": 16,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "medicine": 5,
+        "nature": 3,
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "sylvan_cr": "2",
+        "xp": "450",
+        "summary": "Languages Common, Druidic, Sylvan CR 2 (XP 450; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The druid makes two attacks, using Vine Staff or Verdant Wisp in any combination."
+        },
+        {
+          "name": "Vine Staff",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 2 (1d4) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Verdant Wisp",
+          "desc": "Ranged Attack Roll: +5, range 90 ft. Hit: 10 (3d6) Radiant damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "radiant"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The druid casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13): At Will: Druidcraft, Speak with Animals 2/Day Each: Entangle, Thunderwave 1/Day Each: Animal Messenger, Long- strider, Moonbeam"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "druid"
+    },
+    "dryad": {
+      "index": "dryad",
+      "name": "Dryad",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Neutral",
+      "armor_class": 16,
+      "hit_points": 22,
+      "hit_dice": "5d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 12,
+      "constitution": 11,
+      "intelligence": 14,
+      "wisdom": 15,
+      "charisma": 18,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Elvish, Sylvan",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The dryad has Advantage on saving throws against spells and other magical effects. Speak with Beasts and Plants. The dryad can communicate with Beasts and Plants as if they shared a language."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dryad makes one Vine Lash or Thorn Burst attack, and it can use Spellcasting to cast Charm Monster."
+        },
+        {
+          "name": "Vine Lash",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d8 + 4) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d8+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Thorn Burst",
+          "desc": "Ranged Attack Roll: +6, range 60 ft. Hit: 7 (1d6 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dryad casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14): At Will: Animal Friendship, Charm Monster (lasts 24 hours; ends early if the dryad casts the spell again), Druidcraft 1/Day Each: Entangle, Pass without Trace"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Tree Stride",
+          "desc": "If within 5 feet of a Large or bigger tree, the dryad teleports to an unoccupied space within 5 feet of a second Large or bigger tree that is within 60 feet of the previous tree."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "earth-elemental": {
+      "index": "earth-elemental",
+      "name": "Earth Elemental",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 147,
+      "hit_dice": "14d10 + 70",
+      "speed": {
+        "walk": "30 ft.",
+        "burrow": "30 ft."
+      },
+      "strength": 20,
+      "dexterity": 8,
+      "constitution": 20,
+      "intelligence": 5,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "tremorsense": "60 ft.",
+        "summary": "Darkvision 60 ft., Tremorsense 60 ft."
+      },
+      "languages": "Primordial (Terran)",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": [
+        "Thunder"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Paralyzed",
+        "Petrified"
+      ],
+      "special_abilities": [
+        {
+          "name": "Earth Glide",
+          "desc": "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn’t disturb the material it moves through."
+        },
+        {
+          "name": "Siege Monster",
+          "desc": "The elemental deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The elemental makes two attacks, using Slam or Rock Launch in any combination."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Bludgeoning damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Rock Launch",
+          "desc": "Ranged Attack Roll: +8, range 60 ft. Hit: 8 (1d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "1d6+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "efreeti": {
+      "index": "efreeti",
+      "name": "Efreeti",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 212,
+      "hit_dice": "17d10 + 119",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "60 ft. (hover)"
+      },
+      "strength": 22,
+      "dexterity": 12,
+      "constitution": 24,
+      "intelligence": 16,
+      "wisdom": 15,
+      "charisma": 19,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 6
+        },
+        {
+          "name": "CHA",
+          "value": 8
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Primordial (Ignan)",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Elemental Restoration",
+          "desc": "If the efreeti dies outside the Elemental Plane of Fire, its body dissolves into ash, and it gains a new body in 1d4 days, reviving with all its Hit Points somewhere on the Plane of Fire."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The efreeti has Advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Wishes",
+          "desc": "The efreeti has a 30 percent chance of knowing the Wish spell. If the efreeti knows it, the efreeti can cast it only on behalf of a non-genie creature who communicates a wish in a way the efreeti can understand. If the efreeti casts the spell for the creature, the efreeti suffers none of the spell’s stress. Once the efreeti has cast it three times, the efreeti can’t do so again for 365 days."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The efreeti makes three attacks, using Heated Blade or Hurl Flame in any combination."
+        },
+        {
+          "name": "Heated Blade",
+          "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 13 (2d6 + 6) Slashing damage plus 13 (2d12) Fire damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d6+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Hurl Flame",
+          "desc": "Ranged Attack Roll: +8, range 120 ft. Hit: 24 (7d6) Fire damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "7d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "7d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The efreeti casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16): At Will: Detect Magic, Elementalism 1/Day Each: Gaseous Form, Invisibility, Major Image, Plane Shift, Tongues, Wall of Fire (level 7 version)"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "genie"
+    },
+    "erinyes": {
+      "index": "erinyes",
+      "name": "Erinyes",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 178,
+      "hit_dice": "21d8 + 84",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 18,
+      "dexterity": 16,
+      "constitution": 18,
+      "intelligence": 14,
+      "wisdom": 14,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "CON",
+          "value": 8
+        },
+        {
+          "name": "CHA",
+          "value": 8
+        }
+      ],
+      "skills": {
+        "perception": 6,
+        "persuasion": 8
+      },
+      "senses": {
+        "passive_perception": 16,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 12.0,
+      "xp": 8400,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the erinyes dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The erinyes has Advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Rope",
+          "desc": "The erinyes has a magic rope. While bearing it, the erinyes can use the Entangling Rope action. The rope has AC 20, HP 90, and Immunity to Poison and Psychic damage. The rope turns to dust if reduced to 0 Hit Points, if it is 5+ feet away from the erinyes for 1 hour or more, or if the erinyes dies. If the rope is damaged or destroyed, the erinyes can fully restore it when finishing a Short or Long Rest."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The erinyes makes three Withering Sword attacks and can use Entangling Rope."
+        },
+        {
+          "name": "Withering Sword",
+          "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage plus 11 (2d10) Necrotic damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Entangling Rope (Requires Magic Rope)",
+          "desc": "Strength Saving Throw: DC 16, one creature the erinyes can see within 120 feet. Failure: 14 (4d6) Force damage, and the target has the Restrained condition until the rope is destroyed, the erinyes uses a Bonus Action to release the target, or the erinyes uses Entangling Rope again.",
+          "damage": [
+            {
+              "damage_dice": "4d6",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "4d6",
+          "damage_type": {
+            "name": "force"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The erinyes is hit by a melee attack roll while holding a weapon. Response: The erinyes adds 4 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "ettercap": {
+      "index": "ettercap",
+      "name": "Ettercap",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Neutral Evil",
+      "armor_class": 13,
+      "hit_points": 44,
+      "hit_dice": "8d8 + 8",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 15,
+      "constitution": 13,
+      "intelligence": 7,
+      "wisdom": 12,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 4,
+        "survival": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The ettercap can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The ettercap ignores movement restrictions caused by webs, and the ettercap knows the location of any other creature in contact with the same web."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The ettercap makes one Bite attack and one Claw attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 2 (1d4) Poison damage, and the target has the Poisoned condition until the start of the ettercap’s next turn.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d4+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Web Strand (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 12, one Large or smaller creature the ettercap can see within 30 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Bludgeoning, Poison, and Psychic damage)."
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Reel",
+          "desc": "The ettercap pulls one creature within 30 feet of itself that is Restrained by its Web Strand up to 25 feet straight toward itself."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ettin": {
+      "index": "ettin",
+      "name": "Ettin",
+      "size": "Large",
+      "type": "giant",
+      "alignment": "Chaotic Evil",
+      "armor_class": 12,
+      "hit_points": 85,
+      "hit_dice": "10d10 + 30",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 21,
+      "dexterity": 8,
+      "constitution": 17,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Giant",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Frightened",
+        "Stunned",
+        "Unconscious"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The ettin makes one Battleaxe attack and one Morningstar attack."
+        },
+        {
+          "name": "Battleaxe",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Morningstar",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage, and the target has Disadvantage on the next attack roll it makes before the end of its next turn.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "fire-elemental": {
+      "index": "fire-elemental",
+      "name": "Fire Elemental",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 93,
+      "hit_dice": "11d10 + 33",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 10,
+      "dexterity": 17,
+      "constitution": 16,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "special_abilities": [
+        {
+          "name": "Fire Aura",
+          "desc": "At the end of each of the elemental’s turns, each creature in a 10-foot Emanation originating from the elemental takes 5 (1d10) Fire damage. Creatures and flammable objects in the Emanation start burning."
+        },
+        {
+          "name": "Fire Form",
+          "desc": "The elemental can move through a space as narrow as 1 inch without expending extra movement to do so, and it can enter a creature’s space and stop there. The first time it enters a creature’s space on a turn, that creature takes 5 (1d10) Fire damage."
+        },
+        {
+          "name": "Illumination",
+          "desc": "The elemental sheds Bright Light in a 30foot radius and Dim Light for an additional 30 feet."
+        },
+        {
+          "name": "Water Susceptibility",
+          "desc": "The elemental takes 3 (1d6) Cold damage for every 5 feet the elemental moves in water or for every gallon of water splashed on it."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The elemental makes two Burn attacks."
+        },
+        {
+          "name": "Burn",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Fire damage. If the target is a creature or a flammable object, it starts burning.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "fire-giant": {
+      "index": "fire-giant",
+      "name": "Fire Giant",
+      "size": "Huge",
+      "type": "giant",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 162,
+      "hit_dice": "13d12 + 78",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 25,
+      "dexterity": 9,
+      "constitution": 23,
+      "intelligence": 10,
+      "wisdom": 14,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "CON",
+          "value": 10
+        },
+        {
+          "name": "CHA",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "athletics": 11,
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16
+      },
+      "languages": "Giant",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The giant makes two attacks, using Flame Sword or Hammer Throw in any combination."
+        },
+        {
+          "name": "Flame Sword",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 21 (4d6 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "4d6+7",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+7",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Hammer Throw",
+          "desc": "Ranged Attack Roll: +11, range 60/240 ft. Hit: 23 (3d10 + 7) Bludgeoning damage plus 4 (1d8) Fire damage, and the target is pushed up to 15 feet straight away from the giant and has Disadvantage on the next attack roll it makes before the end of its next turn.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "3d10+7",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d10+7",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "flesh-golem": {
+      "index": "flesh-golem",
+      "name": "Flesh Golem",
+      "size": "Medium",
+      "type": "construct",
+      "alignment": "Neutral",
+      "armor_class": 9,
+      "hit_points": 127,
+      "hit_dice": "15d8 + 60",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 9,
+      "constitution": 18,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Understands Common plus one other language but can’t speak",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion"
+      ],
+      "special_abilities": [
+        {
+          "name": "Berserk",
+          "desc": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it remains so until it is destroyed or it is no longer Bloodied. The golem’s creator, if within 60 feet of the berserk golem, can try to calm it by taking an action to make a DC 15 Charisma (Persuasion) check; the golem must be able to hear its creator. If this check succeeds, the golem ceases being berserk until the start of its next turn, at which point it resumes rolling for the Berserk trait again if it is still Bloodied."
+        },
+        {
+          "name": "Immutable Form",
+          "desc": "The golem can’t shape-shift."
+        },
+        {
+          "name": "Lightning Absorption",
+          "desc": "Whenever the golem is subjected to Lightning damage, it regains a number of Hit Points equal to the Lightning damage dealt."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The golem makes two Slam attacks."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 4 (1d8) Lightning damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "frost-giant": {
+      "index": "frost-giant",
+      "name": "Frost Giant",
+      "size": "Huge",
+      "type": "giant",
+      "alignment": "Neutral Evil",
+      "armor_class": 15,
+      "hit_points": 149,
+      "hit_dice": "13d12 + 65",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 23,
+      "dexterity": 9,
+      "constitution": 21,
+      "intelligence": 9,
+      "wisdom": 10,
+      "charisma": 12,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 3
+        },
+        {
+          "name": "CHA",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "athletics": 9,
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13
+      },
+      "languages": "Giant",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The giant makes two attacks, using Frost Axe or Great Bow in any combination."
+        },
+        {
+          "name": "Frost Axe",
+          "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 19 (2d12 + 6) Slashing damage plus 9 (2d8) Cold damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d12+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Great Bow",
+          "desc": "Ranged Attack Roll: +9, range 150/600 ft. Hit: 17 (2d10 + 6) Piercing damage plus 7 (2d6) Cold damage, and the target’s Speed decreases by 10 feet until the end of its next turn.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d10+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "War Cry (Recharge 5-6)",
+          "desc": "The giant or one creature of its choice that can see or hear it gains 16 (2d10 + 5) Temporary Hit Points and has Advantage on attack rolls until the start of the giant’s next turn."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "shrieker-fungus": {
+      "index": "shrieker-fungus",
+      "name": "Shrieker Fungus",
+      "size": "Medium",
+      "type": "plant",
+      "alignment": "Unaligned",
+      "armor_class": 5,
+      "hit_points": 13,
+      "hit_dice": "3d8",
+      "speed": {
+        "walk": "5 ft."
+      },
+      "strength": 1,
+      "dexterity": 1,
+      "constitution": 10,
+      "intelligence": 1,
+      "wisdom": 3,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 0,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Frightened Senses Blindsight 30 ft."
+      ],
+      "condition_immunities": [
+        "Passive Perception 6 Languages None"
+      ],
+      "special_abilities": null,
+      "actions": null,
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Shriek",
+          "desc": "Trigger: A creature or a source of Bright Light moves within 30 feet of the shrieker. Response: The shrieker emits a shriek audible within 300 feet of itself for 1 minute or until the shrieker dies."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "violet-fungus": {
+      "index": "violet-fungus",
+      "name": "Violet Fungus",
+      "size": "Medium",
+      "type": "plant",
+      "alignment": "Unaligned",
+      "armor_class": 5,
+      "hit_points": 18,
+      "hit_dice": "4d8",
+      "speed": {
+        "walk": "5 ft."
+      },
+      "strength": 3,
+      "dexterity": 1,
+      "constitution": 10,
+      "intelligence": 1,
+      "wisdom": 3,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Frightened Senses Blindsight 30 ft."
+      ],
+      "condition_immunities": [
+        "Passive Perception 6 Languages None"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The fungus makes two Rotting Touch attacks."
+        },
+        {
+          "name": "Rotting Touch",
+          "desc": "Melee Attack Roll: +2, reach 10 ft. Hit: 4 (1d8) Necrotic damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d8",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "1d8",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "gargoyle": {
+      "index": "gargoyle",
+      "name": "Gargoyle",
+      "size": "Medium",
+      "type": "elemental",
+      "alignment": "Chaotic Evil",
+      "armor_class": 15,
+      "hit_points": 67,
+      "hit_dice": "9d8 + 27",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 15,
+      "dexterity": 11,
+      "constitution": 16,
+      "intelligence": 6,
+      "wisdom": 11,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 4
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Petrified",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The gargoyle doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The gargoyle makes two Claw attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d4+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "gelatinous-cube": {
+      "index": "gelatinous-cube",
+      "name": "Gelatinous Cube",
+      "size": "Large",
+      "type": "ooze",
+      "alignment": "Unaligned",
+      "armor_class": 6,
+      "hit_points": 63,
+      "hit_dice": "6d10 + 30",
+      "speed": {
+        "walk": "15 ft."
+      },
+      "strength": 14,
+      "dexterity": 3,
+      "constitution": 20,
+      "intelligence": 1,
+      "wisdom": 6,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Exhaustion",
+        "Frightened",
+        "Prone"
+      ],
+      "special_abilities": [
+        {
+          "name": "Ooze Cube",
+          "desc": "The cube fills its entire space and is transparent. Other creatures can enter that space, but a creature that does so is subjected to the cube’s Engulf and has Disadvantage on the saving throw. Creatures inside the cube have Total Cover, and the cube can hold one Large creature or up to four Medium or Small creatures inside itself at a time. As an action, a creature within 5 feet of the cube can pull a creature or an object out of the cube by succeeding on a DC 12 Strength (Athletics) check, and the puller takes 10 (3d6) Acid damage."
+        },
+        {
+          "name": "Transparent",
+          "desc": "Even when the cube is in plain sight, a creature must succeed on a DC 15 Wisdom (Perception) check to notice the cube if the creature hasn’t witnessed the cube move or otherwise act."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "3d6+2",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "3d6+2",
+          "damage_type": {
+            "name": "acid"
+          }
+        },
+        {
+          "name": "Engulf",
+          "desc": "The cube moves up to its Speed without provoking Opportunity Attacks. The cube can move through the spaces of Large or smaller creatures if it has room inside itself to contain them (see the Ooze Cube trait). Dexterity Saving Throw: DC 12, each creature whose space the cube enters for the first time during this move. Failure: 10 (3d6) Acid damage, and the target is engulfed. An engulfed target is suffocating, can’t cast spells with a Verbal component, has the Restrained condition, and takes 10 (3d6) Acid damage at the start of each of the cube’s turns. When the cube moves, the engulfed target moves with it. An engulfed target can try to escape by taking an action to make a DC 12 Strength (Athletics) check. On a successful check, the target escapes and enters the nearest unoccupied space. Success: Half damage, and the target moves to an unoccupied space within 5 feet of the cube. If there is no unoccupied space, the target fails the save instead.",
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ghast": {
+      "index": "ghast",
+      "name": "Ghast",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "Chaotic Evil",
+      "armor_class": 13,
+      "hit_points": 36,
+      "hit_dice": "8d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 17,
+      "constitution": 10,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 8,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Stench",
+          "desc": "Constitution Saving Throw: DC 10, any creature that starts its turn in a 5-foot Emanation originating from the ghast. Failure: The target has the Poisoned condition until the start of its next turn. Success: The target is immune to this ghast’s Stench for 24 hours."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 9 (2d8) Necrotic damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a non-Undead creature, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ghost": {
+      "index": "ghost",
+      "name": "Ghost",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "Neutral",
+      "armor_class": 11,
+      "hit_points": 45,
+      "hit_dice": "10d8",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "40 ft. (hover)"
+      },
+      "strength": 7,
+      "dexterity": 13,
+      "constitution": 10,
+      "intelligence": 10,
+      "wisdom": 12,
+      "charisma": 17,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "languages_common_plus_one_other_language_cr": "4",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Common plus one other language CR 4 (XP 1,100; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Bludgeoning",
+        "Cold",
+        "Fire",
+        "Lightning",
+        "Piercing",
+        "Slashing",
+        "Thunder"
+      ],
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened",
+        "Grappled",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained"
+      ],
+      "special_abilities": [
+        {
+          "name": "Ethereal Sight",
+          "desc": "The ghost can see 60 feet into the Ethereal Plane when it is on the Material Plane."
+        },
+        {
+          "name": "Incorporeal Movement",
+          "desc": "The ghost can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The ghost makes two Withering Touch attacks."
+        },
+        {
+          "name": "Withering Touch",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 19 (3d10 + 3) Necrotic damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "3d10+3",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "3d10+3",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        },
+        {
+          "name": "Etherealness",
+          "desc": "The ghost casts the Etherealness spell, requiring no spell components and using Charisma as the spellcasting ability. The ghost is visible on the Material Plane while on the Border Ethereal and vice versa, but it can’t affect or be affected by anything on the other plane."
+        },
+        {
+          "name": "Horrific Visage",
+          "desc": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Cone that can see the ghost and isn’t an Undead. Failure: 10 (2d6 + 3) Psychic damage, and the target has the Frightened condition until the start of the ghost’s next turn. Success: The target is immune to this ghost’s Horrific Visage for 24 hours.",
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Possession (Recharge 6)",
+          "desc": "Charisma Saving Throw: DC 13, one Humanoid the ghost can see within 5 feet. Failure: The target is possessed by the ghost; the ghost disappears, and the target has the Incapacitated condition and loses control of its body. The ghost now controls the body, but the target retains awareness. The ghost can’t be targeted by any attack, spell, or other effect, except ones that specifically target Undead. The ghost’s game statistics are the same, except it uses the possessed target’s Speed, as well as the target’s Strength, Dexterity, and Constitution modifiers. The possession lasts until the body drops to 0 Hit Points or the ghost leaves as a Bonus Action. When the possession ends, the ghost appears in an unoccupied space within 5 feet of the target, and the target is immune to this ghost’s Possession for 24 hours. Success: The target is immune to this ghost’s Possession for 24 hours."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
     "ghoul": {
       "index": "ghoul",
       "name": "Ghoul",
       "size": "Medium",
       "type": "undead",
-      "alignment": "chaotic evil",
+      "alignment": "Chaotic Evil",
       "armor_class": 12,
       "hit_points": 22,
       "hit_dice": "5d8",
-      "speed": { "walk": "30 ft." },
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 13,
       "dexterity": 15,
       "constitution": 10,
       "intelligence": 7,
       "wisdom": 10,
       "charisma": 6,
-      "damage_resistances": [],
-      "damage_immunities": [],
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
       "condition_immunities": [
-        { "name": "charmed" },
-        { "name": "exhaustion" },
-        { "name": "poisoned" }
+        "Charmed",
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
       ],
-      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
-      "languages": "Common",
-      "challenge_rating": 1,
-      "xp": 200,
-      "proficiency_bonus": 2,
-      "special_abilities": [
-        {
-          "name": "Keen Smell",
-          "desc": "The ghoul has advantage on Wisdom (Perception) checks that rely on smell."
-        },
-        {
-          "name": "Turning Defiance",
-          "desc": "The ghoul and any ghouls within 30 feet of it have advantage on saving throws against effects that turn undead."
-        }
-      ],
+      "special_abilities": null,
       "actions": [
         {
-          "name": "Bite",
-          "attack_bonus": 2,
-          "damage_dice": "2d6+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) piercing damage."
+          "name": "Multiattack",
+          "desc": "The ghoul makes two Bite attacks."
         },
         {
-          "name": "Claws",
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 3 (1d6) Necrotic damage.",
           "attack_bonus": 4,
-          "damage_dice": "2d4+2",
-          "damage_type": { "name": "slashing" },
-          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage, and if the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute."
-        }
-      ]
-    },
-    "giant-spider": {
-      "index": "giant-spider",
-      "name": "Giant Spider",
-      "size": "Large",
-      "type": "beast",
-      "alignment": "unaligned",
-      "armor_class": 14,
-      "hit_points": 26,
-      "hit_dice": "4d10",
-      "speed": { "walk": "30 ft.", "climb": "30 ft." },
-      "strength": 14,
-      "dexterity": 16,
-      "constitution": 12,
-      "intelligence": 2,
-      "wisdom": 11,
-      "charisma": 4,
-      "skills": { "stealth": 7 },
-      "senses": { "blindsight": "10 ft.", "darkvision": "60 ft.", "passive_perception": 10 },
-      "languages": "--",
-      "challenge_rating": 1,
-      "xp": 200,
-      "proficiency_bonus": 2,
-      "special_abilities": [
-        {
-          "name": "Spider Climb",
-          "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
         },
         {
-          "name": "Web Sense",
-          "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
-        },
-        {
-          "name": "Web Walker",
-          "desc": "The spider ignores movement restrictions caused by webbing."
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage. If the target is a creature that isn’t an Undead or elf, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "slashing"
+          }
         }
       ],
-      "actions": [
-        {
-          "name": "Bite",
-          "attack_bonus": 5,
-          "damage_dice": "1d8+3",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 7 (1d8 + 3) piercing damage plus 7 (2d6) poison damage, or half as much on a successful DC 11 Constitution saving throw."
-        },
-        {
-          "name": "Web (Recharge 5-6)",
-          "desc": "Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing. As an action, the restrained target can make a DC 12 Strength check to burst the webbing."
-        }
-      ]
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
-    "giant-wolf-spider": {
-      "index": "giant-wolf-spider",
-      "name": "Giant Wolf Spider",
+    "gibbering-mouther": {
+      "index": "gibbering-mouther",
+      "name": "Gibbering Mouther",
       "size": "Medium",
-      "type": "beast",
-      "alignment": "unaligned",
-      "armor_class": 13,
-      "hit_points": 11,
-      "hit_dice": "2d8",
-      "speed": { "walk": "40 ft.", "climb": "40 ft." },
-      "strength": 12,
-      "dexterity": 16,
-      "constitution": 13,
+      "type": "aberration",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 9,
+      "hit_points": 52,
+      "hit_dice": "7d8 + 21",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "20 ft."
+      },
+      "strength": 10,
+      "dexterity": 8,
+      "constitution": 16,
       "intelligence": 3,
-      "wisdom": 12,
-      "charisma": 4,
-      "skills": { "perception": 3, "stealth": 7 },
-      "senses": { "blindsight": "10 ft.", "darkvision": "60 ft.", "passive_perception": 13 },
-      "languages": "--",
-      "challenge_rating": 0.25,
-      "xp": 50,
+      "wisdom": 10,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Prone"
+      ],
+      "condition_immunities": null,
       "special_abilities": [
         {
-          "name": "Spider Climb",
-          "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+          "name": "Aberrant Ground",
+          "desc": "The ground in a 10-foot Emanation originating from the mouther is Difficult Terrain."
         },
         {
-          "name": "Web Sense",
-          "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
-        },
-        {
-          "name": "Web Walker",
-          "desc": "The spider ignores movement restrictions caused by webbing."
+          "name": "Gibbering",
+          "desc": "The mouther babbles incoherently while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 10, any creature that starts its turn within 20 feet of the mouther while it is babbling. Failure: The target rolls 1d8 to determine what it does during the current turn: 1-4. The target does nothing. 5-6. The target takes no action or Bonus Action and uses all its movement to move in a random direction. 7-8. The target makes a melee attack against a randomly determined creature within its reach or does nothing if it can’t make such an attack."
         }
       ],
       "actions": [
         {
           "name": "Bite",
-          "attack_bonus": 5,
-          "damage_dice": "1d6+3",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d6 + 3) piercing damage plus 7 (2d6) poison damage, or half as much on a successful DC 11 Constitution saving throw."
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 7 (2d6) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition. The target dies if it is reduced to 0 Hit Points by this attack. Its body is then absorbed into the mouther, leaving only equipment behind.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Blinding Spittle (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 10, each creature in a 10-foot-radius Sphere centered on a point within 30 feet. Failure: 7 (2d6) Radiant damage, and the target has the Blinded condition until the end of the mouther’s next turn.",
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "radiant"
+          }
         }
-      ]
-    },
-    "goblin": {
-      "index": "goblin",
-      "name": "Goblin",
-      "size": "Small",
-      "type": "humanoid",
-      "subtype": "goblinoid",
-      "alignment": "neutral evil",
-      "armor_class": [
-        { "type": "leather armor", "value": 15 }
       ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "glabrezu": {
+      "index": "glabrezu",
+      "name": "Glabrezu",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 17,
+      "hit_points": 189,
+      "hit_dice": "18d10 + 90",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 20,
+      "dexterity": 15,
+      "constitution": 21,
+      "intelligence": 19,
+      "wisdom": 17,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 9
+        },
+        {
+          "name": "CON",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        },
+        {
+          "name": "CHA",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "deception": 7,
+        "perception": 7
+      },
+      "senses": {
+        "passive_perception": 17,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "Abyssal; telepathy 120 ft.",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Demonic Restoration",
+          "desc": "If the glabrezu dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The glabrezu has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The glabrezu makes two Pincer attacks and uses Pummel or Spellcasting."
+        },
+        {
+          "name": "Pincer",
+          "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 15) from one of two pincers.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Pummel",
+          "desc": "Dexterity Saving Throw: DC 17, one creature Grappled by the glabrezu. Failure: 15 (3d6 + 5) Bludgeoning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "3d6+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d6+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The glabrezu casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16): At Will: Darkness, Detect Magic, Dispel Magic 1/Day Each: Confusion, Fly, Power Word Stun"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "gladiator": {
+      "index": "gladiator",
+      "name": "Gladiator",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 16,
+      "hit_points": 112,
+      "hit_dice": "15d8 + 45",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 12,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 7
+        },
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "CON",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "athletics": 10,
+        "performance": 5
+      },
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "Common",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The gladiator makes three Spear attacks. It can replace one attack with a use of Shield Bash."
+        },
+        {
+          "name": "Spear",
+          "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Shield Bash",
+          "desc": "Strength Saving Throw: DC 15, one creature within 5 feet that the gladiator can see. Failure: 9 (2d4 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The gladiator is hit by a melee attack roll while holding a weapon. Response: The gladiator adds 3 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "gnoll-warrior": {
+      "index": "gnoll-warrior",
+      "name": "Gnoll Warrior",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 15,
+      "hit_points": 27,
+      "hit_dice": "6d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 12,
+      "constitution": 11,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Gnoll",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Bone Bow",
+          "desc": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d10+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Rampage (1/Day)",
+          "desc": "Immediately after dealing damage to a creature that is already Bloodied, the gnoll moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "goblin-minion": {
+      "index": "goblin-minion",
+      "name": "Goblin Minion",
+      "size": "Small",
+      "type": "fey",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 12,
       "hit_points": 7,
       "hit_dice": "2d6",
-      "speed": { "walk": "30 ft." },
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 8,
-      "dexterity": 14,
+      "dexterity": 15,
       "constitution": 10,
       "intelligence": 10,
       "wisdom": 8,
       "charisma": 8,
-      "skills": { "stealth": 6 },
-      "senses": { "darkvision": "60 ft.", "passive_perception": 9 },
+      "saving_throws": [],
+      "skills": {
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
       "languages": "Common, Goblin",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Dagger",
+          "desc": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Nimble Escape",
+          "desc": "The goblin takes the Disengage or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
+    },
+    "goblin-warrior": {
+      "index": "goblin-warrior",
+      "name": "Goblin Warrior",
+      "size": "Small",
+      "type": "fey",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 15,
+      "hit_points": 10,
+      "hit_dice": "3d6",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 8,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 10,
+      "wisdom": 8,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 6
+      },
+      "senses": null,
+      "languages": "",
       "challenge_rating": 0.25,
       "xp": 50,
       "proficiency_bonus": 2,
-      "special_abilities": [
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Scimitar",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Shortbow",
+          "desc": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
         {
           "name": "Nimble Escape",
-          "desc": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+          "desc": "The goblin takes the Disengage or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
+    },
+    "goblin-boss": {
+      "index": "goblin-boss",
+      "name": "Goblin Boss",
+      "size": "Small",
+      "type": "fey",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 17,
+      "hit_points": 21,
+      "hit_dice": "6d6",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 10,
+      "wisdom": 8,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 6
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The goblin makes two attacks, using Scimitar or Shortbow in any combination."
+        },
+        {
+          "name": "Scimitar",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Shortbow",
+          "desc": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Nimble Escape",
+          "desc": "The goblin takes the Disengage or Hide action."
+        }
+      ],
+      "reactions": [
+        {
+          "name": "Redirect Attack",
+          "desc": "Trigger: A creature the goblin can see makes an attack roll against it. Response: The goblin chooses a Small or Medium ally within 5 feet of itself. The goblin and that ally swap places, and the ally becomes the target of the attack instead."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
+    },
+    "gold-dragon-wyrmling": {
+      "index": "gold-dragon-wyrmling",
+      "name": "Gold Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 17,
+      "hit_points": 60,
+      "hit_dice": "8d8 + 24",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 14,
+      "constitution": 17,
+      "intelligence": 14,
+      "wisdom": 11,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 3.0,
+      "xp": null,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
         }
       ],
       "actions": [
         {
-          "name": "Scimitar",
-          "attack_bonus": 4,
-          "damage_dice": "1d6+2",
-          "damage_type": { "name": "slashing" },
-          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
         },
         {
-          "name": "Shortbow",
-          "attack_bonus": 4,
-          "damage_dice": "1d6+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 22 (4d10) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d10",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "4d10",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Weakening Breath",
+          "desc": "Strength Saving Throw: DC 13, each creature that isn’t currently affected by this breath in a 15-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 2 (1d4) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "from its"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "from its"
+          }
         }
-      ]
-    },
-    "hobgoblin": {
-      "index": "hobgoblin",
-      "name": "Hobgoblin",
-      "size": "Medium",
-      "type": "humanoid",
-      "subtype": "goblinoid",
-      "alignment": "lawful evil",
-      "armor_class": [
-        { "type": "chain mail", "value": 18 }
       ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "young-gold-dragon": {
+      "index": "young-gold-dragon",
+      "name": "Young Gold Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 18,
+      "hit_points": 178,
+      "hit_dice": "17d10 + 85",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 23,
+      "dexterity": 14,
+      "constitution": 21,
+      "intelligence": 16,
+      "wisdom": 13,
+      "charisma": 20,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "insight": 5,
+        "perception": 9,
+        "persuasion": 9,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 19,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 10.0,
+      "xp": 5900,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Weakening Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d10+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 55 (10d10) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "10d10",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "10d10",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Weakening Breath",
+          "desc": "Strength Saving Throw: DC 17, each creature that isn’t currently affected by this breath in a 30-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+          "damage": [
+            {
+              "damage_dice": "1d6",
+              "damage_type": {
+                "name": "from its"
+              }
+            }
+          ],
+          "damage_dice": "1d6",
+          "damage_type": {
+            "name": "from its"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "adult-gold-dragon": {
+      "index": "adult-gold-dragon",
+      "name": "Adult Gold Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 19,
+      "hit_points": 243,
+      "hit_dice": "18d12 + 126",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 27,
+      "dexterity": 14,
+      "constitution": 25,
+      "intelligence": 16,
+      "wisdom": 15,
+      "charisma": 24,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 8
+        }
+      ],
+      "skills": {
+        "insight": 8,
+        "perception": 14,
+        "persuasion": 13
+      },
+      "senses": {
+        "passive_perception": 24,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 17.0,
+      "xp": 18000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 2 version) or (B) Weakening Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Fire damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "2d8+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 21, each creature in a 60-foot Cone. Failure: 66 (12d10) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d10",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "12d10",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Flame Strike, Zone of Truth"
+        },
+        {
+          "name": "Weakening Breath",
+          "desc": "Strength Saving Throw: DC 21, each creature that isn’t currently affected by this breath in a 60-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+          "damage": [
+            {
+              "damage_dice": "1d6",
+              "damage_type": {
+                "name": "from its"
+              }
+            }
+          ],
+          "damage_dice": "1d6",
+          "damage_type": {
+            "name": "from its"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Banish",
+          "desc": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 10 (3d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it reappears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Guiding Light",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Guiding Bolt (level 2 version)",
+          "desc": ""
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "ancient-gold-dragon": {
+      "index": "ancient-gold-dragon",
+      "name": "Ancient Gold Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 22,
+      "hit_points": 546,
+      "hit_dice": "28d20 + 252",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 30,
+      "dexterity": 14,
+      "constitution": 29,
+      "intelligence": 18,
+      "wisdom": 17,
+      "charisma": 28,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "insight": 10,
+        "perception": 17,
+        "persuasion": 16
+      },
+      "senses": {
+        "passive_perception": 27,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 24.0,
+      "xp": 62000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 4 version) or (B) Weakening Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +17 to hit, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Fire damage.",
+          "attack_bonus": 17,
+          "damage": [
+            {
+              "damage_dice": "2d8+10",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+10",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 71 (13d10) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "13d10",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "13d10",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 24, +16 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 4 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Flame Strike (level 6 version), Word of Recall, Zone of Truth"
+        },
+        {
+          "name": "Weakening Breath",
+          "desc": "Strength Saving Throw: DC 24, each creature that isn’t currently affected by this breath in a 90-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 5 (1d10) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+          "damage": [
+            {
+              "damage_dice": "1d10",
+              "damage_type": {
+                "name": "from its"
+              }
+            }
+          ],
+          "damage_dice": "1d10",
+          "damage_type": {
+            "name": "from its"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Banish",
+          "desc": "Charisma Saving Throw: DC 24, one creature the dragon can see within 120 feet. Failure: 24 (7d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it reappears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "7d6",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "7d6",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Guiding Light",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Guiding Bolt (level 4 version)",
+          "desc": ""
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "gorgon": {
+      "index": "gorgon",
+      "name": "Gorgon",
+      "size": "Large",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 19,
+      "hit_points": 114,
+      "hit_dice": "12d10 + 48",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 20,
+      "dexterity": 11,
+      "constitution": 18,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 7
+      },
+      "senses": {
+        "passive_perception": 17,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Exhaustion",
+        "Petrified"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 18 (2d12 + 5) Piercing damage. If the target is a Large or smaller creature and the gorgon moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d12+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Petrifying Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Trample",
+          "desc": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 16 (2d10 + 5) Bludgeoning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "gray-ooze": {
+      "index": "gray-ooze",
+      "name": "Gray Ooze",
+      "size": "Medium",
+      "type": "ooze",
+      "alignment": "Unaligned",
+      "armor_class": 9,
+      "hit_points": 22,
+      "hit_dice": "3d8 + 9",
+      "speed": {
+        "walk": "10 ft.",
+        "climb": "10 ft."
+      },
+      "strength": 12,
+      "dexterity": 6,
+      "constitution": 16,
+      "intelligence": 1,
+      "wisdom": 6,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 8,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Cold",
+        "Fire"
+      ],
+      "damage_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Exhaustion",
+        "Frightened",
+        "Grappled",
+        "Prone",
+        "Restrained"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amorphous",
+          "desc": "The ooze can move through a space as narrow as 1 inch without expending extra movement to do so."
+        },
+        {
+          "name": "Corrosive Form",
+          "desc": "Nonmagical ammunition is destroyed immediately after hitting the ooze and dealing any damage. Any nonmagical weapon takes a cumulative -1 penalty to attack rolls immediately after dealing damage to the ooze and coming into contact with it. The weapon is destroyed if the penalty reaches -5. The penalty can be removed by casting the Mending spell on the weapon. The ooze can eat through 2-inch-thick, nonmagical metal or wood in 1 round."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 10 (2d8 + 1) Acid damage. Nonmagical armor worn by the target takes a -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "2d8+1",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "2d8+1",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "green-dragon-wyrmling": {
+      "index": "green-dragon-wyrmling",
+      "name": "Green Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 38,
+      "hit_dice": "7d8 + 7",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 14,
+      "wisdom": 11,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d10+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 21 (6d6) Poison damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "6d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "6d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "young-green-dragon": {
+      "index": "young-green-dragon",
+      "name": "Young Green Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 136,
+      "hit_dice": "16d10 + 48",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 19,
+      "dexterity": 12,
+      "constitution": 17,
+      "intelligence": 16,
+      "wisdom": 13,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "deception": 5,
+        "perception": 7,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 17,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 42 (12d6) Poison damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "12d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "adult-green-dragon": {
+      "index": "adult-green-dragon",
+      "name": "Adult Green Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 19,
+      "hit_points": 207,
+      "hit_dice": "18d12 + 90",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 23,
+      "dexterity": 12,
+      "constitution": 21,
+      "intelligence": 18,
+      "wisdom": 15,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "deception": 9,
+        "perception": 12,
+        "persuasion": 9
+      },
+      "senses": {
+        "passive_perception": 22,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 15.0,
+      "xp": 13000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Mind Spike (level 3 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "2d8+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: 56 (16d6) Poison damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "16d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "16d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Magic, Mind Spike (level 3 version) 1/Day: Geas"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Mind Invasion",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Mind Spike (level 3 version)",
+          "desc": ""
+        },
+        {
+          "name": "Noxious Miasma",
+          "desc": "Constitution Saving Throw: DC 17, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 7 (2d6) Poison damage, and the target takes a -2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "ancient-green-dragon": {
+      "index": "ancient-green-dragon",
+      "name": "Ancient Green Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 21,
+      "hit_points": 402,
+      "hit_dice": "23d20 + 161",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 27,
+      "dexterity": 12,
+      "constitution": 25,
+      "intelligence": 20,
+      "wisdom": 17,
+      "charisma": 22,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "deception": 13,
+        "perception": 17,
+        "persuasion": 13
+      },
+      "senses": {
+        "passive_perception": 27,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 22.0,
+      "xp": 41000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Mind Spike (level 5 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 10 (3d6) Poison damage.",
+          "attack_bonus": 15,
+          "damage": [
+            {
+              "damage_dice": "2d8+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: 77 (22d6) Poison damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "22d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "22d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21): At Will: Detect Magic, Mind Spike (level 5 version) 1/Day Each: Geas, Modify Memory"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Mind Invasion",
+          "desc": "The dragon uses Spellcasting to cast"
+        },
+        {
+          "name": "Mind Spike (level 5 version)",
+          "desc": ""
+        },
+        {
+          "name": "Noxious Miasma",
+          "desc": "Constitution Saving Throw: DC 21, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 17 (5d6) Poison damage, and the target takes a -2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "5d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "5d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "green-hag": {
+      "index": "green-hag",
+      "name": "Green Hag",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Neutral Evil",
+      "armor_class": 17,
+      "hit_points": 82,
+      "hit_dice": "11d8 + 33",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 12,
+      "constitution": 16,
+      "intelligence": 13,
+      "wisdom": 14,
+      "charisma": 14,
+      "saving_throws": [],
+      "skills": {
+        "arcana": 5,
+        "deception": 4,
+        "perception": 4,
+        "stealth": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The hag can breathe air and water."
+        },
+        {
+          "name": "Coven Magic",
+          "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hag makes two Claw attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage plus 3 (1d6) Poison damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d8+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The hag casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks): At Will: Dancing Lights, Disguise Self (24-hour duration), Invisibility (self only, and the hag leaves no tracks while Invisible), Minor Illusion, Ray of Sickness (level 3 version)"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "grick": {
+      "index": "grick",
+      "name": "Grick",
+      "size": "Medium",
+      "type": "aberration",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 54,
+      "hit_dice": "12d8",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 14,
+      "constitution": 11,
+      "intelligence": 3,
+      "wisdom": 14,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The grick makes one Beak attack and one Tentacles attack."
+        },
+        {
+          "name": "Beak",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tentacles",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12) from all four tentacles.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d10+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "griffon": {
+      "index": "griffon",
+      "name": "Griffon",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 59,
+      "hit_dice": "7d10 + 21",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 2,
+      "wisdom": 13,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The griffon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 14) from both of the griffon’s front claws.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "grimlock": {
+      "index": "grimlock",
+      "name": "Grimlock",
+      "size": "Medium",
+      "type": "aberration",
+      "alignment": "Neutral Evil",
+      "armor_class": 11,
       "hit_points": 11,
-      "hit_dice": "2d8",
-      "speed": { "walk": "30 ft." },
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 9,
+      "wisdom": 8,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "athletics": 5,
+        "perception": 3,
+        "stealth": 5
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bone Cudgel",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 2 (1d4) Psychic damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "guardian-naga": {
+      "index": "guardian-naga",
+      "name": "Guardian Naga",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 18,
+      "hit_points": 136,
+      "hit_dice": "16d10 + 48",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 19,
+      "dexterity": 18,
+      "constitution": 16,
+      "intelligence": 16,
+      "wisdom": 19,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 8
+        },
+        {
+          "name": "CON",
+          "value": 7
+        },
+        {
+          "name": "INT",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 8
+        },
+        {
+          "name": "CHA",
+          "value": 8
+        }
+      ],
+      "skills": {
+        "arcana": 11,
+        "history": 11,
+        "religion": 11
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Celestial, Common",
+      "challenge_rating": 10.0,
+      "xp": 5900,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Paralyzed",
+        "Poisoned",
+        "Restrained"
+      ],
+      "special_abilities": [
+        {
+          "name": "Celestial Restoration",
+          "desc": "If the naga dies, it returns to life in 1d6 days and regains all its Hit Points unless Dispel Evil and Good is cast on its remains."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The naga makes two Bite attacks. It can replace any attack with a use of Poisonous Spittle."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 17 (2d12 + 4) Piercing damage plus 22 (4d10) Poison damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d12+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Poisonous Spittle",
+          "desc": "Constitution Saving Throw: DC 16, one creature the naga can see within 60 feet. Failure: 31 (7d8) Poison damage, and the target has the Blinded condition until the start of the naga’s next turn. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "7d8",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "7d8",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save DC 16): At Will: Thaumaturgy 1/Day Each: Clairvoyance, Cure Wounds (level 6 version), Flame Strike (level 6 version), Geas, True Seeing"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "guard": {
+      "index": "guard",
+      "name": "Guard",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 16,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 13,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 11,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Spear",
+          "desc": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "guard-captain": {
+      "index": "guard-captain",
+      "name": "Guard Captain",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 18,
+      "hit_points": 75,
+      "hit_dice": "10d8 + 30",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 16,
+      "intelligence": 12,
+      "wisdom": 14,
+      "charisma": 13,
+      "saving_throws": [],
+      "skills": {
+        "athletics": 6,
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14
+      },
+      "languages": "Common",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The guard makes two attacks, using Javelin or Longsword in any combination."
+        },
+        {
+          "name": "Javelin",
+          "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Longsword",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "half-dragon": {
+      "index": "half-dragon",
+      "name": "Half-Dragon",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Neutral",
+      "armor_class": 18,
+      "hit_points": 105,
+      "hit_dice": "14d8 + 42",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 19,
+      "dexterity": 14,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 15,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "athletics": 7,
+        "perception": 5,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Damage type chosen for the Draconic Origin trait below"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Draconic Origin",
+          "desc": "The half-dragon is related to a type of dragon associated with one of the following damage types (GM’s choice): Acid, Cold, Fire, Lightning, or Poison. This choice affects other aspects of the stat block."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The half-dragon makes two Claw attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 6 (1d4 + 4) Slashing damage plus 7 (2d6) damage of the type chosen for the Draconic Origin trait.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Dragon’s Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 28 (8d6) damage of the type chosen for the Draconic Origin trait. Success: Half damage."
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Leap",
+          "desc": "The half-dragon jumps up to 30 feet by spending 10 feet of movement."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "harpy": {
+      "index": "harpy",
+      "name": "Harpy",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 11,
+      "hit_points": 38,
+      "hit_dice": "7d8 + 7",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 12,
+      "dexterity": 13,
+      "constitution": 12,
+      "intelligence": 7,
+      "wisdom": 10,
+      "charisma": 13,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "Common",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Slashing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "2d4+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+1",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Luring Song",
+          "desc": "The harpy sings a magical melody, which lasts until the harpy’s Concentration ends on it. Wisdom Saving Throw: DC 11, each Humanoid and Giant in a 300-foot Emanation originating from the harpy when the song starts. Failure: The target has the Charmed condition until the song ends and repeats the save at the end of each of its turns. While Charmed, the target has the Incapacitated condition and ignores the Luring Song of other harpies. If the target is more than 5 feet from the harpy, the target moves on its turn toward the harpy by the most direct route, trying to get within 5 feet of the harpy. It doesn’t avoid Opportunity Attacks; however, before moving into damaging terrain (such as lava or a pit) and whenever it takes damage from a source other than the harpy, the target repeats the save. Success: The target is immune to this harpy’s Luring Song for 24 hours.",
+          "damage": [
+            {
+              "damage_dice": "suchaslavaorapit",
+              "damage_type": {
+                "name": "and whenever it takes"
+              }
+            }
+          ],
+          "damage_dice": "suchaslavaorapit",
+          "damage_type": {
+            "name": "and whenever it takes"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hell-hound": {
+      "index": "hell-hound",
+      "name": "Hell Hound",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 15,
+      "hit_points": 58,
+      "hit_dice": "9d8 + 18",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 17,
+      "dexterity": 12,
+      "constitution": 14,
+      "intelligence": 6,
+      "wisdom": 13,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "t_speak_cr": "3",
+        "xp": "700",
+        "summary": "Darkvision 60 ft.; Languages Understands Infernal but can’t speak CR 3 (XP 700; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The hound has Advantage on an attack roll against a creature if at least one of the hound’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hound makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 3 (1d6) Fire damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 17 (5d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "5d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "5d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hezrou": {
+      "index": "hezrou",
+      "name": "Hezrou",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 18,
+      "hit_points": 157,
+      "hit_dice": "15d10 + 75",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 17,
+      "constitution": 20,
+      "intelligence": 5,
+      "wisdom": 12,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 7
+        },
+        {
+          "name": "CON",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Abyssal; telepathy 120 ft.",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Demonic Restoration",
+          "desc": "If the hezrou dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The hezrou has Advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Stench",
+          "desc": "Constitution Saving Throw: DC 16, any creature that starts its turn in a 10-foot Emanation originating from the hezrou. Failure: The target has the Poisoned condition until the start of its next turn."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hezrou makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 6 (1d4 + 4) Slashing damage plus 9 (2d8) Poison damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Leap",
+          "desc": "The hezrou jumps up to 30 feet by spending 10 feet of movement."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "hill-giant": {
+      "index": "hill-giant",
+      "name": "Hill Giant",
+      "size": "Huge",
+      "type": "giant",
+      "alignment": "Chaotic Evil",
+      "armor_class": 13,
+      "hit_points": 105,
+      "hit_dice": "10d12 + 40",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 21,
+      "dexterity": 8,
+      "constitution": 19,
+      "intelligence": 5,
+      "wisdom": 9,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12
+      },
+      "languages": "Giant",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The giant makes two attacks, using Tree Club or Trash Lob in any combination."
+        },
+        {
+          "name": "Tree Club",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "3d8+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d8+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Trash Lob",
+          "desc": "Ranged Attack Roll: +8, range 60/240 ft. Hit: 16 (2d10 + 5) Bludgeoning damage, and the target has the Poisoned condition until the end of its next turn.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hippogriff": {
+      "index": "hippogriff",
+      "name": "Hippogriff",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 26,
+      "hit_dice": "4d10 + 4",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 17,
+      "dexterity": 13,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The hippogriff doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hippogriff makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hobgoblin-warrior": {
+      "index": "hobgoblin-warrior",
+      "name": "Hobgoblin Warrior",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 13,
       "dexterity": 12,
       "constitution": 12,
       "intelligence": 10,
       "wisdom": 10,
       "charisma": 9,
-      "skills": { "martial": 0 },
-      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
-      "languages": "Common, Goblin",
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
       "challenge_rating": 0.5,
       "xp": 100,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
       "special_abilities": [
         {
-          "name": "Martial Advantage",
-          "desc": "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 feet of an ally of the hobgoblin that isn't incapacitated."
+          "name": "Pack Tactics",
+          "desc": "The hobgoblin has Advantage on an attack roll against a creature if at least one of the hobgoblin’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
         }
       ],
       "actions": [
         {
           "name": "Longsword",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 12 (2d10 + 1) Slashing damage.",
           "attack_bonus": 3,
-          "damage_dice": "1d8+1",
-          "damage_type": { "name": "slashing" },
-          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage or 6 (1d10 + 1) slashing damage if used with two hands."
+          "damage": [
+            {
+              "damage_dice": "2d10+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+1",
+          "damage_type": {
+            "name": "slashing"
+          }
         },
         {
           "name": "Longbow",
+          "desc": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 5 (1d8 + 1) Piercing damage plus 7 (3d4) Poison damage.",
           "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d8+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
           "damage_dice": "1d8+1",
-          "damage_type": { "name": "piercing" },
-          "desc": "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+          "damage_type": {
+            "name": "piercing"
+          }
         }
-      ]
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
     },
-    "kobold": {
-      "index": "kobold",
-      "name": "Kobold",
+    "hobgoblin-captain": {
+      "index": "hobgoblin-captain",
+      "name": "Hobgoblin Captain",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 58,
+      "hit_dice": "9d8 + 18",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 14,
+      "constitution": 14,
+      "intelligence": 12,
+      "wisdom": 10,
+      "charisma": 13,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hobgoblin makes two attacks, using Greatsword or Longbow in any combination."
+        },
+        {
+          "name": "Greatsword",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d6+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Longbow",
+          "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 5 (2d4) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "goblinoid"
+    },
+    "homunculus": {
+      "index": "homunculus",
+      "name": "Homunculus",
+      "size": "Tiny",
+      "type": "construct",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 4,
+      "hit_dice": "1d4 + 2",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 4,
+      "dexterity": 15,
+      "constitution": 14,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 7,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 2
+        },
+        {
+          "name": "CHA",
+          "value": 0
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Understands Common plus one other language but can’t speak",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Telepathic Bond",
+          "desc": "While the homunculus is on the same plane of existence as its master, the two of them can communicate telepathically with each other."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage, and the target is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target has the Poisoned condition until the end of the homunculus’s next turn. Failure by 5 or More: The target has the Poisoned condition for 1 minute. While Poisoned, the target has the Unconscious condition, which ends early if the target takes any damage.",
+          "attack_bonus": 4
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "horned-devil": {
+      "index": "horned-devil",
+      "name": "Horned Devil",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 199,
+      "hit_dice": "19d10 + 95",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 22,
+      "dexterity": 17,
+      "constitution": 21,
+      "intelligence": 12,
+      "wisdom": 16,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 10
+        },
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        },
+        {
+          "name": "CHA",
+          "value": 8
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "150 ft.",
+        "summary": "Darkvision 150 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The devil makes three attacks, using Searing Fork or Hurl Flame in any combination. It can replace one attack with a use of Infernal Tail."
+        },
+        {
+          "name": "Searing Fork",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Piercing damage plus 9 (2d8) Fire damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d8+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Hurl Flame",
+          "desc": "Ranged Attack Roll: +8, range 150 ft. Hit: 26 (5d8 + 4) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "5d8+4",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "5d8+4",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Infernal Tail",
+          "desc": "Dexterity Saving Throw: DC 17, one creature the devil can see within 10 feet. Failure: 10 (1d8 + 6) Necrotic damage, and the target receives an infernal wound if it doesn’t have one. While wounded, the target loses 10 (3d6) Hit Points at the start of each of its turns. The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 17 Wisdom (Medicine) check.",
+          "damage": [
+            {
+              "damage_dice": "1d8+6",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "1d8+6",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "hydra": {
+      "index": "hydra",
+      "name": "Hydra",
+      "size": "Huge",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 15,
+      "hit_points": 184,
+      "hit_dice": "16d12 + 80",
+      "speed": {
+        "walk": "40 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 20,
+      "dexterity": 12,
+      "constitution": 20,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Blinded",
+        "Charmed",
+        "Deafened",
+        "Frightened",
+        "Stunned",
+        "Unconscious"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Hold Breath",
+          "desc": "The hydra can hold its breath for 1 hour."
+        },
+        {
+          "name": "Multiple Heads",
+          "desc": "The hydra has five heads. Whenever the hydra takes 25 damage or more on a single turn, one of its heads dies. The hydra dies if all its heads are dead. At the end of each of its turns when it has at least one living head, the hydra grows two heads for each of its heads that died since its last turn, unless it has taken Fire damage since its last turn. The hydra regains 20 Hit Points when it grows new heads."
+        },
+        {
+          "name": "Reactive Heads",
+          "desc": "For each head the hydra has beyond one, it gets an extra Reaction that can be used only for Opportunity Attacks."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hydra makes as many Bite attacks as it has heads."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 10 (1d10 + 5) Piercing damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "1d10+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ice-devil": {
+      "index": "ice-devil",
+      "name": "Ice Devil",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 18,
+      "hit_points": 228,
+      "hit_dice": "24d10 + 96",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 21,
+      "dexterity": 14,
+      "constitution": 18,
+      "intelligence": 18,
+      "wisdom": 15,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "CON",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        },
+        {
+          "name": "CHA",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "insight": 7,
+        "perception": 7,
+        "persuasion": 9
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 14.0,
+      "xp": 11500,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The devil makes three Ice Spear attacks. It can replace one attack with a Tail attack."
+        },
+        {
+          "name": "Ice Spear",
+          "desc": "Melee or Ranged Attack Roll: +10, reach 5 ft. or range 30/120 ft. Hit: 14 (2d8 + 5) Piercing damage plus 10 (3d6) Cold damage. Until the end of its next turn, the target can’t take a Bonus Action or Reaction, its Speed decreases by 10 feet, and it can move or take one action on its turn, not both. Hit or Miss: The spear magically returns to the devil’s hand immediately after a ranged attack.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tail",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (3d6 + 5) Bludgeoning damage plus 18 (4d8) Cold damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "3d6+5",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d6+5",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Ice Wall (Recharge 6)",
+          "desc": "The devil casts Wall of Ice (level 8 version), requiring no spell components and using Intelligence as the spellcasting ability (spell save DC 17)."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "imp": {
+      "index": "imp",
+      "name": "Imp",
+      "size": "Tiny",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 13,
+      "hit_points": 21,
+      "hit_dice": "6d4 + 6",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 6,
+      "dexterity": 17,
+      "constitution": 13,
+      "intelligence": 11,
+      "wisdom": 12,
+      "charisma": 14,
+      "saving_throws": [],
+      "skills": {
+        "deception": 4,
+        "insight": 3,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Common, Infernal",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The imp has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Sting",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Invisibility",
+          "desc": "The imp casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+        },
+        {
+          "name": "Shape-Shift",
+          "desc": "The imp shape-shifts to resemble a rat (Speed 20 ft.), a raven (20 ft., Fly 60 ft.), or a spider (20 ft., Climb 20 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "incubus": {
+      "index": "incubus",
+      "name": "Incubus",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Neutral Evil",
+      "armor_class": 15,
+      "hit_points": 66,
+      "hit_dice": "12d8 + 12",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 8,
+      "dexterity": 17,
+      "constitution": 13,
+      "intelligence": 15,
+      "wisdom": 12,
+      "charisma": 20,
+      "saving_throws": [],
+      "skills": {
+        "deception": 9,
+        "insight": 5,
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "telepathy": "60 ft.",
+        "cr": "4",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Abyssal, Common, Infernal; telepathy 60 ft. CR 4 (XP 1,100; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Poison",
+        "Psychic"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Succubus Form",
+          "desc": "When the incubus finishes a Long Rest, it can shape-shift into a Succubus, using that stat block instead of this one. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The incubus makes two Restless Touch attacks."
+        },
+        {
+          "name": "Restless Touch",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 15 (3d6 + 5) Psychic damage, and the target is cursed for 24 hours or until the incubus dies. Until the curse ends, the target gains no benefit from finishing Short Rests.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "3d6+5",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "3d6+5",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The incubus casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15): At Will: Disguise Self, Etherealness 1/Day Each: Dream, Hypnotic Pattern"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Nightmare (Recharge 6)",
+          "desc": "Wisdom Saving Throw: DC 15, one creature the incubus can see within 60 feet. Failure: If the target has 20 Hit Points or fewer, it has the Unconscious condition for 1 hour, until it takes damage, or until a creature within 5 feet of it takes an action to wake it. Otherwise, the target takes 18 (4d8) Psychic damage.",
+          "damage": [
+            {
+              "damage_dice": "4d8",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "4d8",
+          "damage_type": {
+            "name": "psychic"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "invisible-stalker": {
+      "index": "invisible-stalker",
+      "name": "Invisible Stalker",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 97,
+      "hit_dice": "13d10 + 26",
+      "speed": {
+        "walk": "50 ft.",
+        "fly": "50 ft. (hover)"
+      },
+      "strength": 16,
+      "dexterity": 19,
+      "constitution": 14,
+      "intelligence": 10,
+      "wisdom": 15,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "perception": 8,
+        "stealth": 10
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "special_abilities": [
+        {
+          "name": "Air Form",
+          "desc": "The stalker can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+        },
+        {
+          "name": "Invisibility",
+          "desc": "The stalker has the Invisible condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The stalker makes three Wind Swipe attacks. It can replace one attack with a use of Vortex."
+        },
+        {
+          "name": "Wind Swipe",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Force damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Vortex",
+          "desc": "Constitution Saving Throw: DC 14, one Large or smaller creature in the stalker’s space. Failure: 7 (1d8 + 3) Thunder damage, and the target has the Grappled condition (escape DC 13). Until the grapple ends, the target can’t cast spells with a Verbal component and takes 7 (2d6) Thunder damage at the start of each of the stalker’s turns.",
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "thunder"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "iron-golem": {
+      "index": "iron-golem",
+      "name": "Iron Golem",
+      "size": "Large",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 20,
+      "hit_points": 252,
+      "hit_dice": "24d10 + 120",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 24,
+      "dexterity": 9,
+      "constitution": 20,
+      "intelligence": 3,
+      "wisdom": 11,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 16.0,
+      "xp": 15000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire",
+        "Poison",
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion"
+      ],
+      "special_abilities": [
+        {
+          "name": "Fire Absorption",
+          "desc": "Whenever the golem is subjected to Fire damage, it regains a number of Hit Points equal to the Fire damage dealt."
+        },
+        {
+          "name": "Immutable Form",
+          "desc": "The golem can’t shape-shift."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The golem makes two attacks, using Bladed Arm or Fiery Bolt in any combination."
+        },
+        {
+          "name": "Bladed Arm",
+          "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 20 (3d8 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "3d8+7",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "3d8+7",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fiery Bolt",
+          "desc": "Ranged Attack Roll: +10, range 120 ft. Hit: 36 (8d8) Fire damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "8d8",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "8d8",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Poison Breath (Recharge 6)",
+          "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: 55 (10d10) Poison damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "10d10",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "10d10",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "knight": {
+      "index": "knight",
+      "name": "Knight",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 18,
+      "hit_points": 52,
+      "hit_dice": "8d8 + 16",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 11,
+      "constitution": 14,
+      "intelligence": 11,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Frightened"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The knight makes two attacks, using Greatsword or Heavy Crossbow in any combination."
+        },
+        {
+          "name": "Greatsword",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 4 (1d8) Radiant damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Heavy Crossbow",
+          "desc": "Ranged Attack Roll: +2, range 100/400 ft. Hit: 11 (2d10) Piercing damage plus 4 (1d8) Radiant damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "2d10",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The knight is hit by a melee attack roll while holding a weapon. Response: The knight adds 2 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "kobold-warrior": {
+      "index": "kobold-warrior",
+      "name": "Kobold Warrior",
       "size": "Small",
-      "type": "humanoid",
-      "subtype": "kobold",
-      "alignment": "lawful evil",
-      "armor_class": 12,
-      "hit_points": 5,
-      "hit_dice": "2d6",
-      "speed": { "walk": "30 ft." },
+      "type": "dragon",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 7,
+      "hit_dice": "3d6 − 3",
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 7,
       "dexterity": 15,
       "constitution": 9,
       "intelligence": 8,
       "wisdom": 7,
       "charisma": 8,
-      "skills": { "stealth": 4 },
-      "senses": { "darkvision": "60 ft.", "passive_perception": 8 },
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
       "languages": "Common, Draconic",
       "challenge_rating": 0.125,
       "xp": 25,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
       "special_abilities": [
         {
-          "name": "Sunlight Sensitivity",
-          "desc": "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+          "name": "Pack Tactics",
+          "desc": "The kobold has Advantage on an attack roll against a creature if at least one of the kobold’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
         },
         {
-          "name": "Pack Tactics",
-          "desc": "The kobold has advantage on an attack roll against a creature if at least one of the kobold's allies is within 5 feet of the creature and the ally isn't incapacitated."
+          "name": "Sunlight Sensitivity",
+          "desc": "While in sunlight, the kobold has Disadvantage on ability checks and attack rolls."
         }
       ],
       "actions": [
         {
           "name": "Dagger",
+          "desc": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
           "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
           "damage_dice": "1d4+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "kraken": {
+      "index": "kraken",
+      "name": "Kraken",
+      "size": "Gargantuan",
+      "type": "monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 18,
+      "hit_points": 481,
+      "hit_dice": "26d20 + 208",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "120 ft."
+      },
+      "strength": 30,
+      "dexterity": 11,
+      "constitution": 26,
+      "intelligence": 22,
+      "wisdom": 18,
+      "charisma": 20,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 17
         },
         {
-          "name": "Sling",
-          "attack_bonus": 4,
-          "damage_dice": "1d4+2",
-          "damage_type": { "name": "bludgeoning" },
-          "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage."
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "CON",
+          "value": 15
+        },
+        {
+          "name": "WIS",
+          "value": 11
         }
-      ]
+      ],
+      "skills": {
+        "history": 13,
+        "perception": 11
+      },
+      "senses": {
+        "passive_perception": 21,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "Understands Abyssal, Celestial, Infernal, and Primordial but can’t speak; telepathy 120 ft.",
+      "challenge_rating": 23.0,
+      "xp": 50000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold",
+        "Lightning"
+      ],
+      "condition_immunities": [
+        "Frightened",
+        "Grappled",
+        "Paralyzed",
+        "Restrained"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The kraken can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the kraken fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Siege Monster",
+          "desc": "The kraken deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The kraken makes two Tentacle attacks and uses Fling, Lightning Strike, or Swallow."
+        },
+        {
+          "name": "Tentacle",
+          "desc": "Melee Attack Roll: +17, reach 30 ft. Hit: 24 (4d6 + 10) Bludgeoning damage. The target has the Grappled condition (escape DC 20) from one of ten tentacles, and it has the Restrained condition until the grapple ends.",
+          "attack_bonus": 17,
+          "damage": [
+            {
+              "damage_dice": "4d6+10",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "4d6+10",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Fling",
+          "desc": "The kraken throws a Large or smaller creature Grappled by it to a space it can see within 60 feet of itself that isn’t in the air. Dexterity Saving Throw: DC 25, the creature thrown and each creature in the destination space. Failure: 18 (4d8) Bludgeoning damage, and the target has the Prone condition. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "4d8",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "4d8",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Lightning Strike",
+          "desc": "Dexterity Saving Throw: DC 23, one creature the kraken can see within 120 feet. Failure: 33 (6d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "6d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "6d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Swallow",
+          "desc": "Dexterity Saving Throw: DC 25, one creature Grappled by the kraken (it can have up to four creatures swallowed at a time). Failure: 23 (3d8 + 10) Piercing damage. If the target is Large or smaller, it is swallowed and no longer Grappled. A swallowed creature has the Restrained condition, has Total Cover against attacks and other effects outside the kraken, and takes 24 (7d6) Acid damage at the start of each of its turns.",
+          "damage": [
+            {
+              "damage_dice": "3d8+10",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d8+10",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the kraken can expend a use to take one of the following actions. The kraken regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Storm Bolt",
+          "desc": "The kraken uses Lightning Strike."
+        },
+        {
+          "name": "Toxic Ink",
+          "desc": "Constitution Saving Throw: DC 23, each creature in a 15-foot Emanation originating from the kraken while it is underwater. Failure: The target has the Blinded and Poisoned conditions until the end of the kraken’s next turn. The kraken then moves up to its Speed. Failure or Success: The kraken can’t take this action again until the start of its next turn."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "titan"
+    },
+    "lamia": {
+      "index": "lamia",
+      "name": "Lamia",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 13,
+      "hit_points": 97,
+      "hit_dice": "13d10 + 26",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 15,
+      "intelligence": 14,
+      "wisdom": 15,
+      "charisma": 16,
+      "saving_throws": [],
+      "skills": {
+        "deception": 7,
+        "insight": 4,
+        "stealth": 5
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The lamia makes two Claw attacks. It can replace one attack with a use of Corrupting Touch."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 7 (2d6) Psychic damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Corrupting Touch",
+          "desc": "Wisdom Saving Throw: DC 13, one creature the lamia can see within 5 feet. Failure: 13 (3d8) Psychic damage, and the target is cursed for 1 hour. Until the curse ends, the target has the Charmed and Poisoned conditions.",
+          "damage": [
+            {
+              "damage_dice": "3d8",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "3d8",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The lamia casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13): At Will: Disguise Self (can appear as a Large or Medium biped), Minor Illusion 1/Day Each: Geas, Major Image, Scrying"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Leap",
+          "desc": "The lamia jumps up to 30 feet by spending 10 feet of movement."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "lemure": {
+      "index": "lemure",
+      "name": "Lemure",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 9,
+      "hit_points": 9,
+      "hit_dice": "2d8",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 10,
+      "dexterity": 5,
+      "constitution": 11,
+      "intelligence": 1,
+      "wisdom": 11,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft. (unimpeded by magical Darkness)"
+      },
+      "languages": "Understands Infernal but can’t speak",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Frightened",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Hellish Restoration",
+          "desc": "If the lemure dies in the Nine Hells, it revives with all its Hit Points in 1d10 days unless it is killed by a creature under the effects of a Bless spell or its remains are sprinkled with Holy Water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Vile Slime",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Poison damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "lich": {
+      "index": "lich",
+      "name": "Lich",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "Neutral Evil",
+      "armor_class": 20,
+      "hit_points": 315,
+      "hit_dice": "42d8 + 126",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 16,
+      "constitution": 16,
+      "intelligence": 21,
+      "wisdom": 14,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 10
+        },
+        {
+          "name": "CON",
+          "value": 10
+        },
+        {
+          "name": "INT",
+          "value": 12
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "arcana": 19,
+        "history": 12,
+        "insight": 9,
+        "perception": 9
+      },
+      "senses": {
+        "passive_perception": 19,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "All",
+      "challenge_rating": 21.0,
+      "xp": 33000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened",
+        "Paralyzed",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the lich fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Spirit Jar",
+          "desc": "If destroyed, the lich reforms in 1d10 days if it has a spirit jar, reviving with all its Hit Points. The new body appears in an unoccupied space within the lich’s lair."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The lich makes three attacks, using Eldritch Burst or Paralyzing Touch in any combination."
+        },
+        {
+          "name": "Eldritch Burst",
+          "desc": "Melee or Ranged Attack Roll: +12, reach 5 ft. or range 120 ft. Hit: 31 (4d12 + 5) Force damage.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "4d12+5",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "4d12+5",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Paralyzing Touch",
+          "desc": "Melee Attack Roll: +12, reach 5 ft. Hit: 15 (3d6 + 5) Cold damage, and the target has the Paralyzed condition until the start of the lich’s next turn.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "3d6+5",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "3d6+5",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The lich casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 20): At Will: Detect Magic, Detect Thoughts, Dispel Magic, Fireball (level 5 version), Invisibility, Lightning Bolt (level 5 version), Mage Hand, Prestidigitation 2/Day Each: Animate Dead, Dimension Door, Plane Shift 1/Day Each: Chain Lightning, Finger of Death, Power Word Kill, Scrying"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Protective Magic",
+          "desc": "The lich casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the lich can expend a use to take one of the following actions. The lich regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Deathly Teleport",
+          "desc": "The lich teleports up to 60 feet to an unoccupied space it can see, and each creature within 10 feet of the space it left takes 11 (2d10) Necrotic damage."
+        },
+        {
+          "name": "Disrupt Life",
+          "desc": "Constitution Saving Throw: DC 20, each creature that isn’t an Undead in a 20-foot Emanation originating from the lich. Failure: 31 (9d6) Necrotic damage. Success: Half damage. Failure or Success: The lich can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "9d6",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "9d6",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        },
+        {
+          "name": "Frightening Gaze",
+          "desc": "The lich casts Fear, using the same spellcasting ability as Spellcasting. The lich can’t take this action again until the start of its next turn."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "wizard"
+    },
+    "mage": {
+      "index": "mage",
+      "name": "Mage",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 15,
+      "hit_points": 81,
+      "hit_dice": "18d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 9,
+      "dexterity": 14,
+      "constitution": 11,
+      "intelligence": 17,
+      "wisdom": 12,
+      "charisma": 11,
+      "saving_throws": [
+        {
+          "name": "INT",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "arcana": 6,
+        "history": 6,
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14
+      },
+      "languages": "Common plus three other languages",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The mage makes three Arcane Burst attacks."
+        },
+        {
+          "name": "Arcane Burst",
+          "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 120 ft. Hit: 16 (3d8 + 3) Force damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d8+3",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "3d8+3",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The mage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 14): At Will: Detect Magic, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation 2/Day Each: Fireball (level 4 version), Invisibility 1/Day Each: Cone of Cold, Fly"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Misty Step (3/Day)",
+          "desc": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": [
+        {
+          "name": "Protective Magic (3/Day)",
+          "desc": "The mage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "wizard"
+    },
+    "archmage": {
+      "index": "archmage",
+      "name": "Archmage",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 170,
+      "hit_dice": "31d8 + 31",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 20,
+      "wisdom": 15,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "INT",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "arcana": 13,
+        "history": 9,
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16
+      },
+      "languages": "Common plus five other languages",
+      "challenge_rating": 12.0,
+      "xp": 8000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The archmage has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The archmage makes four Arcane Burst attacks."
+        },
+        {
+          "name": "Arcane Burst",
+          "desc": "Melee or Ranged Attack Roll: +9, reach 5 ft. or range 150 ft. Hit: 27 (4d10 + 5) Force damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "4d10+5",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "4d10+5",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The archmage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 17): At Will: Detect Magic, Detect Thoughts, Disguise Self, Invisibility, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation 2/Day Each: Fly, Lightning Bolt (level 7 version) 1/Day Each: Cone of Cold (level 9 version), Mind Blank (cast before combat), Scrying, Teleport"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Misty Step (3/Day)",
+          "desc": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": [
+        {
+          "name": "Protective Magic (3/Day)",
+          "desc": "The archmage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "wizard"
+    },
+    "magmin": {
+      "index": "magmin",
+      "name": "Magmin",
+      "size": "Small",
+      "type": "elemental",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 14,
+      "hit_points": 13,
+      "hit_dice": "3d6 + 3",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 7,
+      "dexterity": 15,
+      "constitution": 12,
+      "intelligence": 8,
+      "wisdom": 11,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Primordial (Ignan)",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Death Burst",
+          "desc": "The magmin explodes when it dies. Dexterity Saving Throw: DC 11, each creature in a 10-foot Emanation originating from the magmin. Failure: 7 (2d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "Touch",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Fire damage. If the target is a creature or a flammable object that isn’t being worn or carried, it starts burning.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d4+2",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d4+2",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Ignited Illumination",
+          "desc": "The magmin sets itself ablaze or extinguishes its flames. While ablaze, the magmin sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "manticore": {
+      "index": "manticore",
+      "name": "Manticore",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Lawful Evil",
+      "armor_class": 14,
+      "hit_points": 68,
+      "hit_dice": "8d10 + 24",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "50 ft."
+      },
+      "strength": 17,
+      "dexterity": 16,
+      "constitution": 17,
+      "intelligence": 7,
+      "wisdom": 12,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Common",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The manticore makes three attacks, using Rend or Tail Spike in any combination."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Tail Spike",
+          "desc": "Ranged Attack Roll: +5, range 100/200 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "marilith": {
+      "index": "marilith",
+      "name": "Marilith",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 16,
+      "hit_points": 220,
+      "hit_dice": "21d10 + 105",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 20,
+      "constitution": 20,
+      "intelligence": 18,
+      "wisdom": 16,
+      "charisma": 20,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 9
+        },
+        {
+          "name": "CON",
+          "value": 10
+        },
+        {
+          "name": "WIS",
+          "value": 8
+        },
+        {
+          "name": "CHA",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "perception": 8
+      },
+      "senses": {
+        "passive_perception": 18,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "Abyssal; telepathy 120 ft.",
+      "challenge_rating": 16.0,
+      "xp": 15000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Demonic Restoration",
+          "desc": "If the marilith dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The marilith has Advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Reactive",
+          "desc": "The marilith can take one Reaction on every turn of combat."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The marilith makes six Pact Blade attacks and uses Constrict."
+        },
+        {
+          "name": "Pact Blade",
+          "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 10 (1d10 + 5) Slashing damage plus 7 (2d6) Necrotic damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "1d10+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Constrict",
+          "desc": "Strength Saving Throw: DC 17, one Medium or smaller creature the marilith can see within 5 feet. Failure: 15 (2d10 + 4) Bludgeoning damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Teleport (Recharge 5-6)",
+          "desc": "The marilith teleports up to 120 feet to an unoccupied space it can see."
+        }
+      ],
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The marilith is hit by a melee attack roll while holding a weapon. Response: The marilith adds 5 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "medusa": {
+      "index": "medusa",
+      "name": "Medusa",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Lawful Evil",
+      "armor_class": 15,
+      "hit_points": 127,
+      "hit_dice": "17d8 + 51",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 17,
+      "constitution": 16,
+      "intelligence": 12,
+      "wisdom": 13,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "deception": 5,
+        "perception": 4,
+        "stealth": 6,
+        "pb": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The medusa makes two Claw attacks and one Snake Hair attack, or it makes three Poison Ray attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Snake Hair",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 14 (4d6) Poison damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Poison Ray",
+          "desc": "Ranged Attack Roll: +5, range 150 ft. Hit: 11 (2d8 + 2) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d8+2",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "2d8+2",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Petrifying Gaze (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 13, each creature in a 30-foot Cone. If the medusa sees its reflection in the Cone, the medusa must make this save. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "dust-mephit": {
+      "index": "dust-mephit",
+      "name": "Dust Mephit",
+      "size": "Small",
+      "type": "elemental",
+      "alignment": "Neutral Evil",
+      "armor_class": 12,
+      "hit_points": 17,
+      "hit_dice": "5d6",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 5,
+      "dexterity": 14,
+      "constitution": 10,
+      "intelligence": 9,
+      "wisdom": 11,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "stealth": 4
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Death Burst",
+          "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 10, each creature in a 5-foot Emanation originating from the mephit. Failure: 5 (2d4) Bludgeoning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Blinding Breath (Recharge 6)",
+          "desc": "Dexterity Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: The target has the Blinded condition until the end of the mephit’s next turn."
+        },
+        {
+          "name": "Sleep (1/Day)",
+          "desc": "The mephit casts the Sleep spell, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 10)."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ice-mephit": {
+      "index": "ice-mephit",
+      "name": "Ice Mephit",
+      "size": "Small",
+      "type": "elemental",
+      "alignment": "Neutral Evil",
+      "armor_class": 11,
+      "hit_points": 21,
+      "hit_dice": "6d6",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 7,
+      "dexterity": 13,
+      "constitution": 10,
+      "intelligence": 9,
+      "wisdom": 11,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "stealth": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Death Burst",
+          "desc": "The mephit explodes when it dies. Constitution Saving Throw: DC 10, each creature in a 5-foot Emanation originating from the mephit. Failure: 5 (2d4) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "cold"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 2 (1d4) Cold damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d4+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+1",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fog Cloud (1/Day)",
+          "desc": "The mephit casts Fog Cloud, requiring no spell components and using Charisma as the spellcasting ability."
+        },
+        {
+          "name": "Frost Breath (Recharge 6)",
+          "desc": "Constitution Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: 7 (3d4) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "3d4",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "3d4",
+          "damage_type": {
+            "name": "cold"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "magma-mephit": {
+      "index": "magma-mephit",
+      "name": "Magma Mephit",
+      "size": "Small",
+      "type": "elemental",
+      "alignment": "Neutral Evil",
+      "armor_class": 11,
+      "hit_points": 18,
+      "hit_dice": "4d6 + 4",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 8,
+      "dexterity": 12,
+      "constitution": 12,
+      "intelligence": 7,
+      "wisdom": 10,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Cold"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Death Burst",
+          "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 11, each creature in a 5-foot Emanation originating from the mephit. Failure: 7 (2d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 3 (1d6) Fire damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d4+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+1",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 6)",
+          "desc": "Dexterity Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 7 (2d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "steam-mephit": {
+      "index": "steam-mephit",
+      "name": "Steam Mephit",
+      "size": "Small",
+      "type": "elemental",
+      "alignment": "Neutral Evil",
+      "armor_class": 10,
+      "hit_points": 17,
+      "hit_dice": "5d6",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 5,
+      "dexterity": 11,
+      "constitution": 10,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 2
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Blurred Form",
+          "desc": "Attack rolls against the mephit are made with Disadvantage unless the mephit has the Incapacitated condition."
+        },
+        {
+          "name": "Death Burst",
+          "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 10, each creature in a 5-foot Emanation originating from the mephit. Failure: 5 (2d4) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Slashing damage plus 2 (1d4) Fire damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Steam Breath (Recharge 6)",
+          "desc": "Constitution Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: 5 (2d4) Fire damage, and the target’s Speed decreases by 10 feet until the end of the mephit’s next turn. Success: Half damage only. Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage.",
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "merfolk-skirmisher": {
+      "index": "merfolk-skirmisher",
+      "name": "Merfolk Skirmisher",
+      "size": "Medium",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 11,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "10 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 10,
+      "dexterity": 13,
+      "constitution": 12,
+      "intelligence": 11,
+      "wisdom": 14,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 12
+      },
+      "languages": "Common, Primordial (Aquan)",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The merfolk can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ocean Spear",
+          "desc": "Melee or Ranged Attack Roll: +2, reach 5 ft. or range 20/60 ft. Hit: 3 (1d6) Piercing damage plus 2 (1d4) Cold damage. If the target is a creature, its Speed decreases by 10 feet until the end of its next turn. Hit or Miss: The spear magically returns to the merfolk’s hand immediately after a ranged attack.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "merrow": {
+      "index": "merrow",
+      "name": "Merrow",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 13,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "10 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 15,
+      "intelligence": 8,
+      "wisdom": 10,
+      "charisma": 9,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Abyssal, Primordial (Aquan)",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The merrow can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The merrow makes two attacks, using Bite, Claw, or Harpoon in any combination."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage, and the target has the Poisoned condition until the end of the merrow’s next turn.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Harpoon",
+          "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, the merrow pulls the target up to 15 feet straight toward itself.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "mimic": {
+      "index": "mimic",
+      "name": "Mimic",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Neutral",
+      "armor_class": 12,
+      "hit_points": 58,
+      "hit_dice": "9d8 + 18",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 17,
+      "dexterity": 12,
+      "constitution": 15,
+      "intelligence": 5,
+      "wisdom": 13,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Acid"
+      ],
+      "condition_immunities": [
+        "Prone"
+      ],
+      "special_abilities": [
+        {
+          "name": "Adhesive (Object Form Only)",
+          "desc": "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the mimic), reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage-or 12 (2d8 + 3) Piercing damage if the target is Grappled by the mimic-plus 4 (1d8) Acid damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Pseudopod",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 4 (1d8) Acid damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The mimic shape-shifts to resemble a Medium or Small object while retaining its game statistics, or it returns to its true blob form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "minotaur-of-baphomet": {
+      "index": "minotaur-of-baphomet",
+      "name": "Minotaur of Baphomet",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 14,
+      "hit_points": 85,
+      "hit_dice": "10d10 + 30",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 11,
+      "constitution": 16,
+      "intelligence": 6,
+      "wisdom": 16,
+      "charisma": 9,
+      "saving_throws": [],
+      "skills": {
+        "perception": 7,
+        "survival": 7
+      },
+      "senses": {
+        "passive_perception": 17,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Abyssal",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Abyssal Glaive",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 10 (3d6) Necrotic damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d12+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d12+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Gore (Recharge 5-6)",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 18 (4d6 + 4) Piercing damage. If the target is a Large or smaller creature and the minotaur moved 10+ feet straight toward it immediately before the hit, the target takes an extra 10 (3d6) Piercing damage and has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "4d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "mummy": {
+      "index": "mummy",
+      "name": "Mummy",
+      "size": "Medium",
+      "type": "or small undead",
+      "alignment": "Lawful Evil",
+      "armor_class": 11,
+      "hit_points": 58,
+      "hit_dice": "9d8 + 18",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 16,
+      "dexterity": 8,
+      "constitution": 15,
+      "intelligence": 6,
+      "wisdom": 12,
+      "charisma": 12,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "languages_common_plus_two_other_languages_cr": "3",
+        "xp": "700",
+        "summary": "Darkvision 60 ft.; Languages Common plus two other languages CR 3 (XP 700; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened",
+        "Paralyzed",
+        "Poisoned"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The mummy makes two Rotting Fist attacks and uses Dreadful Glare."
+        },
+        {
+          "name": "Rotting Fist",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, its Hit Point maximum doesn’t return to normal when finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Dreadful Glare",
+          "desc": "Wisdom Saving Throw: DC 11, one creature the mummy can see within 60 feet. Failure: The target has the Frightened condition until the end of the mummy’s next turn. Success: The target is immune to this mummy’s Dreadful Glare for 24 hours."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "mummy-lord": {
+      "index": "mummy-lord",
+      "name": "Mummy Lord",
+      "size": "Medium",
+      "type": "or small undead",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 187,
+      "hit_dice": "25d8 + 75",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 10,
+      "constitution": 17,
+      "intelligence": 11,
+      "wisdom": 19,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "INT",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "history": 5,
+        "perception": 9,
+        "religion": 5
+      },
+      "senses": {
+        "passive_perception": 19,
+        "truesight": "60 ft.",
+        "languages_common_plus_three_other_languages_cr": "15",
+        "xp": "13",
+        "or": "15",
+        "summary": "Truesight 60 ft.; Languages Common plus three other languages CR 15 (XP 13,000, or 15,000 in lair; PB +5)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened",
+        "Paralyzed",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the mummy fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The mummy has Advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Undead Restoration",
+          "desc": "If destroyed, the mummy gains a new body in 24 hours if its heart is intact, reviving with all its Hit Points. The new body appears in an unoccupied space within the mummy’s lair. The heart is a Tiny object that has AC 17, HP 10, and Immunity to all damage except Fire."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The mummy makes one Rotting Fist or Channel Negative Energy attack, and it uses Dreadful Glare."
+        },
+        {
+          "name": "Rotting Fist",
+          "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, it gains no benefit from finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Channel Negative Energy",
+          "desc": "Ranged Attack Roll: +9, range 60 ft. Hit: 25 (6d6 + 4) Necrotic damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "6d6+4",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "6d6+4",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        },
+        {
+          "name": "Dreadful Glare",
+          "desc": "Wisdom Saving Throw: DC 17, one creature the mummy can see within 60 feet. Failure: 25 (6d6 + 4) Psychic damage, and the target has the Paralyzed condition until the end of the mummy’s next turn.",
+          "damage": [
+            {
+              "damage_dice": "6d6+4",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "6d6+4",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The mummy casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks): At Will: Dispel Magic, Thaumaturgy 1/Day Each: Animate Dead, Harm, Insect Plague (level 7 version)"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the mummy can expend a use to take one of the following actions. The mummy regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Dread Command",
+          "desc": "The mummy casts Command (level 2 version), using the same spellcasting ability as Spellcasting. The mummy can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Glare",
+          "desc": "The mummy uses Dreadful Glare. The mummy can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Necrotic Strike",
+          "desc": "The mummy makes one Rotting Fist or Channel Negative Energy attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "cleric"
+    },
+    "nalfeshnee": {
+      "index": "nalfeshnee",
+      "name": "Nalfeshnee",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 18,
+      "hit_points": 184,
+      "hit_dice": "16d10 + 96",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 21,
+      "dexterity": 10,
+      "constitution": 22,
+      "intelligence": 19,
+      "wisdom": 12,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 11
+        },
+        {
+          "name": "INT",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        },
+        {
+          "name": "CHA",
+          "value": 7
+        }
+      ],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 13.0,
+      "xp": 10000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Frightened",
+        "Poisoned Senses Truesight 120 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Demonic Restoration",
+          "desc": "If the nalfeshnee dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The nalfeshnee has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The nalfeshnee makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage plus 11 (2d10) Force damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Teleport",
+          "desc": "The nalfeshnee teleports up to 120 feet to an unoccupied space it can see."
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Horror Nimbus (Recharge 5-6)",
+          "desc": "Wisdom Saving Throw: DC 15, each creature in a 15-foot Emanation originating from the nalfeshnee. Failure: 28 (8d6) Psychic damage, and the target has the Frightened condition for 1 minute, until it takes damage, or until it ends its turn with the nalfeshnee out of line of sight. Success: The target is immune to this nalfeshnee’s Horror Nimbus for 24 hours.",
+          "damage": [
+            {
+              "damage_dice": "8d6",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "8d6",
+          "damage_type": {
+            "name": "psychic"
+          }
+        }
+      ],
+      "reactions": [
+        {
+          "name": "Pursuit",
+          "desc": "Trigger: Another creature the nalfeshnee can see ends its move within 120 feet of the nalfeshnee. Response: The nalfeshnee uses Teleport, but its destination space must be within 10 feet of the triggering creature."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "night-hag": {
+      "index": "night-hag",
+      "name": "Night Hag",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Neutral Evil",
+      "armor_class": 17,
+      "hit_points": 112,
+      "hit_dice": "15d8 + 45",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 16,
+      "wisdom": 14,
+      "charisma": 16,
+      "saving_throws": [],
+      "skills": {
+        "deception": 6,
+        "insight": 5,
+        "perception": 5,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "120 ft.",
+        "primordial_cr": "5",
+        "xp": "1",
+        "summary": "Darkvision 120 ft.; Languages Abyssal, Common, Infernal, Primordial CR 5 (XP 1,800; PB +3)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire"
+      ],
+      "damage_immunities": [
+        "Charmed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Coven Magic",
+          "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 14): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hag makes two Claw attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Nightmare Haunting (1/Day; Requires Soul Bag)",
+          "desc": "While on the Ethereal Plane, the hag casts Dream, using the same spellcasting ability as Spellcasting. Only the hag can serve as the spell’s messenger, and the tar- get must be a creature the hag can see on the Material Plane. The spell fails and is wasted if the target is under the effect of the Protection from Evil and Good spell or within a Magic Circle spell. If the target takes damage from the Dream spell, the target’s Hit Point maximum decreases by an amount equal to that damage. If the spell kills the target, its soul is trapped in the hag’s soul bag, and the target can’t be raised from the dead until its soul is released."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The hag casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 14): At Will: Detect Magic, Etherealness, Magic Missile (level 4 version) 2/Day Each: Phantasmal Killer, Plane Shift (self only)"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The hag shape-shifts into a Small or Medium Humanoid, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "nightmare": {
+      "index": "nightmare",
+      "name": "Nightmare",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Neutral Evil",
+      "armor_class": 13,
+      "hit_points": 68,
+      "hit_dice": "8d10 + 24",
+      "speed": {
+        "walk": "60 ft.",
+        "fly": "90 ft. (hover)"
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 13,
+      "charisma": 15,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "Understands Abyssal, Common, and Infernal but can’t speak",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Confer Fire Resistance",
+          "desc": "The nightmare can grant Resistance to Fire damage to a rider while it is on the nightmare."
+        },
+        {
+          "name": "Illumination",
+          "desc": "The nightmare sheds Bright Light in a 10foot radius and Dim Light for an additional 10 feet."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 10 (3d6) Fire damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Ethereal Stride",
+          "desc": "The nightmare and up to three willing creatures within 5 feet of it teleport to the Ethereal Plane from the Material Plane or vice versa."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "noble": {
+      "index": "noble",
+      "name": "Noble",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 15,
+      "hit_points": 9,
+      "hit_dice": "2d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 12,
+      "constitution": 11,
+      "intelligence": 12,
+      "wisdom": 14,
+      "charisma": 16,
+      "saving_throws": [],
+      "skills": {
+        "deception": 5,
+        "insight": 4,
+        "persuasion": 5
+      },
+      "senses": {
+        "passive_perception": 12
+      },
+      "languages": "Common plus two other languages",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rapier",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d8+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The noble is hit by a melee attack roll while holding a weapon. Response: The noble adds 2 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ochre-jelly": {
+      "index": "ochre-jelly",
+      "name": "Ochre Jelly",
+      "size": "Large",
+      "type": "ooze",
+      "alignment": "Unaligned",
+      "armor_class": 8,
+      "hit_points": 52,
+      "hit_dice": "7d10 + 14",
+      "speed": {
+        "walk": "20 ft.",
+        "climb": "20 ft."
+      },
+      "strength": 15,
+      "dexterity": 6,
+      "constitution": 14,
+      "intelligence": 2,
+      "wisdom": 6,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid"
+      ],
+      "damage_immunities": [
+        "Lightning",
+        "Slashing"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Deafened",
+        "Exhaustion",
+        "Frightened",
+        "Grappled",
+        "Prone",
+        "Restrained"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amorphous",
+          "desc": "The jelly can move through a space as narrow as 1 inch without expending extra movement to do so."
+        },
+        {
+          "name": "Spider Climb",
+          "desc": "The jelly can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "3d6+2",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "3d6+2",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Split",
+          "desc": "Trigger: While the jelly is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The jelly splits into two new Ochre Jellies. Each new jelly is one size smaller than the original jelly and acts on its Initiative. The original jelly’s Hit Points are divided evenly between the new jellies (round down)."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
     "ogre": {
       "index": "ogre",
       "name": "Ogre",
       "size": "Large",
       "type": "giant",
-      "alignment": "chaotic evil",
+      "alignment": "Chaotic Evil",
       "armor_class": 11,
-      "hit_points": 59,
-      "hit_dice": "7d10",
-      "speed": { "walk": "40 ft." },
+      "hit_points": 68,
+      "hit_dice": "8d10 + 24",
+      "speed": {
+        "walk": "40 ft."
+      },
       "strength": 19,
       "dexterity": 8,
       "constitution": 16,
       "intelligence": 5,
       "wisdom": 7,
       "charisma": 7,
-      "senses": { "darkvision": "60 ft.", "passive_perception": 8 },
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
       "languages": "Common, Giant",
-      "challenge_rating": 2,
+      "challenge_rating": 2.0,
       "xp": 450,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
       "actions": [
         {
           "name": "Greatclub",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage.",
           "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
           "damage_dice": "2d8+4",
-          "damage_type": { "name": "bludgeoning" },
-          "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+          "damage_type": {
+            "name": "bludgeoning"
+          }
         },
         {
           "name": "Javelin",
+          "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 11 (2d6 + 4) Piercing damage.",
           "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
           "damage_dice": "2d6+4",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 11 (2d6 + 4) piercing damage."
+          "damage_type": {
+            "name": "piercing"
+          }
         }
-      ]
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
-    "orc": {
-      "index": "orc",
-      "name": "Orc",
-      "size": "Medium",
-      "type": "humanoid",
-      "subtype": "orc",
-      "alignment": "chaotic evil",
-      "armor_class": 13,
-      "hit_points": 15,
-      "hit_dice": "2d8",
-      "speed": { "walk": "30 ft." },
-      "strength": 16,
-      "dexterity": 12,
+    "oni": {
+      "index": "oni",
+      "name": "Oni",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 119,
+      "hit_dice": "14d10 + 42",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "30 ft. (hover)"
+      },
+      "strength": 19,
+      "dexterity": 11,
       "constitution": 16,
-      "intelligence": 7,
-      "wisdom": 11,
-      "charisma": 10,
-      "senses": { "darkvision": "60 ft.", "passive_perception": 10 },
-      "languages": "Common, Orc",
-      "challenge_rating": 0.5,
-      "xp": 100,
-      "proficiency_bonus": 2,
+      "intelligence": 14,
+      "wisdom": 12,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "CON",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        },
+        {
+          "name": "CHA",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "arcana": 5,
+        "deception": 8,
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Common, Giant",
+      "challenge_rating": 7.0,
+      "xp": 2900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
       "special_abilities": [
         {
-          "name": "Aggressive",
-          "desc": "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."
+          "name": "Regeneration",
+          "desc": "The oni regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point."
         }
       ],
       "actions": [
         {
-          "name": "Greataxe",
-          "attack_bonus": 5,
-          "damage_dice": "1d12+3",
-          "damage_type": { "name": "slashing" },
-          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage."
+          "name": "Multiattack",
+          "desc": "The oni makes two Claw or Nightmare Ray attacks. It can replace one attack with a use of Spellcasting."
         },
         {
-          "name": "Javelin",
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 9 (2d8) Necrotic damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d12+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d12+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Nightmare Ray",
+          "desc": "Ranged Attack Roll: +5, range 60 ft. Hit: 9 (2d6 + 2) Psychic damage, and the target has the Frightened condition until the start of the oni’s next turn.",
           "attack_bonus": 5,
-          "damage_dice": "1d6+3",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 8 (1d6 + 3) piercing damage."
+          "damage": [
+            {
+              "damage_dice": "2d6+2",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "2d6+2",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Shape-Shift",
+          "desc": "The oni shape-shifts into a Small or Medium Humanoid or a Large Giant, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The oni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13): 1/Day Each: Charm Person (level 2 version), Darkness, Gaseous Form, Sleep"
         }
-      ]
+      ],
+      "bonus_actions": [
+        {
+          "name": "Invisibility",
+          "desc": "The oni casts Invisibility on itself, requiring no spell components and using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "otyugh": {
+      "index": "otyugh",
+      "name": "Otyugh",
+      "size": "Large",
+      "type": "aberration",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 104,
+      "hit_dice": "11d10 + 44",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 11,
+      "constitution": 19,
+      "intelligence": 6,
+      "wisdom": 13,
+      "charisma": 6,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 7
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Otyugh; telepathy 120 ft. (doesn’t allow the receiving creature to respond telepathically)",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The otyugh makes one Bite attack and two Tentacle attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage, and the target has the Poisoned condition. Whenever the Poisoned target finishes a Long Rest, it is subjected to the following effect. Constitution Saving Throw: DC 15. Failure: The target’s Hit Point maximum decreases by 5 (1d10) and doesn’t return to normal until the Poisoned condition ends on the target. Success: The Poisoned condition ends.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tentacle",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two tentacles.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tentacle Slam",
+          "desc": "Constitution Saving Throw: DC 14, each creature Grappled by the otyugh. Failure: 16 (3d8 + 3) Bludgeoning damage, and the target has the Stunned condition until the start of the otyugh’s next turn. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "3d8+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d8+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "owlbear": {
+      "index": "owlbear",
+      "name": "Owlbear",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 59,
+      "hit_dice": "7d10 + 21",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 20,
+      "dexterity": 12,
+      "constitution": 17,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The owlbear makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "pegasus": {
+      "index": "pegasus",
+      "name": "Pegasus",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Chaotic Good",
+      "armor_class": 12,
+      "hit_points": 59,
+      "hit_dice": "7d10 + 21",
+      "speed": {
+        "walk": "60 ft.",
+        "fly": "90 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 15,
+      "charisma": 13,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "CON",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        },
+        {
+          "name": "CHA",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16
+      },
+      "languages": "Understands Celestial, Common, Elvish, and Sylvan but can’t speak",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "phase-spider": {
+      "index": "phase-spider",
+      "name": "Phase Spider",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 45,
+      "hit_dice": "7d10 + 7",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 16,
+      "constitution": 12,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Ethereal Sight",
+          "desc": "The spider can see 60 feet into the Ethereal Plane while on the Material Plane and vice versa."
+        },
+        {
+          "name": "Spider Climb",
+          "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The spider makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage plus 9 (2d8) Poison damage. If this damage reduces the target to 0 Hit Points, the target becomes Stable, and it has the Poisoned condition for 1 hour. While Poisoned, the target also has the Paralyzed condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Ethereal Jaunt",
+          "desc": "The spider teleports from the Material Plane to the Ethereal Plane or vice versa."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "pirate": {
+      "index": "pirate",
+      "name": "Pirate",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 33,
+      "hit_dice": "6d8 + 6",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 16,
+      "constitution": 12,
+      "intelligence": 8,
+      "wisdom": 12,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "CHA",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The pirate makes two Dagger attacks. It can replace one attack with a use of Enthralling Panache."
+        },
+        {
+          "name": "Dagger",
+          "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Enthralling Panache",
+          "desc": "Wisdom Saving Throw: DC 12, one creature the pirate can see within 30 feet. Failure: The target has the Charmed condition until the start of the pirate’s next turn."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "pirate-captain": {
+      "index": "pirate-captain",
+      "name": "Pirate Captain",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 84,
+      "hit_dice": "13d8 + 26",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 18,
+      "constitution": 14,
+      "intelligence": 10,
+      "wisdom": 14,
+      "charisma": 17,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 3
+        },
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 5
+        },
+        {
+          "name": "CHA",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "acrobatics": 7,
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The pirate makes three attacks, using Rapier or Pistol in any combination."
+        },
+        {
+          "name": "Rapier",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage, and the pirate has Advantage on the next attack roll it makes before the end of this turn.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Pistol",
+          "desc": "Ranged Attack Roll: +7, range 30/90 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Captain’s Charm",
+          "desc": "Wisdom Saving Throw: DC 14, one creature the pirate can see within 30 feet. Failure: The target has the Charmed condition until the start of the pirate’s next turn."
+        }
+      ],
+      "reactions": [
+        {
+          "name": "Riposte",
+          "desc": "Trigger: The pirate is hit by a melee attack roll while holding a weapon. Response: The pirate adds 3 to its AC against that attack, possibly causing it to miss. On a miss, the pirate makes one Rapier attack against the triggering creature if within range."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "pit-fiend": {
+      "index": "pit-fiend",
+      "name": "Pit Fiend",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 21,
+      "hit_points": 337,
+      "hit_dice": "27d10 + 189",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 26,
+      "dexterity": 14,
+      "constitution": 24,
+      "intelligence": 22,
+      "wisdom": 18,
+      "charisma": 24,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "perception": 10,
+        "persuasion": 19
+      },
+      "senses": {
+        "passive_perception": 20,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "Infernal; telepathy 120 ft.",
+      "challenge_rating": 20.0,
+      "xp": 25000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Diabolical Restoration",
+          "desc": "If the pit fiend dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        },
+        {
+          "name": "Fear Aura",
+          "desc": "The pit fiend emanates an aura in a 20foot Emanation while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 21, any enemy that starts its turn in the aura. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this pit fiend’s aura for 24 hours."
+        },
+        {
+          "name": "Legendary Resistance (4/Day)",
+          "desc": "If the pit fiend fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The pit fiend has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The pit fiend makes one Bite attack, two Devilish Claw attacks, and one Fiery Mace attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 18 (3d6 + 8) Piercing damage. If the target is a creature, it must make the following saving throw. Constitution Saving Throw: DC 21. Failure: The target has the Poisoned condition. While Poisoned, the target can’t regain Hit Points and takes 21 (6d6) Poison damage at the start of each of its turns, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "3d6+8",
+              "damage_type": {
+                "name": "piercing"
+              }
+            },
+            {
+              "damage_dice": "6d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Devilish Claw",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 26 (4d8 + 8) Necrotic damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "4d8+8",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "4d8+8",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        },
+        {
+          "name": "Fiery Mace",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (4d6 + 8) Force damage plus 21 (6d6) Fire damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "4d6+8",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "4d6+8",
+          "damage_type": {
+            "name": "force"
+          }
+        },
+        {
+          "name": "Hellfire Spellcasting (Recharge 4-6)",
+          "desc": "The pit fiend casts Fireball (level 5 version) twice, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21). It can replace one Fireball with Hold Monster (level 7 version) or Wall of Fire."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "devil"
+    },
+    "planetar": {
+      "index": "planetar",
+      "name": "Planetar",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 19,
+      "hit_points": 262,
+      "hit_dice": "21d10 + 147",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "120 ft. (hover)"
+      },
+      "strength": 24,
+      "dexterity": 20,
+      "constitution": 24,
+      "intelligence": 19,
+      "wisdom": 22,
+      "charisma": 25,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 12
+        },
+        {
+          "name": "CON",
+          "value": 12
+        },
+        {
+          "name": "WIS",
+          "value": 11
+        },
+        {
+          "name": "CHA",
+          "value": 12
+        }
+      ],
+      "skills": {
+        "perception": 11
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 16.0,
+      "xp": 15000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Radiant"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened Senses Truesight 120 ft."
+      ],
+      "condition_immunities": [
+        "Passive Perception 21 Languages All"
+      ],
+      "special_abilities": [
+        {
+          "name": "Divine Awareness",
+          "desc": "The planetar knows if it hears a lie."
+        },
+        {
+          "name": "Exalted Restoration",
+          "desc": "If the planetar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The planetar has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The planetar makes three Radiant Sword attacks or uses Holy Burst twice."
+        },
+        {
+          "name": "Radiant Sword",
+          "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 14 (2d6 + 7) Slashing damage plus 18 (4d8) Radiant damage.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "2d6+7",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+7",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Holy Burst",
+          "desc": "Dexterity Saving Throw: DC 20, each enemy in a 20-foot-radius Sphere centered on a point the planetar can see within 120 feet. Failure: 24 (7d6) Radiant damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "7d6",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "7d6",
+          "damage_type": {
+            "name": "radiant"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The planetar casts one of the following spells, requiring no Material components and using Charisma as spellcasting ability (spell save DC 20): At Will: Detect Evil and Good 1/Day Each: Commune, Control Weather, Dispel Evil and Good, Raise Dead"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Divine Aid (2/Day)",
+          "desc": "The planetar casts Cure Wounds, Invisibility, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "angel"
+    },
+    "priest-acolyte": {
+      "index": "priest-acolyte",
+      "name": "Priest Acolyte",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 10,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 14,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "medicine": 4,
+        "religion": 2
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Mace",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage plus 2 (1d4) Radiant damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Radiant Flame",
+          "desc": "Ranged Attack Roll: +4, range 60 ft. Hit: 7 (2d6) Radiant damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "radiant"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability: At Will: Light, Thaumaturgy"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Divine Aid (1/Day)",
+          "desc": "The priest casts Bless, Healing Word, or Sanctuary, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "cleric"
+    },
+    "priest": {
+      "index": "priest",
+      "name": "Priest",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 38,
+      "hit_dice": "7d8 + 7",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 10,
+      "constitution": 12,
+      "intelligence": 13,
+      "wisdom": 16,
+      "charisma": 13,
+      "saving_throws": [],
+      "skills": {
+        "medicine": 7,
+        "perception": 5,
+        "religion": 5
+      },
+      "senses": {
+        "passive_perception": 15
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The priest makes two attacks, using Mace or Radiant Flame in any combination."
+        },
+        {
+          "name": "Mace",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 5 (2d4) Radiant damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Radiant Flame",
+          "desc": "Ranged Attack Roll: +5, range 60 ft. Hit: 11 (2d10) Radiant damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d10",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "2d10",
+          "damage_type": {
+            "name": "radiant"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13): At Will: Light, Thaumaturgy 1/Day: Spirit Guardians"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Divine Aid (3/Day)",
+          "desc": "The priest casts Bless, Dispel Magic, Healing Word, or Lesser Restoration, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "cleric"
+    },
+    "pseudodragon": {
+      "index": "pseudodragon",
+      "name": "Pseudodragon",
+      "size": "Tiny",
+      "type": "dragon",
+      "alignment": "Neutral Good",
+      "armor_class": 14,
+      "hit_points": 10,
+      "hit_dice": "3d4 + 3",
+      "speed": {
+        "walk": "15 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 6,
+      "dexterity": 15,
+      "constitution": 13,
+      "intelligence": 10,
+      "wisdom": 12,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Understands Common and Draconic but can’t speak",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The pseudodragon has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The pseudodragon makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Sting",
+          "desc": "Constitution Saving Throw: DC 12, one creature the pseudodragon can see within 5 feet. Failure: 5 (2d4) Poison damage, and the target has the Poisoned condition for 1 hour. Failure by 5 or More: While Poisoned, the target also has the Unconscious condition, which ends early if the target takes damage or a creature within 5 feet of it takes an action to wake it.",
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "purple-worm": {
+      "index": "purple-worm",
+      "name": "Purple Worm",
+      "size": "Gargantuan",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 18,
+      "hit_points": 247,
+      "hit_dice": "15d20 + 90",
+      "speed": {
+        "walk": "50 ft.",
+        "burrow": "50 ft."
+      },
+      "strength": 28,
+      "dexterity": 7,
+      "constitution": 22,
+      "intelligence": 1,
+      "wisdom": 8,
+      "charisma": 4,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 11
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "blindsight": "30 ft.",
+        "tremorsense": "60 ft.",
+        "summary": "Blindsight 30 ft., Tremorsense 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 15.0,
+      "xp": 13000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Tunneler",
+          "desc": "The worm can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The worm makes one Bite attack and one Tail Stinger attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (3d8 + 9) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 19), and it has the Restrained condition until the grapple ends.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "3d8+9",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d8+9",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tail Stinger",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 16 (2d6 + 9) Piercing damage plus 35 (10d6) Poison damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "2d6+9",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+9",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Swallow",
+          "desc": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the worm (it can have up to three creatures swallowed at a time). Failure: The target is swallowed by the worm, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the worm, and takes 17 (5d6) Acid damage at the start of each of the worm’s turns. If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the worm and has the Prone condition. If the worm dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone.",
+          "damage": [
+            {
+              "damage_dice": "5d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "5d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "quasit": {
+      "index": "quasit",
+      "name": "Quasit",
+      "size": "Tiny",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 13,
+      "hit_points": 25,
+      "hit_dice": "10d4",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 5,
+      "dexterity": 17,
+      "constitution": 10,
+      "intelligence": 7,
+      "wisdom": 10,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Abyssal, Common",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The quasit has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage, and the target has the Poisoned condition until the start of the quasit’s next turn.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Invisibility",
+          "desc": "The quasit casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+        },
+        {
+          "name": "Scare (1/Day)",
+          "desc": "Wisdom Saving Throw: DC 10, one creature within 20 feet. Failure: The target has the Frightened condition. At the end of each of its turns, the target repeats the save, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        },
+        {
+          "name": "Shape-Shift",
+          "desc": "The quasit shape-shifts to resemble a bat (Speed 10 ft., Fly 40 ft.), a centipede (40 ft., Climb 40 ft.), or a toad (40 ft., Swim 40 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "rakshasa": {
+      "index": "rakshasa",
+      "name": "Rakshasa",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 17,
+      "hit_points": 221,
+      "hit_dice": "26d8 + 104",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 14,
+      "dexterity": 17,
+      "constitution": 18,
+      "intelligence": 13,
+      "wisdom": 16,
+      "charisma": 20,
+      "saving_throws": [],
+      "skills": {
+        "deception": 10,
+        "insight": 8,
+        "perception": 8
+      },
+      "senses": {
+        "passive_perception": 18,
+        "truesight": "60 ft.",
+        "summary": "Truesight 60 ft."
+      },
+      "languages": "Common, Infernal",
+      "challenge_rating": 13.0,
+      "xp": 10000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": [
+        "Piercing damage from weapons wielded by creatures under the effect of a Bless spell"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Charmed",
+        "Frightened"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Greater Magic Resistance",
+          "desc": "The rakshasa automatically succeeds on saving throws against spells and other magical effects, and the attack rolls of spells automatically miss it. Without the rakshasa’s permission, no spell can observe the rakshasa remotely or detect its thoughts, creature type, or alignment."
+        },
+        {
+          "name": "Fiendish Restoration",
+          "desc": "If the rakshasa dies outside the Nine Hells, its body turns to ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The rakshasa makes three Cursed Touch attacks."
+        },
+        {
+          "name": "Cursed Touch",
+          "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 12 (2d6 + 5) Slashing damage plus 19 (3d12) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target gains no benefit from finishing a Short or Long Rest.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d6+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Baleful Command (Recharge 5-6)",
+          "desc": "Wisdom Saving Throw: DC 18, each enemy in a 30-foot Emanation originating from the rakshasa. Failure: 28 (8d6) Psychic damage, and the target has the Frightened and Incapacitated conditions until the start of the rakshasa’s next turn.",
+          "damage": [
+            {
+              "damage_dice": "8d6",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "8d6",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The rakshasa casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18): At Will: Detect Magic, Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion 1/Day Each: Fly, Invisibility, Major Image, Plane Shift"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "red-dragon-wyrmling": {
+      "index": "red-dragon-wyrmling",
+      "name": "Red Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 17,
+      "hit_points": 75,
+      "hit_dice": "10d8 + 30",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 19,
+      "dexterity": 10,
+      "constitution": 17,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage plus 3 (1d6) Fire damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 24 (7d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "7d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "7d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "young-red-dragon": {
+      "index": "young-red-dragon",
+      "name": "Young Red Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 18,
+      "hit_points": 178,
+      "hit_dice": "17d10 + 85",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 23,
+      "dexterity": 10,
+      "constitution": 21,
+      "intelligence": 14,
+      "wisdom": 11,
+      "charisma": 19,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "perception": 8,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 18,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 10.0,
+      "xp": 5900,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 3 (1d6) Fire damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d6+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "16d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "16d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "adult-red-dragon": {
+      "index": "adult-red-dragon",
+      "name": "Adult Red Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 19,
+      "hit_points": 256,
+      "hit_dice": "19d12 + 133",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 27,
+      "dexterity": 10,
+      "constitution": 25,
+      "intelligence": 16,
+      "wisdom": 13,
+      "charisma": 23,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "perception": 13,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 23,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 17.0,
+      "xp": 18000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Scorching Ray."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 13 (1d10 + 8) Slashing damage plus 5 (2d4) Fire damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "1d10+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 21, each creature in a 60-foot Cone. Failure: 59 (17d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "17d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "17d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks): At Will: Command (level 2 version), Detect Magic, Scorching Ray 1/Day: Fireball"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Commanding Presence",
+          "desc": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Fiery Rays",
+          "desc": "The dragon uses Spellcasting to cast Scorching Ray. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "ancient-red-dragon": {
+      "index": "ancient-red-dragon",
+      "name": "Ancient Red Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 22,
+      "hit_points": 507,
+      "hit_dice": "26d20 + 234",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 30,
+      "dexterity": 10,
+      "constitution": 29,
+      "intelligence": 18,
+      "wisdom": 15,
+      "charisma": 27,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "perception": 16,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 26,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 24.0,
+      "xp": 62000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Scorching Ray (level 3 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +17, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 10 (3d6) Fire damage.",
+          "attack_bonus": 17,
+          "damage": [
+            {
+              "damage_dice": "2d8+10",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+10",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 91 (26d6) Fire damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "26d6",
+              "damage_type": {
+                "name": "fire"
+              }
+            }
+          ],
+          "damage_dice": "26d6",
+          "damage_type": {
+            "name": "fire"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks): At Will: Command (level 2 version), Detect Magic, Scorching Ray (level 3 version) 1/Day Each: Fireball (level 6 version), Scrying"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Commanding Presence",
+          "desc": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Fiery Rays",
+          "desc": "The dragon uses Spellcasting to cast Scorching Ray (level 3 version). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "remorhaz": {
+      "index": "remorhaz",
+      "name": "Remorhaz",
+      "size": "Huge",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 17,
+      "hit_points": 195,
+      "hit_dice": "17d12 + 85",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "30 ft."
+      },
+      "strength": 24,
+      "dexterity": 13,
+      "constitution": 21,
+      "intelligence": 4,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "tremorsense": "60 ft.",
+        "summary": "Darkvision 60 ft., Tremorsense 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold",
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Heat Aura",
+          "desc": "At the end of each of the remorhaz’s turns, each creature in a 5-foot Emanation originating from the remorhaz takes 16 (3d10) Fire damage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage plus 14 (4d6) Fire damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17), and it has the Restrained condition until the grapple ends.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "2d10+7",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+7",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Swallow",
+          "desc": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the remorhaz (it can have up to two creatures swallowed at a time). Failure: The target is swallowed by the remorhaz, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions, it has Total Cover against attacks and other effects outside the remorhaz, and it takes 10 (3d6) Acid damage plus 10 (3d6) Fire damage at the start of each of the remorhaz’s turns. If the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the remorhaz and has the Prone condition. If the remorhaz dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse by using 15 feet of movement, exiting Prone.",
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "roc": {
+      "index": "roc",
+      "name": "Roc",
+      "size": "Gargantuan",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 15,
+      "hit_points": 248,
+      "hit_dice": "16d20 + 80",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "120 ft."
+      },
+      "strength": 28,
+      "dexterity": 10,
+      "constitution": 20,
+      "intelligence": 3,
+      "wisdom": 10,
+      "charisma": 9,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "perception": 8
+      },
+      "senses": {
+        "passive_perception": 18
+      },
+      "languages": "",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The roc makes two Beak attacks. It can replace one attack with a Talons attack."
+        },
+        {
+          "name": "Beak",
+          "desc": "Melee Attack Roll: +13, reach 10 ft. Hit: 28 (3d12 + 9) Piercing damage.",
+          "attack_bonus": 13,
+          "damage": [
+            {
+              "damage_dice": "3d12+9",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d12+9",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Talons",
+          "desc": "Melee Attack Roll: +13, reach 5 ft. Hit: 23 (4d6 + 9) Slashing damage. If the target is a Huge or smaller creature, it has the Grappled condition (escape DC 19) from both talons, and it has the Restrained condition until the grapple ends.",
+          "attack_bonus": 13,
+          "damage": [
+            {
+              "damage_dice": "4d6+9",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+9",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Swoop (Recharge 5-6)",
+          "desc": "If the roc has a creature Grappled, the roc flies up to half its Fly Speed without provoking Opportunity Attacks and drops that creature."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "roper": {
+      "index": "roper",
+      "name": "Roper",
+      "size": "Large",
+      "type": "aberration",
+      "alignment": "Neutral Evil",
+      "armor_class": 20,
+      "hit_points": 93,
+      "hit_dice": "11d10 + 33",
+      "speed": {
+        "walk": "10 ft.",
+        "climb": "20 ft."
+      },
+      "strength": 18,
+      "dexterity": 8,
+      "constitution": 17,
+      "intelligence": 7,
+      "wisdom": 16,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The roper can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The roper makes two Tentacle attacks, uses Reel, and makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (3d8 + 4) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "3d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tentacle",
+          "desc": "Melee Attack Roll: +7, reach 60 ft. Hit: The target has the Grappled condition (escape DC 14) from one of six tentacles, and the target has the Poisoned condition until the grapple ends. The tentacle can be damaged, freeing a creature it has Grappled when destroyed (AC 20, HP 10, Immunity to Poison and Psychic damage). Damaging the tentacle deals no damage to the roper, and a destroyed tentacle regrows at the start of the roper’s next turn.",
+          "attack_bonus": 7
+        },
+        {
+          "name": "Reel",
+          "desc": "The roper pulls each creature Grappled by it up to 30 feet straight toward it."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "rust-monster": {
+      "index": "rust-monster",
+      "name": "Rust Monster",
+      "size": "Medium",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 33,
+      "hit_dice": "6d8 + 6",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 13,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 13,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Iron Scent",
+          "desc": "The rust monster can pinpoint the location of ferrous metal within 30 feet of itself."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The rust monster makes one Bite attack and uses Antennae twice."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d8+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Antennae",
+          "desc": "The rust monster targets one nonmagical metal object-armor or a weapon-worn or carried by a creature within 5 feet of itself. Dexterity Saving Throw: DC 11, the creature with the object. Failure: The object takes a -1 penalty to the AC it offers (armor) or to its attack rolls (weapon). Armor is destroyed if the penalty reduces its AC to 10, and a weapon is destroyed if its penalty reaches -5. The penalty can be removed by casting the Mending spell on the armor or weapon."
+        },
+        {
+          "name": "Destroy Metal",
+          "desc": "The rust monster touches a nonmagical metal object within 5 feet of itself that isn’t being worn or carried. The touch destroys a 1-foot Cube of the object."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Reflexive Antennae",
+          "desc": "Trigger: An attack roll hits the rust monster. Response: The rust monster uses Antennae."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "sahuagin-warrior": {
+      "index": "sahuagin-warrior",
+      "name": "Sahuagin Warrior",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Lawful Evil",
+      "armor_class": 12,
+      "hit_points": 22,
+      "hit_dice": "4d8 + 4",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 13,
+      "dexterity": 11,
+      "constitution": 12,
+      "intelligence": 12,
+      "wisdom": 13,
+      "charisma": 9,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Sahuagin",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Cold"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Blood Frenzy",
+          "desc": "The sahuagin has Advantage on attack rolls against any creature that doesn’t have all its Hit Points."
+        },
+        {
+          "name": "Limited Amphibiousness",
+          "desc": "The sahuagin can breathe air and water, but it must be submerged at least once every 4 hours to avoid suffocating outside water."
+        },
+        {
+          "name": "Shark Telepathy",
+          "desc": "The sahuagin can magically control sharks within 120 feet of itself, using a special telepathy."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The sahuagin makes two Claw attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Aquatic Charge",
+          "desc": "The sahuagin swims up to its Swim Speed straight toward an enemy it can see."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "salamander": {
+      "index": "salamander",
+      "name": "Salamander",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral Evil",
+      "armor_class": 15,
+      "hit_points": 90,
+      "hit_dice": "12d10 + 24",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 15,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Primordial (Ignan)",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": [
+        "Cold"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Fire"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Fire Aura",
+          "desc": "At the end of each of the salamander’s turns, each creature of the salamander’s choice in a 5-foot Emanation originating from the salamander takes 7 (2d6) Fire damage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The salamander makes two Flame Spear attacks. It can replace one attack with a use of Constrict."
+        },
+        {
+          "name": "Flame Spear",
+          "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft. or range 20/60 ft. Hit: 13 (2d8 + 4) Piercing damage plus 7 (2d6) Fire damage. Hit or Miss: The spear magically returns to the salamander’s hand immediately after a ranged attack.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Constrict",
+          "desc": "Strength Saving Throw: DC 15, one Large or smaller creature the salamander can see within 10 feet. Failure: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Fire damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "satyr": {
+      "index": "satyr",
+      "name": "Satyr",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Chaotic Neutral",
+      "armor_class": 13,
+      "hit_points": 31,
+      "hit_dice": "7d8",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 12,
+      "dexterity": 16,
+      "constitution": 11,
+      "intelligence": 12,
+      "wisdom": 10,
+      "charisma": 14,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "performance": 6,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 12,
+        "sylvan_cr": "1",
+        "xp": "100",
+        "summary": "Languages Common, Elvish, Sylvan CR 1/2 (XP 100; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The satyr has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the satyr pushes the target up to 10 feet straight away from itself.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Mockery",
+          "desc": "Wisdom Saving Throw: DC 12, one creature the satyr can see within 90 feet. Failure: 5 (1d6 + 2) Psychic damage.",
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "psychic"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "scout": {
+      "index": "scout",
+      "name": "Scout",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 16,
+      "hit_dice": "3d8 + 3",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 11,
+      "wisdom": 13,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "nature": 4,
+        "perception": 5,
+        "stealth": 6,
+        "survival": 5
+      },
+      "senses": {
+        "passive_perception": 15
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The scout makes two attacks, using Shortsword and Longbow in any combination."
+        },
+        {
+          "name": "Shortsword",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Longbow",
+          "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "sea-hag": {
+      "index": "sea-hag",
+      "name": "Sea Hag",
+      "size": "Medium",
+      "type": "fey",
+      "alignment": "Chaotic Evil",
+      "armor_class": 14,
+      "hit_points": 52,
+      "hit_dice": "7d8 + 21",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 16,
+      "intelligence": 12,
+      "wisdom": 12,
+      "charisma": 13,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "cr": "2",
+        "xp": "450",
+        "summary": "Darkvision 60 ft.; Languages Common, Giant, Primordial (Aquan) CR 2 (XP 450; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The hag can breathe air and water."
+        },
+        {
+          "name": "Coven Magic",
+          "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Death Glare (Recharge 5-6)",
+          "desc": "Wisdom Saving Throw: DC 11, one Frightened creature the hag can see within 30 feet. Failure: If the target has 20 Hit Points or fewer, it drops to 0 Hit Points. Otherwise, the target takes 13 (3d8) Psychic damage.",
+          "damage": [
+            {
+              "damage_dice": "3d8",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "3d8",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Illusory Appearance",
+          "desc": "The hag casts Disguise Self, using Constitution as the spellcasting ability (spell save DC 13). The spell’s duration is 24 hours."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "shadow": {
+      "index": "shadow",
+      "name": "Shadow",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "Chaotic Evil",
+      "armor_class": 12,
+      "hit_points": 27,
+      "hit_dice": "5d8 + 5",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 6,
+      "dexterity": 14,
+      "constitution": 13,
+      "intelligence": 6,
+      "wisdom": 10,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Radiant"
+      ],
+      "damage_resistances": [
+        "Acid",
+        "Cold",
+        "Fire",
+        "Lightning",
+        "Thunder"
+      ],
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Frightened",
+        "Grappled",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained",
+        "Unconscious"
+      ],
+      "special_abilities": [
+        {
+          "name": "Amorphous",
+          "desc": "The shadow can move through a space as narrow as 1 inch without expending extra movement to do so."
+        },
+        {
+          "name": "Sunlight Weakness",
+          "desc": "While in sunlight, the shadow has Disadvantage on D20 Tests."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Draining Swipe",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Necrotic damage, and the target’s Strength score decreases by 1d4. The target dies if this reduces that score to 0. If a Humanoid is slain by this attack, a Shadow rises from the corpse 1d4 hours later.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shadow Stealth",
+          "desc": "While in Dim Light or Darkness, the shadow takes the Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "shambling-mound": {
+      "index": "shambling-mound",
+      "name": "Shambling Mound",
+      "size": "Large",
+      "type": "plant",
+      "alignment": "Unaligned",
+      "armor_class": 15,
+      "hit_points": 110,
+      "hit_dice": "13d10 + 39",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "20 ft."
+      },
+      "strength": 18,
+      "dexterity": 8,
+      "constitution": 16,
+      "intelligence": 5,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 3
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire"
+      ],
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": [
+        "Deafened",
+        "Exhaustion Senses Blindsight 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Lightning Absorption",
+          "desc": "Whenever the shambling mound is subjected to Lightning damage, it regains a number of Hit Points equal to the Lightning damage dealt."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The shambling mound makes three Charged Tendril attacks. It can replace one attack with a use of Engulf."
+        },
+        {
+          "name": "Charged Tendril",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Lightning damage. If the target is a Medium or smaller creature, the shambling mound pulls the target 5 feet straight toward itself.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Engulf",
+          "desc": "Strength Saving Throw: DC 15, one Medium or smaller creature within 5 feet. Failure: The target is pulled into the shambling mound’s space and has the Grappled condition (escape DC 14). Until the grapple ends, the target has the Blinded and Restrained conditions, and it takes 10 (3d6) Lightning damage at the start of each of its turns. When the shambling mound moves, the Grappled target moves with it, costing it no extra movement. The shambling mound can have only one creature Grappled by this action at a time."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "shield-guardian": {
+      "index": "shield-guardian",
+      "name": "Shield Guardian",
+      "size": "Large",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 17,
+      "hit_points": 142,
+      "hit_dice": "15d10 + 60",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 8,
+      "constitution": 18,
+      "intelligence": 7,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Understands commands given in any language but can’t speak",
+      "challenge_rating": 7.0,
+      "xp": 2900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened"
+      ],
+      "special_abilities": [
+        {
+          "name": "Bound",
+          "desc": "The guardian is magically bound to an amulet. While the guardian and its amulet are on the same plane of existence, the amulet’s wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet’s wearer, half of any damage the wearer takes (round up) is transferred to the guardian."
+        },
+        {
+          "name": "Regeneration",
+          "desc": "The guardian regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point."
+        },
+        {
+          "name": "Spell Storing",
+          "desc": "A spellcaster who wears the guardian’s amulet can cause the guardian to store one spell of level 4 or lower. To do so, the wearer must cast the spell on the guardian while within 5 feet of it. The spell has no effect but is stored within the guardian. Any previously stored spell is lost when a new spell is stored. The guardian can cast the spell stored with any parameters set by the original caster, requiring no spell components and using the caster’s spellcasting ability. The stored spell is then lost."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The guardian makes two Fist attacks."
+        },
+        {
+          "name": "Fist",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Force damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Protection",
+          "desc": "Trigger: An attack roll hits the wearer of the guardian’s amulet while the wearer is within 5 feet of the guardian. Response: The wearer gains a +5 bonus to AC, including against the triggering attack and possibly causing it to miss, until the start of the guardian’s next turn."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "silver-dragon-wyrmling": {
+      "index": "silver-dragon-wyrmling",
+      "name": "Silver Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 17,
+      "hit_points": 45,
+      "hit_dice": "6d8 + 18",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 19,
+      "dexterity": 10,
+      "constitution": 17,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 2.0,
+      "xp": null,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "4d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Paralyzing Breath",
+          "desc": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "young-silver-dragon": {
+      "index": "young-silver-dragon",
+      "name": "Young Silver Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 18,
+      "hit_points": 168,
+      "hit_dice": "16d10 + 80",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 23,
+      "dexterity": 10,
+      "constitution": 21,
+      "intelligence": 14,
+      "wisdom": 11,
+      "charisma": 19,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "history": 6,
+        "perception": 8,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 18,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Paralyzing Breath."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d8+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 49 (11d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "11d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "11d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Paralyzing Breath",
+          "desc": "Constitution Saving Throw: DC 17, each creature in a 30-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "adult-silver-dragon": {
+      "index": "adult-silver-dragon",
+      "name": "Adult Silver Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 19,
+      "hit_points": 216,
+      "hit_dice": "16d12 + 112",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 27,
+      "dexterity": 10,
+      "constitution": 25,
+      "intelligence": 16,
+      "wisdom": 13,
+      "charisma": 22,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "history": 8,
+        "perception": 11,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 21,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 16.0,
+      "xp": 15000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing Breath or (B) Spellcasting to cast Ice Knife."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +13, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Cold damage.",
+          "attack_bonus": 13,
+          "damage": [
+            {
+              "damage_dice": "2d8+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "12d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Paralyzing Breath",
+          "desc": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 19, +11 to hit with spell attacks): At Will: Detect Magic, Hold Monster, Ice Knife, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Ice Storm (level 5 version), Zone of Truth"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Chill",
+          "desc": "The dragon uses Spellcasting to cast Hold Monster. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Cold Gale",
+          "desc": "Dexterity Saving Throw: DC 19, each creature in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half damage only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "4d6",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "4d6",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
+    },
+    "ancient-silver-dragon": {
+      "index": "ancient-silver-dragon",
+      "name": "Ancient Silver Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Lawful Good",
+      "armor_class": 22,
+      "hit_points": 468,
+      "hit_dice": "24d20 + 216",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 30,
+      "dexterity": 10,
+      "constitution": 29,
+      "intelligence": 18,
+      "wisdom": 15,
+      "charisma": 26,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "history": 11,
+        "perception": 16,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 26,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 23.0,
+      "xp": 50000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing Breath or (B) Spellcasting to cast Ice Knife (level 2 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +17, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Cold damage.",
+          "attack_bonus": 17,
+          "damage": [
+            {
+              "damage_dice": "2d8+10",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+10",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 67 (15d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "15d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "15d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Paralyzing Breath",
+          "desc": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks): At Will: Detect Magic, Hold Monster, Ice Knife (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Control Weather, Ice Storm (level 7 version), Teleport, Zone of Truth"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Chill",
+          "desc": "The dragon uses Spellcasting to cast Hold Monster. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Cold Gale",
+          "desc": "Dexterity Saving Throw: DC 23, each creature in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half damage only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "4d6",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "4d6",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "metallic"
     },
     "skeleton": {
       "index": "skeleton",
       "name": "Skeleton",
       "size": "Medium",
       "type": "undead",
-      "alignment": "lawful evil",
-      "armor_class": 13,
+      "alignment": "Lawful Evil",
+      "armor_class": 14,
       "hit_points": 13,
-      "hit_dice": "2d8",
-      "speed": { "walk": "30 ft." },
+      "hit_dice": "2d8 + 4",
+      "speed": {
+        "walk": "30 ft."
+      },
       "strength": 10,
-      "dexterity": 14,
+      "dexterity": 16,
       "constitution": 15,
       "intelligence": 6,
       "wisdom": 8,
       "charisma": 5,
-      "damage_vulnerabilities": ["bludgeoning"],
-      "damage_resistances": ["piercing", "slashing"],
-      "damage_immunities": ["poison"],
-      "condition_immunities": [
-        { "name": "poisoned" }
-      ],
-      "senses": { "darkvision": "60 ft.", "passive_perception": 9 },
-      "languages": "Understands all languages it spoke in life but can't speak",
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Understands Common plus one other language but can’t speak",
       "challenge_rating": 0.25,
       "xp": 50,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": [
+        "Bludgeoning"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned"
+      ],
+      "special_abilities": null,
       "actions": [
         {
           "name": "Shortsword",
-          "attack_bonus": 4,
-          "damage_dice": "1d6+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
         },
         {
           "name": "Shortbow",
-          "attack_bonus": 4,
-          "damage_dice": "1d6+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+          "desc": "Ranged Attack Roll: +5, range 80/320 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
         }
-      ]
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
-    "wolf": {
-      "index": "wolf",
-      "name": "Wolf",
-      "size": "Medium",
-      "type": "beast",
-      "alignment": "unaligned",
+    "warhorse-skeleton": {
+      "index": "warhorse-skeleton",
+      "name": "Warhorse Skeleton",
+      "size": "Large",
+      "type": "undead",
+      "alignment": "Lawful Evil",
       "armor_class": 13,
-      "hit_points": 11,
-      "hit_dice": "2d8",
-      "speed": { "walk": "40 ft." },
-      "strength": 12,
-      "dexterity": 15,
-      "constitution": 12,
-      "intelligence": 3,
-      "wisdom": 12,
-      "charisma": 6,
-      "skills": { "perception": 3, "stealth": 4 },
-      "senses": { "passive_perception": 13 },
-      "languages": "--",
-      "challenge_rating": 0.25,
-      "xp": 50,
+      "hit_points": 22,
+      "hit_dice": "3d10 + 6",
+      "speed": {
+        "walk": "60 ft."
+      },
+      "strength": 18,
+      "dexterity": 12,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 8,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
       "proficiency_bonus": 2,
-      "special_abilities": [
+      "damage_vulnerabilities": [
+        "Bludgeoning"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": null,
+      "actions": [
         {
-          "name": "Keen Hearing and Smell",
-          "desc": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "minotaur-skeleton": {
+      "index": "minotaur-skeleton",
+      "name": "Minotaur Skeleton",
+      "size": "Large",
+      "type": "undead",
+      "alignment": "Lawful Evil",
+      "armor_class": 12,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 11,
+      "constitution": 15,
+      "intelligence": 6,
+      "wisdom": 8,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": [
+        "Bludgeoning"
+      ],
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
         },
         {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d10+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "solar": {
+      "index": "solar",
+      "name": "Solar",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 21,
+      "hit_points": 297,
+      "hit_dice": "22d10 + 176",
+      "speed": {
+        "walk": "50 ft.",
+        "fly": "150 ft. (hover)"
+      },
+      "strength": 26,
+      "dexterity": 22,
+      "constitution": 26,
+      "intelligence": 25,
+      "wisdom": 25,
+      "charisma": 30,
+      "saving_throws": [],
+      "skills": {
+        "perception": 14
+      },
+      "senses": {
+        "passive_perception": 24,
+        "truesight": "120 ft.",
+        "summary": "Truesight 120 ft."
+      },
+      "languages": "All; telepathy 120 ft.",
+      "challenge_rating": 21.0,
+      "xp": 33000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison",
+        "Radiant"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Frightened",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Divine Awareness",
+          "desc": "The solar knows if it hears a lie."
+        },
+        {
+          "name": "Exalted Restoration",
+          "desc": "If the solar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+        },
+        {
+          "name": "Legendary Resistance (4/Day)",
+          "desc": "If the solar fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The solar has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The solar makes two Flying Sword attacks. It can replace one attack with a use of Slaying Bow."
+        },
+        {
+          "name": "Flying Sword",
+          "desc": "Melee or Ranged Attack Roll: +15, reach 10 ft. or range 120 ft. Hit: 22 (4d6 + 8) Slashing damage plus 36 (8d8) Radiant damage. Hit or Miss: The sword magically returns to the solar’s hand or hovers within 5 feet of the solar immediately after a ranged attack.",
+          "attack_bonus": 15,
+          "damage": [
+            {
+              "damage_dice": "4d6+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Slaying Bow",
+          "desc": "Dexterity Saving Throw: DC 21, one creature the solar can see within 600 feet. Failure: If the creature has 100 Hit Points or fewer, it dies. It otherwise takes 24 (4d8 + 6) Piercing damage plus 36 (8d8) Radiant damage.",
+          "damage": [
+            {
+              "damage_dice": "4d8+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "4d8+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The solar casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 25): At Will: Detect Evil and Good 1/Day Each: Commune, Control Weather, Dispel Evil and Good, Resurrection"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Divine Aid (3/Day)",
+          "desc": "The solar casts Cure Wounds (level 2 version), Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3",
+          "desc": "Immediately after another creature’s turn, the solar can expend a use to take one of the following actions. The solar regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Blinding Gaze",
+          "desc": "Constitution Saving Throw: DC 25, one creature the solar can see within 120 feet. Failure: The target has the Blinded condition for 1 minute. Failure or Success: The solar can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Radiant Teleport",
+          "desc": "The solar teleports up to 60 feet to an unoccupied space it can see. Dexterity Saving Throw: DC 25, each creature in a 10-foot Emanation originating from the solar at its destination space. Failure: 11 (2d10) Radiant damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d10",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "2d10",
+          "damage_type": {
+            "name": "radiant"
+          }
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "angel"
+    },
+    "specter": {
+      "index": "specter",
+      "name": "Specter",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "Chaotic Evil",
+      "armor_class": 12,
+      "hit_points": 22,
+      "hit_dice": "5d8",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "50 ft. (hover)"
+      },
+      "strength": 1,
+      "dexterity": 14,
+      "constitution": 11,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Understands Common plus one other language but can’t speak",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Bludgeoning",
+        "Cold",
+        "Fire",
+        "Lightning",
+        "Piercing",
+        "Slashing",
+        "Thunder"
+      ],
+      "damage_immunities": [
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained",
+        "Unconscious"
+      ],
+      "special_abilities": [
+        {
+          "name": "Incorporeal Movement",
+          "desc": "The specter can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "desc": "While in sunlight, the specter has Disadvantage on ability checks and attack rolls."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Life Drain",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d6) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "sphinx-of-wonder": {
+      "index": "sphinx-of-wonder",
+      "name": "Sphinx of Wonder",
+      "size": "Tiny",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 13,
+      "hit_points": 24,
+      "hit_dice": "7d4 + 7",
+      "speed": {
+        "walk": "20 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 6,
+      "dexterity": 17,
+      "constitution": 13,
+      "intelligence": 15,
+      "wisdom": 12,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "arcana": 4,
+        "religion": 4,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Celestial, Common",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic",
+        "Psychic",
+        "Radiant"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Magic Resistance",
+          "desc": "The sphinx has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 7 (2d6) Radiant damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "sphinx-of-lore": {
+      "index": "sphinx-of-lore",
+      "name": "Sphinx of Lore",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Lawful Neutral",
+      "armor_class": 17,
+      "hit_points": 170,
+      "hit_dice": "20d10 + 60",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 18,
+      "wisdom": 18,
+      "charisma": 18,
+      "saving_throws": [],
+      "skills": {
+        "arcana": 12,
+        "history": 12,
+        "perception": 8
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 11.0,
+      "xp": 7200,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic",
+        "Radiant"
+      ],
+      "damage_immunities": [
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Frightened Senses Truesight 120 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Inscrutable",
+          "desc": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sincerity are made with Disadvantage."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the sphinx fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The sphinx makes three Claw attacks."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "3d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Mind-Rending Roar (Recharge 5-6)",
+          "desc": "Wisdom Saving Throw: DC 16, each enemy in a 300-foot Emanation originating from the sphinx. Failure: 35 (10d6) Psychic damage, and the target has the Incapacitated condition until the start of the sphinx’s next turn.",
+          "damage": [
+            {
+              "damage_dice": "10d6",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "10d6",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The sphinx casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16): At Will: Detect Magic, Identify, Mage Hand, Minor Illusion, Prestidigitation 1/Day Each: Dispel Magic, Legend Lore, Locate Object, Plane Shift, Remove Curse, Tongues"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the sphinx can expend a use to take one of the following actions. The sphinx regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Arcane Prowl",
+          "desc": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one Claw attack. Weight of Years. Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure: The target gains 1 Exhaustion level. While the target has any Exhaustion levels, it appears 3d10 years older. Failure or Success: The sphinx can’t take this action again until the start of its next turn."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "sphinx-of-valor": {
+      "index": "sphinx-of-valor",
+      "name": "Sphinx of Valor",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Lawful Neutral",
+      "armor_class": 17,
+      "hit_points": 199,
+      "hit_dice": "19d10 + 95",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 22,
+      "dexterity": 10,
+      "constitution": 20,
+      "intelligence": 16,
+      "wisdom": 23,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "CON",
+          "value": 11
+        },
+        {
+          "name": "INT",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 12
+        }
+      ],
+      "skills": {
+        "arcana": 9,
+        "perception": 12,
+        "religion": 15
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 17.0,
+      "xp": 18000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic",
+        "Radiant"
+      ],
+      "damage_immunities": [
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Frightened Senses Truesight 120 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Inscrutable",
+          "desc": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sincerity are made with Disadvantage."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the sphinx fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The sphinx makes two Claw attacks and uses Roar."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +12, reach 5 ft. Hit: 20 (4d6 + 6) Slashing damage.",
+          "attack_bonus": 12,
+          "damage": [
+            {
+              "damage_dice": "4d6+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Roar (3/Day)",
+          "desc": "The sphinx emits a magical roar. Whenever it roars, the roar has a different effect, as detailed below (the sequence resets when it takes a Long Rest):"
+        },
+        {
+          "name": "First Roar",
+          "desc": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Frightened condition for 1 minute."
+        },
+        {
+          "name": "Second Roar",
+          "desc": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+        },
+        {
+          "name": "Third Roar",
+          "desc": "Constitution Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: 44 (8d10) Thunder damage, and the target has the Prone condition. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "8d10",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "8d10",
+          "damage_type": {
+            "name": "thunder"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The sphinx casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 20): At Will: Detect Evil and Good, Thaumaturgy 1/Day Each: Detect Magic, Dispel Magic, Greater Restoration, Heroes’ Feast, Zone of Truth"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the sphinx can expend a use to take one of the following actions. The sphinx regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Arcane Prowl",
+          "desc": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one Claw attack. Weight of Years. Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure: The target gains 1 Exhaustion level. While the target has any Exhaustion levels, it appears 3d10 years older. Failure or Success: The sphinx can’t take this action again until the start of its next turn."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "spirit-naga": {
+      "index": "spirit-naga",
+      "name": "Spirit Naga",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 17,
+      "hit_points": 135,
+      "hit_dice": "18d10 + 36",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 17,
+      "constitution": 14,
+      "intelligence": 16,
+      "wisdom": 15,
+      "charisma": 16,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "CON",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 5
+        },
+        {
+          "name": "CHA",
+          "value": 6
+        }
+      ],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Fiendish Restoration",
+          "desc": "If it dies, the naga returns to life in 1d6 days and regains all its Hit Points. Only a Wish spell can prevent this trait from functioning."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The naga makes three attacks, using Bite or Necrotic Ray in any combination."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 7 (1d6 + 4) Piercing damage plus 14 (4d6) Poison damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Necrotic Ray",
+          "desc": "Ranged Attack Roll: +6, range 60 ft. Hit: (6d6) Necrotic damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "6d6",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "6d6",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Intelligence as the spellcasting ability (spell save DC 14): At Will: Detect Magic, Mage Hand, Minor Illusion, Water Breathing 2/Day Each: Detect Thoughts, Dimension Door, Hold Person (level 3 version), Lightning Bolt (level 4 version)"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "sprite": {
+      "index": "sprite",
+      "name": "Sprite",
+      "size": "Tiny",
+      "type": "fey",
+      "alignment": "Neutral Good",
+      "armor_class": 15,
+      "hit_points": 10,
+      "hit_dice": "4d4",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 3,
+      "dexterity": 18,
+      "constitution": 10,
+      "intelligence": 14,
+      "wisdom": 13,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 8,
+        "pb": 2
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Needle Sword",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Enchanting Bow",
+          "desc": "Ranged Attack Roll: +6, range 40/160 ft. Hit: 1 Piercing damage, and the target has the Charmed condition until the start of the sprite’s next turn.",
+          "attack_bonus": 6
+        },
+        {
+          "name": "Heart Sight",
+          "desc": "Charisma Saving Throw: DC 10, one creature within 5 feet the sprite can see (Celestials, Fiends, and Undead automatically fail the save). Failure: The sprite knows the target’s emotions and alignment."
+        },
+        {
+          "name": "Invisibility",
+          "desc": "The sprite casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "spy": {
+      "index": "spy",
+      "name": "Spy",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 12,
+      "hit_points": 27,
+      "hit_dice": "6d8",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 12,
+      "wisdom": 14,
+      "charisma": 16,
+      "saving_throws": [],
+      "skills": {
+        "deception": 5,
+        "insight": 4,
+        "investigation": 5
+      },
+      "senses": null,
+      "languages": "Common plus one other language",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Shortsword",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Hand Crossbow",
+          "desc": "Ranged Attack Roll: +4, range 30/120 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Cunning Action",
+          "desc": "The spy takes the Dash, Disengage, or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "stirge": {
+      "index": "stirge",
+      "name": "Stirge",
+      "size": "Tiny",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 5,
+      "hit_dice": "2d4",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "40 ft."
+      },
+      "strength": 4,
+      "dexterity": 16,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 8,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Proboscis",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage, and the stirge attaches to the target. While attached, the stirge can’t make Proboscis attacks, and the target takes 5 (2d4) Necrotic damage at the start of each of the stirge’s turns. The stirge can detach itself by spending 5 feet of its movement. The target or a creature within 5 feet of it can detach the stirge as an action.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "stone-giant": {
+      "index": "stone-giant",
+      "name": "Stone Giant",
+      "size": "Huge",
+      "type": "giant",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 126,
+      "hit_dice": "11d12 + 55",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 23,
+      "dexterity": 15,
+      "constitution": 20,
+      "intelligence": 10,
+      "wisdom": 12,
+      "charisma": 9,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "CON",
+          "value": 8
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "athletics": 12,
+        "perception": 4,
+        "stealth": 5
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 7.0,
+      "xp": 2900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The giant makes two attacks, using Stone Club or Boulder in any combination."
+        },
+        {
+          "name": "Stone Club",
+          "desc": "Melee Attack Roll: +9, reach 15 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "3d10+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d10+6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Boulder",
+          "desc": "Ranged Attack Roll: +9, range 60/240 ft. Hit: 15 (2d8 + 6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d8+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Deflect Missile (Recharge 5-6)",
+          "desc": "Trigger: The giant is hit by a ranged attack roll and takes Bludgeoning, Piercing, or Slashing damage from it. Response: The giant reduces the damage it takes from the attack by 11 (1d10 + 6), and if that damage is reduced to 0, the giant can redirect some of the attack’s force. Dexterity Saving Throw: DC 17, one creature the giant can see within 60 feet. Failure: 11 (1d10 + 6) Force damage.",
+          "damage": [
+            {
+              "damage_dice": "1d10+6",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "1d10+6",
+          "damage_type": {
+            "name": "force"
+          }
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "stone-golem": {
+      "index": "stone-golem",
+      "name": "Stone Golem",
+      "size": "Large",
+      "type": "construct",
+      "alignment": "Unaligned",
+      "armor_class": 18,
+      "hit_points": 220,
+      "hit_dice": "21d10 + 105",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 22,
+      "dexterity": 9,
+      "constitution": 20,
+      "intelligence": 3,
+      "wisdom": 11,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 10.0,
+      "xp": 5900,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison",
+        "Psychic"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion"
+      ],
+      "special_abilities": [
+        {
+          "name": "Immutable Form",
+          "desc": "The golem can’t shape-shift."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The golem makes two attacks, using Slam or Force Bolt in any combination."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 15 (2d8 + 6) Bludgeoning damage plus 9 (2d8) Force damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d8+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Force Bolt",
+          "desc": "Ranged Attack Roll: +9, range 120 ft. Hit: (4d10) Force damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "4d10",
+              "damage_type": {
+                "name": "force"
+              }
+            }
+          ],
+          "damage_dice": "4d10",
+          "damage_type": {
+            "name": "force"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Slow (Recharge 5-6)",
+          "desc": "The golem casts the Slow spell, requiring no spell components and using Constitution as the spellcasting ability (spell save DC 17)."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "storm-giant": {
+      "index": "storm-giant",
+      "name": "Storm Giant",
+      "size": "Huge",
+      "type": "giant",
+      "alignment": "Chaotic Good",
+      "armor_class": 16,
+      "hit_points": 230,
+      "hit_dice": "20d12 + 100",
+      "speed": {
+        "walk": "50 ft.",
+        "fly": "25 ft. (hover)",
+        "swim": "50 ft."
+      },
+      "strength": 29,
+      "dexterity": 14,
+      "constitution": 20,
+      "intelligence": 16,
+      "wisdom": 20,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 14
+        },
+        {
+          "name": "CON",
+          "value": 10
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        },
+        {
+          "name": "CHA",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "arcana": 8,
+        "athletics": 14,
+        "history": 8,
+        "perception": 10
+      },
+      "senses": {
+        "passive_perception": 20,
+        "darkvision": "120 ft.",
+        "truesight": "30 ft.",
+        "summary": "Darkvision 120 ft., Truesight 30 ft."
+      },
+      "languages": "Common, Giant",
+      "challenge_rating": 13.0,
+      "xp": 10000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": [
+        "Lightning",
+        "Thunder"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The giant can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The giant makes two attacks, using Storm Sword or Thunderbolt in any combination."
+        },
+        {
+          "name": "Storm Sword",
+          "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 23 (4d6 + 9) Slashing damage plus 13 (3d8) Lightning damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "4d6+9",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+9",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Thunderbolt",
+          "desc": "Ranged Attack Roll: +14, range 500 ft. Hit: 22 (2d12 + 9) Lightning damage, and the target has the Blinded and Deafened conditions until the start of the giant’s next turn.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "2d12+9",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "2d12+9",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Lightning Storm (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 18, each creature in a 10-foot-radius, 40-foot-high Cylinder originating from a point the giant can see within 500 feet. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "10d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "10d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The giant casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 18): At Will: Detect Magic, Light 1/Day: Control Weather"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "succubus": {
+      "index": "succubus",
+      "name": "Succubus",
+      "size": "Medium",
+      "type": "fiend",
+      "alignment": "Neutral Evil",
+      "armor_class": 15,
+      "hit_points": 71,
+      "hit_dice": "13d8 + 13",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 8,
+      "dexterity": 17,
+      "constitution": 13,
+      "intelligence": 15,
+      "wisdom": 12,
+      "charisma": 20,
+      "saving_throws": [],
+      "skills": {
+        "deception": 9,
+        "insight": 5,
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "telepathy": "60 ft.",
+        "cr": "4",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Abyssal, Common, Infernal; telepathy 60 ft. CR 4 (XP 1,100; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Poison",
+        "Psychic"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Incubus Form",
+          "desc": "When the succubus finishes a Long Rest, it can shape-shift into an Incubus, using that stat block instead of this one."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The succubus makes one Fiendish Touch attack and uses Charm or Draining Kiss."
+        },
+        {
+          "name": "Fiendish Touch",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 16 (2d10 + 5) Psychic damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "psychic"
+          }
+        },
+        {
+          "name": "Charm",
+          "desc": "The succubus casts Dominate Person (level 8 version), requiring no spell components and using Charisma as the spellcasting ability (spell save DC 15)."
+        },
+        {
+          "name": "Draining Kiss",
+          "desc": "Constitution Saving Throw: DC 15, one creature Charmed by the succubus within 5 feet. Failure: 13 (3d8) Psychic damage. Success: Half damage. Failure or Success: The target’s Hit Point maximum decreases by an amount equal to the damage taken.",
+          "damage": [
+            {
+              "damage_dice": "3d8",
+              "damage_type": {
+                "name": "psychic"
+              }
+            }
+          ],
+          "damage_dice": "3d8",
+          "damage_type": {
+            "name": "psychic"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The succubus shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics are the same in each form, except its Fly Speed is available only in its true form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "tarrasque": {
+      "index": "tarrasque",
+      "name": "Tarrasque",
+      "size": "Gargantuan",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 25,
+      "hit_points": 697,
+      "hit_dice": "34d20 + 340",
+      "speed": {
+        "walk": "60 ft.",
+        "burrow": "40 ft.",
+        "climb": "60 ft."
+      },
+      "strength": 30,
+      "dexterity": 11,
+      "constitution": 30,
+      "intelligence": 3,
+      "wisdom": 11,
+      "charisma": 11,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 9
+        },
+        {
+          "name": "INT",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 9
+        },
+        {
+          "name": "CHA",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "perception": 9
+      },
+      "senses": {
+        "passive_perception": 19,
+        "blindsight": "120 ft.",
+        "summary": "Blindsight 120 ft."
+      },
+      "languages": "",
+      "challenge_rating": 30.0,
+      "xp": 155000,
+      "proficiency_bonus": 9,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Fire",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Deafened",
+        "Frightened",
+        "Paralyzed",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
           "name": "Pack Tactics",
-          "desc": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 feet of the creature and the ally isn't incapacitated."
+          "desc": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Mace",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Heavy Crossbow",
+          "desc": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d10+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Swallow",
+          "desc": "Strength Saving Throw: DC 27, one Large or smaller creature Grappled by the tarrasque (it can have up to six creatures swallowed at a time). Failure: The target is swallowed, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions and can’t teleport, it has Total Cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) Acid damage at the start of each of the tarrasque’s turns. If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the tarrasque and has the Prone condition. If the tarrasque dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone.",
+          "damage": [
+            {
+              "damage_dice": "16d6",
+              "damage_type": {
+                "name": "acid"
+              }
+            }
+          ],
+          "damage_dice": "16d6",
+          "damage_type": {
+            "name": "acid"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3",
+          "desc": "Immediately after another creature’s turn, the tarrasque can expend a use to take one of the following actions. The tarrasque regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Onslaught",
+          "desc": "The tarrasque moves up to half its Speed, and it makes one Claw or Tail attack."
+        },
+        {
+          "name": "World-Shaking Movement",
+          "desc": "The tarrasque moves up to its Speed. At the end of this movement, the tarrasque creates an instantaneous shock wave in a 60-foot Emanation originating from itself. Creatures in that area lose Concentration and, if Medium or smaller, have the Prone condition. The tarrasque can’t take this action again until the start of its next turn."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "titan"
+    },
+    "tough-boss": {
+      "index": "tough-boss",
+      "name": "Tough Boss",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 16,
+      "hit_points": 82,
+      "hit_dice": "11d8 + 33",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 14,
+      "constitution": 16,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 11,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 5
+        },
+        {
+          "name": "CON",
+          "value": 5
+        },
+        {
+          "name": "CHA",
+          "value": 2
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The tough makes two attacks, using Warhammer or Heavy Crossbow in any combination."
+        },
+        {
+          "name": "Warhammer",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Bludgeoning damage. If the target is a Large or smaller creature, the tough pushes the target up to 10 feet straight away from itself.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d8+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Heavy Crossbow",
+          "desc": "Ranged Attack Roll: +4, range 100/400 ft. Hit: 13 (2d10 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d10+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "tough": {
+      "index": "tough",
+      "name": "Tough",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 12,
+      "hit_points": 32,
+      "hit_dice": "5d8 + 10",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": null,
+      "dexterity": null,
+      "constitution": null,
+      "intelligence": null,
+      "wisdom": null,
+      "charisma": null,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": null,
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "treant": {
+      "index": "treant",
+      "name": "Treant",
+      "size": "Huge",
+      "type": "plant",
+      "alignment": "Chaotic Good",
+      "armor_class": 16,
+      "hit_points": 138,
+      "hit_dice": "12d12 + 60",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 23,
+      "dexterity": 8,
+      "constitution": 21,
+      "intelligence": 12,
+      "wisdom": 16,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 13
+      },
+      "languages": "Common, Druidic, Elvish, Sylvan",
+      "challenge_rating": 9.0,
+      "xp": 5000,
+      "proficiency_bonus": 4,
+      "damage_vulnerabilities": [
+        "Fire"
+      ],
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Siege Monster",
+          "desc": "The treant deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The treant makes two Slam attacks."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 16 (3d6 + 6) Bludgeoning damage. Hail of Bark. Ranged Attack Roll: +10, range 180 ft. Hit: 28 (4d10 + 6) Piercing damage.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "3d6+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            },
+            {
+              "damage_dice": "4d10+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Animate Trees (1/Day)",
+          "desc": "The treant magically animates up to two trees it can see within 60 feet of itself. Each tree uses the Treant stat block, except it has Intelligence and Charisma scores of 1, it can’t speak, and it lacks this action. The tree takes its turn immediately after the treant on the same Initiative count, and it obeys the treant. A tree remains animate for 1 day or until it dies, the treant dies, or it is more than 120 feet from the treant. The tree then takes root if possible."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "troll": {
+      "index": "troll",
+      "name": "Troll",
+      "size": "Large",
+      "type": "giant",
+      "alignment": "Chaotic Evil",
+      "armor_class": 15,
+      "hit_points": 94,
+      "hit_dice": "9d10 + 45",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 18,
+      "dexterity": 13,
+      "constitution": 20,
+      "intelligence": 7,
+      "wisdom": 9,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Giant",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Loathsome Limbs (4/Day)",
+          "desc": "If the troll ends any turn Bloodied and took 15+ Slashing damage during that turn, one of the troll’s limbs is severed, falls into the troll’s space, and becomes a Troll Limb. The limb acts immediately after the troll’s turn. The troll has 1 Exhaustion level for each missing limb, and it grows replacement limbs the next time it regains Hit Points."
+        },
+        {
+          "name": "Regeneration",
+          "desc": "The troll regains 15 Hit Points at the start of each of its turns. If the troll takes Acid or Fire damage, this trait doesn’t function on the troll’s next turn. The troll dies only if it starts its turn with 0 Hit Points and doesn’t regenerate."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The troll makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Charge",
+          "desc": "The troll moves up to half its Speed straight toward an enemy it can see."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "troll-limb": {
+      "index": "troll-limb",
+      "name": "Troll Limb",
+      "size": "Small",
+      "type": "giant",
+      "alignment": "Chaotic Evil",
+      "armor_class": 13,
+      "hit_points": 14,
+      "hit_dice": "4d6",
+      "speed": {
+        "walk": "20 ft."
+      },
+      "strength": 18,
+      "dexterity": 12,
+      "constitution": 10,
+      "intelligence": 1,
+      "wisdom": 9,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Regeneration",
+          "desc": "The limb regains 5 Hit Points at the start of each of its turns. If the limb takes Acid or Fire damage, this trait doesn’t function on the limb’s next turn. The limb dies only if it starts its turn with 0 Hit Points and doesn’t regenerate."
+        },
+        {
+          "name": "Troll Spawn",
+          "desc": "The limb uncannily has the same senses as a whole troll. If the limb isn’t destroyed within 24 hours, roll 1d12. On a 12, the limb turns into a Troll. Otherwise, the limb withers away."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "unicorn": {
+      "index": "unicorn",
+      "name": "Unicorn",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Lawful Good",
+      "armor_class": 12,
+      "hit_points": 97,
+      "hit_dice": "13d10 + 26",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 15,
+      "intelligence": 11,
+      "wisdom": 17,
+      "charisma": 16,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Paralyzed",
+        "Poisoned Senses Darkvision 60 ft."
+      ],
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "desc": "If the unicorn fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The unicorn has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The unicorn makes one Hooves attack and one Radiant Horn attack."
+        },
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Radiant Horn",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 9 (1d10 + 4) Radiant damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "radiant"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "radiant"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The unicorn casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 14): At Will: Detect Evil and Good, Druidcraft 1/Day Each: Calm Emotions, Dispel Evil and Good, Entangle, Pass without Trace, Word of Recall"
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Unicorn’s Blessing (3/Day)",
+          "desc": "The unicorn touches another creature with its horn and casts Cure Wounds or Lesser Restoration on that creature, using the same spellcasting ability as Spellcasting."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3",
+          "desc": "Immediately after another creature’s turn, the unicorn can expend a use to take one of the following actions. The unicorn regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Charging Horn",
+          "desc": "The unicorn moves up to half its Speed without provoking Opportunity Attacks, and it makes one Radiant Horn attack."
+        },
+        {
+          "name": "Shimmering Shield",
+          "desc": "The unicorn targets itself or one creature it can see within 60 feet of itself. The target gains 10 (3d6) Temporary Hit Points, and its AC increases by 2 until the end of the unicorn’s next turn. The unicorn can’t take this action again until the start of its next turn."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "vampire-familiar": {
+      "index": "vampire-familiar",
+      "name": "Vampire Familiar",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral Evil",
+      "armor_class": 15,
+      "hit_points": 65,
+      "hit_dice": "10d8 + 20",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 16,
+      "constitution": 15,
+      "intelligence": 10,
+      "wisdom": 10,
+      "charisma": 14,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "persuasion": 4,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "languages_common_plus_one_other_language_cr": "3",
+        "xp": "700",
+        "summary": "Darkvision 60 ft.; Languages Common plus one other language CR 3 (XP 700; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic"
+      ],
+      "damage_immunities": [
+        "Charmed (except from its vampire master)"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Vampiric Connection",
+          "desc": "While the familiar and its vampire master are on the same plane of existence, the vampire can communicate with the familiar telepathically, and the vampire can perceive through the familiar’s senses."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The familiar makes two Umbral Dagger attacks."
+        },
+        {
+          "name": "Umbral Dagger",
+          "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage plus 7 (3d4) Necrotic damage. If the target is reduced to 0 Hit Points by this attack, the target becomes Stable but has the Poisoned condition for 1 hour. While it has the Poisoned condition, the target has the Paralyzed condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Deathless Agility",
+          "desc": "The familiar takes the Dash or Disengage action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "vampire-spawn": {
+      "index": "vampire-spawn",
+      "name": "Vampire Spawn",
+      "size": "Medium",
+      "type": "or small undead",
+      "alignment": "Neutral Evil",
+      "armor_class": 16,
+      "hit_points": 90,
+      "hit_dice": "12d8 + 36",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 16,
+      "constitution": 16,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 12,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "perception": 3,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "languages_common_plus_one_other_language_cr": "5",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Common plus one other language CR 5 (XP 1,800; PB +3)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Vampire Weakness",
+          "desc": "The vampire has these weaknesses:"
+        },
+        {
+          "name": "Forbiddance",
+          "desc": "The vampire can’t enter a residence without an invitation from an occupant."
+        },
+        {
+          "name": "Running Water",
+          "desc": "The vampire takes 20 Acid damage if it ends its turn in running water. Stake to the Heart. The vampire is destroyed if a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition."
+        },
+        {
+          "name": "Sunlight",
+          "desc": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The vampire makes two Claw attacks and uses Bite."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (2d4 + 3) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d4+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Bite",
+          "desc": "Constitution Saving Throw: DC 14, one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 5 (1d4 + 3) Piercing damage plus 10 (3d6) Necrotic damage. The target’s Hit Point maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount.",
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Deathless Agility",
+          "desc": "The vampire takes the Dash or Disengage action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "vampire": {
+      "index": "vampire",
+      "name": "Vampire",
+      "size": "Medium",
+      "type": "or small undead",
+      "alignment": "Lawful Evil",
+      "armor_class": 16,
+      "hit_points": 195,
+      "hit_dice": "23d8 + 92",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 18,
+      "constitution": 18,
+      "intelligence": 17,
+      "wisdom": 15,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 9
+        },
+        {
+          "name": "CON",
+          "value": 9
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        },
+        {
+          "name": "CHA",
+          "value": 9
+        }
+      ],
+      "skills": {
+        "perception": 7,
+        "stealth": 9
+      },
+      "senses": {
+        "passive_perception": 17,
+        "darkvision": "120 ft.",
+        "languages_common_plus_two_other_languages_cr": "13",
+        "xp": "10",
+        "or": "11",
+        "summary": "Darkvision 120 ft.; Languages Common plus two other languages CR 13 (XP 10,000, or 11,500 in lair; PB +5)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the vampire fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Misty Escape",
+          "desc": "If the vampire drops to 0 Hit Points outside its resting place, the vampire uses Shape-Shift to become mist (no action required). If it can’t use ShapeShift, it is destroyed. While it has 0 Hit Points in mist form, it can’t return to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it returns to its vampire form and has the Paralyzed condition until it regains any Hit Points, and it regains 1 Hit Point after spending 1 hour there."
+        },
+        {
+          "name": "Spider Climb",
+          "desc": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Vampire Weakness",
+          "desc": "The vampire has these weaknesses:"
+        },
+        {
+          "name": "Forbiddance",
+          "desc": "The vampire can’t enter a residence without an invitation from an occupant."
+        },
+        {
+          "name": "Running Water",
+          "desc": "The vampire takes 20 Acid damage if it ends its turn in running water. Stake to the Heart. If a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition in its resting place, the vampire has the Paralyzed condition until the weapon is removed."
+        },
+        {
+          "name": "Sunlight",
+          "desc": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack (Vampire Form Only)",
+          "desc": "The vampire makes two Grave Strike attacks and uses Bite."
+        },
+        {
+          "name": "Grave Strike (Vampire Form Only)",
+          "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 8 (1d8 + 4) Bludgeoning damage plus 7 (2d6) Necrotic damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two hands.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "1d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d8+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Bite (Bat or Vampire Form Only)",
+          "desc": "Constitution Saving Throw: DC 17, one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 6 (1d4 + 4) Piercing damage plus 13 (3d8) Necrotic damage. The target’s Hit Point maximum STR13+1+1DEX 11+0+0CON 11+0+0INT8-1-1WIS 11+0+0CHA 8-1-1Gear Chain Shirt, Spear Senses Passive Perception 10 Languages CommonCR 1/8 (XP 25; PB +2)decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount. A Humanoid reduced to 0 Hit Points by this damage and then buried rises the following sunset as a Vampire Spawn under the vampire’s control.",
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Charm (Recharge 5-6)",
+          "desc": "The vampire casts Charm Person, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 17), and the duration is 24 hours. The Charmed target is a willing recipient of the vampire’s Bite, the damage of which doesn’t end the spell. When the spell ends, the target is unaware it was Charmed by the vampire."
+        },
+        {
+          "name": "Shape-Shift",
+          "desc": "If the vampire isn’t in sunlight or running water, it shape-shifts into a Tiny bat (Speed 5 ft., Fly Speed 30 ft.) or a Medium cloud of mist (Speed 5 ft., Fly Speed 20 ft. [hover]), or it returns to its vampire form. Anything it is wearing transforms with it. While in bat form, the vampire can’t speak. Its game statistics, other than its size and Speed, are unchanged. While in mist form, the vampire can’t take any actions, speak, or manipulate objects. It is weightless and can enter an enemy’s space and stop there. If air can pass through a space, the mist can do so, but it can’t pass through liquid. It has Resistance to all damage, except the damage it takes from sunlight."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the vampire can expend a use to take one of the following actions. The vampire regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Beguile",
+          "desc": "The vampire casts Command, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 17). The vampire can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Deathless Strike",
+          "desc": "The vampire moves up to half its Speed, and it makes one Grave Strike attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "vrock": {
+      "index": "vrock",
+      "name": "Vrock",
+      "size": "Large",
+      "type": "fiend",
+      "alignment": "Chaotic Evil",
+      "armor_class": 15,
+      "hit_points": 152,
+      "hit_dice": "16d10 + 64",
+      "speed": {
+        "walk": "40 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 17,
+      "dexterity": 15,
+      "constitution": 18,
+      "intelligence": 8,
+      "wisdom": 13,
+      "charisma": 8,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        },
+        {
+          "name": "CHA",
+          "value": 2
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Abyssal; telepathy 120 ft.",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold",
+        "Fire",
+        "Lightning"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Demonic Restoration",
+          "desc": "If the vrock dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+        },
+        {
+          "name": "Magic Resistance",
+          "desc": "The vrock has Advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The vrock makes two Shred attacks."
+        },
+        {
+          "name": "Shred",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 10 (3d6) Poison damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Spores (Recharge 6)",
+          "desc": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. While Poisoned, the target takes 5 (1d10) Poison damage at the start of each of its turns. Emptying a flask of Holy Water on the target ends the effect early.",
+          "damage": [
+            {
+              "damage_dice": "1d10",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "1d10",
+          "damage_type": {
+            "name": "poison"
+          }
+        },
+        {
+          "name": "Stunning Screech (1/Day)",
+          "desc": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock (demons succeed automatically). Failure: 10 (3d6) Thunder damage, and the target has the Stunned condition until the end of the vrock’s next turn.",
+          "damage": [
+            {
+              "damage_dice": "3d6",
+              "damage_type": {
+                "name": "thunder"
+              }
+            }
+          ],
+          "damage_dice": "3d6",
+          "damage_type": {
+            "name": "thunder"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "demon"
+    },
+    "warrior-infantry": {
+      "index": "warrior-infantry",
+      "name": "Warrior Infantry",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 13,
+      "hit_points": 9,
+      "hit_dice": "2d8",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": null,
+      "dexterity": null,
+      "constitution": null,
+      "intelligence": null,
+      "wisdom": null,
+      "charisma": null,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The warrior has Advantage on an attack roll against a creature if at least one of the warrior’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Spear",
+          "desc": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "warrior-veteran": {
+      "index": "warrior-veteran",
+      "name": "Warrior Veteran",
+      "size": "Medium",
+      "type": "or small humanoid",
+      "alignment": "Neutral",
+      "armor_class": 17,
+      "hit_points": 65,
+      "hit_dice": "10d8 + 20",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 14,
+      "intelligence": 10,
+      "wisdom": 11,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "athletics": 5,
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12
+      },
+      "languages": "Common plus one other language",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The warrior makes two Greatsword or Heavy Crossbow attacks."
+        },
+        {
+          "name": "Greatsword",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Heavy Crossbow",
+          "desc": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 12 (2d10 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "2d10+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Parry",
+          "desc": "Trigger: The warrior is hit by a melee attack roll while holding a weapon. Response: The warrior adds 2 to its AC against that attack, possibly causing it to miss."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "water-elemental": {
+      "index": "water-elemental",
+      "name": "Water Elemental",
+      "size": "Large",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 14,
+      "hit_points": 114,
+      "hit_dice": "12d10 + 48",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "90 ft."
+      },
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 18,
+      "intelligence": 5,
+      "wisdom": 10,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Fire"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "special_abilities": [
+        {
+          "name": "Freeze",
+          "desc": "If the elemental takes Cold damage, its Speed decreases by 20 feet until the end of its next turn."
+        },
+        {
+          "name": "Water Form",
+          "desc": "The elemental can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The elemental makes two Slam attacks."
+        },
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Whelm (Recharge 4-6)",
+          "desc": "Strength Saving Throw: DC 15, each creature in the elemental’s space. Failure: 22 (4d8 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14). Until the grapple ends, the target has the Restrained condition, is suffocating unless it can breathe water, and takes 9 (2d8) Bludgeoning damage at the start of each of the elemental’s turns. The elemental can grapple one Large creature or up to two Medium or smaller creatures at a time with Whelm. As an action, a creature within 5 feet of the elemental can pull a creature out of it by succeeding on a DC 14 Strength (Athletics) check. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "4d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "4d8+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "werebear": {
+      "index": "werebear",
+      "name": "Werebear",
+      "size": "Medium",
+      "type": "or small monstrosity",
+      "alignment": "Neutral Good",
+      "armor_class": 15,
+      "hit_points": 135,
+      "hit_dice": "18d8 + 54",
+      "speed": {
+        "walk": "40 ft. (bear form only)",
+        "climb": "30 ft. (bear form only)"
+      },
+      "strength": 19,
+      "dexterity": 10,
+      "constitution": 17,
+      "intelligence": 11,
+      "wisdom": 12,
+      "charisma": 12,
+      "saving_throws": [],
+      "skills": {
+        "perception": 7
+      },
+      "senses": {
+        "passive_perception": 17,
+        "darkvision": "60 ft.",
+        "cr": "5",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Common (can’t speak in bear form) CR 5 (XP 1,800; PB +3)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The werebear makes two attacks, using Handaxe or Rend in any combination. It can replace one attack with a Bite attack."
+        },
+        {
+          "name": "Bite (Bear or Hybrid Form Only)",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 14. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Werebear under the GM’s control and has 10 Hit Points. Success: The target is immune to this werebear’s curse for 24 hours.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d12+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Handaxe (Humanoid or Hybrid Form Only)",
+          "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft or range 20/60 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "3d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Rend (Bear or Hybrid Form Only)",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The werebear shape-shifts into a Large bear-humanoid hybrid form or a Large bear, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "lycanthrope"
+    },
+    "wereboar": {
+      "index": "wereboar",
+      "name": "Wereboar",
+      "size": "Medium",
+      "type": "or small monstrosity",
+      "alignment": "Neutral Evil",
+      "armor_class": 15,
+      "hit_points": 97,
+      "hit_dice": "15d8 + 30",
+      "speed": {
+        "walk": "40 ft. (boar form only)"
+      },
+      "strength": 17,
+      "dexterity": 10,
+      "constitution": 15,
+      "intelligence": 10,
+      "wisdom": 11,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12
+      },
+      "languages": "Common (can’t speak in boar form)",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The wereboar makes two attacks, using Javelin or Tusk in any combination. It can replace one attack with a Gore attack."
+        },
+        {
+          "name": "Gore (Boar or Hybrid Form Only)",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Wereboar under the GM’s control and has 10 Hit Points. Success: The target is immune to this wereboar’s curse for 24 hours.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Javelin (Humanoid or Hybrid Form Only)",
+          "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "3d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tusk (Boar or Hybrid Form Only)",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Medium or smaller creature and the wereboar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The wereboar shape-shifts into a Medium boar-humanoid hybrid or a Small boar, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "lycanthrope"
+    },
+    "wererat": {
+      "index": "wererat",
+      "name": "Wererat",
+      "size": "Medium",
+      "type": "or small monstrosity",
+      "alignment": "Lawful Evil",
+      "armor_class": 13,
+      "hit_points": 60,
+      "hit_dice": "11d8 + 11",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 10,
+      "dexterity": 16,
+      "constitution": 12,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "cr": "2",
+        "xp": "450",
+        "summary": "Darkvision 60 ft.; Languages Common (can’t speak in rat form) CR 2 (XP 450; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The wererat makes two attacks, using Scratch or Hand Crossbow in any combination. It can replace one attack with a Bite attack."
+        },
+        {
+          "name": "Bite (Rat or Hybrid Form Only)",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 11. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Wererat under the GM’s control and has 10 Hit Points. Success: The target is immune to this wererat’s curse for 24 hours.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Scratch",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Hand Crossbow (Humanoid or Hybrid Form Only)",
+          "desc": "Ranged Attack Roll: +5, range 30/120 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The wererat shape-shifts into a Medium rat-humanoid hybrid or a Small rat, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "lycanthrope"
+    },
+    "weretiger": {
+      "index": "weretiger",
+      "name": "Weretiger",
+      "size": "Medium",
+      "type": "or small monstrosity",
+      "alignment": "Neutral",
+      "armor_class": 12,
+      "hit_points": 120,
+      "hit_dice": "16d8 + 48",
+      "speed": {
+        "walk": "40 ft. (tiger form only)"
+      },
+      "strength": 17,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 13,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "cr": "4",
+        "xp": "1",
+        "summary": "Darkvision 60 ft.; Languages Common (can’t speak in tiger form) CR 4 (XP 1,100; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The werewolf has Advantage on an attack roll against a creature if at least one of the werewolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The werewolf makes two attacks, using Scratch or Longbow in any combination. It can replace one attack with a Bite attack."
+        },
+        {
+          "name": "Bite (Wolf or Hybrid Form Only)",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Werewolf under the GM’s control and has 10 Hit Points. Success: The target is immune to this werewolf’s curse for 24 hours.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Scratch",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Longbow (Humanoid or Hybrid Form Only)",
+          "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Shape-Shift",
+          "desc": "The werewolf shape-shifts into a Large wolf-humanoid hybrid or a Medium wolf, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "lycanthrope"
+    },
+    "white-dragon-wyrmling": {
+      "index": "white-dragon-wyrmling",
+      "name": "White Dragon Wyrmling",
+      "size": "Medium",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 16,
+      "hit_points": 32,
+      "hit_dice": "5d8 + 10",
+      "speed": {
+        "walk": "30 ft.",
+        "burrow": "15 ft.",
+        "fly": "60 ft.",
+        "swim": "30 ft."
+      },
+      "strength": null,
+      "dexterity": null,
+      "constitution": null,
+      "intelligence": null,
+      "wisdom": null,
+      "charisma": null,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": null,
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "werewolf": {
+      "index": "werewolf",
+      "name": "Werewolf",
+      "size": "Medium",
+      "type": "or small monstrosity",
+      "alignment": "Chaotic Evil",
+      "armor_class": 15,
+      "hit_points": 71,
+      "hit_dice": "11d8 + 22",
+      "speed": {
+        "walk": "40 ft. (wolf form only)"
+      },
+      "strength": 14,
+      "dexterity": 10,
+      "constitution": 14,
+      "intelligence": 5,
+      "wisdom": 10,
+      "charisma": 11,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 4,
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 14,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "Draconic",
+      "challenge_rating": 2.0,
+      "xp": null,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Ice Walk",
+          "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 2 (1d4) Cold damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 22 (5d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "5d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "5d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "lycanthrope"
+    },
+    "young-white-dragon": {
+      "index": "young-white-dragon",
+      "name": "Young White Dragon",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 17,
+      "hit_points": 123,
+      "hit_dice": "13d10 + 52",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "20 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 10,
+      "constitution": 18,
+      "intelligence": 6,
+      "wisdom": 11,
+      "charisma": 12,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        },
+        {
+          "name": "INT",
+          "value": 2
+        },
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "perception": 6,
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 16,
+        "blindsight": "30 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 30 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 6.0,
+      "xp": null,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Ice Walk",
+          "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 2 (1d4) Cold damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: 40 (9d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "9d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "9d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "adult-white-dragon": {
+      "index": "adult-white-dragon",
+      "name": "Adult White Dragon",
+      "size": "Huge",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 18,
+      "hit_points": 200,
+      "hit_dice": "16d12 + 96",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "30 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 22,
+      "dexterity": 10,
+      "constitution": null,
+      "intelligence": null,
+      "wisdom": null,
+      "charisma": null,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "perception": 11,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 21,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 13.0,
+      "xp": 10000,
+      "proficiency_bonus": 5,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Ice Walk",
+          "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+        },
+        {
+          "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Cold damage.",
+          "attack_bonus": 11,
+          "damage": [
+            {
+              "damage_dice": "2d6+6",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+6",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "12d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "12d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Freezing Burst",
+          "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 7 (2d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "2d6",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "2d6",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Frightful Presence",
+          "desc": "The dragon casts Fear, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "ancient-white-dragon": {
+      "index": "ancient-white-dragon",
+      "name": "Ancient White Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Chaotic Evil",
+      "armor_class": 20,
+      "hit_points": 333,
+      "hit_dice": "18d20 + 144",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "40 ft.",
+        "fly": "80 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 26,
+      "dexterity": 10,
+      "constitution": 26,
+      "intelligence": 10,
+      "wisdom": 13,
+      "charisma": 18,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 6
+        },
+        {
+          "name": "WIS",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "perception": 13,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 23,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft.",
+        "summary": "Blindsight 60 ft., Darkvision 120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 20.0,
+      "xp": 25000,
+      "proficiency_bonus": 6,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Cold"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Ice Walk",
+          "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+        },
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +14, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 7 (2d6) Cold damage.",
+          "attack_bonus": 14,
+          "damage": [
+            {
+              "damage_dice": "2d8+8",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+8",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: 63 (14d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "14d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "14d8",
+          "damage_type": {
+            "name": "cold"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Freezing Burst",
+          "desc": "Constitution Saving Throw: DC 20, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 14 (4d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "4d6",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "4d6",
+          "damage_type": {
+            "name": "cold"
+          }
+        },
+        {
+          "name": "Frightful Presence",
+          "desc": "The dragon casts Fear, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18). The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "wight": {
+      "index": "wight",
+      "name": "Wight",
+      "size": "Medium",
+      "type": "undead",
+      "alignment": "Neutral Evil",
+      "armor_class": 14,
+      "hit_points": 82,
+      "hit_dice": "11d8 + 33",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 14,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 13,
+      "charisma": 15,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "languages_common_plus_one_other_language_cr": "3",
+        "xp": "700",
+        "summary": "Darkvision 60 ft.; Languages Common plus one other language CR 3 (XP 700; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic"
+      ],
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Sunlight Sensitivity",
+          "desc": "While in sunlight, the wight has Disadvantage on ability checks and attack rolls."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The wight makes two attacks, using Necrotic Sword or Necrotic Bow in any combination. It can replace one attack with a use of Life Drain."
+        },
+        {
+          "name": "Necrotic Sword",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 4 (1d8) Necrotic damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Necrotic Bow",
+          "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 4 (1d8) Necrotic damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Life Drain",
+          "desc": "Constitution Saving Throw: DC 13, one creature within 5 feet. Failure: 6 (1d8 + 2) Necrotic damage, and the target’s Hit Point maximum decreases by an amount equal to the damage taken. A Humanoid slain by this attack rises 24 hours later as a Zombie under the wight’s control, unless the Humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at a time. Will-o’-Wisp",
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "will-o-wisp": {
+      "index": "will-o-wisp",
+      "name": "Will-o’-Wisp",
+      "size": "Tiny",
+      "type": "undead",
+      "alignment": "Chaotic Evil",
+      "armor_class": 19,
+      "hit_points": 27,
+      "hit_dice": "11d4",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "50 ft. (hover)"
+      },
+      "strength": 1,
+      "dexterity": 28,
+      "constitution": 10,
+      "intelligence": 13,
+      "wisdom": 14,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "120 ft.",
+        "languages_common_plus_one_other_language_cr": "2",
+        "xp": "450",
+        "summary": "Darkvision 120 ft.; Languages Common plus one other language CR 2 (XP 450; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Bludgeoning",
+        "Cold",
+        "Fire",
+        "Necrotic",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Lightning",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained",
+        "Unconscious"
+      ],
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
         }
       ],
       "actions": [
         {
           "name": "Bite",
-          "attack_bonus": 4,
-          "damage_dice": "2d4+2",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "desc": "Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d8",
+              "damage_type": {
+                "name": "cold"
+              }
+            }
+          ],
+          "damage_dice": "4d8",
+          "damage_type": {
+            "name": "cold"
+          }
         }
-      ]
+      ],
+      "bonus_actions": [
+        {
+          "name": "Consume Life",
+          "desc": "Constitution Saving Throw: DC 10, one living creature the wisp can see within 5 feet that has 0 Hit Points. Failure: The target dies, and the wisp regains 10 (3d6) Hit Points."
+        },
+        {
+          "name": "Vanish",
+          "desc": "The wisp and its light have the Invisible condition until the wisp’s Concentration ends on this effect, which ends early immediately after the wisp makes an attack roll or uses Consume Life."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
     "worg": {
       "index": "worg",
       "name": "Worg",
       "size": "Large",
-      "type": "monstrosity",
-      "alignment": "neutral evil",
+      "type": "fey",
+      "alignment": "Neutral Evil",
       "armor_class": 13,
-      "hit_points": 26,
-      "hit_dice": "4d10",
-      "speed": { "walk": "50 ft." },
-      "strength": 16,
-      "dexterity": 13,
-      "constitution": 13,
-      "intelligence": 7,
-      "wisdom": 11,
-      "charisma": 8,
-      "skills": { "perception": 4, "stealth": 3 },
-      "senses": { "darkvision": "60 ft.", "passive_perception": 14 },
+      "hit_points": 67,
+      "hit_dice": "9d8 + 27",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "60 ft. (hover)"
+      },
+      "strength": 6,
+      "dexterity": 16,
+      "constitution": 16,
+      "intelligence": 12,
+      "wisdom": 14,
+      "charisma": 15,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft.; Languages Common plus two other languages CR 5 (XP 1,800; PB +3)",
+        "giant_cr": "3",
+        "xp": "1",
+        "languages_common_plus_two_other_languages_cr": "5"
+      },
       "languages": "Goblin, Worg",
       "challenge_rating": 0.5,
       "xp": 100,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Acid",
+        "Bludgeoning",
+        "Cold",
+        "Fire",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Cold",
+        "Necrotic",
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Charmed",
+        "Exhaustion",
+        "Grappled",
+        "Paralyzed",
+        "Petrified",
+        "Poisoned",
+        "Prone",
+        "Restrained",
+        "Unconscious"
+      ],
+      "special_abilities": [
+        {
+          "name": "Incorporeal Movement",
+          "desc": "The wraith can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "desc": "While in sunlight, the wraith has Disadvantage on ability checks and attack rolls."
+        }
+      ],
       "actions": [
         {
-          "name": "Bite",
-          "attack_bonus": 5,
-          "damage_dice": "2d6+3",
-          "damage_type": { "name": "piercing" },
-          "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+          "name": "Life Drain",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (4d8 + 3) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "4d8+3",
+              "damage_type": {
+                "name": "necrotic"
+              }
+            }
+          ],
+          "damage_dice": "4d8+3",
+          "damage_type": {
+            "name": "necrotic"
+          }
+        },
+        {
+          "name": "Create Specter",
+          "desc": "The wraith targets a Humanoid corpse within 10 feet of itself that has been dead for no longer than 1 minute. The target’s spirit rises as a Specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith’s control. The wraith can have no more than seven specters under its control at a time."
         }
-      ]
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "wyvern": {
+      "index": "wyvern",
+      "name": "Wyvern",
+      "size": "Large",
+      "type": "dragon",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 127,
+      "hit_dice": "15d10 + 45",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 19,
+      "dexterity": 10,
+      "constitution": 16,
+      "intelligence": 5,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The wyvern makes one Bite attack and one Sting attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Sting",
+          "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage plus 24 (7d6) Poison damage, and the target has the Poisoned condition until the start of the wyvern’s next turn.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "xorn": {
+      "index": "xorn",
+      "name": "Xorn",
+      "size": "Medium",
+      "type": "elemental",
+      "alignment": "Neutral",
+      "armor_class": 19,
+      "hit_points": 84,
+      "hit_dice": "8d8 + 48",
+      "speed": {
+        "walk": "20 ft.",
+        "burrow": "20 ft."
+      },
+      "strength": 17,
+      "dexterity": 10,
+      "constitution": 22,
+      "intelligence": 11,
+      "wisdom": 10,
+      "charisma": 11,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "60 ft.",
+        "tremorsense": "60 ft.",
+        "summary": "Darkvision 60 ft., Tremorsense 60 ft."
+      },
+      "languages": "Primordial (Terran)",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Paralyzed",
+        "Petrified",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Earth Glide",
+          "desc": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn’t disturb the material it moves through."
+        },
+        {
+          "name": "Treasure Sense",
+          "desc": "The xorn can pinpoint the location of precious metals and stones within 60 feet of itself."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The xorn makes one Bite attack and three Claw attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 17 (4d6 + 3) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "4d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "4d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Charge",
+          "desc": "The xorn moves up to its Speed or Burrow Speed straight toward an enemy it can sense."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     },
     "zombie": {
       "index": "zombie",
       "name": "Zombie",
       "size": "Medium",
       "type": "undead",
-      "alignment": "neutral evil",
+      "alignment": "Neutral Evil",
       "armor_class": 8,
-      "hit_points": 22,
-      "hit_dice": "3d8",
-      "speed": { "walk": "20 ft." },
+      "hit_points": 15,
+      "hit_dice": "2d8 + 6",
+      "speed": {
+        "walk": "20 ft."
+      },
       "strength": 13,
       "dexterity": 6,
       "constitution": 16,
       "intelligence": 3,
       "wisdom": 6,
       "charisma": 5,
-      "damage_immunities": ["poison"],
-      "condition_immunities": [
-        { "name": "poisoned" }
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 0
+        }
       ],
-      "senses": { "darkvision": "60 ft.", "passive_perception": 8 },
-      "languages": "Understands the languages it knew in life but can't speak",
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Understands Common plus one other language but can’t speak",
       "challenge_rating": 0.25,
       "xp": 50,
       "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned"
+      ],
       "special_abilities": [
         {
           "name": "Undead Fortitude",
-          "desc": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+          "desc": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead."
         }
       ],
       "actions": [
         {
           "name": "Slam",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Bludgeoning damage.",
           "attack_bonus": 3,
-          "damage_dice": "1d6+1",
-          "damage_type": { "name": "bludgeoning" },
-          "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage."
+          "damage": [
+            {
+              "damage_dice": "1d8+1",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d8+1",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
         }
-      ]
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "ogre-zombie": {
+      "index": "ogre-zombie",
+      "name": "Ogre Zombie",
+      "size": "Large",
+      "type": "undead",
+      "alignment": "Neutral Evil",
+      "armor_class": 8,
+      "hit_points": 85,
+      "hit_dice": "9d10 + 36",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 6,
+      "constitution": 18,
+      "intelligence": 3,
+      "wisdom": 6,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 0
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "Understands Common and Giant but can’t speak",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Poison"
+      ],
+      "condition_immunities": [
+        "Exhaustion",
+        "Poisoned"
+      ],
+      "special_abilities": [
+        {
+          "name": "Undead Fortitude",
+          "desc": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Slam",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d8+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d8+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "allosaurus": {
+      "index": "allosaurus",
+      "name": "Allosaurus",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": null,
+      "hit_points": null,
+      "hit_dice": null,
+      "speed": {},
+      "strength": null,
+      "dexterity": null,
+      "constitution": null,
+      "intelligence": null,
+      "wisdom": null,
+      "charisma": null,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": null,
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "ankylosaurus": {
+      "index": "ankylosaurus",
+      "name": "Ankylosaurus",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 15,
+      "hit_points": 68,
+      "hit_dice": "8d12 + 16",
+      "speed": {
+        "walk": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 11,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 6
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The ankylosaurus makes two Tail attacks."
+        },
+        {
+          "name": "Tail",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d10+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d10+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "ape": {
+      "index": "ape",
+      "name": "Ape",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 51,
+      "hit_dice": "6d10 + 18",
+      "speed": {
+        "walk": "60 ft."
+      },
+      "strength": 19,
+      "dexterity": 13,
+      "constitution": 17,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "athletics": 5,
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The ape makes two Fist attacks."
+        },
+        {
+          "name": "Fist",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Rock (Recharge 6)",
+          "desc": "Ranged Attack Roll: +5, range 25/50 ft. Hit: 10 (2d6 + 3) Bludgeoning damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "archelon": {
+      "index": "archelon",
+      "name": "Archelon",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 17,
+      "hit_points": 90,
+      "hit_dice": "12d12 + 12",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "80 ft."
+      },
+      "strength": 18,
+      "dexterity": 16,
+      "constitution": 13,
+      "intelligence": 4,
+      "wisdom": 14,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 12
+      },
+      "languages": "",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The archelon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The archelon makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "baboon": {
+      "index": "baboon",
+      "name": "Baboon",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 3,
+      "hit_dice": "1d6",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 8,
+      "dexterity": 14,
+      "constitution": 11,
+      "intelligence": 4,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The baboon has Advantage on an attack roll against a creature if at least one of the baboon’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 - 1) Piercing damage.",
+          "attack_bonus": 1,
+          "damage": [
+            {
+              "damage_dice": "1d4-1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4-1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "badger": {
+      "index": "badger",
+      "name": "Badger",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 5,
+      "hit_dice": "1d4 + 3",
+      "speed": {
+        "walk": "20 ft.",
+        "burrow": "5 ft."
+      },
+      "strength": 10,
+      "dexterity": 11,
+      "constitution": 16,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Poison"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 2
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "bat": {
+      "index": "bat",
+      "name": "Bat",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 2,
+      "dexterity": 15,
+      "constitution": 8,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 4
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "black-bear": {
+      "index": "black-bear",
+      "name": "Black Bear",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 19,
+      "hit_dice": "3d8 + 6",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 12,
+      "constitution": 14,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The bear makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "blood-hawk": {
+      "index": "blood-hawk",
+      "name": "Blood Hawk",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 7,
+      "hit_dice": "2d6",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "60 ft."
+      },
+      "strength": null,
+      "dexterity": null,
+      "constitution": null,
+      "intelligence": null,
+      "wisdom": null,
+      "charisma": null,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The hawk has Advantage on an attack roll against a creature if at least one of the hawk’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beak",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, or 6 (1d8 + 2) Piercing damage if the target is Bloodied.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "boar": {
+      "index": "boar",
+      "name": "Boar",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 13,
+      "hit_dice": "2d8 + 4",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 13,
+      "dexterity": 11,
+      "constitution": 14,
+      "intelligence": 2,
+      "wisdom": 9,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Bloodied Fury",
+          "desc": "While Bloodied, the boar has Advantage on attack rolls."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Piercing damage and has the Prone condition.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "brown-bear": {
+      "index": "brown-bear",
+      "name": "Brown Bear",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 22,
+      "hit_dice": "3d10 + 6",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 12,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 13,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The bear makes one Bite attack and one Claw attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "camel": {
+      "index": "camel",
+      "name": "Camel",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 17,
+      "hit_dice": "2d10 + 6",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 15,
+      "dexterity": 8,
+      "constitution": 17,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 5
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "cat": {
+      "index": "cat",
+      "name": "Cat",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 2,
+      "hit_dice": "1d4",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 3,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "perception": 3,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Jumper",
+          "desc": "The cat’s jump distance is determined using its Dexterity rather than its Strength."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Scratch",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Slashing damage.",
+          "attack_bonus": 4
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "constrictor-snake": {
+      "index": "constrictor-snake",
+      "name": "Constrictor Snake",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 13,
+      "hit_dice": "2d10 + 2",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 12,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Constrict",
+          "desc": "Strength Saving Throw: DC 12, one Medium or smaller creature the snake can see within 5 feet. Failure: 7 (3d4) Bludgeoning damage, and the target has the Grappled condition (escape DC 12).",
+          "damage": [
+            {
+              "damage_dice": "3d4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "crab": {
+      "index": "crab",
+      "name": "Crab",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 3,
+      "hit_dice": "1d4 + 1",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "20 ft."
+      },
+      "strength": 6,
+      "dexterity": 11,
+      "constitution": 12,
+      "intelligence": 1,
+      "wisdom": 8,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 9,
+        "blindsight": "30 ft.",
+        "summary": "Blindsight 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The crab can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Bludgeoning damage.",
+          "attack_bonus": 2
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "crocodile": {
+      "index": "crocodile",
+      "name": "Crocodile",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 13,
+      "hit_dice": "2d10 + 2",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 10,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "CON",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "stealth": 2
+      },
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Hold Breath",
+          "desc": "The crocodile can hold its breath for 1 hour."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12). While Grappled, the target has the Restrained condition.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "deer": {
+      "index": "deer",
+      "name": "Deer",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 4,
+      "hit_dice": "1d8",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 11,
+      "dexterity": 16,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 14,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Agile",
+          "desc": "The deer doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "dire-wolf": {
+      "index": "dire-wolf",
+      "name": "Dire Wolf",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 22,
+      "hit_dice": "3d10 + 6",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 17,
+      "dexterity": 15,
+      "constitution": 15,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d10+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "draft-horse": {
+      "index": "draft-horse",
+      "name": "Draft Horse",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 15,
+      "hit_dice": "2d10 + 4",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 10,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Bludgeoning damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "eagle": {
+      "index": "eagle",
+      "name": "Eagle",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 4,
+      "hit_dice": "1d6 + 1",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 6,
+      "dexterity": 15,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 14,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Talons",
+          "desc": "Melee Attack Roll: +4, reach 5 feet. Hit: 4 (1d4 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "elephant": {
+      "index": "elephant",
+      "name": "Elephant",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 76,
+      "hit_dice": "8d12 + 24",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 22,
+      "dexterity": 9,
+      "constitution": 17,
+      "intelligence": 3,
+      "wisdom": 11,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The elephant makes two Gore attacks."
+        },
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 15 (2d8 + 6) Piercing damage. If the target is a Huge or smaller creature and the elephant moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+          "attack_bonus": 8,
+          "damage": [
+            {
+              "damage_dice": "2d8+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Trample",
+          "desc": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 17 (2d10 + 6) Bludgeoning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "2d10+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d10+6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "elk": {
+      "index": "elk",
+      "name": "Elk",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 11,
+      "hit_dice": "2d10",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 16,
+      "dexterity": 10,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Bludgeoning damage and has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "flying-snake": {
+      "index": "flying-snake",
+      "name": "Flying Snake",
+      "size": "Tiny",
+      "type": "monstrosity",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 5,
+      "hit_dice": "2d4",
+      "speed": {
+        "walk": "30 ft.",
+        "fly": "60 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 4,
+      "dexterity": 15,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The snake doesn’t provoke an Opportunity At- tack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 5 (2d4) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "frog": {
+      "index": "frog",
+      "name": "Frog",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "20 ft."
+      },
+      "strength": 1,
+      "dexterity": 13,
+      "constitution": 8,
+      "intelligence": 1,
+      "wisdom": 8,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": {
+        "perception": 1,
+        "stealth": 3
+      },
+      "senses": {
+        "passive_perception": 11,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The frog can breathe air and water."
+        },
+        {
+          "name": "Standing Leap",
+          "desc": "The frog’s Long Jump is up to 10 feet and its High Jump is up to 5 feet with or without a running start."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 3
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-ape": {
+      "index": "giant-ape",
+      "name": "Giant Ape",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 168,
+      "hit_dice": "16d12 + 64",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 23,
+      "dexterity": 14,
+      "constitution": 18,
+      "intelligence": 5,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "athletics": 9,
+        "perception": 4,
+        "survival": 4
+      },
+      "senses": {
+        "passive_perception": 14
+      },
+      "languages": "",
+      "challenge_rating": 7.0,
+      "xp": 2900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The ape makes two Fist attacks."
+        },
+        {
+          "name": "Fist",
+          "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "3d10+6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "3d10+6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Boulder Toss (Recharge 6)",
+          "desc": "The ape hurls a boulder at a point it can see within 90 feet. Dexterity Saving Throw: DC 17, each creature in a 5-foot-radius Sphere centered on that point. Failure: 24 (7d6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition. Success: Half damage only.",
+          "damage": [
+            {
+              "damage_dice": "7d6",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "7d6",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Leap",
+          "desc": "The ape jumps up to 30 feet by spending 10 feet of movement."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-badger": {
+      "index": "giant-badger",
+      "name": "Giant Badger",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 15,
+      "hit_dice": "2d8 + 6",
+      "speed": {
+        "walk": "30 ft.",
+        "burrow": "10 ft."
+      },
+      "strength": 13,
+      "dexterity": 10,
+      "constitution": 17,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Poison"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Piercing damage.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "2d4+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-bat": {
+      "index": "giant-bat",
+      "name": "Giant Bat",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 22,
+      "hit_dice": "4d10",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 15,
+      "dexterity": 16,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "blindsight": "120 ft.",
+        "summary": "Blindsight 120 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-boar": {
+      "index": "giant-boar",
+      "name": "Giant Boar",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 42,
+      "hit_dice": "5d10 + 15",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 17,
+      "dexterity": 10,
+      "constitution": 16,
+      "intelligence": 2,
+      "wisdom": 7,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 5
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Bloodied Fury",
+          "desc": "The boar has Advantage on melee attack rolls while it is Bloodied."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-centipede": {
+      "index": "giant-centipede",
+      "name": "Giant Centipede",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 9,
+      "hit_dice": "2d6 + 2",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 5,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 1,
+      "wisdom": 7,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "blindsight": "30 ft.",
+        "summary": "Blindsight 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, and the target has the Poisoned condition until the start of the centipede’s next turn.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-constrictor-snake": {
+      "index": "giant-constrictor-snake",
+      "name": "Giant Constrictor Snake",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 60,
+      "hit_dice": "8d12 + 8",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 19,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11) from one of two claws.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-crocodile": {
+      "index": "giant-crocodile",
+      "name": "Giant Crocodile",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 26,
+      "hit_dice": "4d10 + 4",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 16,
+      "dexterity": 17,
+      "constitution": 13,
+      "intelligence": 8,
+      "wisdom": 14,
+      "charisma": 10,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 3,
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 9,
+        "blindsight": "30 ft.",
+        "summary": "Blindsight 30 ft."
+      },
+      "languages": "Celestial; understands Common and Primordial (Auran) but can’t speak them",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The crab can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The eagle makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 3 (1d6) Radiant damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-elk": {
+      "index": "giant-elk",
+      "name": "Giant Elk",
+      "size": "Huge",
+      "type": "celestial",
+      "alignment": "Neutral Good",
+      "armor_class": 14,
+      "hit_points": 42,
+      "hit_dice": "5d12 + 10",
+      "speed": {
+        "walk": "60 ft."
+      },
+      "strength": 19,
+      "dexterity": 18,
+      "constitution": 14,
+      "intelligence": 7,
+      "wisdom": 14,
+      "charisma": 10,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 6
+        },
+        {
+          "name": "DEX",
+          "value": 6
+        }
+      ],
+      "skills": {
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "90 ft.",
+        "summary": "Darkvision 90 ft."
+      },
+      "languages": "Celestial; understands Common, Elvish, and Sylvan but can’t speak them",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic",
+        "Radiant"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage. If the target is a Huge or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-fire-beetle": {
+      "index": "giant-fire-beetle",
+      "name": "Giant Fire Beetle",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 4,
+      "hit_dice": "1d6 + 1",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 8,
+      "dexterity": 10,
+      "constitution": 12,
+      "intelligence": 1,
+      "wisdom": 7,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "blindsight": "30 ft.",
+        "summary": "Blindsight 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Fire"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Illumination",
+          "desc": "The beetle sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Fire damage.",
+          "attack_bonus": 1
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-frog": {
+      "index": "giant-frog",
+      "name": "Giant Frog",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 18,
+      "hit_dice": "4d8",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 12,
+      "dexterity": 13,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The frog can breathe air and water."
+        },
+        {
+          "name": "Standing Leap",
+          "desc": "The frog’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11).",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Swallow",
+          "desc": "The frog swallows a Small or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the frog. While swallowing the target, the frog can’t use Bite, and if the frog dies, the swallowed target is no longer Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition. At the end of the frog’s next turn, the swallowed target takes 5 (2d4) Acid damage. If that damage doesn’t kill it, the frog disgorges it, causing it to exit Prone."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-goat": {
+      "index": "giant-goat",
+      "name": "Giant Goat",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 19,
+      "hit_dice": "3d10 + 3",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 17,
+      "dexterity": 13,
+      "constitution": 12,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the goat moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-hyena": {
+      "index": "giant-hyena",
+      "name": "Giant Hyena",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 16,
+      "dexterity": 14,
+      "constitution": 14,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Rampage (1/Day)",
+          "desc": "Immediately after dealing damage to a creature that was already Bloodied, the hyena can move up to half its Speed, and it makes one Bite attack."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-lizard": {
+      "index": "giant-lizard",
+      "name": "Giant Lizard",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 19,
+      "hit_dice": "3d10 + 3",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 15,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 3
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-octopus": {
+      "index": "giant-octopus",
+      "name": "Giant Octopus",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 45,
+      "hit_dice": "7d10 + 7",
+      "speed": {
+        "walk": "10 ft.",
+        "swim": "60 ft."
+      },
+      "strength": 17,
+      "dexterity": 13,
+      "constitution": 13,
+      "intelligence": 5,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Water Breathing",
+          "desc": "The octopus can breathe only underwater. It can hold its breath for 1 hour outside water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Tentacles",
+          "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from all eight tentacles. While Grappled, the target has the Restrained condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Ink Cloud (1/Day)",
+          "desc": "Trigger: The octopus takes damage while underwater. Response: The octopus releases ink that fills a 10-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect disperses the ink."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-owl": {
+      "index": "giant-owl",
+      "name": "Giant Owl",
+      "size": "Large",
+      "type": "celestial",
+      "alignment": "Neutral",
+      "armor_class": 12,
+      "hit_points": 19,
+      "hit_dice": "3d10 + 3",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 13,
+      "dexterity": 15,
+      "constitution": 12,
+      "intelligence": 10,
+      "wisdom": 14,
+      "charisma": 10,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "perception": 6,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "Celestial; understands Common, Elvish, and Sylvan but can’t speak them",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic",
+        "Radiant"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Talons",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d10+2",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d10+2",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The owl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability: At Will: Detect Evil and Good, Detect Magic 1/Day: Clairvoyance"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-rat": {
+      "index": "giant-rat",
+      "name": "Giant Rat",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 7,
+      "hit_dice": "2d6",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 7,
+      "dexterity": 16,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The rat has Advantage on an attack roll against a creature if at least one of the rat’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 feet. Hit: 5 (1d4 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-scorpion": {
+      "index": "giant-scorpion",
+      "name": "Giant Scorpion",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 15,
+      "hit_points": 52,
+      "hit_dice": "7d10 + 14",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 15,
+      "intelligence": 1,
+      "wisdom": 9,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The scorpion makes two Claw attacks and one Sting attack."
+        },
+        {
+          "name": "Claw",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        },
+        {
+          "name": "Sting",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 11 (2d10) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-seahorse": {
+      "index": "giant-seahorse",
+      "name": "Giant Seahorse",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 16,
+      "hit_dice": "3d10",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 15,
+      "dexterity": 12,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Water Breathing",
+          "desc": "The seahorse can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Bludgeoning damage, or 11 (2d8 + 2) Bludgeoning damage if the seahorse moved 20+ feet straight toward the target immediately before the hit.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d6+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d6+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Bubble Dash",
+          "desc": "While underwater, the seahorse moves up to half its Swim Speed without provoking Opportunity Attacks."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-shark": {
+      "index": "giant-shark",
+      "name": "Giant Shark",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 92,
+      "hit_dice": "8d12 + 40",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "60 ft."
+      },
+      "strength": 23,
+      "dexterity": 11,
+      "constitution": 21,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Water Breathing",
+          "desc": "The shark can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The shark makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +9 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 22 (3d10 + 6) Piercing damage.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "3d10+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d10+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-spider": {
+      "index": "giant-spider",
+      "name": "Giant Spider",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 26,
+      "hit_dice": "4d10 + 4",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 16,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The spider ignores movement restrictions caused by webs, and it knows the location of any other creature in contact with the same web."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Web (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 13, one creature the spider can see within 60 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Poison and Psychic damage)."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-toad": {
+      "index": "giant-toad",
+      "name": "Giant Toad",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 39,
+      "hit_dice": "6d10 + 6",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 15,
+      "dexterity": 13,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Amphibious",
+          "desc": "The toad can breathe air and water."
+        },
+        {
+          "name": "Standing Leap",
+          "desc": "The toad’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Swallow",
+          "desc": "The toad swallows a Medium or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the toad. In addition, the target takes 10 (3d6) Acid damage at the end of each of the toad’s turns. The toad can have only one target swallowed at a time, and it can’t use Bite while it has a swallowed target. If the toad dies, a swallowed creature is no longer Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-venomous-snake": {
+      "index": "giant-venomous-snake",
+      "name": "Giant Venomous Snake",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "40 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 10,
+      "dexterity": 18,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 6 (1d4 + 4) Piercing damage plus 4 (1d8) Poison damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d4+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-vulture": {
+      "index": "giant-vulture",
+      "name": "Giant Vulture",
+      "size": "Large",
+      "type": "monstrosity",
+      "alignment": "Neutral Evil",
+      "armor_class": 10,
+      "hit_points": 25,
+      "hit_dice": "3d10 + 9",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 15,
+      "dexterity": 10,
+      "constitution": 16,
+      "intelligence": 6,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "t_speak_cr": "1",
+        "xp": "200",
+        "summary": "Darkvision 60 ft.; Languages Understands Common but can’t speak CR 1 (XP 200; PB +2)"
+      },
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Necrotic"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gouge",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage, and the target has the Poisoned condition until the end of its next turn.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-wasp": {
+      "index": "giant-wasp",
+      "name": "Giant Wasp",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 22,
+      "hit_dice": "5d8",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "50 ft."
+      },
+      "strength": 10,
+      "dexterity": 14,
+      "constitution": 10,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The wasp doesn’t provoke an Opportunity At- tack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Sting",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-weasel": {
+      "index": "giant-weasel",
+      "name": "Giant Weasel",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 9,
+      "hit_dice": "2d8",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 17,
+      "constitution": 10,
+      "intelligence": 4,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "acrobatics": 5,
+        "perception": 3,
+        "stealth": 5
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "giant-wolf-spider": {
+      "index": "giant-wolf-spider",
+      "name": "Giant Wolf Spider",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 12,
+      "dexterity": 16,
+      "constitution": 13,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 13,
+        "blindsight": "10 ft.",
+        "darkvision": "60 ft.",
+        "summary": "Blindsight 10 ft., Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 5 (2d4) Poison damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "goat": {
+      "index": "goat",
+      "name": "Goat",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 4,
+      "hit_dice": "1d8",
+      "speed": {
+        "walk": "40 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 11,
+      "dexterity": 10,
+      "constitution": 11,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 2
+        }
+      ],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Ram",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Bludgeoning damage, or 2 (1d4) Bludgeoning damage if the goat moved 20+ feet straight toward the target immediately before the hit.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hawk": {
+      "index": "hawk",
+      "name": "Hawk",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 5,
+      "dexterity": 16,
+      "constitution": 8,
+      "intelligence": 2,
+      "wisdom": 14,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Talons",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Slashing damage.",
+          "attack_bonus": 5
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hippopotamus": {
+      "index": "hippopotamus",
+      "name": "Hippopotamus",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 82,
+      "hit_dice": "11d10 + 22",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 21,
+      "dexterity": 7,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 4,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 7
+        }
+      ],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13
+      },
+      "languages": "",
+      "challenge_rating": 4.0,
+      "xp": 1100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Hold Breath",
+          "desc": "The hippopotamus can hold its breath for 10 minutes."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The hippopotamus makes two Bite attacks."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 16 (2d10 + 5) Piercing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d10+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hunter-shark": {
+      "index": "hunter-shark",
+      "name": "Hunter Shark",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 15,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Water Breathing",
+          "desc": "The shark can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "3d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "3d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "hyena": {
+      "index": "hyena",
+      "name": "Hyena",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 5,
+      "hit_dice": "1d8 + 1",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 11,
+      "dexterity": 13,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The hyena has Advantage on an attack roll against a creature if at least one of the hyena’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 3 (1d6) Piercing damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "jackal": {
+      "index": "jackal",
+      "name": "Jackal",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 3,
+      "hit_dice": "1d6",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 8,
+      "dexterity": 15,
+      "constitution": 11,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "90 ft.",
+        "summary": "Darkvision 90 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 - 1) Piercing damage.",
+          "attack_bonus": 1,
+          "damage": [
+            {
+              "damage_dice": "1d4-1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4-1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "killer-whale": {
+      "index": "killer-whale",
+      "name": "Killer Whale",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 22,
+      "hit_dice": "4d10",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 17,
+      "dexterity": 15,
+      "constitution": 11,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 13,
+        "blindsight": "120 ft.",
+        "summary": "Darkvision 60 ft.",
+        "darkvision": "60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The lion has Advantage on an attack roll against a creature if at least one of the lion’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        },
+        {
+          "name": "Running Leap",
+          "desc": "With a 10-foot running start, the lion can Long Jump up to 25 feet."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The lion makes two Rend attacks. It can replace one attack with a use of Roar."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Roar",
+          "desc": "Wisdom Saving Throw: DC 11, one creature within 15 feet. Failure: The target has the Frightened condition until the start of the lion’s next turn."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "lizard": {
+      "index": "lizard",
+      "name": "Lizard",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 2,
+      "hit_dice": "1d4",
+      "speed": {
+        "walk": "20 ft.",
+        "climb": "20 ft."
+      },
+      "strength": 2,
+      "dexterity": 11,
+      "constitution": 10,
+      "intelligence": 1,
+      "wisdom": 8,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 2
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "mammoth": {
+      "index": "mammoth",
+      "name": "Mammoth",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 126,
+      "hit_dice": "11d12 + 55",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 24,
+      "dexterity": 9,
+      "constitution": 21,
+      "intelligence": 3,
+      "wisdom": 11,
+      "charisma": 6,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 10
+        },
+        {
+          "name": "CON",
+          "value": 8
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 6.0,
+      "xp": 2300,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The mammoth makes two Gore attacks."
+        },
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage. If the target is a Huge or smaller creature and the mammoth moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "2d10+7",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+7",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Trample",
+          "desc": "Dexterity Saving Throw: DC 18, one creature within 5 feet that has the Prone condition. Failure: 29 (4d10 + 7) Bludgeoning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "4d10+7",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "4d10+7",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "mastiff": {
+      "index": "mastiff",
+      "name": "Mastiff",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 5,
+      "hit_dice": "1d8 + 1",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 13,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": {
+        "perception": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "1d6+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "mule": {
+      "index": "mule",
+      "name": "Mule",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 14,
+      "dexterity": 10,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 5,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "octopus": {
+      "index": "octopus",
+      "name": "Octopus",
+      "size": "Small",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 3,
+      "hit_dice": "1d6",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 4,
+      "dexterity": 15,
+      "constitution": 11,
+      "intelligence": 3,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "stealth": 6
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Compression",
+          "desc": "The octopus can move through a space as narrow as 1 inch without expending extra movement to do so."
+        },
+        {
+          "name": "Water Breathing",
+          "desc": "The octopus can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Tentacles",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Bludgeoning damage.",
+          "attack_bonus": 4
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Ink Cloud (1/Day)",
+          "desc": "Trigger: A creature ends its turn within 5 feet of the octopus while underwater. Response: The octopus releases ink that fills a 5-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect disperses the ink."
+        }
+      ],
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "owl": {
+      "index": "owl",
+      "name": "Owl",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 3,
+      "dexterity": 13,
+      "constitution": 8,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 5
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "120 ft.",
+        "summary": "Darkvision 120 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Talons",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Slashing damage.",
+          "attack_bonus": 3
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "panther": {
+      "index": "panther",
+      "name": "Panther",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 13,
+      "hit_dice": "3d8",
+      "speed": {
+        "walk": "50 ft.",
+        "climb": "40 ft."
+      },
+      "strength": 14,
+      "dexterity": 16,
+      "constitution": 10,
+      "intelligence": 3,
+      "wisdom": 14,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 4,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 14,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Nimble Escape",
+          "desc": "The panther takes the Disengage or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "piranha": {
+      "index": "piranha",
+      "name": "Piranha",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 2,
+      "dexterity": 16,
+      "constitution": 9,
+      "intelligence": 1,
+      "wisdom": 7,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Water Breathing",
+          "desc": "The piranha can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 5
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "plesiosaurus": {
+      "index": "plesiosaurus",
+      "name": "Plesiosaurus",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 68,
+      "hit_dice": "8d10 + 24",
+      "speed": {
+        "walk": "20 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 15,
+      "constitution": 16,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 4
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Hold Breath",
+          "desc": "The plesiosaurus can hold its breath for 1 hour."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "polar-bear": {
+      "index": "polar-bear",
+      "name": "Polar Bear",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 42,
+      "hit_dice": "5d10 + 15",
+      "speed": {
+        "walk": "40 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 20,
+      "dexterity": 14,
+      "constitution": 16,
+      "intelligence": 2,
+      "wisdom": 13,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Cold"
+      ],
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The bear makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 9 (1d8 + 5) Slashing damage.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "1d8+5",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+5",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "pony": {
+      "index": "pony",
+      "name": "Pony",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 15,
+      "dexterity": 10,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 7,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 4
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "pteranodon": {
+      "index": "pteranodon",
+      "name": "Pteranodon",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 13,
+      "hit_dice": "3d8",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "60 ft."
+      },
+      "strength": 12,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 2,
+      "wisdom": 9,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": {
+        "perception": 1
+      },
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Flyby",
+          "desc": "The pteranodon doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d8+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "rat": {
+      "index": "rat",
+      "name": "Rat",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "20 ft.",
+        "climb": "20 ft."
+      },
+      "strength": 2,
+      "dexterity": 11,
+      "constitution": 9,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Agile",
+          "desc": "The rat doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 2
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "raven": {
+      "index": "raven",
+      "name": "Raven",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 2,
+      "hit_dice": "1d4",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "50 ft."
+      },
+      "strength": 2,
+      "dexterity": 14,
+      "constitution": 10,
+      "intelligence": 5,
+      "wisdom": 13,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Mimicry",
+          "desc": "The raven can mimic simple sounds it has heard, such as a whisper or chitter. A hearer can discern the sounds are imitations with a successful DC 10 Wisdom (Insight) check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beak",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage.",
+          "attack_bonus": 4
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "reef-shark": {
+      "index": "reef-shark",
+      "name": "Reef Shark",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 22,
+      "hit_dice": "4d8 + 4",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 14,
+      "dexterity": 15,
+      "constitution": 13,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2
+      },
+      "senses": {
+        "passive_perception": 12,
+        "blindsight": "30 ft.",
+        "summary": "Blindsight 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The shark has Advantage on an attack roll against a creature if at least one of the shark’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        },
+        {
+          "name": "Water Breathing",
+          "desc": "The shark can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Piercing damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "rhinoceros": {
+      "index": "rhinoceros",
+      "name": "Rhinoceros",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 45,
+      "hit_dice": "6d10 + 12",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 21,
+      "dexterity": 8,
+      "constitution": 15,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage. If target is a Large or smaller creature and the rhinoceros moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+          "attack_bonus": 7,
+          "damage": [
+            {
+              "damage_dice": "2d8+5",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d8+5",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "riding-horse": {
+      "index": "riding-horse",
+      "name": "Riding Horse",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 13,
+      "hit_dice": "2d10 + 2",
+      "speed": {
+        "walk": "60 ft."
+      },
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 12,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 7,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "1d8+3",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "1d8+3",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "saber-toothed-tiger": {
+      "index": "saber-toothed-tiger",
+      "name": "Saber-Toothed Tiger",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 52,
+      "hit_dice": "7d10 + 14",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 18,
+      "dexterity": 17,
+      "constitution": 15,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 8,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 6
+        },
+        {
+          "name": "DEX",
+          "value": 5
+        }
+      ],
+      "skills": {
+        "perception": 5,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Running Leap",
+          "desc": "With a 10-foot running start, the tiger can Long Jump up to 25 feet."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The tiger makes two Rend attacks."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d6+4",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+4",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Nimble Escape",
+          "desc": "The tiger takes the Disengage or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "scorpion": {
+      "index": "scorpion",
+      "name": "Scorpion",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "10 ft."
+      },
+      "strength": 2,
+      "dexterity": 11,
+      "constitution": 8,
+      "intelligence": 1,
+      "wisdom": 8,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 9,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Sting",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage plus 3 (1d6) Poison damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d6",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "1d6",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "seahorse": {
+      "index": "seahorse",
+      "name": "Seahorse",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "20 ft."
+      },
+      "strength": 1,
+      "dexterity": 12,
+      "constitution": 8,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": {
+        "perception": 2,
+        "stealth": 5
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 0,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Water Breathing",
+          "desc": "The seahorse can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bubble Dash",
+          "desc": "While underwater, the seahorse moves up to its Swim Speed without provoking Opportunity Attacks."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "spider": {
+      "index": "spider",
+      "name": "Spider",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "20 ft.",
+        "climb": "20 ft."
+      },
+      "strength": 2,
+      "dexterity": 14,
+      "constitution": 8,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": {
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Walker",
+          "desc": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 2 (1d4) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-bats": {
+      "index": "swarm-of-bats",
+      "name": "Swarm of Bats",
+      "size": "Large",
+      "type": "swarm of tiny beasts",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 11,
+      "hit_dice": "2d10",
+      "speed": {
+        "walk": "5 ft.",
+        "fly": "30 ft."
+      },
+      "strength": 5,
+      "dexterity": 15,
+      "constitution": 10,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11,
+        "blindsight": "60 ft.",
+        "summary": "Blindsight 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Frightened",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-insects": {
+      "index": "swarm-of-insects",
+      "name": "Swarm of Insects",
+      "size": "Medium",
+      "type": "swarm of tiny beasts",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 19,
+      "hit_dice": "3d8 + 6",
+      "speed": {
+        "walk": "20 ft.",
+        "climb": "or Fly 20 ft. (GM’s choice)"
+      },
+      "strength": 3,
+      "dexterity": 13,
+      "constitution": 14,
+      "intelligence": 1,
+      "wisdom": 7,
+      "charisma": 1,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Frightened",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Spider Climb",
+          "desc": "If the swarm has a Climb Speed, the swarm can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Poison damage, or 3 (1d4 + 1) Poison damage if the swarm is Bloodied.",
+          "attack_bonus": 3,
+          "damage": [
+            {
+              "damage_dice": "2d4+1",
+              "damage_type": {
+                "name": "poison"
+              }
+            }
+          ],
+          "damage_dice": "2d4+1",
+          "damage_type": {
+            "name": "poison"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-piranhas": {
+      "index": "swarm-of-piranhas",
+      "name": "Swarm of Piranhas",
+      "size": "Medium",
+      "type": "swarm of tiny beasts",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 28,
+      "hit_dice": "8d8 − 8",
+      "speed": {
+        "walk": "5 ft.",
+        "swim": "40 ft."
+      },
+      "strength": 13,
+      "dexterity": 16,
+      "constitution": 9,
+      "intelligence": 1,
+      "wisdom": 7,
+      "charisma": 2,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 8,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Frightened",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny piranha. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        },
+        {
+          "name": "Water Breathing",
+          "desc": "The swarm can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "desc": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage, or 5 (1d4 + 3) Piercing damage if the swarm is Bloodied.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d4+3",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+3",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-rats": {
+      "index": "swarm-of-rats",
+      "name": "Swarm of Rats",
+      "size": "Medium",
+      "type": "swarm of tiny beasts",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 14,
+      "hit_dice": "4d8 − 4",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 9,
+      "dexterity": 11,
+      "constitution": 9,
+      "intelligence": 2,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 2
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "darkvision": "30 ft.",
+        "summary": "Darkvision 30 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Frightened",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "2d4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-ravens": {
+      "index": "swarm-of-ravens",
+      "name": "Swarm of Ravens",
+      "size": "Medium",
+      "type": "swarm of tiny beasts",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "50 ft."
+      },
+      "strength": 6,
+      "dexterity": 14,
+      "constitution": 12,
+      "intelligence": 5,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5
+      },
+      "senses": null,
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Frightened",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beaks",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Cacophony (Recharge 6)",
+          "desc": "Wisdom Saving Throw: DC 10, one creature in the swarm’s space. Failure: The target has the Deafened condition until the start of the swarm’s next turn. While Deafened, the target also has Disadvantage on ability checks and attack rolls."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "swarm-of-venomous-snakes": {
+      "index": "swarm-of-venomous-snakes",
+      "name": "Swarm of Venomous Snakes",
+      "size": "Medium",
+      "type": "swarm of tiny beasts",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 36,
+      "hit_dice": "8d8",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 8,
+      "dexterity": 18,
+      "constitution": 11,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 2.0,
+      "xp": 450,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": [
+        "Bludgeoning",
+        "Piercing",
+        "Slashing"
+      ],
+      "damage_immunities": [
+        "Charmed",
+        "Frightened",
+        "Grappled",
+        "Paralyzed"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Swarm",
+          "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage-or 6 (1d4 + 4) Piercing damage if the swarm is Bloodied-plus 10 (3d6) Poison damage.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "1d8+4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d8+4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "tiger": {
+      "index": "tiger",
+      "name": "Tiger",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 30,
+      "hit_dice": "4d10 + 8",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 17,
+      "dexterity": 16,
+      "constitution": 14,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 8,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 13,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 1.0,
+      "xp": 200,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+          "attack_bonus": 5,
+          "damage": [
+            {
+              "damage_dice": "2d6+3",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d6+3",
+          "damage_type": {
+            "name": "slashing"
+          }
+        }
+      ],
+      "bonus_actions": [
+        {
+          "name": "Nimble Escape",
+          "desc": "The tiger takes the Disengage or Hide action."
+        }
+      ],
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "triceratops": {
+      "index": "triceratops",
+      "name": "Triceratops",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 14,
+      "hit_points": 114,
+      "hit_dice": "12d12 + 36",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 22,
+      "dexterity": 9,
+      "constitution": 17,
+      "intelligence": 2,
+      "wisdom": 11,
+      "charisma": 5,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10
+      },
+      "languages": "",
+      "challenge_rating": 5.0,
+      "xp": 1800,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The triceratops makes two Gore attacks."
+        },
+        {
+          "name": "Gore",
+          "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 19 (2d12 + 6) Piercing damage. If the target is Huge or smaller and the triceratops moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+          "attack_bonus": 9,
+          "damage": [
+            {
+              "damage_dice": "2d12+6",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d12+6",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "tyrannosaurus-rex": {
+      "index": "tyrannosaurus-rex",
+      "name": "Tyrannosaurus Rex",
+      "size": "Huge",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 136,
+      "hit_dice": "13d12 + 52",
+      "speed": {
+        "walk": "50 ft."
+      },
+      "strength": 25,
+      "dexterity": 10,
+      "constitution": 19,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 9,
+      "saving_throws": [
+        {
+          "name": "STR",
+          "value": 10
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "perception": 4
+      },
+      "senses": {
+        "passive_perception": 14
+      },
+      "languages": "",
+      "challenge_rating": 8.0,
+      "xp": 3900,
+      "proficiency_bonus": 3,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The tyrannosaurus makes one Bite attack and one Tail attack."
+        },
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 33 (4d12 + 7) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17). While Grappled, the target has the Restrained condition and can’t be targeted by the tyrannosaurus’s Tail.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "4d12+7",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "4d12+7",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Tail",
+          "desc": "Melee Attack Roll: +10, reach 15 ft. Hit: 25 (4d8 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+          "attack_bonus": 10,
+          "damage": [
+            {
+              "damage_dice": "4d8+7",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "4d8+7",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "dinosaur"
+    },
+    "venomous-snake": {
+      "index": "venomous-snake",
+      "name": "Venomous Snake",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 5,
+      "hit_dice": "2d4",
+      "speed": {
+        "walk": "30 ft.",
+        "swim": "30 ft."
+      },
+      "strength": 2,
+      "dexterity": 15,
+      "constitution": 11,
+      "intelligence": 1,
+      "wisdom": 10,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": {
+        "passive_perception": 10,
+        "blindsight": "10 ft.",
+        "summary": "Blindsight 10 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.125,
+      "xp": 25,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage plus 3 (1d6) Poison damage.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d4+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "vulture": {
+      "index": "vulture",
+      "name": "Vulture",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 10,
+      "hit_points": 5,
+      "hit_dice": "1d8 + 1",
+      "speed": {
+        "walk": "10 ft.",
+        "fly": "50 ft."
+      },
+      "strength": 7,
+      "dexterity": 10,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 4,
+      "saving_throws": [],
+      "skills": {
+        "perception": 3
+      },
+      "senses": {
+        "passive_perception": 13
+      },
+      "languages": "",
+      "challenge_rating": 0.0,
+      "xp": 10,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beak",
+          "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Piercing damage.",
+          "attack_bonus": 2,
+          "damage": [
+            {
+              "damage_dice": "1d4",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d4",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "warhorse": {
+      "index": "warhorse",
+      "name": "Warhorse",
+      "size": "Large",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 11,
+      "hit_points": 19,
+      "hit_dice": "3d10 + 3",
+      "speed": {
+        "walk": "60 ft."
+      },
+      "strength": 18,
+      "dexterity": 12,
+      "constitution": 13,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 7,
+      "saving_throws": [
+        {
+          "name": "WIS",
+          "value": 3
+        }
+      ],
+      "skills": null,
+      "senses": {
+        "passive_perception": 11
+      },
+      "languages": "",
+      "challenge_rating": 0.5,
+      "xp": 100,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Hooves",
+          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the horse moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+          "attack_bonus": 6,
+          "damage": [
+            {
+              "damage_dice": "2d4+4",
+              "damage_type": {
+                "name": "bludgeoning"
+              }
+            }
+          ],
+          "damage_dice": "2d4+4",
+          "damage_type": {
+            "name": "bludgeoning"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "wolf": {
+      "index": "wolf",
+      "name": "Wolf",
+      "size": "Medium",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 12,
+      "hit_points": 11,
+      "hit_dice": "2d8 + 2",
+      "speed": {
+        "walk": "40 ft."
+      },
+      "strength": 14,
+      "dexterity": 15,
+      "constitution": 12,
+      "intelligence": 3,
+      "wisdom": 12,
+      "charisma": 6,
+      "saving_throws": [],
+      "skills": {
+        "perception": 5,
+        "stealth": 4
+      },
+      "senses": {
+        "passive_perception": 15,
+        "darkvision": "60 ft.",
+        "summary": "Darkvision 60 ft."
+      },
+      "languages": "",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Pack Tactics",
+          "desc": "The wolf has Advantage on attack rolls against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+          "attack_bonus": 4,
+          "damage": [
+            {
+              "damage_dice": "1d6+2",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "1d6+2",
+          "damage_type": {
+            "name": "piercing"
+          }
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "weasel": {
+      "index": "weasel",
+      "name": "Weasel",
+      "size": "Tiny",
+      "type": "beast",
+      "alignment": "Unaligned",
+      "armor_class": 13,
+      "hit_points": 1,
+      "hit_dice": "1d4 − 1",
+      "speed": {
+        "walk": "30 ft.",
+        "climb": "30 ft."
+      },
+      "strength": 3,
+      "dexterity": 16,
+      "constitution": 8,
+      "intelligence": 2,
+      "wisdom": 12,
+      "charisma": 3,
+      "saving_throws": [],
+      "skills": null,
+      "senses": null,
+      "languages": "",
+      "challenge_rating": null,
+      "xp": null,
+      "proficiency_bonus": null,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
+      "actions": null,
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
     }
   }
 }

--- a/server/scripts/generate_monsters_json.py
+++ b/server/scripts/generate_monsters_json.py
@@ -1,0 +1,503 @@
+import json
+import re
+import zipfile
+from pathlib import Path
+from unicodedata import normalize
+
+DOC_PATH = Path(__file__).resolve().parents[2] / 'docs' / 'rules' / 'playerHandbook.docx'
+OUTPUT_PATH = Path(__file__).resolve().parents[1] / 'data' / 'monsters.json'
+
+SECTION_TITLES = {
+    'Traits',
+    'Actions',
+    'Bonus Actions',
+    'Reactions',
+    'Legendary Actions',
+    'Lair Actions',
+    'Regional Effects',
+}
+SIZE_PATTERN = re.compile(r'^(Tiny|Small|Medium|Large|Huge|Gargantuan) ')
+CLEAN_HYPHEN_RE = re.compile(r'(\w)[\u2010\u2011\u2012\u2013\u2014\u2015-]\s+(\w)')
+DAMAGE_ENTRY_RE = re.compile(r'(?:Hit|Failure|Success|Critical Hit):[^()]*\(([^)]+)\)\s*([A-Za-z ]+?) damage', re.IGNORECASE)
+ATTACK_BONUS_RE = re.compile(r'(?:Attack Roll|Weapon Attack):\s*\+?(-?\d+)')
+SAVING_THROW_RE = re.compile(r'Saving Throw:?\s*([A-Z][a-z]+)\s*DC\s*(\d+)', re.IGNORECASE)
+SKILL_ENTRY_RE = re.compile(r'([A-Za-z ]+)\s*([+-]\d+)')
+ABILITY_SAVE_RE = re.compile(r'([A-Z][a-z]+)\s*([+-]\d+)')
+PASSIVE_PERCEPTION_RE = re.compile(r'Passive Perception\s*(\d+)', re.IGNORECASE)
+SENSE_ENTRY_RE = re.compile(r'([A-Za-z][A-Za-z ]*?)\s*(\d+\s*ft\.?|\d+\s*miles?|\d+)', re.IGNORECASE)
+CHALLENGE_RE = re.compile(r'^CR\s*([^\s(]+)\s*(?:\(([^)]*)\))?')
+XP_RE = re.compile(r'XP\s*([\d,]+)')
+PB_RE = re.compile(r'PB\s*([+-]?\d+)')
+SAVE_MAP = {
+    'Strength': 'str',
+    'Dexterity': 'dex',
+    'Constitution': 'con',
+    'Intelligence': 'int',
+    'Wisdom': 'wis',
+    'Charisma': 'cha',
+}
+
+
+def load_paragraphs(doc_path: Path):
+    with zipfile.ZipFile(doc_path) as zf:
+        with zf.open('word/document.xml') as doc:
+            from xml.etree import ElementTree as ET
+
+            tree = ET.parse(doc)
+    ns = '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}'
+    paragraphs = []
+    for para in tree.getroot().iter(ns + 'p'):
+        text = ''.join(node.text or '' for node in para.iter(ns + 't'))
+        text = normalize('NFKC', text)
+        if text:
+            text = text.replace('\u2014', '-')
+        paragraphs.append(text)
+    return paragraphs
+
+
+def slugify(name: str) -> str:
+    text = normalize('NFKD', name)
+    text = ''.join(ch for ch in text if not ord(ch) > 127 or ch.isalnum() or ch in "-' ")
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", '-', text)
+    text = text.strip('-')
+    return text
+
+
+def clean_text(text: str) -> str:
+    if not text:
+        return ''
+    text = text.replace('\u2013', '-').replace('\u2014', '-').replace('\u2012', '-').replace('\u2212', '-')
+    text = CLEAN_HYPHEN_RE.sub(r'\1\2', text)
+    text = re.sub(r'\s+', ' ', text)
+    return text.strip()
+
+
+def parse_speed(text: str) -> dict:
+    if not text.startswith('Speed '):
+        return {}
+    value = text[len('Speed ') :].strip()
+    parts = [part.strip() for part in value.split(',') if part.strip()]
+    speeds = {}
+    for part in parts:
+        tokens = part.split(' ', 1)
+        if tokens and tokens[0][0].isdigit():
+            key = 'walk'
+            speeds[key] = part
+            continue
+        if len(tokens) != 2:
+            continue
+        key = tokens[0].lower()
+        speeds[key] = tokens[1].strip()
+    return speeds
+
+
+def parse_skill_line(text: str) -> dict:
+    text = text.replace('Skills ', '').strip()
+    skills = {}
+    for match in SKILL_ENTRY_RE.finditer(text):
+        name = match.group(1).strip().lower().replace(' ', '_')
+        value = int(match.group(2))
+        skills[name] = value
+    return skills
+
+
+def parse_saving_throws(text: str) -> dict:
+    text = text.replace('Saving Throws ', '').strip()
+    saves = {}
+    for match in ABILITY_SAVE_RE.finditer(text):
+        ability = match.group(1).strip()
+        if ability in SAVE_MAP:
+            saves[SAVE_MAP[ability]] = int(match.group(2))
+    return saves
+
+
+def parse_list(text: str) -> list:
+    if not text:
+        return []
+    items = []
+    for part in re.split(r'[;,]', text):
+        part = part.strip()
+        if not part or part == '—':
+            continue
+        if part.lower() == 'none':
+            continue
+        items.append(part)
+    return items
+
+
+def parse_senses(text: str) -> dict:
+    value = text.replace('Senses ', '').strip()
+    senses = {}
+    passive_match = PASSIVE_PERCEPTION_RE.search(value)
+    if passive_match:
+        senses['passive_perception'] = int(passive_match.group(1))
+        value = PASSIVE_PERCEPTION_RE.sub('', value)
+    for match in SENSE_ENTRY_RE.finditer(value):
+        key = match.group(1).strip().lower().replace(' ', '_')
+        val = match.group(2).strip()
+        senses[key] = val
+    summary = value.strip(' ;,')
+    if summary:
+        summary = re.sub(r'\s+', ' ', summary)
+        summary = summary.strip(' ;,')
+    if summary:
+        senses['summary'] = summary
+    return senses
+
+
+def parse_languages(text: str) -> str:
+    value = text.replace('Languages ', '').strip()
+    if value in {'—', 'None'}:
+        return ''
+    return value
+
+
+def parse_cr_line(text: str):
+    m = CHALLENGE_RE.match(text)
+    if not m:
+        return None, None, None
+    cr_raw = m.group(1).strip()
+    xp = None
+    pb = None
+    details = m.group(2) or ''
+    xp_match = XP_RE.search(details)
+    if xp_match:
+        xp = int(xp_match.group(1).replace(',', ''))
+    pb_match = PB_RE.search(details)
+    if pb_match:
+        pb = int(pb_match.group(1))
+    def parse_cr(value: str):
+        if '/' in value:
+            num, den = value.split('/', 1)
+            return float(num) / float(den)
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return parse_cr(cr_raw), xp, pb
+
+
+def parse_actions(lines):
+    entries = []
+    current = None
+    for raw in lines:
+        line = clean_text(raw)
+        if not line:
+            continue
+        if SIZE_PATTERN.match(line):
+            break
+        if re.match(r"^[A-Z][A-Za-z0-9'\- ]+$", line) and '.' not in line:
+            break
+        m = re.match(r'^([A-Z][^.]*)\.\s*(.*)$', line)
+        heading = False
+        if m:
+            candidate = re.sub(r'\([^)]*\)', '', m.group(1)).strip()
+            words = [re.sub(r'[^A-Za-z0-9]', '', word) for word in candidate.split()]
+            if words and all(word[:1].isupper() or word[:1].isdigit() for word in words if word):
+                heading = True
+            if candidate.lower().startswith(('success', 'failure', 'hit', 'miss', 'critical')):
+                heading = False
+        if m and heading:
+            if current:
+                entries.append(current)
+            name = m.group(1).strip()
+            desc = m.group(2).strip()
+            current = {'name': name, 'desc': desc}
+        else:
+            if current:
+                current['desc'] = (current['desc'] + ' ' + line).strip()
+    if current:
+        entries.append(current)
+    for entry in entries:
+        desc = entry.get('desc', '')
+        attack_match = ATTACK_BONUS_RE.search(desc)
+        if attack_match:
+            try:
+                entry['attack_bonus'] = int(attack_match.group(1))
+            except ValueError:
+                pass
+        damages = []
+        for match in DAMAGE_ENTRY_RE.finditer(desc):
+            dice = match.group(1).strip()
+            dice = dice.replace(' ', '')
+            dtype = match.group(2).strip().lower()
+            if dice:
+                damages.append({'damage_dice': dice, 'damage_type': {'name': dtype}})
+        if damages:
+            entry['damage'] = damages
+            if len(damages) == 1:
+                entry['damage_dice'] = damages[0]['damage_dice']
+                entry['damage_type'] = damages[0]['damage_type']
+    return entries
+
+
+def parse_monster_block(block):
+    cleaned_block = [line for line in block if line]
+    if not cleaned_block:
+        return None
+    name = cleaned_block[0].strip()
+    # locate size line
+    size_idx = None
+    for idx, line in enumerate(cleaned_block[1:], start=1):
+        if SIZE_PATTERN.match(line.strip()):
+            size_idx = idx
+            break
+    if size_idx is None:
+        return None
+    size_line = clean_text(cleaned_block[size_idx])
+    size_part, _, alignment_part = size_line.partition(',')
+    size_tokens = size_part.split(' ', 1)
+    size = size_tokens[0].strip()
+    type_part = size_tokens[1].strip() if len(size_tokens) > 1 else ''
+    subtype = None
+    type_lower = type_part.lower()
+    if '(' in type_part and ')' in type_part:
+        base, _, rest = type_part.partition('(')
+        subtype = rest.rstrip(')').strip()
+        type_part = base.strip()
+    alignment = clean_text(alignment_part)
+    # parse AC, HP, Speed
+    ac_value = None
+    hit_points = None
+    hit_dice = None
+    speed = {}
+    ability_scores = {}
+    ability_mods = {}
+    saving_throws = {}
+    skills = {}
+    senses = {}
+    languages = ''
+    challenge = None
+    xp = None
+    pb = None
+    damage_resistances = []
+    damage_immunities = []
+    damage_vulnerabilities = []
+    condition_immunities = []
+    traits = []
+    actions = []
+    bonus_actions = []
+    reactions = []
+    legendary_actions = []
+    lair_actions = []
+    regional_effects = []
+
+    idx = size_idx + 1
+    while idx < len(cleaned_block):
+        line = cleaned_block[idx].strip()
+        if line.startswith('AC '):
+            m = re.search(r'AC\s*(\d+)', line)
+            if m:
+                ac_value = int(m.group(1))
+        elif line.startswith('HP '):
+            m = re.search(r'HP\s*(\d+)', line)
+            if m:
+                hit_points = int(m.group(1))
+            dice_match = re.search(r'\(([^)]+)\)', line)
+            if dice_match:
+                hit_dice = dice_match.group(1).strip()
+        elif line.startswith('Speed '):
+            speed = parse_speed(line)
+        elif line.startswith('MOD '):
+            idx += 1
+            ability_index = 0
+            while ability_index < 6 and idx < len(cleaned_block):
+                entry = cleaned_block[idx].strip()
+                name_match = re.match(r'^(STR|DEX|CON|INT|WIS|CHA)(?:\s+(\d+))?$', entry)
+                if not name_match:
+                    break
+                ability = name_match.group(1)
+                if name_match.group(2):
+                    score = int(name_match.group(2))
+                else:
+                    idx += 1
+                    score = int(cleaned_block[idx].strip())
+                idx += 1
+                mod_text = cleaned_block[idx].strip().replace('−', '-')
+                idx += 1
+                save_text = cleaned_block[idx].strip().replace('−', '-')
+                ability_scores[ability.lower()] = score
+                try:
+                    ability_mods[ability.lower()] = int(mod_text)
+                except ValueError:
+                    ability_mods[ability.lower()] = None
+                try:
+                    saving_throws[ability.lower()] = int(save_text)
+                except ValueError:
+                    saving_throws[ability.lower()] = None
+                ability_index += 1
+                idx += 1
+            continue
+        elif line.startswith('Saving Throws '):
+            saving_throws.update(parse_saving_throws(line))
+        elif line.startswith('Skills '):
+            skills.update(parse_skill_line(line))
+        elif line.startswith('Senses '):
+            senses.update(parse_senses(line))
+        elif line.startswith('Languages '):
+            languages = parse_languages(line)
+        elif line.startswith('Resistances '):
+            damage_resistances.extend(parse_list(line.replace('Resistances ', '')))
+        elif line.startswith('Damage Resistances '):
+            damage_resistances.extend(parse_list(line.replace('Damage Resistances ', '')))
+        elif line.startswith('Immunities '):
+            parts = [part.strip() for part in line.replace('Immunities ', '').split(';') if part.strip()]
+            if parts:
+                damage_immunities.extend(parse_list(parts[0]))
+                if len(parts) > 1:
+                    condition_immunities.extend(parse_list(parts[1]))
+        elif line.startswith('Damage Immunities '):
+            damage_immunities.extend(parse_list(line.replace('Damage Immunities ', '')))
+        elif line.startswith('Condition Immunities '):
+            condition_immunities.extend(parse_list(line.replace('Condition Immunities ', '')))
+        elif line.startswith('Vulnerabilities '):
+            damage_vulnerabilities.extend(parse_list(line.replace('Vulnerabilities ', '')))
+        elif line.startswith('Damage Vulnerabilities '):
+            damage_vulnerabilities.extend(parse_list(line.replace('Damage Vulnerabilities ', '')))
+        elif line.startswith('CR '):
+            challenge, xp, pb = parse_cr_line(line)
+        elif line in SECTION_TITLES:
+            section = line
+            idx += 1
+            section_lines = []
+            while idx < len(cleaned_block):
+                next_line = cleaned_block[idx].strip()
+                if next_line in SECTION_TITLES:
+                    break
+                if SIZE_PATTERN.match(next_line):
+                    break
+                if (
+                    idx + 2 < len(cleaned_block)
+                    and cleaned_block[idx + 1].strip() == next_line
+                    and SIZE_PATTERN.match(cleaned_block[idx + 2].strip())
+                ):
+                    break
+                if (
+                    idx + 3 < len(cleaned_block)
+                    and cleaned_block[idx + 1].strip() == ''
+                    and cleaned_block[idx + 2].strip() == next_line
+                    and SIZE_PATTERN.match(cleaned_block[idx + 3].strip())
+                ):
+                    break
+                section_lines.append(cleaned_block[idx])
+                idx += 1
+            if section == 'Traits':
+                traits = parse_actions(section_lines)
+            elif section == 'Actions':
+                actions = parse_actions(section_lines)
+            elif section == 'Bonus Actions':
+                bonus_actions = parse_actions(section_lines)
+            elif section == 'Reactions':
+                reactions = parse_actions(section_lines)
+            elif section == 'Legendary Actions':
+                legendary_actions = parse_actions(section_lines)
+            elif section == 'Lair Actions':
+                lair_actions = parse_actions(section_lines)
+            elif section == 'Regional Effects':
+                regional_effects = parse_actions(section_lines)
+            continue
+        idx += 1
+
+    prof_saves = []
+    for ability, value in list(saving_throws.items()):
+        mod = ability_mods.get(ability)
+        if value is None or value == mod:
+            continue
+        prof_saves.append({'name': ability.upper(), 'value': value})
+
+    monster = {
+        'index': slugify(name),
+        'name': name,
+        'size': size,
+        'type': type_part.lower(),
+        'alignment': alignment if alignment != '—' else '',
+        'armor_class': ac_value,
+        'hit_points': hit_points,
+        'hit_dice': hit_dice,
+        'speed': speed,
+        'strength': ability_scores.get('str'),
+        'dexterity': ability_scores.get('dex'),
+        'constitution': ability_scores.get('con'),
+        'intelligence': ability_scores.get('int'),
+        'wisdom': ability_scores.get('wis'),
+        'charisma': ability_scores.get('cha'),
+        'saving_throws': prof_saves,
+        'skills': skills or None,
+        'senses': senses or None,
+        'languages': languages,
+        'challenge_rating': challenge,
+        'xp': xp,
+        'proficiency_bonus': pb,
+        'damage_vulnerabilities': damage_vulnerabilities or None,
+        'damage_resistances': damage_resistances or None,
+        'damage_immunities': damage_immunities or None,
+        'condition_immunities': condition_immunities or None,
+        'special_abilities': traits or None,
+        'actions': actions or None,
+        'bonus_actions': bonus_actions or None,
+        'reactions': reactions or None,
+        'legendary_actions': legendary_actions or None,
+        'lair_actions': lair_actions or None,
+        'regional_effects': regional_effects or None,
+    }
+    if subtype:
+        monster['subtype'] = subtype.lower()
+    return monster
+
+
+def extract_monster_blocks(paragraphs):
+    start = paragraphs.index('Monsters A–Z') + 1
+    monsters = []
+    i = start
+    while i < len(paragraphs) - 5:
+        line = paragraphs[i].strip()
+        if not line or line in SECTION_TITLES:
+            i += 1
+            continue
+        # look for size pattern
+        if i + 2 < len(paragraphs) and paragraphs[i + 1].strip() == line and SIZE_PATTERN.match(paragraphs[i + 2].strip()):
+            name = line
+            block_start = i
+            i += 2
+        elif i + 3 < len(paragraphs) and paragraphs[i + 1].strip() == '' and paragraphs[i + 2].strip() == line and SIZE_PATTERN.match(paragraphs[i + 3].strip()):
+            name = line
+            block_start = i
+            i += 3
+        else:
+            i += 1
+            continue
+        j = i
+        while j < len(paragraphs) - 5:
+            next_line = paragraphs[j].strip()
+            if next_line and next_line not in SECTION_TITLES:
+                if j + 2 < len(paragraphs) and paragraphs[j + 1].strip() == next_line and SIZE_PATTERN.match(paragraphs[j + 2].strip()):
+                    break
+                if j + 3 < len(paragraphs) and paragraphs[j + 1].strip() == '' and paragraphs[j + 2].strip() == next_line and SIZE_PATTERN.match(paragraphs[j + 3].strip()):
+                    break
+            j += 1
+        block = paragraphs[block_start:j]
+        monsters.append(block)
+        i = j
+    return monsters
+
+
+def main():
+    paragraphs = load_paragraphs(DOC_PATH)
+    monster_blocks = extract_monster_blocks(paragraphs)
+    results = []
+    monsters = {}
+    for block in monster_blocks:
+        monster = parse_monster_block(block)
+        if not monster:
+            continue
+        index = monster['index']
+        results.append({'index': index, 'name': monster['name'], 'url': f'/api/monsters/{index}'})
+        monsters[index] = monster
+    results.sort(key=lambda entry: entry['name'])
+    data = {'results': results, 'monsters': monsters}
+    OUTPUT_PATH.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a generate_monsters_json.py utility that parses docs/rules/playerHandbook.docx to extract SRD monster statistics
- regenerate server/data/monsters.json so every SRD monster is available offline to the DM view

## Testing
- npm --prefix server test *(fails: spells route expectation mismatch in __tests__/spells.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f79a330920832e9aaccfd3b3d5b734