### PR TITLE
Disable Cloudinary search fallback for enemy figurines

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -32,18 +32,9 @@ describe('suggestEnemyFigurine helper', () => {
     process.env = { ...originalEnv };
   });
 
-  test('returns DM folder substring matches as confident suggestions', async () => {
-    const mockExecute = jest.fn().mockResolvedValue({
-      resources: [
-        {
-          public_id: 'Tokens/DM/goblin_token',
-          secure_url:
-            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/goblin_token.png',
-          folder: 'Tokens/DM',
-          filename: 'goblin_token',
-        },
-      ],
-    });
+  test('returns null when adversary folder has no matching assets', async () => {
+    const mockResources = jest.fn().mockResolvedValue({ resources: [] });
+    const mockExecute = jest.fn();
 
     const searchInstance = {};
     searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
@@ -57,6 +48,9 @@ describe('suggestEnemyFigurine helper', () => {
     jest.doMock('cloudinary', () => ({
       v2: {
         config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
         search: {
           expression: mockExpression,
         },
@@ -69,29 +63,20 @@ describe('suggestEnemyFigurine helper', () => {
 
     const result = await actualSuggestEnemyFigurine({ index: 'goblin', name: 'Goblin' });
 
-    expect(mockExpression).toHaveBeenCalled();
-    expect(mockExecute).toHaveBeenCalled();
-    expect(result).toEqual({
-      figurineImagePublicId: 'Tokens/DM/goblin_token',
-      figurineImageUrl:
-        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/goblin_token.png',
+    expect(mockResources).toHaveBeenCalled();
+    expect(mockResources.mock.calls[0][0]).toMatchObject({
+      prefix: 'Tokens/Adversaries/Goblin',
     });
+    expect(mockExpression).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
   test('reuses cached figurine suggestions for the same monster keys', async () => {
     process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS = '1000';
 
-    const mockExecute = jest.fn().mockResolvedValue({
-      resources: [
-        {
-          public_id: 'Tokens/DM/skeleton_token',
-          secure_url:
-            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/skeleton_token.png',
-          folder: 'Tokens/DM',
-          filename: 'skeleton_token',
-        },
-      ],
-    });
+    const mockResources = jest.fn().mockResolvedValue({ resources: [] });
+    const mockExecute = jest.fn();
 
     const searchInstance = {};
     searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
@@ -105,6 +90,9 @@ describe('suggestEnemyFigurine helper', () => {
     jest.doMock('cloudinary', () => ({
       v2: {
         config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
         search: {
           expression: mockExpression,
         },
@@ -115,23 +103,38 @@ describe('suggestEnemyFigurine helper', () => {
       '../utils/cloudinary'
     );
 
+    mockResources.mockResolvedValueOnce({
+      resources: [
+        {
+          public_id: 'Tokens/Adversaries/Skeleton/token-1',
+          secure_url:
+            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Skeleton/token-1.png',
+          folder: 'Tokens/Adversaries/Skeleton',
+          filename: 'token-1',
+        },
+      ],
+    });
+
     const first = await actualSuggestEnemyFigurine({ index: 'skeleton', name: 'Skeleton' });
+    const resourceCallsAfterFirst = mockResources.mock.calls.length;
     const second = await actualSuggestEnemyFigurine({ index: 'skeleton', name: 'Skeleton' });
 
     expect(first).toEqual({
-      figurineImagePublicId: 'Tokens/DM/skeleton_token',
+      figurineImagePublicId: 'Tokens/Adversaries/Skeleton/token-1',
       figurineImageUrl:
-        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/skeleton_token.png',
+        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Skeleton/token-1.png',
     });
     expect(second).toEqual(first);
-    expect(mockExpression).toHaveBeenCalledTimes(1);
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockResources.mock.calls.length).toBe(resourceCallsAfterFirst);
+    expect(mockExpression).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
   });
 
   test('caches null figurine suggestions to avoid repeated searches', async () => {
     process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS = '1000';
 
-    const mockExecute = jest.fn().mockResolvedValue({ resources: [] });
+    const mockResources = jest.fn().mockResolvedValue({ resources: [] });
+    const mockExecute = jest.fn();
 
     const searchInstance = {};
     searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
@@ -145,6 +148,9 @@ describe('suggestEnemyFigurine helper', () => {
     jest.doMock('cloudinary', () => ({
       v2: {
         config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
         search: {
           expression: mockExpression,
         },
@@ -156,31 +162,30 @@ describe('suggestEnemyFigurine helper', () => {
     );
 
     const first = await actualSuggestEnemyFigurine({ index: 'wight', name: 'Wight' });
+    const resourceCallsAfterFirst = mockResources.mock.calls.length;
     const second = await actualSuggestEnemyFigurine({ index: 'wight', name: 'Wight' });
 
     expect(first).toBeNull();
     expect(second).toBeNull();
-    expect(mockExpression).toHaveBeenCalledTimes(2);
-    expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(mockResources.mock.calls.length).toBe(resourceCallsAfterFirst);
+    expect(mockExpression).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
   });
 
-  test('tracks Cloudinary API call counts across figurine search scenarios', async () => {
-    process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS = '1000';
+  test('returns adversary folder assets without using Cloudinary search', async () => {
+    const mockResources = jest.fn().mockResolvedValue({
+      resources: [
+        {
+          public_id: 'Tokens/Adversaries/Goblin/token-1',
+          secure_url:
+            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Goblin/token-1.png',
+          folder: 'Tokens/Adversaries/Goblin',
+          filename: 'token-1',
+        },
+      ],
+    });
 
-    const mockExecute = jest
-      .fn()
-      .mockResolvedValueOnce({ resources: [] })
-      .mockResolvedValueOnce({
-        resources: [
-          {
-            public_id: 'Tokens/DM/ogre_token',
-            secure_url:
-              'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/ogre_token.png',
-            folder: 'Tokens/DM',
-            filename: 'ogre_token',
-          },
-        ],
-      });
+    const mockExecute = jest.fn();
 
     const searchInstance = {};
     searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
@@ -194,6 +199,120 @@ describe('suggestEnemyFigurine helper', () => {
     jest.doMock('cloudinary', () => ({
       v2: {
         config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
+        search: {
+          expression: mockExpression,
+        },
+      },
+    }));
+
+    const { suggestEnemyFigurine: actualSuggestEnemyFigurine } = jest.requireActual(
+      '../utils/cloudinary'
+    );
+
+    const result = await actualSuggestEnemyFigurine({ index: 'goblin', name: 'Goblin' });
+
+    expect(mockResources).toHaveBeenCalledTimes(1);
+    expect(mockExpression).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      figurineImagePublicId: 'Tokens/Adversaries/Goblin/token-1',
+      figurineImageUrl:
+        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Goblin/token-1.png',
+    });
+  });
+
+  test('requests adversary folders using underscores for monster names with spaces', async () => {
+    const mockResources = jest.fn().mockResolvedValue({
+      resources: [
+        {
+          public_id: 'Tokens/Adversaries/Adult_Blue_Dragon/token-2',
+          secure_url:
+            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Adult_Blue_Dragon/token-2.png',
+          folder: 'Tokens/Adversaries/Adult_Blue_Dragon',
+          filename: 'token-2',
+        },
+      ],
+    });
+
+    const mockExecute = jest.fn();
+
+    const searchInstance = {};
+    searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.max_results = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.with_field = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.next_cursor = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.execute = mockExecute;
+
+    const mockExpression = jest.fn().mockImplementation(() => searchInstance);
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
+        search: {
+          expression: mockExpression,
+        },
+      },
+    }));
+
+    const { suggestEnemyFigurine: actualSuggestEnemyFigurine } = jest.requireActual(
+      '../utils/cloudinary'
+    );
+
+    const result = await actualSuggestEnemyFigurine({
+      index: 'adult-blue-dragon',
+      name: 'Adult Blue Dragon',
+    });
+
+    expect(mockResources).toHaveBeenCalledTimes(1);
+    expect(mockResources.mock.calls[0][0]).toMatchObject({
+      prefix: 'Tokens/Adversaries/Adult_Blue_Dragon',
+    });
+    expect(mockExpression).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      figurineImagePublicId: 'Tokens/Adversaries/Adult_Blue_Dragon/token-2',
+      figurineImageUrl:
+        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Adult_Blue_Dragon/token-2.png',
+    });
+  });
+
+  test('tracks Cloudinary API call counts across figurine search scenarios', async () => {
+    process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS = '1000';
+
+    const mockResources = jest.fn().mockResolvedValue({
+      resources: [
+        {
+          public_id: 'Tokens/Adversaries/Ogre/token-3',
+          secure_url:
+            'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Ogre/token-3.png',
+          folder: 'Tokens/Adversaries/Ogre',
+          filename: 'token-3',
+        },
+      ],
+    });
+    const mockExecute = jest.fn();
+
+    const searchInstance = {};
+    searchInstance.sort_by = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.max_results = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.with_field = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.next_cursor = jest.fn().mockImplementation(() => searchInstance);
+    searchInstance.execute = mockExecute;
+
+    const mockExpression = jest.fn().mockImplementation(() => searchInstance);
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
         search: {
           expression: mockExpression,
         },
@@ -209,17 +328,19 @@ describe('suggestEnemyFigurine helper', () => {
     const result = await actualSuggestEnemyFigurine({ index: 'ogre', name: 'Ogre' });
 
     expect(result).toEqual({
-      figurineImagePublicId: 'Tokens/DM/ogre_token',
+      figurineImagePublicId: 'Tokens/Adversaries/Ogre/token-3',
       figurineImageUrl:
-        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/DM/ogre_token.png',
+        'https://res.cloudinary.com/demo/image/upload/v1/Tokens/Adversaries/Ogre/token-3.png',
     });
 
-    expect(mockExpression).toHaveBeenCalledTimes(2);
-    expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(mockExpression).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockResources).toHaveBeenCalledTimes(1);
 
     const counts = getCloudinaryApiCallCounts();
-    expect(counts.total).toBe(2);
-    expect(counts.byAction).toEqual({ 'search.execute': 2 });
+    const resourceCalls = mockResources.mock.calls.length;
+    expect(counts.total).toBe(resourceCalls);
+    expect(counts.byAction).toEqual({ 'api.resources': resourceCalls });
 
     resetCloudinaryApiCallCounts();
     expect(getCloudinaryApiCallCounts()).toEqual({ total: 0, byAction: {} });

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -8,6 +8,7 @@ const DEFAULT_FOLDER_TREE_CACHE_TTL_MS = 1_800_000; // 30 minutes
 const DEFAULT_FIGURINE_SUGGESTION_CACHE_TTL_MS = 3_600_000;
 const DEFAULT_FOLDER_TREE_CONCURRENCY = 4;
 const MAX_FOLDER_TREE_CONCURRENCY = 12;
+const MAX_ADVERSARY_FOLDER_RESULTS = 60;
 
 const tokenListCache = new Map();
 const folderTreeCache = new Map();
@@ -217,20 +218,19 @@ const buildFolderTreeCacheKey = ({ rootFolder, folders }) => {
   return [rootFolder || DEFAULT_TOKEN_ROOT_FOLDER, serializedFolders].join('::');
 };
 
-const buildFigurineSuggestionCacheKey = ({ keys, includeGeneralSearch, rootFolder }) => {
+const buildFigurineSuggestionCacheKey = ({ keys, rootFolder }) => {
   if (!Array.isArray(keys) || keys.length === 0) {
     return null;
   }
 
   const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
   const normalizedKeys = Array.from(new Set(keys.filter(Boolean))).sort();
-  const scope = includeGeneralSearch ? 'general' : 'restricted';
 
   if (normalizedKeys.length === 0) {
     return null;
   }
 
-  return [normalizedRoot, scope, normalizedKeys.join('|')].join('::');
+  return [normalizedRoot, normalizedKeys.join('|')].join('::');
 };
 
 const resolveCloudinary = () => {
@@ -914,7 +914,6 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
   return response;
 };
 
-const DM_FOLDER_HINTS = ['DM', 'DM Only', 'DM-Only', 'DMOnly', '_DM'];
 const DM_FOLDER_PATTERN = /(^|\/)dm([ -]?only)?(\/|$)/i;
 const CONFIDENT_SUGGESTION_SCORE = 5;
 
@@ -986,6 +985,109 @@ const collectMonsterKeys = (monsterDetail = {}) => {
   });
 
   return Array.from(sanitized).filter(Boolean);
+};
+
+const getMonsterNameForFolder = (monsterDetail = {}) => {
+  if (!monsterDetail || typeof monsterDetail !== 'object') {
+    return null;
+  }
+
+  const candidateKeys = [
+    'name',
+    'monster_name',
+    'monsterName',
+    'displayName',
+    'index',
+    'monster_index',
+    'slug',
+    'monster_slug',
+  ];
+
+  for (const key of candidateKeys) {
+    const value = monsterDetail[key];
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return null;
+};
+
+const buildAdversaryFolderPath = (monsterDetail = {}, rootFolder = DEFAULT_TOKEN_ROOT_FOLDER) => {
+  const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
+  const monsterName = getMonsterNameForFolder(monsterDetail);
+
+  if (!monsterName) {
+    return null;
+  }
+
+  const normalizedName = monsterName.replace(/[\\/]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalizedName) {
+    return null;
+  }
+
+  const folderSegment = normalizedName
+    .replace(/[^0-9A-Za-z\s_-]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  if (!folderSegment) {
+    return null;
+  }
+
+  return sanitizeFolderSegment(`${normalizedRoot}/Adversaries/${folderSegment}`);
+};
+
+const fetchAdversaryFolderResources = async (sdk, folderPath) => {
+  if (!sdk?.api || typeof sdk.api.resources !== 'function') {
+    return null;
+  }
+
+  const sanitizedFolder = sanitizeFolderSegment(folderPath);
+  if (!sanitizedFolder) {
+    return null;
+  }
+
+  const maxResults = MAX_ADVERSARY_FOLDER_RESULTS;
+
+  try {
+    logCloudinaryApiCall('api.resources', {
+      context: 'suggestEnemyFigurine.adversaryFolder',
+      prefix: sanitizedFolder,
+      maxResults,
+    });
+
+    const response = await sdk.api.resources({
+      type: 'upload',
+      resource_type: 'image',
+      prefix: sanitizedFolder,
+      max_results: maxResults,
+      context: true,
+      metadata: true,
+    });
+
+    return Array.isArray(response?.resources) ? response.resources : [];
+  } catch (error) {
+    return null;
+  }
+};
+
+const suggestFromAdversaryFolders = async (sdk, { rootFolder, keys, monsterDetail }) => {
+  const folderPath = buildAdversaryFolderPath(monsterDetail, rootFolder);
+  if (!folderPath) {
+    return null;
+  }
+
+  const resources = await fetchAdversaryFolderResources(sdk, folderPath);
+  if (!resources || resources.length === 0) {
+    return null;
+  }
+
+  return selectBestSuggestion(resources, keys, rootFolder);
 };
 
 const collectCandidateTokens = (resource) => {
@@ -1152,99 +1254,12 @@ const selectBestSuggestion = (resources, keys, rootFolder) => {
   };
 };
 
-const buildMatchExpressions = (keys) => {
-  if (!Array.isArray(keys) || keys.length === 0) {
-    return [];
-  }
-
-  const metaKeys = [
-    'monsterIndex',
-    'monster_index',
-    'monsterSlug',
-    'monster_slug',
-    'slug',
-    'name',
-    'type',
-    'subtype',
-    'creatureType',
-    'creature_type',
-    'creatureSubtype',
-    'creature_subtype',
-  ];
-
-  const expressions = new Set();
-
-  keys.forEach((key) => {
-    const variants = expandKeyVariants(key);
-    variants.forEach((variant) => {
-      const escaped = escapeExpressionValue(variant);
-      expressions.add(`public_id="${escaped}"`);
-      expressions.add(`public_id="${escapeExpressionValue(`*${variant}*`)}"`);
-      expressions.add(`filename="${escaped}"`);
-      expressions.add(`filename="${escapeExpressionValue(`*${variant}*`)}"`);
-      metaKeys.forEach((metaKey) => {
-        expressions.add(`metadata.${metaKey}="${escaped}"`);
-      });
-    });
-  });
-
-  return Array.from(expressions);
-};
-
-const executeFigurineSearch = async (sdk, { rootFolder, keys, folderHints }) => {
-  if (!sdk?.search || typeof sdk.search.expression !== 'function') {
-    return null;
-  }
-
-  const matchExpressions = buildMatchExpressions(keys);
-  if (matchExpressions.length === 0) {
-    return null;
-  }
-
-  const expressionSegments = ['resource_type:image'];
-  const folderExpressions = buildFolderExpressions(rootFolder, folderHints || []);
-
-  if (folderExpressions.length > 0) {
-    expressionSegments.push(`(${folderExpressions.join(' OR ')})`);
-  }
-
-  expressionSegments.push(`(${matchExpressions.join(' OR ')})`);
-
-  const expression = expressionSegments.join(' AND ');
-
-  const maxResults = Math.min(Math.max(keys.length * 20, 50), TOKEN_FALLBACK_MAX_RESULTS);
-
-  try {
-    let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
-    search = search
-      .max_results(maxResults)
-      .with_field('context')
-      .with_field('metadata');
-
-    logCloudinaryApiCall('search.execute', {
-      context: 'suggestEnemyFigurine',
-      expression,
-      maxResults,
-      folderHints: folderHints || [],
-      keys,
-    });
-
-    const result = await search.execute();
-    const resources = Array.isArray(result?.resources) ? result.resources : [];
-
-    return selectBestSuggestion(resources, keys, rootFolder);
-  } catch (error) {
-    return null;
-  }
-};
-
-const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true } = {}) => {
+const suggestEnemyFigurine = async (monsterDetail) => {
   const keys = collectMonsterKeys(monsterDetail);
   if (keys.length === 0) {
     return null;
   }
 
-  const includeGeneral = Boolean(includeGeneralSearch);
   const rootFolder = getTokenRootFolder();
   const cacheTtlMs = getFigurineSuggestionCacheTtlMs();
 
@@ -1254,7 +1269,6 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
     cacheTtlMs > 0
       ? buildFigurineSuggestionCacheKey({
           keys,
-          includeGeneralSearch: includeGeneral,
           rootFolder,
         })
       : null;
@@ -1277,25 +1291,11 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
 
   const sdk = resolveCloudinary();
 
-  const searchScenarios = [{ folderHints: DM_FOLDER_HINTS }];
-
-  if (includeGeneral) {
-    searchScenarios.push({ folderHints: [] });
-  }
-
-  let suggestion = null;
-
-  for (const scenario of searchScenarios) {
-    suggestion = await executeFigurineSearch(sdk, {
-      rootFolder,
-      keys,
-      folderHints: scenario.folderHints,
-    });
-
-    if (suggestion) {
-      break;
-    }
-  }
+  let suggestion = await suggestFromAdversaryFolders(sdk, {
+    rootFolder,
+    keys,
+    monsterDetail,
+  });
 
   if (cacheTtlMs > 0 && cacheKey) {
     setFigurineSuggestionCacheEntry(cacheKey, suggestion || null, cacheTtlMs);


### PR DESCRIPTION
## Summary
- stop enemy figurine suggestions from issuing general Cloudinary searches and only query the Tokens/Adversaries/<Monster_Name> folder
- update figurine caching logic and tests to reflect the direct-folder-only lookup and revised cache key scope

## Testing
- `npm --prefix server test -- __tests__/campaigns.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68fa35ce2a3c832e81d69924c86b19e0