### PR TITLE
Add full ancient blue dragon stat block

### DIFF
--- a/server/data/monsters.json
+++ b/server/data/monsters.json
@@ -71,6 +71,11 @@
       "url": "/api/monsters/ancient-black-dragon"
     },
     {
+      "index": "ancient-blue-dragon",
+      "name": "Ancient Blue Dragon",
+      "url": "/api/monsters/ancient-blue-dragon"
+    },
+    {
       "index": "ancient-brass-dragon",
       "name": "Ancient Brass Dragon",
       "url": "/api/monsters/ancient-brass-dragon"
@@ -3746,6 +3751,140 @@
         {
           "name": "Frightful Presence",
           "desc": "The dragon uses Spellcasting to cast Fear. The dragon can’t take this action again until the start of its next turn."
+        },
+        {
+          "name": "Pounce",
+          "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+        }
+      ],
+      "lair_actions": null,
+      "regional_effects": null,
+      "subtype": "chromatic"
+    },
+    "ancient-blue-dragon": {
+      "index": "ancient-blue-dragon",
+      "name": "Ancient Blue Dragon",
+      "size": "Gargantuan",
+      "type": "dragon",
+      "alignment": "Lawful Evil",
+      "armor_class": 22,
+      "hit_points": 481,
+      "hit_dice": "26d20 + 208",
+      "speed": {
+        "walk": "40 ft.",
+        "burrow": "40 ft.",
+        "fly": "80 ft."
+      },
+      "strength": 29,
+      "dexterity": 10,
+      "constitution": 27,
+      "intelligence": 18,
+      "wisdom": 17,
+      "charisma": 21,
+      "saving_throws": [
+        {
+          "name": "DEX",
+          "value": 7
+        },
+        {
+          "name": "WIS",
+          "value": 10
+        }
+      ],
+      "skills": {
+        "perception": 17,
+        "stealth": 7
+      },
+      "senses": {
+        "passive_perception": 27,
+        "blindsight": "60 ft.",
+        "darkvision": "120 ft."
+      },
+      "languages": "Common, Draconic",
+      "challenge_rating": 23.0,
+      "xp": 50000,
+      "proficiency_bonus": 7,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": [
+        "Lightning"
+      ],
+      "condition_immunities": null,
+      "special_abilities": [
+        {
+          "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+          "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Lightning Bolt (level 6 version)."
+        },
+        {
+          "name": "Rend",
+          "desc": "Melee Attack Roll: +16, reach 15 ft. Hit: 20 (2d10 + 9) Slashing damage plus 11 (3d6) Lightning damage.",
+          "attack_bonus": 16,
+          "damage": [
+            {
+              "damage_dice": "2d10+9",
+              "damage_type": {
+                "name": "slashing"
+              }
+            }
+          ],
+          "damage_dice": "2d10+9",
+          "damage_type": {
+            "name": "slashing"
+          }
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "desc": "Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 88 (16d10) Lightning damage. Success: Half damage.",
+          "damage": [
+            {
+              "damage_dice": "16d10",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "16d10",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Spellcasting",
+          "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks): At Will: Detect Magic, Hallucinatory Terrain, Lightning Bolt (level 6 version) 1/Day Each: Chain Lightning, Mirage Arcane"
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": null,
+      "legendary_actions": [
+        {
+          "name": "Legendary Action Uses: 3 (4 in Lair)",
+          "desc": "Immediately after another creature’s turn, the dragon can expend a use to take one of the following actions. The dragon regains all expended uses at the start of each of its turns."
+        },
+        {
+          "name": "Charged Gust",
+          "desc": "Dexterity Saving Throw: DC 20, each creature in a 30-foot Cone. Failure: 18 (4d8) Lightning damage, and the target is pushed up to 10 feet away from the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+          "damage": [
+            {
+              "damage_dice": "4d8",
+              "damage_type": {
+                "name": "lightning"
+              }
+            }
+          ],
+          "damage_dice": "4d8",
+          "damage_type": {
+            "name": "lightning"
+          }
+        },
+        {
+          "name": "Mirage Step",
+          "desc": "The dragon uses Spellcasting to cast Hallucinatory Terrain, and it can burrow up to half its Burrow Speed without provoking Opportunity Attacks. The dragon can’t take this action again until the start of its next turn."
         },
         {
           "name": "Pounce",


### PR DESCRIPTION
## Summary
- populate the Ancient Blue Dragon entry in the monster compendium with a complete stat block
- add actions, spellcasting, and legendary options consistent with the other ancient chromatic dragons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9bc807fcc832391c49abb96807442