### PR TITLE
Add caching for Cloudinary figurine suggestions

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -77,6 +77,92 @@ describe('suggestEnemyFigurine helper', () => {
         'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/goblin_token.png',
     });
   });
+
+  test('reuses cached figurine suggestions for the same monster keys', async () => {
+    process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS = '1000';
+
+    const mockExecute = jest.fn().mockResolvedValue({
+      resources: [
+        {
+          public_id: 'Tokens/DM/skeleton_token',
+          secure_url:
+            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/skeleton_token.png',
+          folder: 'Tokens/DM',
+          filename: 'skeleton_token',
+        },
+      ],
+    });
+
+    const searchInstance = {};
+    searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.max_results = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.with_field = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.next_cursor = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.execute = mockExecute;
+
+    const mockExpression = jest.fn().mockImplementation(() => searchInstance);
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        search: {
+          expression: mockExpression,
+        },
+      },
+    }));
+
+    const { suggestEnemyFigurine: actualSuggestEnemyFigurine } = jest.requireActual(
+      '../utils/cloudinary'
+    );
+
+    const first = await actualSuggestEnemyFigurine({ index: 'skeleton', name: 'Skeleton' });
+    const second = await actualSuggestEnemyFigurine({ index: 'skeleton', name: 'Skeleton' });
+
+    expect(first).toEqual({
+      figurineImagePublicId: 'Tokens/DM/skeleton_token',
+      figurineImageUrl:
+        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/skeleton_token.png',
+    });
+    expect(second).toEqual(first);
+    expect(mockExpression).toHaveBeenCalledTimes(1);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  test('caches null figurine suggestions to avoid repeated searches', async () => {
+    process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS = '1000';
+
+    const mockExecute = jest.fn().mockResolvedValue({ resources: [] });
+
+    const searchInstance = {};
+    searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.max_results = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.with_field = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.next_cursor = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.execute = mockExecute;
+
+    const mockExpression = jest.fn().mockImplementation(() => searchInstance);
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        search: {
+          expression: mockExpression,
+        },
+      },
+    }));
+
+    const { suggestEnemyFigurine: actualSuggestEnemyFigurine } = jest.requireActual(
+      '../utils/cloudinary'
+    );
+
+    const first = await actualSuggestEnemyFigurine({ index: 'wight', name: 'Wight' });
+    const second = await actualSuggestEnemyFigurine({ index: 'wight', name: 'Wight' });
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(mockExpression).toHaveBeenCalledTimes(2);
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('Cloudinary caching helpers', () => {

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -5,11 +5,13 @@ const DEFAULT_TOKEN_ROOT_FOLDER = 'Tokens';
 const TOKEN_FALLBACK_MAX_RESULTS = 200;
 const DEFAULT_TOKEN_CACHE_TTL_MS = 60_000;
 const DEFAULT_FOLDER_TREE_CACHE_TTL_MS = 120_000;
+const DEFAULT_FIGURINE_SUGGESTION_CACHE_TTL_MS = 3_600_000;
 const DEFAULT_FOLDER_TREE_CONCURRENCY = 4;
 const MAX_FOLDER_TREE_CONCURRENCY = 12;
 
 const tokenListCache = new Map();
 const folderTreeCache = new Map();
+const figurineSuggestionCache = new Map();
 
 const parseCacheTtl = (value, fallback) => {
   const numericValue = Number(value);
@@ -26,6 +28,12 @@ const getFolderTreeCacheTtlMs = () =>
   parseCacheTtl(
     process.env.CLOUDINARY_FOLDER_TREE_CACHE_TTL_MS,
     DEFAULT_FOLDER_TREE_CACHE_TTL_MS
+  );
+
+const getFigurineSuggestionCacheTtlMs = () =>
+  parseCacheTtl(
+    process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS,
+    DEFAULT_FIGURINE_SUGGESTION_CACHE_TTL_MS
   );
 
 const parsePositiveInteger = (value, fallback, max) => {
@@ -116,6 +124,23 @@ const clearCacheWhenDisabled = (cache, ttlMs) => {
   }
 };
 
+const getFigurineSuggestionCacheEntry = (key) => {
+  const entry = getCacheEntry(figurineSuggestionCache, key);
+  if (!entry || typeof entry !== 'object' || entry.__figurineSuggestionCache !== true) {
+    return undefined;
+  }
+
+  return entry.value;
+};
+
+const setFigurineSuggestionCacheEntry = (key, value, ttlMs) => {
+  if (!key) {
+    return;
+  }
+
+  setCacheEntry(figurineSuggestionCache, key, { __figurineSuggestionCache: true, value }, ttlMs);
+};
+
 const buildTokenListCacheKey = ({ rootFolder, folders, nextCursor, maxResults }) => {
   const normalizedFolders = Array.isArray(folders) ? folders.slice().sort() : [];
   const serializedFolders = normalizedFolders.length > 0 ? normalizedFolders.join('|') : '__ALL__';
@@ -131,6 +156,22 @@ const buildFolderTreeCacheKey = ({ rootFolder, folders }) => {
   const normalizedFolders = Array.isArray(folders) ? folders.slice().sort() : [];
   const serializedFolders = normalizedFolders.length > 0 ? normalizedFolders.join('|') : '__ROOT__';
   return [rootFolder || DEFAULT_TOKEN_ROOT_FOLDER, serializedFolders].join('::');
+};
+
+const buildFigurineSuggestionCacheKey = ({ keys, includeGeneralSearch, rootFolder }) => {
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return null;
+  }
+
+  const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
+  const normalizedKeys = Array.from(new Set(keys.filter(Boolean))).sort();
+  const scope = includeGeneralSearch ? 'general' : 'restricted';
+
+  if (normalizedKeys.length === 0) {
+    return null;
+  }
+
+  return [normalizedRoot, scope, normalizedKeys.join('|')].join('::');
 };
 
 const resolveCloudinary = () => {
@@ -936,36 +977,64 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
     return null;
   }
 
+  const includeGeneral = Boolean(includeGeneralSearch);
+  const rootFolder = getTokenRootFolder();
+  const cacheTtlMs = getFigurineSuggestionCacheTtlMs();
+
+  clearCacheWhenDisabled(figurineSuggestionCache, cacheTtlMs);
+
+  const cacheKey =
+    cacheTtlMs > 0
+      ? buildFigurineSuggestionCacheKey({
+          keys,
+          includeGeneralSearch: includeGeneral,
+          rootFolder,
+        })
+      : null;
+
+  if (cacheTtlMs > 0 && cacheKey) {
+    const cachedSuggestion = getFigurineSuggestionCacheEntry(cacheKey);
+    if (cachedSuggestion !== undefined) {
+      return cachedSuggestion;
+    }
+  }
+
   try {
     configure();
   } catch (error) {
+    if (cacheTtlMs > 0 && cacheKey) {
+      setFigurineSuggestionCacheEntry(cacheKey, null, cacheTtlMs);
+    }
     return null;
   }
 
   const sdk = resolveCloudinary();
-  const rootFolder = getTokenRootFolder();
 
-  const searchScenarios = [
-    { folderHints: DM_FOLDER_HINTS },
-  ];
+  const searchScenarios = [{ folderHints: DM_FOLDER_HINTS }];
 
-  if (includeGeneralSearch) {
+  if (includeGeneral) {
     searchScenarios.push({ folderHints: [] });
   }
 
+  let suggestion = null;
+
   for (const scenario of searchScenarios) {
-    const suggestion = await executeFigurineSearch(sdk, {
+    suggestion = await executeFigurineSearch(sdk, {
       rootFolder,
       keys,
       folderHints: scenario.folderHints,
     });
 
     if (suggestion) {
-      return suggestion;
+      break;
     }
   }
 
-  return null;
+  if (cacheTtlMs > 0 && cacheKey) {
+    setFigurineSuggestionCacheEntry(cacheKey, suggestion || null, cacheTtlMs);
+  }
+
+  return suggestion;
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary
- add a configurable in-memory cache for Cloudinary figurine suggestion searches to reduce repeated API calls
- reuse cached suggestion results (including misses) based on monster keys and search scope
- expand the Cloudinary utility tests to cover the new caching behaviour

## Testing
- npm --prefix server test -- --runTestsByPath __tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f94bc789b4832e89d7f6e5fed79b4d