### PR TITLE
Deduplicate concurrent Cloudinary token manifest fetches

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -458,6 +458,69 @@ describe('Cloudinary caching helpers', () => {
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
+  test('listTokenAssets deduplicates concurrent identical requests', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      CLOUDINARY_CLOUD_NAME: 'demo',
+      CLOUDINARY_API_KEY: 'key',
+      CLOUDINARY_API_SECRET: 'secret',
+      CLOUDINARY_TOKEN_CACHE_TTL_MS: '1000',
+    };
+
+    let resolveExecute;
+    const executePromise = new Promise((resolve) => {
+      resolveExecute = resolve;
+    });
+
+    const mockExecute = jest.fn().mockReturnValue(executePromise);
+
+    const searchInstance = {};
+    searchInstance.sort_by = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.max_results = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.with_field = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.next_cursor = jest.fn().mockReturnValue(searchInstance);
+    searchInstance.execute = mockExecute;
+
+    const mockExpression = jest.fn().mockReturnValue(searchInstance);
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        search: {
+          expression: mockExpression,
+        },
+      },
+    }));
+
+    const { listTokenAssets: actualListTokenAssets } = jest.requireActual('../utils/cloudinary');
+
+    const firstCall = actualListTokenAssets({ folders: ['DM'], nextCursor: null });
+    const secondCall = actualListTokenAssets({ folders: ['DM'], nextCursor: null });
+
+    expect(mockExpression).toHaveBeenCalledTimes(1);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+
+    resolveExecute({
+      resources: [
+        {
+          public_id: 'Tokens/DM/goblin_token',
+          secure_url: 'https://res.cloudinary.com/demo/image/upload/Tokens/DM/goblin_token.png',
+          folder: 'Tokens/DM',
+          filename: 'goblin_token',
+        },
+      ],
+      next_cursor: null,
+      total_count: 1,
+    });
+
+    const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
+
+    expect(firstResult).toEqual(secondResult);
+    expect(mockExpression).toHaveBeenCalledTimes(1);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
   test('listTokenFolderTree reuses cached results when inputs repeat', async () => {
     jest.resetModules();
     process.env = {

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -11,6 +11,7 @@ const MAX_FOLDER_TREE_CONCURRENCY = 12;
 const MAX_ADVERSARY_FOLDER_RESULTS = 60;
 
 const tokenListCache = new Map();
+const tokenListInFlight = new Map();
 const folderTreeCache = new Map();
 const figurineSuggestionCache = new Map();
 
@@ -877,41 +878,70 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
     }
   }
 
-  let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
-
-  search = search.max_results(resolvedMaxResults).with_field('context').with_field('metadata');
-
-  if (sanitizedNextCursor) {
-    search = search.next_cursor(sanitizedNextCursor);
+  const existingInFlight = tokenListInFlight.get(cacheKey);
+  if (existingInFlight) {
+    return existingInFlight;
   }
 
-  logCloudinaryApiCall('search.execute', {
-    context: 'listTokenAssets',
-    expression,
-    maxResults: resolvedMaxResults,
-    nextCursor: sanitizedNextCursor,
-    folders: sanitizedFolders,
-  });
+  const runSearch = async () => {
+    let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
 
-  const result = await search.execute();
-  const resources = Array.isArray(result?.resources) ? result.resources : [];
-  const assets = resources
-    .map((resource) => sanitizeTokenResource(resource, rootFolder))
-    .filter(Boolean);
+    search = search.max_results(resolvedMaxResults).with_field('context').with_field('metadata');
 
-  const response = {
-    assets,
-    nextCursor: typeof result?.next_cursor === 'string' ? result.next_cursor : null,
-    totalCount: typeof result?.total_count === 'number' ? result.total_count : null,
-    appliedFolders: sanitizedFolders,
-    rootFolder,
+    if (sanitizedNextCursor) {
+      search = search.next_cursor(sanitizedNextCursor);
+    }
+
+    logCloudinaryApiCall('search.execute', {
+      context: 'listTokenAssets',
+      expression,
+      maxResults: resolvedMaxResults,
+      nextCursor: sanitizedNextCursor,
+      folders: sanitizedFolders,
+    });
+
+    const result = await search.execute();
+    const resources = Array.isArray(result?.resources) ? result.resources : [];
+    const assets = resources
+      .map((resource) => sanitizeTokenResource(resource, rootFolder))
+      .filter(Boolean);
+
+    const response = {
+      assets,
+      nextCursor: typeof result?.next_cursor === 'string' ? result.next_cursor : null,
+      totalCount: typeof result?.total_count === 'number' ? result.total_count : null,
+      appliedFolders: sanitizedFolders,
+      rootFolder,
+    };
+
+    if (cacheTtlMs > 0) {
+      setCacheEntry(tokenListCache, cacheKey, response, cacheTtlMs);
+    }
+
+    return response;
   };
 
-  if (cacheTtlMs > 0) {
-    setCacheEntry(tokenListCache, cacheKey, response, cacheTtlMs);
-  }
+  let resolveInFlight;
+  let rejectInFlight;
+  const inFlightPromise = new Promise((resolve, reject) => {
+    resolveInFlight = resolve;
+    rejectInFlight = reject;
+  });
 
-  return response;
+  tokenListInFlight.set(cacheKey, inFlightPromise);
+
+  (async () => {
+    try {
+      const response = await runSearch();
+      resolveInFlight(response);
+    } catch (error) {
+      rejectInFlight(error);
+    } finally {
+      tokenListInFlight.delete(cacheKey);
+    }
+  })();
+
+  return inFlightPromise;
 };
 
 const DM_FOLDER_PATTERN = /(^|\/)dm([ -]?only)?(\/|$)/i;


### PR DESCRIPTION
## Summary
- deduplicate in-flight Cloudinary token manifest lookups so identical requests share the same search execution
- add a regression test covering concurrent listTokenAssets callers to guard against repeated API hits

## Testing
- npm test -- --runTestsByPath __tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fa47699e8c832e8e6b637a3b51743a