### PR TITLE
Respect explicit figurine sizes when scaling tokens

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3753,8 +3753,12 @@ h1 {
     position: absolute;
     left: 50%;
     top: var(--figurine-rotation-origin-y-token);
-    width: calc(var(--figurine-base-size) * 1.35);
-    height: calc(var(--figurine-base-size) * 1.35);
+    width: calc(
+      var(--figurine-base-size) * var(--rotation-handle-distance-scale, 1.35)
+    );
+    height: calc(
+      var(--figurine-base-size) * var(--rotation-handle-distance-scale, 1.35)
+    );
     transform: translate(-50%, -50%);
     display: flex;
     align-items: center;

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -71,8 +71,8 @@ const normalizeText = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
 
 const FIGURINE_SIZE_MULTIPLIERS = {
-  tiny: 0.5,
-  small: 1,
+  tiny: 0.25,
+  small: 0.5,
   medium: 1,
   large: 2,
   huge: 3,
@@ -82,6 +82,31 @@ const FIGURINE_SIZE_MULTIPLIERS = {
 const MAX_FIGURINE_GRID_SQUARES = FIGURINE_SIZE_MULTIPLIERS.gargantuan;
 const DEFAULT_FIGURINE_GRID_SQUARES = FIGURINE_SIZE_MULTIPLIERS.medium;
 const FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE = 512;
+
+const ROTATION_HANDLE_DISTANCE_BASE_SCALE = 1.35;
+const ROTATION_HANDLE_DISTANCE_MIN_SCALE = 1.05;
+const ROTATION_HANDLE_DISTANCE_REDUCTION_PER_EXTRA_SCALE = 0.15;
+
+const resolveRotationHandleDistanceScale = (figurineScale) => {
+  if (!Number.isFinite(figurineScale) || figurineScale <= 0) {
+    return ROTATION_HANDLE_DISTANCE_BASE_SCALE;
+  }
+
+  const extraScale = Math.max(0, figurineScale - 1);
+  const reducedScale =
+    ROTATION_HANDLE_DISTANCE_BASE_SCALE -
+    ROTATION_HANDLE_DISTANCE_REDUCTION_PER_EXTRA_SCALE * extraScale;
+
+  if (reducedScale < ROTATION_HANDLE_DISTANCE_MIN_SCALE) {
+    return ROTATION_HANDLE_DISTANCE_MIN_SCALE;
+  }
+
+  if (reducedScale > ROTATION_HANDLE_DISTANCE_BASE_SCALE) {
+    return ROTATION_HANDLE_DISTANCE_BASE_SCALE;
+  }
+
+  return reducedScale;
+};
 
 const DEFAULT_GRID_DIMENSION = 24;
 
@@ -362,9 +387,27 @@ const resolveFigurineSquaresFromImageSize = (metrics, metadataSquareSize) => {
   }
 
   const maxDimension = Math.max(numericWidth, numericHeight);
-  const squareSize = Number.isFinite(metadataSquareSize) && metadataSquareSize > 0
-    ? metadataSquareSize
-    : FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE;
+  if (!Number.isFinite(maxDimension) || maxDimension <= 0) {
+    return null;
+  }
+
+  if (maxDimension < FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE) {
+    return 1;
+  }
+
+  const squareSize = (() => {
+    if (Number.isFinite(metadataSquareSize) && metadataSquareSize > 0) {
+      if (metadataSquareSize >= FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE) {
+        return metadataSquareSize;
+      }
+
+      if (maxDimension >= FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE) {
+        return metadataSquareSize;
+      }
+    }
+
+    return FALLBACK_FIGURINE_PIXEL_SQUARE_SIZE;
+  })();
 
   if (!Number.isFinite(squareSize) || squareSize <= 0) {
     return null;
@@ -1387,16 +1430,26 @@ const CampaignMapBoard = ({
                   ? resolveFigurineSquaresFromImageSize(metrics, metadataSquareSize)
                   : null;
                 const sizeKey = resolveFigurineSizeKey(size);
+                const hasExplicitSize = typeof size === 'string' && size.trim() !== '';
                 const baseFigurineScale =
                   FIGURINE_SIZE_MULTIPLIERS[sizeKey] ?? DEFAULT_FIGURINE_GRID_SQUARES;
-                const figurineScale =
-                  sizeKey === 'medium'
-                    ? 1
-                    : Number.isFinite(imageFootprint)
-                      ? imageFootprint
-                      : Number.isFinite(baseFigurineScale)
-                        ? baseFigurineScale
-                        : DEFAULT_FIGURINE_GRID_SQUARES;
+                const figurineScale = (() => {
+                  if (!hasExplicitSize && Number.isFinite(imageFootprint) && imageFootprint > 0) {
+                    return imageFootprint;
+                  }
+
+                  if (Number.isFinite(baseFigurineScale) && baseFigurineScale > 0) {
+                    return baseFigurineScale;
+                  }
+
+                  if (sizeKey === 'medium') {
+                    return 1;
+                  }
+
+                  return DEFAULT_FIGURINE_GRID_SQUARES;
+                })();
+                const rotationHandleDistanceScale =
+                  resolveRotationHandleDistanceScale(figurineScale);
 
                 const figurineColor =
                   normalizedVariant === 'enemy'
@@ -1439,6 +1492,7 @@ const CampaignMapBoard = ({
                       top: `${(position?.y ?? 0) * 100}%`,
                       '--figurine-size-scale': figurineScale,
                       '--figurine-rotation': rotationStyleValue,
+                      '--rotation-handle-distance-scale': rotationHandleDistanceScale,
                       '--rotation-handle-angle': rotationHandleStyleValue,
                     }}
                     title={displayLabel || undefined}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -428,7 +428,7 @@ describe('CampaignMapBoard pointer interactions', () => {
         tokens={[
           {
             ...baseToken,
-            size: 'medium',
+            size: undefined,
             figurineImageUrl: 'https://example.com/figurines/large.png',
           },
         ]}
@@ -466,7 +466,7 @@ describe('CampaignMapBoard pointer interactions', () => {
         tokens={[
           {
             ...baseToken,
-            size: 'medium',
+            size: undefined,
             figurineImageUrl: 'https://example.com/figurines/colossal.png',
           },
         ]}
@@ -493,6 +493,44 @@ describe('CampaignMapBoard pointer interactions', () => {
 
       await waitFor(() => {
         expect(tokenElement?.style.getPropertyValue('--figurine-size-scale')).toBe('2');
+      });
+    }
+  });
+
+  it('keeps explicit figurine sizes even when image footprint is larger', async () => {
+    const { container } = render(
+      <CampaignMapBoard
+        map={{ ...baseMap, pixelsPerSquare: 256 }}
+        tokens={[
+          {
+            ...baseToken,
+            size: 'medium',
+            figurineImageUrl: 'https://example.com/figurines/oversized.png',
+          },
+        ]}
+      />
+    );
+
+    const tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    const figurineImage = tokenElement?.querySelector('.campaign-map-board__figurine-image');
+    expect(figurineImage).not.toBeNull();
+
+    if (figurineImage) {
+      Object.defineProperty(figurineImage, 'naturalWidth', {
+        configurable: true,
+        value: 512,
+      });
+      Object.defineProperty(figurineImage, 'naturalHeight', {
+        configurable: true,
+        value: 512,
+      });
+
+      fireEvent.load(figurineImage);
+
+      await waitFor(() => {
+        expect(tokenElement?.style.getPropertyValue('--figurine-size-scale')).toBe('1');
       });
     }
   });


### PR DESCRIPTION
## Summary
- align figurine size multipliers with the visual classes so small and tiny categories remain compact
- avoid overriding an explicitly provided figurine size with derived image footprints while retaining image-based sizing for tokens without a size
- add coverage to ensure explicit sizes win over large image footprints

## Testing
- CI=1 npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f803a790d8832e94d64e5cceee3215