### PR TITLE
Fix sprite stat block details

### DIFF
--- a/server/data/monsters.json
+++ b/server/data/monsters.json
@@ -20306,11 +20306,13 @@
         "stealth": 8,
         "pb": 2
       },
-      "senses": null,
-      "languages": "",
-      "challenge_rating": null,
-      "xp": null,
-      "proficiency_bonus": null,
+      "senses": {
+        "passive_perception": 13
+      },
+      "languages": "Common, Elvish, Sylvan",
+      "challenge_rating": 0.25,
+      "xp": 50,
+      "proficiency_bonus": 2,
       "damage_vulnerabilities": null,
       "damage_resistances": null,
       "damage_immunities": null,
@@ -20341,7 +20343,7 @@
         },
         {
           "name": "Heart Sight",
-          "desc": "Charisma Saving Throw: DC 10, one creature within 5 feet the sprite can see (Celestials, Fiends, and Undead automatically fail the save). Failure: The sprite knows the target’s emotions and alignment."
+          "desc": "Charisma Saving Throw: DC 10, one creature within 5 feet of the sprite that the sprite can see (Celestials, Fiends, and Undead automatically fail the save). Failure: The sprite knows the target’s emotions and alignment."
         },
         {
           "name": "Invisibility",


### PR DESCRIPTION
## Summary
- update the sprite entry in the monsters data to include the correct senses, languages, and challenge metadata
- clarify the Heart Sight action description so it matches the official stat block wording

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9a9bd62ac832392293ab3e97a7f9e