### PR TITLE
Improve Cloudinary usage error handling

### DIFF
--- a/server/__tests__/cloudinaryUsage.test.js
+++ b/server/__tests__/cloudinaryUsage.test.js
@@ -7,7 +7,7 @@ const express = require('express');
 
 const originalEnv = { ...process.env };
 
-const buildApp = (usageImpl) => {
+const buildApp = (usageImpl, { envOverrides } = {}) => {
   jest.resetModules();
 
   process.env = {
@@ -15,6 +15,7 @@ const buildApp = (usageImpl) => {
     CLOUDINARY_CLOUD_NAME: 'demo',
     CLOUDINARY_API_KEY: 'key',
     CLOUDINARY_API_SECRET: 'secret',
+    ...envOverrides,
   };
 
   jest.doMock('../db/conn', () => jest.fn().mockResolvedValue({}));
@@ -85,6 +86,27 @@ describe('Cloudinary usage route', () => {
       reason: 'usage unavailable',
     });
     expect(usageImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 503 when Cloudinary is not configured', async () => {
+    const usageImpl = jest.fn();
+
+    const { app } = buildApp(usageImpl, {
+      envOverrides: {
+        CLOUDINARY_CLOUD_NAME: undefined,
+        CLOUDINARY_API_KEY: undefined,
+        CLOUDINARY_API_SECRET: undefined,
+      },
+    });
+
+    const res = await request(app).get('/usage');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      message: 'Failed to retrieve Cloudinary usage',
+      reason: 'Cloudinary environment variables are not configured',
+    });
+    expect(usageImpl).not.toHaveBeenCalled();
   });
 
   test('uses Cloudinary http_code when available', async () => {

--- a/server/data/spells.js
+++ b/server/data/spells.js
@@ -1262,8 +1262,8 @@ const RAW_SPELLS = [
 "v"
 ],
 "duration": "Instantaneous",
-"description": "A creature of your choice that you can see within range regains Hit Points equal to 2d4 plus your spellcasting ability modifier.",
-"higherLevelSlot": "The healing increases by 2d4 for each spell slot level above 1."
+"description": "A creature of your choice that you can see within range regains Hit Points equal to 1d4 plus your spellcasting ability modifier.",
+"higherLevelSlot": "The healing increases by 1d4 for each spell slot level above 1."
 },
 {
 "name": "Hellish Rebuke",

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -422,7 +422,21 @@ class CloudinaryUsageError extends Error {
 }
 
 const fetchUsage = async () => {
-  configure();
+  try {
+    configure();
+  } catch (error) {
+    const statusCode = Number.isInteger(error?.statusCode) ? error.statusCode : 503;
+
+    throw new CloudinaryUsageError('Failed to fetch Cloudinary usage', {
+      cause: error,
+      statusCode,
+      details:
+        error?.message && typeof error.message === 'string'
+          ? { reason: error.message }
+          : undefined,
+    });
+  }
+
   const sdk = resolveCloudinary();
 
   if (!sdk?.api || typeof sdk.api.usage !== 'function') {


### PR DESCRIPTION
## Summary
- convert Cloudinary configuration failures into CloudinaryUsageErrors so the /usage route returns a helpful status and reason
- allow the usage route test helper to override Cloudinary env vars and cover the misconfiguration scenario
- fix the Healing Word spell data so its base healing matches the expected 1d4 scaling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f96adb1ae4832eb602424ba6a3ee82