### PR TITLE
Add challenge rating filtering to enemy selection

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -675,6 +675,8 @@ export default function ZombiesDM() {
     const [monsterCatalogLoading, setMonsterCatalogLoading] = useState(false);
     const [monsterCatalogLoaded, setMonsterCatalogLoaded] = useState(false);
     const [monsterCatalogError, setMonsterCatalogError] = useState(null);
+    const [monsterMinChallengeRating, setMonsterMinChallengeRating] = useState('');
+    const [monsterMaxChallengeRating, setMonsterMaxChallengeRating] = useState('');
     const [monsterSearch, setMonsterSearch] = useState('');
     const [selectedMonsterIndex, setSelectedMonsterIndex] = useState('');
     const [selectedMonster, setSelectedMonster] = useState(null);
@@ -1762,6 +1764,34 @@ export default function ZombiesDM() {
       return null;
     }, []);
 
+    const formatChallengeRatingValue = useCallback((value) => {
+      if (value === null || value === undefined || value === '') {
+        return '—';
+      }
+
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return String(value);
+      }
+
+      const fractionMap = {
+        '0.125': '1/8',
+        '0.25': '1/4',
+        '0.5': '1/2',
+      };
+
+      const fractionKey = numeric.toString();
+      if (Object.prototype.hasOwnProperty.call(fractionMap, fractionKey)) {
+        return fractionMap[fractionKey];
+      }
+
+      if (Number.isInteger(numeric)) {
+        return numeric.toString();
+      }
+
+      return numeric.toString();
+    }, []);
+
     const handleEnemyDamageRoll = useCallback(
       (enemy, action) => {
         if (!enemy || !action) {
@@ -1804,16 +1834,121 @@ export default function ZombiesDM() {
       [getEnemyActionDamageString, setStatus]
     );
 
+    const challengeRatingOptions = useMemo(() => {
+      if (!Array.isArray(monsterCatalog) || monsterCatalog.length === 0) {
+        return [];
+      }
+
+      const values = new Set();
+      monsterCatalog.forEach((monster) => {
+        const rating =
+          monster?.challengeRating !== undefined && monster?.challengeRating !== null
+            ? monster.challengeRating
+            : monster?.challenge_rating !== undefined && monster?.challenge_rating !== null
+            ? monster.challenge_rating
+            : null;
+        const numeric = Number(rating);
+        if (Number.isFinite(numeric)) {
+          values.add(numeric);
+        }
+      });
+
+      return Array.from(values)
+        .sort((a, b) => a - b)
+        .map((value) => ({
+          value: value.toString(),
+          label: formatChallengeRatingValue(value),
+        }));
+    }, [monsterCatalog, formatChallengeRatingValue]);
+
+    useEffect(() => {
+      if (monsterMinChallengeRating) {
+        const hasOption = challengeRatingOptions.some(
+          (option) => option.value === monsterMinChallengeRating
+        );
+        if (!hasOption) {
+          setMonsterMinChallengeRating('');
+        }
+      }
+
+      if (monsterMaxChallengeRating) {
+        const hasOption = challengeRatingOptions.some(
+          (option) => option.value === monsterMaxChallengeRating
+        );
+        if (!hasOption) {
+          setMonsterMaxChallengeRating('');
+        }
+      }
+    }, [challengeRatingOptions, monsterMinChallengeRating, monsterMaxChallengeRating]);
+
     const filteredMonsterCatalog = useMemo(() => {
       if (!Array.isArray(monsterCatalog) || monsterCatalog.length === 0) {
         return [];
       }
+
       const query = monsterSearch.trim().toLowerCase();
-      if (!query) {
-        return monsterCatalog;
+      const minValue =
+        monsterMinChallengeRating !== '' ? Number(monsterMinChallengeRating) : null;
+      const maxValue =
+        monsterMaxChallengeRating !== '' ? Number(monsterMaxChallengeRating) : null;
+
+      let effectiveMin = minValue;
+      let effectiveMax = maxValue;
+      if (effectiveMin !== null && effectiveMax !== null && effectiveMin > effectiveMax) {
+        [effectiveMin, effectiveMax] = [effectiveMax, effectiveMin];
       }
-      return monsterCatalog.filter((monster) => monster?.name?.toLowerCase().includes(query));
-    }, [monsterCatalog, monsterSearch]);
+
+      return monsterCatalog.filter((monster) => {
+        const nameMatches =
+          !query || monster?.name?.toLowerCase().includes(query);
+        if (!nameMatches) {
+          return false;
+        }
+
+        const ratingRaw =
+          monster?.challengeRating !== undefined && monster?.challengeRating !== null
+            ? monster.challengeRating
+            : monster?.challenge_rating !== undefined && monster?.challenge_rating !== null
+            ? monster.challenge_rating
+            : null;
+        const ratingNumeric = Number(ratingRaw);
+        const hasNumericRating = Number.isFinite(ratingNumeric);
+
+        if (effectiveMin !== null || effectiveMax !== null) {
+          if (!hasNumericRating) {
+            return false;
+          }
+          if (effectiveMin !== null && ratingNumeric < effectiveMin) {
+            return false;
+          }
+          if (effectiveMax !== null && ratingNumeric > effectiveMax) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    }, [
+      monsterCatalog,
+      monsterSearch,
+      monsterMinChallengeRating,
+      monsterMaxChallengeRating,
+    ]);
+
+    useEffect(() => {
+      if (!selectedMonsterIndex) {
+        return;
+      }
+
+      const existsInFiltered = filteredMonsterCatalog.some(
+        (monster) => monster?.index === selectedMonsterIndex
+      );
+
+      if (!existsInFiltered) {
+        setSelectedMonsterIndex('');
+        setSelectedMonster(null);
+      }
+    }, [filteredMonsterCatalog, selectedMonsterIndex, setSelectedMonster]);
 
 
     useEffect(() => {
@@ -5990,7 +6125,7 @@ const resolveIcon = (category, iconMap, fallback) => {
               <Container className="mt-3">
                 <Form onSubmit={handleAddEnemy}>
                   <Row className="g-3 align-items-end">
-                    <Col md={6}>
+                    <Col md={6} lg={4}>
                       <Form.Group className="mb-3 mb-md-0">
                         <Form.Label className="text-light">Search Monsters</Form.Label>
                         <Form.Control
@@ -6002,7 +6137,40 @@ const resolveIcon = (category, iconMap, fallback) => {
                         />
                       </Form.Group>
                     </Col>
-                    <Col md={6}>
+                    <Col md={6} lg={4}>
+                      <Form.Group className="mb-3 mb-md-0">
+                        <Form.Label className="text-light">Challenge Rating</Form.Label>
+                        <div className="d-flex flex-column flex-lg-row gap-2">
+                          <Form.Select
+                            value={monsterMinChallengeRating}
+                            onChange={(event) => setMonsterMinChallengeRating(event.target.value)}
+                            disabled={monsterCatalogLoading && !monsterCatalogLoaded}
+                            aria-label="Minimum challenge rating"
+                          >
+                            <option value="">No minimum</option>
+                            {challengeRatingOptions.map((option) => (
+                              <option key={`min-${option.value}`} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </Form.Select>
+                          <Form.Select
+                            value={monsterMaxChallengeRating}
+                            onChange={(event) => setMonsterMaxChallengeRating(event.target.value)}
+                            disabled={monsterCatalogLoading && !monsterCatalogLoaded}
+                            aria-label="Maximum challenge rating"
+                          >
+                            <option value="">No maximum</option>
+                            {challengeRatingOptions.map((option) => (
+                              <option key={`max-${option.value}`} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </Form.Select>
+                        </div>
+                      </Form.Group>
+                    </Col>
+                    <Col md={12} lg={4}>
                       <Form.Group>
                         <Form.Label className="text-light">Select Monster</Form.Label>
                         <Form.Select
@@ -6024,7 +6192,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           ) : (
                             monsterCatalogLoaded && (
                               <option value="" disabled>
-                                No monsters match your search
+                                No monsters match your filters
                               </option>
                             )
                           )}
@@ -6121,7 +6289,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                         <Card.Subtitle className="text-white-50 small mb-3">
                           {[selectedMonster.size, selectedMonster.type].filter(Boolean).join(' ') || '—'}
                           {selectedMonster.challengeRating !== null && selectedMonster.challengeRating !== undefined
-                            ? ` • CR ${selectedMonster.challengeRating}`
+                            ? ` • CR ${formatChallengeRatingValue(selectedMonster.challengeRating)}`
                             : ''}
                         </Card.Subtitle>
                         <div className="d-grid gap-1">
@@ -6202,7 +6370,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                   const inCombat = Boolean(participantInfo);
                   const challengeText =
                     enemy.challengeRating !== null && enemy.challengeRating !== undefined
-                      ? `CR ${enemy.challengeRating}`
+                      ? `CR ${formatChallengeRatingValue(enemy.challengeRating)}`
                       : null;
                   const languagesDisplay = Array.isArray(enemy.languages)
                     ? enemy.languages.join(', ')

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -2051,5 +2051,82 @@ describe('ZombiesDM AI generation', () => {
     ).toBeInTheDocument();
   });
 
+  test('filters monsters by challenge rating range', async () => {
+    const characters = [];
+    const monsters = [
+      { index: 'goblin', name: 'Goblin', challengeRating: 0.25 },
+      { index: 'ogre', name: 'Ogre', challengeRating: 2 },
+      { index: 'adult-red-dragon', name: 'Adult Red Dragon', challengeRating: 17 },
+    ];
+
+    apiFetch.mockImplementation((url, options = {}) => {
+      switch (url) {
+        case '/campaigns/Camp1/characters':
+          return Promise.resolve({ ok: true, json: async () => characters });
+        case '/campaigns/dm/dm/Camp1':
+          return Promise.resolve({ ok: true, json: async () => ({ players: [] }) });
+        case '/users':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/combat':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ participants: [], activeTurn: null }),
+          });
+        case '/campaigns/Camp1/enemies':
+          return Promise.resolve({ ok: true, json: async () => [] });
+        case '/campaigns/Camp1/maps':
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              maps: [],
+              activeMapId: null,
+              map: null,
+              tokensByMapId: {},
+              activeMapTokens: {},
+            }),
+          });
+        case '/monsters':
+          return Promise.resolve({ ok: true, json: async () => monsters });
+        default:
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+    });
+
+    render(<ZombiesDM />);
+
+    const enemiesTab = await screen.findByRole('tab', { name: 'Enemies' });
+    await userEvent.click(enemiesTab);
+
+    const monsterSelect = await screen.findByLabelText('Select Monster');
+    await waitFor(() => {
+      expect(within(monsterSelect).getByRole('option', { name: 'Goblin' })).toBeInTheDocument();
+      expect(within(monsterSelect).getByRole('option', { name: 'Ogre' })).toBeInTheDocument();
+      expect(
+        within(monsterSelect).getByRole('option', { name: 'Adult Red Dragon' })
+      ).toBeInTheDocument();
+    });
+
+    const minSelect = await screen.findByLabelText('Minimum challenge rating');
+    const maxSelect = await screen.findByLabelText('Maximum challenge rating');
+
+    await userEvent.selectOptions(minSelect, '2');
+    await waitFor(() => {
+      expect(
+        within(monsterSelect).queryByRole('option', { name: 'Goblin' })
+      ).not.toBeInTheDocument();
+      expect(
+        within(monsterSelect).getByRole('option', { name: 'Adult Red Dragon' })
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.selectOptions(maxSelect, '2');
+    await waitFor(() => {
+      expect(within(monsterSelect).getByRole('option', { name: 'Ogre' })).toBeInTheDocument();
+      expect(
+        within(monsterSelect).queryByRole('option', { name: 'Adult Red Dragon' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
 
 });

--- a/server/routes/monsters.js
+++ b/server/routes/monsters.js
@@ -16,11 +16,26 @@ module.exports = (router) => {
         filtered = results.filter((monster) => monster?.name?.toLowerCase().includes(search));
       }
 
-      res.json(filtered.map((monster) => ({
-        index: monster.index,
-        name: monster.name,
-        url: monster.url,
-      })));
+      res.json(
+        filtered.map((monster) => {
+          const rawChallengeRating =
+            monster.challenge_rating !== undefined && monster.challenge_rating !== null
+              ? monster.challenge_rating
+              : monster.challengeRating !== undefined && monster.challengeRating !== null
+              ? monster.challengeRating
+              : null;
+          const numericChallengeRating = Number(rawChallengeRating);
+
+          return {
+            index: monster.index,
+            name: monster.name,
+            url: monster.url,
+            challengeRating: Number.isFinite(numericChallengeRating)
+              ? numericChallengeRating
+              : null,
+          };
+        })
+      );
     } catch (err) {
       next(err);
     }

--- a/server/utils/dnd5eApi.js
+++ b/server/utils/dnd5eApi.js
@@ -4,15 +4,6 @@ const localMonsterData = require('../data/monsters.json');
 
 const API_BASE = 'https://www.dnd5eapi.co';
 
-const localMonsterList =
-  localMonsterData && Array.isArray(localMonsterData.results)
-    ? localMonsterData.results.map((monster) => ({
-        index: monster.index,
-        name: monster.name,
-        url: monster.url,
-      }))
-    : [];
-
 const localMonsterMap = new Map();
 if (localMonsterData && localMonsterData.monsters && typeof localMonsterData.monsters === 'object') {
   Object.entries(localMonsterData.monsters).forEach(([index, monster]) => {
@@ -31,6 +22,49 @@ if (localMonsterData && localMonsterData.monsters && typeof localMonsterData.mon
     });
   });
 }
+
+const getChallengeRatingFromLocal = (index) => {
+  if (!index || typeof index !== 'string') {
+    return null;
+  }
+
+  const normalized = index.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  const monster = localMonsterMap.get(normalized);
+  if (!monster) {
+    return null;
+  }
+
+  const raw =
+    monster.challenge_rating !== undefined && monster.challenge_rating !== null
+      ? monster.challenge_rating
+      : monster.challengeRating !== undefined && monster.challengeRating !== null
+      ? monster.challengeRating
+      : null;
+
+  if (raw === null) {
+    return null;
+  }
+
+  const numeric = Number(raw);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const localMonsterList =
+  localMonsterData && Array.isArray(localMonsterData.results)
+    ? localMonsterData.results.map((monster) => ({
+        index: monster.index,
+        name: monster.name,
+        url: monster.url,
+        challenge_rating:
+          monster.challenge_rating !== undefined && monster.challenge_rating !== null
+            ? monster.challenge_rating
+            : getChallengeRatingFromLocal(monster.index),
+      }))
+    : [];
 
 function fetchJson(path) {
   return new Promise((resolve, reject) => {
@@ -83,7 +117,21 @@ async function getMonsterList() {
   }
 
   try {
-    monsterListCache = await fetchJson('/api/monsters');
+    const list = await fetchJson('/api/monsters');
+    if (list && Array.isArray(list.results)) {
+      monsterListCache = {
+        ...list,
+        results: list.results.map((monster) => ({
+          ...monster,
+          challenge_rating:
+            monster.challenge_rating !== undefined && monster.challenge_rating !== null
+              ? monster.challenge_rating
+              : getChallengeRatingFromLocal(monster.index),
+        })),
+      };
+    } else {
+      monsterListCache = list;
+    }
   } catch (err) {
     if (localMonsterList.length) {
       logger.warn('Falling back to bundled 5e SRD monster list', { error: err.message });


### PR DESCRIPTION
## Summary
- expose challenge ratings from the monster list API so the client can use them when filtering monsters
- add challenge rating filter controls and improved CR formatting on the enemies tab
- cover the new challenge rating filtering workflow with a UI test

## Testing
- `npm --prefix client test -- --watchAll=false` *(fails: multiple pre-existing suites emit act() warnings and prevent the run from completing)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a5a76b58832e9d8e2e63167aeec6