### PR TITLE
Limit token manifest lookups to a single folder

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -418,7 +418,7 @@ describe('Cloudinary caching helpers', () => {
       CLOUDINARY_TOKEN_CACHE_TTL_MS: '1000',
     };
 
-    const mockExecute = jest.fn().mockResolvedValue({
+    const mockResources = jest.fn().mockResolvedValue({
       resources: [
         {
           public_id: 'Tokens/DM/goblin_token',
@@ -431,20 +431,11 @@ describe('Cloudinary caching helpers', () => {
       total_count: 1,
     });
 
-    const searchInstance = {};
-    searchInstance.sort_by = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.max_results = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.with_field = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.next_cursor = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.execute = mockExecute;
-
-    const mockExpression = jest.fn().mockReturnValue(searchInstance);
-
     jest.doMock('cloudinary', () => ({
       v2: {
         config: jest.fn(),
-        search: {
-          expression: mockExpression,
+        api: {
+          resources: mockResources,
         },
       },
     }));
@@ -454,8 +445,11 @@ describe('Cloudinary caching helpers', () => {
     await actualListTokenAssets({ folders: ['DM'], nextCursor: null });
     await actualListTokenAssets({ folders: ['DM'], nextCursor: null });
 
-    expect(mockExpression).toHaveBeenCalledTimes(1);
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockResources).toHaveBeenCalledTimes(1);
+    expect(mockResources.mock.calls[0][0]).toMatchObject({
+      prefix: 'Tokens/DM',
+      max_results: 200,
+    });
   });
 
   test('listTokenAssets deduplicates concurrent identical requests', async () => {
@@ -473,22 +467,13 @@ describe('Cloudinary caching helpers', () => {
       resolveExecute = resolve;
     });
 
-    const mockExecute = jest.fn().mockReturnValue(executePromise);
-
-    const searchInstance = {};
-    searchInstance.sort_by = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.max_results = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.with_field = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.next_cursor = jest.fn().mockReturnValue(searchInstance);
-    searchInstance.execute = mockExecute;
-
-    const mockExpression = jest.fn().mockReturnValue(searchInstance);
+    const mockResources = jest.fn().mockReturnValue(executePromise);
 
     jest.doMock('cloudinary', () => ({
       v2: {
         config: jest.fn(),
-        search: {
-          expression: mockExpression,
+        api: {
+          resources: mockResources,
         },
       },
     }));
@@ -498,8 +483,7 @@ describe('Cloudinary caching helpers', () => {
     const firstCall = actualListTokenAssets({ folders: ['DM'], nextCursor: null });
     const secondCall = actualListTokenAssets({ folders: ['DM'], nextCursor: null });
 
-    expect(mockExpression).toHaveBeenCalledTimes(1);
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockResources).toHaveBeenCalledTimes(1);
 
     resolveExecute({
       resources: [
@@ -517,8 +501,99 @@ describe('Cloudinary caching helpers', () => {
     const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
 
     expect(firstResult).toEqual(secondResult);
-    expect(mockExpression).toHaveBeenCalledTimes(1);
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockResources).toHaveBeenCalledTimes(1);
+  });
+
+  test('listTokenAssets requests Cloudinary resources with normalized folder prefix', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      CLOUDINARY_CLOUD_NAME: 'demo',
+      CLOUDINARY_API_KEY: 'key',
+      CLOUDINARY_API_SECRET: 'secret',
+    };
+
+    const mockResources = jest.fn().mockResolvedValue({ resources: [] });
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
+      },
+    }));
+
+    const { listTokenAssets: actualListTokenAssets } = jest.requireActual('../utils/cloudinary');
+
+    await actualListTokenAssets({ folders: ['Adversaries/ape'] });
+
+    expect(mockResources).toHaveBeenCalledTimes(1);
+    expect(mockResources.mock.calls[0][0]).toMatchObject({
+      prefix: 'Tokens/Adversaries/ape',
+      max_results: 200,
+      context: true,
+      metadata: true,
+    });
+  });
+
+  test('listTokenAssets only queries the first sanitized folder when multiple are provided', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      CLOUDINARY_CLOUD_NAME: 'demo',
+      CLOUDINARY_API_KEY: 'key',
+      CLOUDINARY_API_SECRET: 'secret',
+    };
+
+    const mockResources = jest.fn().mockResolvedValue({
+      resources: [
+        {
+          public_id: 'Tokens/Adversaries/ape/token-1',
+          secure_url: 'https://res.cloudinary.com/demo/image/upload/Tokens/Adversaries/ape/token-1.png',
+          folder: 'Tokens/Adversaries/ape',
+          filename: 'token-1',
+        },
+        {
+          public_id: 'Tokens/Adversaries/apes/token-2',
+          secure_url: 'https://res.cloudinary.com/demo/image/upload/Tokens/Adversaries/apes/token-2.png',
+          folder: 'Tokens/Adversaries/apes',
+          filename: 'token-2',
+        },
+      ],
+      next_cursor: 'cursor-2',
+      total_count: 2,
+    });
+
+    jest.doMock('cloudinary', () => ({
+      v2: {
+        config: jest.fn(),
+        api: {
+          resources: mockResources,
+        },
+      },
+    }));
+
+    const { listTokenAssets: actualListTokenAssets } = jest.requireActual('../utils/cloudinary');
+
+    const result = await actualListTokenAssets({
+      folders: ['Adversaries/ape', 'Adversaries/apes'],
+    });
+
+    expect(mockResources).toHaveBeenCalledTimes(1);
+    expect(mockResources.mock.calls[0][0]).toMatchObject({
+      prefix: 'Tokens/Adversaries/ape',
+    });
+    expect(result.assets).toEqual([
+      expect.objectContaining({
+        publicId: 'Tokens/Adversaries/ape/token-1',
+        folder: 'Tokens/Adversaries/ape',
+        filename: 'token-1',
+      }),
+    ]);
+    expect(result.appliedFolders).toEqual(['Tokens/Adversaries/ape']);
+    expect(result.nextCursor).toBe('cursor-2');
+    expect(result.totalCount).toBe(2);
   });
 
   test('listTokenFolderTree reuses cached results when inputs repeat', async () => {

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -272,8 +272,6 @@ const getMapFolder = () => process.env.CLOUDINARY_MAP_FOLDER || 'Realm Tracker M
 const getTokenRootFolder = () =>
   process.env.CLOUDINARY_TOKEN_ROOT_FOLDER || DEFAULT_TOKEN_ROOT_FOLDER;
 
-const escapeExpressionValue = (value) => value.replace(/(["\\])/g, '\\$1');
-
 const sanitizeFolderSegment = (value) => {
   if (typeof value !== 'string') {
     return null;
@@ -294,42 +292,6 @@ const sanitizeFolderSegment = (value) => {
   }
 
   return segments.join('/');
-};
-
-const buildFolderExpressions = (rootFolder, folders = []) => {
-  const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
-  const expressions = [];
-
-  const normalizedFilters = Array.isArray(folders)
-    ? folders
-        .map((folder) => {
-          const sanitized = sanitizeFolderSegment(folder);
-          if (!sanitized) {
-            return null;
-          }
-
-          if (sanitized === normalizedRoot) {
-            return sanitized;
-          }
-
-          if (sanitized.startsWith(`${normalizedRoot}/`)) {
-            return sanitized;
-          }
-
-          return `${normalizedRoot}/${sanitized}`;
-        })
-        .filter(Boolean)
-    : [];
-
-  const targets = normalizedFilters.length > 0 ? normalizedFilters : [normalizedRoot];
-
-  targets.forEach((folderPath) => {
-    const escaped = escapeExpressionValue(folderPath);
-    expressions.push(`folder="${escaped}"`);
-    expressions.push(`folder="${escaped}/*"`);
-  });
-
-  return expressions;
 };
 
 const sanitizeTokenResource = (resource = {}, rootFolder = DEFAULT_TOKEN_ROOT_FOLDER) => {
@@ -834,29 +796,40 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
   configure();
   const sdk = resolveCloudinary();
 
-  if (!sdk?.search || typeof sdk.search.expression !== 'function') {
-    throw new Error('Cloudinary search API is unavailable');
+  if (!sdk?.api || typeof sdk.api.resources !== 'function') {
+    throw new Error('Cloudinary resources API is unavailable');
   }
 
   const rootFolder = getTokenRootFolder();
-  const expressionSegments = ['resource_type:image'];
-  const folderExpressions = buildFolderExpressions(rootFolder, folders || []);
-
-  if (folderExpressions.length > 0) {
-    expressionSegments.push(`(${folderExpressions.join(' OR ')})`);
-  }
-
-  const expression = expressionSegments.join(' AND ');
 
   const resolvedMaxResults = Number.isInteger(maxResults)
     ? Math.max(1, Math.min(maxResults, 500))
     : TOKEN_FALLBACK_MAX_RESULTS;
 
+  const normalizedRoot = sanitizeFolderSegment(rootFolder) || DEFAULT_TOKEN_ROOT_FOLDER;
   const sanitizedFolders = Array.isArray(folders)
     ? folders
-        .map((folder) => sanitizeFolderSegment(folder))
+        .map((folder) => {
+          const sanitized = sanitizeFolderSegment(folder);
+          if (!sanitized) {
+            return null;
+          }
+
+          if (sanitized === normalizedRoot) {
+            return sanitized;
+          }
+
+          if (sanitized.startsWith(`${normalizedRoot}/`)) {
+            return sanitized;
+          }
+
+          return `${normalizedRoot}/${sanitized}`;
+        })
         .filter(Boolean)
     : [];
+
+  const selectedFolder = sanitizedFolders.length > 0 ? sanitizedFolders[0] : null;
+  const effectiveFolders = selectedFolder ? [selectedFolder] : [];
 
   const sanitizedNextCursor =
     typeof nextCursor === 'string' && nextCursor.trim() !== '' ? nextCursor.trim() : null;
@@ -866,7 +839,7 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
 
   const cacheKey = buildTokenListCacheKey({
     rootFolder,
-    folders: sanitizedFolders,
+    folders: effectiveFolders,
     nextCursor: sanitizedNextCursor,
     maxResults: resolvedMaxResults,
   });
@@ -884,33 +857,45 @@ const listTokenAssets = async ({ folders = null, nextCursor = null, maxResults }
   }
 
   const runSearch = async () => {
-    let search = sdk.search.expression(expression).sort_by('public_id', 'asc');
+    const targetFolder =
+      selectedFolder || normalizedRoot;
 
-    search = search.max_results(resolvedMaxResults).with_field('context').with_field('metadata');
-
-    if (sanitizedNextCursor) {
-      search = search.next_cursor(sanitizedNextCursor);
-    }
-
-    logCloudinaryApiCall('search.execute', {
+    logCloudinaryApiCall('api.resources', {
       context: 'listTokenAssets',
-      expression,
+      prefix: targetFolder,
       maxResults: resolvedMaxResults,
       nextCursor: sanitizedNextCursor,
-      folders: sanitizedFolders,
+      folders: effectiveFolders,
+      requestedFolders: sanitizedFolders,
     });
 
-    const result = await search.execute();
+    const result = await sdk.api.resources({
+      type: 'upload',
+      resource_type: 'image',
+      prefix: targetFolder,
+      max_results: resolvedMaxResults,
+      next_cursor: sanitizedNextCursor || undefined,
+      context: true,
+      metadata: true,
+    });
+
     const resources = Array.isArray(result?.resources) ? result.resources : [];
     const assets = resources
       .map((resource) => sanitizeTokenResource(resource, rootFolder))
-      .filter(Boolean);
+      .filter(Boolean)
+      .filter((asset) => {
+        if (effectiveFolders.length === 0) {
+          return true;
+        }
+
+        return effectiveFolders.some((folder) => asset.folder === folder);
+      });
 
     const response = {
       assets,
       nextCursor: typeof result?.next_cursor === 'string' ? result.next_cursor : null,
       totalCount: typeof result?.total_count === 'number' ? result.total_count : null,
-      appliedFolders: sanitizedFolders,
+      appliedFolders: effectiveFolders,
       rootFolder,
     };
 


### PR DESCRIPTION
## Summary
- restrict token manifest requests to query only the first sanitized folder so we avoid falling back to the entire token root
- include the originally requested folder list in Cloudinary logging and filter results using the selected folder list
- add a regression test proving only the initial folder triggers a Cloudinary resources call when multiple folders are supplied

## Testing
- npm --prefix server test -- --runTestsByPath __tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fa4bb0c5fc832eb39cfbb34e7b8074