### PR TITLE
Improve Cloudinary usage error reporting

### DIFF
--- a/server/__tests__/cloudinaryUsage.test.js
+++ b/server/__tests__/cloudinaryUsage.test.js
@@ -1,0 +1,106 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.ATLAS_URI = 'mongodb://localhost/test';
+process.env.CLIENT_ORIGINS = 'http://localhost';
+
+const request = require('supertest');
+const express = require('express');
+
+const originalEnv = { ...process.env };
+
+const buildApp = (usageImpl) => {
+  jest.resetModules();
+
+  process.env = {
+    ...originalEnv,
+    CLOUDINARY_CLOUD_NAME: 'demo',
+    CLOUDINARY_API_KEY: 'key',
+    CLOUDINARY_API_SECRET: 'secret',
+  };
+
+  jest.doMock('../db/conn', () => jest.fn().mockResolvedValue({}));
+  jest.doMock('../middleware/auth', () => (req, res, next) => next());
+  jest.doMock('cloudinary', () => ({
+    v2: {
+      config: jest.fn(),
+      api: { usage: usageImpl },
+    },
+  }));
+
+  let app;
+  let cloudinaryUtils;
+
+  jest.isolateModules(() => {
+    cloudinaryUtils = require('../utils/cloudinary');
+    const routes = require('../routes');
+
+    app = express();
+    app.use(express.json());
+    app.use(routes);
+    app.use((err, req, res, next) => {
+      const status = err.status || 500;
+      const message = status === 500 ? 'Internal Server Error' : err.message;
+      res.status(status).json({ message });
+    });
+  });
+
+  return { app, cloudinaryUtils };
+};
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock('cloudinary');
+  jest.dontMock('../db/conn');
+  jest.dontMock('../middleware/auth');
+  process.env = { ...originalEnv };
+});
+
+describe('Cloudinary usage route', () => {
+  test('responds with usage data and records API call metrics', async () => {
+    const mockUsage = { credits: { usage: 42 } };
+    const usageImpl = jest.fn().mockResolvedValue(mockUsage);
+
+    const { app, cloudinaryUtils } = buildApp(usageImpl);
+
+    const res = await request(app).get('/usage');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ usage: mockUsage });
+    expect(usageImpl).toHaveBeenCalledTimes(1);
+
+    const counts = cloudinaryUtils.getCloudinaryApiCallCounts();
+    expect(counts.byAction['api.usage']).toBe(1);
+    expect(counts.total).toBe(1);
+  });
+
+  test('returns 500 when Cloudinary usage retrieval fails', async () => {
+    const usageImpl = jest.fn().mockRejectedValue(new Error('usage unavailable'));
+
+    const { app } = buildApp(usageImpl);
+
+    const res = await request(app).get('/usage');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({
+      message: 'Failed to retrieve Cloudinary usage',
+      reason: 'usage unavailable',
+    });
+    expect(usageImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses Cloudinary http_code when available', async () => {
+    const error = new Error('Not allowed in current plan');
+    error.http_code = 403;
+    const usageImpl = jest.fn().mockRejectedValue(error);
+
+    const { app } = buildApp(usageImpl);
+
+    const res = await request(app).get('/usage');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      message: 'Failed to retrieve Cloudinary usage',
+      reason: 'Not allowed in current plan',
+    });
+    expect(usageImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/routes/cloudinary.js
+++ b/server/routes/cloudinary.js
@@ -1,0 +1,41 @@
+const logger = require('../utils/logger');
+const { fetchUsage } = require('../utils/cloudinary');
+
+module.exports = (router) => {
+  router.get('/usage', async (req, res) => {
+    try {
+      const usage = await fetchUsage();
+
+      logger.info('Fetched Cloudinary usage data', {
+        source: 'cloudinaryUsageRoute',
+        usage,
+      });
+
+      res.json({ usage });
+    } catch (error) {
+      const statusCode =
+        Number.isInteger(error?.statusCode) && error.statusCode >= 400 && error.statusCode < 600
+          ? error.statusCode
+          : 500;
+
+      const reason =
+        error?.details?.reason && typeof error.details.reason === 'string'
+          ? error.details.reason
+          : null;
+
+      logger.warn('Failed to fetch Cloudinary usage data', {
+        source: 'cloudinaryUsageRoute',
+        error: error.message,
+        statusCode,
+        reason,
+      });
+
+      const payload = { message: 'Failed to retrieve Cloudinary usage' };
+      if (reason) {
+        payload.reason = reason;
+      }
+
+      res.status(statusCode).json(payload);
+    }
+  });
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -26,6 +26,7 @@ const monsters = require('./monsters');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
 const ai = require('./ai');
+const cloudinary = require('./cloudinary');
 
 routes.use(async (req, res, next) => {
   try {
@@ -61,5 +62,6 @@ feats(routes);
 equipment(routes);
 weaponProficiency(routes);
 armorProficiency(routes);
+cloudinary(routes);
 
 module.exports = routes;

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -400,6 +400,67 @@ const sanitizeTokenResource = (resource = {}, rootFolder = DEFAULT_TOKEN_ROOT_FO
   };
 };
 
+class CloudinaryUsageError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'CloudinaryUsageError';
+
+    const { statusCode, details, cause } = options;
+
+    if (Number.isInteger(statusCode)) {
+      this.statusCode = statusCode;
+    }
+
+    if (details && typeof details === 'object') {
+      this.details = details;
+    }
+
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+}
+
+const fetchUsage = async () => {
+  configure();
+  const sdk = resolveCloudinary();
+
+  if (!sdk?.api || typeof sdk.api.usage !== 'function') {
+    throw new CloudinaryUsageError('Cloudinary usage API is unavailable', {
+      statusCode: 503,
+    });
+  }
+
+  logCloudinaryApiCall('api.usage', { context: 'fetchUsage' });
+
+  try {
+    const usage = await sdk.api.usage();
+    if (!usage || typeof usage !== 'object') {
+      throw new CloudinaryUsageError('Cloudinary usage response was empty', {
+        statusCode: 502,
+      });
+    }
+
+    return usage;
+  } catch (error) {
+    const httpCode =
+      typeof error?.http_code === 'number' && error.http_code >= 400 && error.http_code < 600
+        ? error.http_code
+        : undefined;
+
+    const statusCode = Number.isInteger(error?.statusCode) ? error.statusCode : httpCode;
+
+    throw new CloudinaryUsageError('Failed to fetch Cloudinary usage', {
+      cause: error,
+      statusCode,
+      details:
+        error?.message && typeof error.message === 'string'
+          ? { reason: error.message }
+          : undefined,
+    });
+  }
+};
+
 const uploadMapImage = async (image, options = {}) => {
   configure();
   const sdk = resolveCloudinary();
@@ -1113,6 +1174,8 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
 };
 
 module.exports = {
+  CloudinaryUsageError,
+  fetchUsage,
   uploadMapImage,
   deleteMapImage,
   getMapFolder,


### PR DESCRIPTION
## Summary
- wrap Cloudinary usage lookups in a custom error that preserves HTTP status codes and reasons
- return richer error responses from the `/usage` route and log the status/reason metadata
- extend the Jest suite to cover propagation of Cloudinary failure details

## Testing
- npm test -- cloudinaryUsage

------
https://chatgpt.com/codex/tasks/task_e_68f96439f248832e9e1e7ecf2a5bb903