### PR TITLE
Add Cloudinary usage endpoint and tests

### DIFF
--- a/server/__tests__/cloudinaryUsage.test.js
+++ b/server/__tests__/cloudinaryUsage.test.js
@@ -1,0 +1,86 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+const originalEnv = { ...process.env };
+
+const buildApp = (usageImpl) => {
+  jest.resetModules();
+
+  process.env = {
+    ...originalEnv,
+    CLOUDINARY_CLOUD_NAME: 'demo',
+    CLOUDINARY_API_KEY: 'key',
+    CLOUDINARY_API_SECRET: 'secret',
+  };
+
+  jest.doMock('../db/conn', () => jest.fn().mockResolvedValue({}));
+  jest.doMock('../middleware/auth', () => (req, res, next) => next());
+  jest.doMock('cloudinary', () => ({
+    v2: {
+      config: jest.fn(),
+      api: { usage: usageImpl },
+    },
+  }));
+
+  let app;
+  let cloudinaryUtils;
+
+  jest.isolateModules(() => {
+    cloudinaryUtils = require('../utils/cloudinary');
+    const routes = require('../routes');
+
+    app = express();
+    app.use(express.json());
+    app.use(routes);
+    app.use((err, req, res, next) => {
+      const status = err.status || 500;
+      const message = status === 500 ? 'Internal Server Error' : err.message;
+      res.status(status).json({ message });
+    });
+  });
+
+  return { app, cloudinaryUtils };
+};
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock('cloudinary');
+  jest.dontMock('../db/conn');
+  jest.dontMock('../middleware/auth');
+  process.env = { ...originalEnv };
+});
+
+describe('Cloudinary usage route', () => {
+  test('responds with usage data and records API call metrics', async () => {
+    const mockUsage = { credits: { usage: 42 } };
+    const usageImpl = jest.fn().mockResolvedValue(mockUsage);
+
+    const { app, cloudinaryUtils } = buildApp(usageImpl);
+
+    const res = await request(app).get('/usage');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ usage: mockUsage });
+    expect(usageImpl).toHaveBeenCalledTimes(1);
+
+    const counts = cloudinaryUtils.getCloudinaryApiCallCounts();
+    expect(counts.byAction['api.usage']).toBe(1);
+    expect(counts.total).toBe(1);
+  });
+
+  test('returns 500 when Cloudinary usage retrieval fails', async () => {
+    const usageImpl = jest.fn().mockRejectedValue(new Error('usage unavailable'));
+
+    const { app } = buildApp(usageImpl);
+
+    const res = await request(app).get('/usage');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ message: 'Failed to retrieve Cloudinary usage' });
+    expect(usageImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/routes/cloudinary.js
+++ b/server/routes/cloudinary.js
@@ -1,0 +1,24 @@
+const logger = require('../utils/logger');
+const { fetchUsage } = require('../utils/cloudinary');
+
+module.exports = (router) => {
+  router.get('/usage', async (req, res) => {
+    try {
+      const usage = await fetchUsage();
+
+      logger.info('Fetched Cloudinary usage data', {
+        source: 'cloudinaryUsageRoute',
+        usage,
+      });
+
+      res.json({ usage });
+    } catch (error) {
+      logger.warn('Failed to fetch Cloudinary usage data', {
+        source: 'cloudinaryUsageRoute',
+        error: error.message,
+      });
+
+      res.status(500).json({ message: 'Failed to retrieve Cloudinary usage' });
+    }
+  });
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -26,6 +26,7 @@ const monsters = require('./monsters');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
 const ai = require('./ai');
+const cloudinary = require('./cloudinary');
 
 routes.use(async (req, res, next) => {
   try {
@@ -61,5 +62,6 @@ feats(routes);
 equipment(routes);
 weaponProficiency(routes);
 armorProficiency(routes);
+cloudinary(routes);
 
 module.exports = routes;

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -400,6 +400,21 @@ const sanitizeTokenResource = (resource = {}, rootFolder = DEFAULT_TOKEN_ROOT_FO
   };
 };
 
+const fetchUsage = async () => {
+  configure();
+  const sdk = resolveCloudinary();
+
+  if (!sdk?.api || typeof sdk.api.usage !== 'function') {
+    throw new Error('Cloudinary usage API is unavailable');
+  }
+
+  logCloudinaryApiCall('api.usage', { context: 'fetchUsage' });
+
+  const usage = await sdk.api.usage();
+
+  return usage && typeof usage === 'object' ? usage : null;
+};
+
 const uploadMapImage = async (image, options = {}) => {
   configure();
   const sdk = resolveCloudinary();
@@ -1113,6 +1128,7 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
 };
 
 module.exports = {
+  fetchUsage,
   uploadMapImage,
   deleteMapImage,
   getMapFolder,


### PR DESCRIPTION
## Summary
- add a Cloudinary helper that records API metrics when fetching account usage
- expose a GET /usage route that logs the returned usage payload
- cover the new helper and route with Jest tests

## Testing
- npm test -- cloudinaryUsage

------
https://chatgpt.com/codex/tasks/task_e_68f96439f248832e9e1e7ecf2a5bb903