### PR TITLE
Add persistent Cloudinary folder cache to reduce API usage

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -12,6 +12,13 @@ jest.mock('../middleware/auth', () => (req, res, next) => {
   req.user = mockUser;
   next();
 });
+jest.mock('../utils/cloudinaryCache', () => ({
+  buildTokenFolderCacheKey: jest.fn(() => 'tokenFolders::dm'),
+  getCachedTokenFolderTree: jest.fn(),
+  setCachedTokenFolderTree: jest.fn(),
+  getPersistentFolderTreeCacheTtlMs: jest.fn(() => 0),
+}));
+const cloudinaryCache = require('../utils/cloudinaryCache');
 
 describe('suggestEnemyFigurine helper', () => {
   const originalEnv = { ...process.env };
@@ -834,6 +841,13 @@ describe('Campaign routes', () => {
     listTokenFolderTree.mockReset();
     getTokenRootFolder.mockReset();
     suggestEnemyFigurine.mockReset();
+    cloudinaryCache.buildTokenFolderCacheKey.mockReset();
+    cloudinaryCache.buildTokenFolderCacheKey.mockReturnValue('tokenFolders::dm');
+    cloudinaryCache.getCachedTokenFolderTree.mockReset();
+    cloudinaryCache.getCachedTokenFolderTree.mockResolvedValue(undefined);
+    cloudinaryCache.setCachedTokenFolderTree.mockReset();
+    cloudinaryCache.getPersistentFolderTreeCacheTtlMs.mockReset();
+    cloudinaryCache.getPersistentFolderTreeCacheTtlMs.mockReturnValue(0);
     uploadMapImage.mockResolvedValue({
       secure_url:
         'https://res.cloudinary.com/demo/image/upload/v1729012354/maps/default.png',
@@ -2321,6 +2335,69 @@ describe('Campaign routes', () => {
     expect(listTokenFolderTree).toHaveBeenCalledWith({
       folders: ['Tokens/Adventurers/Heroes'],
     });
+  });
+
+  test('reuses cached DM token folder tree when available', async () => {
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [],
+      flatFolders: [],
+    };
+
+    cloudinaryCache.getPersistentFolderTreeCacheTtlMs.mockReturnValueOnce(3600000);
+    cloudinaryCache.getCachedTokenFolderTree.mockResolvedValueOnce(folderTree);
+
+    const findOne = jest.fn().mockResolvedValue({ campaignName: 'Test', dm: 'DM' });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return { findOne };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    });
+
+    const res = await request(app).get('/campaigns/Test/token-folders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(folderTree);
+    expect(listTokenFolderTree).not.toHaveBeenCalled();
+    expect(cloudinaryCache.setCachedTokenFolderTree).not.toHaveBeenCalled();
+  });
+
+  test('stores DM token folder tree in persistent cache when fetched', async () => {
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [],
+      flatFolders: [],
+    };
+
+    cloudinaryCache.getPersistentFolderTreeCacheTtlMs.mockReturnValueOnce(7200000);
+    cloudinaryCache.getCachedTokenFolderTree.mockResolvedValueOnce(null);
+
+    const findOne = jest.fn().mockResolvedValue({ campaignName: 'Test', dm: 'DM' });
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return { findOne };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    });
+
+    listTokenFolderTree.mockResolvedValue(folderTree);
+
+    const res = await request(app).get('/campaigns/Test/token-folders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(folderTree);
+    expect(listTokenFolderTree).toHaveBeenCalledWith({ folders: [] });
+    expect(cloudinaryCache.setCachedTokenFolderTree).toHaveBeenCalledWith(
+      expect.anything(),
+      'tokenFolders::dm',
+      folderTree,
+      7200000
+    );
   });
 
   test('player token manifest is limited to Adventurers folders', async () => {

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -23,6 +23,12 @@ const {
   listTokenFolderTree,
   suggestEnemyFigurine,
 } = require('../utils/cloudinary');
+const {
+  buildTokenFolderCacheKey,
+  getCachedTokenFolderTree,
+  setCachedTokenFolderTree,
+  getPersistentFolderTreeCacheTtlMs,
+} = require('../utils/cloudinaryCache');
 
 const deriveCloudinaryPublicIdFromUrl = (url) => {
   if (typeof url !== 'string' || url.trim() === '') {
@@ -1824,8 +1830,41 @@ module.exports = (router) => {
           if (isDm) {
             const requestedFolders = parseFolderFilters(req.query.folders);
 
+            const persistentCacheTtlMs = getPersistentFolderTreeCacheTtlMs();
+            const cacheKey = buildTokenFolderCacheKey({
+              role: 'dm',
+              rootFolder: tokenRootFolder,
+              folders: requestedFolders,
+            });
+
+            if (persistentCacheTtlMs > 0) {
+              try {
+                const cached = await getCachedTokenFolderTree(req.db, cacheKey);
+                if (cached) {
+                  return res.json(cached);
+                }
+              } catch (cacheError) {
+                logger.warn('Failed to read token folder cache', {
+                  error: cacheError.message,
+                  context: 'dmTokenFolders',
+                });
+              }
+            }
+
             try {
               const folderTree = await listTokenFolderTree({ folders: requestedFolders });
+
+              if (persistentCacheTtlMs > 0 && folderTree) {
+                try {
+                  await setCachedTokenFolderTree(req.db, cacheKey, folderTree, persistentCacheTtlMs);
+                } catch (cacheError) {
+                  logger.warn('Failed to store token folder cache', {
+                    error: cacheError.message,
+                    context: 'dmTokenFolders',
+                  });
+                }
+              }
+
               return res.json(folderTree);
             } catch (error) {
               logger.warn('Failed to load token folder tree from Cloudinary', {
@@ -1854,8 +1893,42 @@ module.exports = (router) => {
           const folderTargets =
             allowedFolders.length > 0 ? allowedFolders : [playerRootFolder];
 
+          const persistentCacheTtlMs = getPersistentFolderTreeCacheTtlMs();
+          const cacheKey = buildTokenFolderCacheKey({
+            role: 'player',
+            rootFolder: tokenRootFolder,
+            playerRootFolder,
+            folders: folderTargets,
+          });
+
+          if (persistentCacheTtlMs > 0) {
+            try {
+              const cached = await getCachedTokenFolderTree(req.db, cacheKey);
+              if (cached) {
+                return res.json(cached);
+              }
+            } catch (cacheError) {
+              logger.warn('Failed to read token folder cache', {
+                error: cacheError.message,
+                context: 'playerTokenFolders',
+              });
+            }
+          }
+
           try {
             const folderTree = await listTokenFolderTree({ folders: folderTargets });
+
+            if (persistentCacheTtlMs > 0 && folderTree) {
+              try {
+                await setCachedTokenFolderTree(req.db, cacheKey, folderTree, persistentCacheTtlMs);
+              } catch (cacheError) {
+                logger.warn('Failed to store token folder cache', {
+                  error: cacheError.message,
+                  context: 'playerTokenFolders',
+                });
+              }
+            }
+
             return res.json(folderTree);
           } catch (error) {
             logger.warn('Failed to load token folder tree from Cloudinary', {

--- a/server/utils/cloudinaryCache.js
+++ b/server/utils/cloudinaryCache.js
@@ -1,0 +1,133 @@
+const DEFAULT_PERSISTENT_FOLDER_TREE_CACHE_TTL_MS = 21_600_000; // 6 hours
+const TOKEN_FOLDER_CACHE_COLLECTION = 'CloudinaryTokenFolderCache';
+
+const parseCacheTtl = (value, fallback) => {
+  const numericValue = Number(value);
+
+  if (Number.isFinite(numericValue) && numericValue >= 0) {
+    return numericValue;
+  }
+
+  return fallback;
+};
+
+const getPersistentFolderTreeCacheTtlMs = () =>
+  parseCacheTtl(
+    process.env.CLOUDINARY_PERSISTENT_FOLDER_TREE_CACHE_TTL_MS,
+    DEFAULT_PERSISTENT_FOLDER_TREE_CACHE_TTL_MS
+  );
+
+const normalizeFolderList = (folders) => {
+  if (!Array.isArray(folders) || folders.length === 0) {
+    return [];
+  }
+
+  const normalized = folders
+    .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
+    .filter(Boolean);
+
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  return Array.from(new Set(normalized)).sort((a, b) => a.localeCompare(b));
+};
+
+const buildTokenFolderCacheKey = ({
+  role = 'dm',
+  rootFolder = '',
+  folders = [],
+  playerRootFolder = '',
+} = {}) => {
+  const normalizedRole = role === 'player' ? 'player' : 'dm';
+  const normalizedRoot = typeof rootFolder === 'string' ? rootFolder.trim() : '';
+  const normalizedPlayerRoot =
+    normalizedRole === 'player' && typeof playerRootFolder === 'string'
+      ? playerRootFolder.trim()
+      : '';
+  const normalizedFolders = normalizeFolderList(folders);
+
+  const keyParts = ['tokenFolders', normalizedRole];
+
+  if (normalizedRoot) {
+    keyParts.push(`root=${normalizedRoot}`);
+  }
+
+  if (normalizedPlayerRoot) {
+    keyParts.push(`playerRoot=${normalizedPlayerRoot}`);
+  }
+
+  if (normalizedFolders.length > 0) {
+    keyParts.push(`folders=${normalizedFolders.join('|')}`);
+  }
+
+  return keyParts.join('::');
+};
+
+const getCacheCollection = (db) => {
+  if (!db || typeof db.collection !== 'function') {
+    return null;
+  }
+
+  return db.collection(TOKEN_FOLDER_CACHE_COLLECTION);
+};
+
+const getCachedTokenFolderTree = async (db, key) => {
+  if (!key) {
+    return null;
+  }
+
+  const collection = getCacheCollection(db);
+  if (!collection) {
+    return null;
+  }
+
+  const now = new Date();
+  const doc = await collection.findOne({ key, expiresAt: { $gt: now } });
+
+  if (!doc || typeof doc.value !== 'object') {
+    return null;
+  }
+
+  return doc.value;
+};
+
+const setCachedTokenFolderTree = async (db, key, value, ttlMs) => {
+  if (!key || !value || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    return;
+  }
+
+  const collection = getCacheCollection(db);
+  if (!collection) {
+    return;
+  }
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + ttlMs);
+
+  await collection.updateOne(
+    { key },
+    {
+      $set: {
+        key,
+        value,
+        updatedAt: now,
+        expiresAt,
+      },
+    },
+    { upsert: true }
+  );
+
+  try {
+    await collection.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+  } catch (error) {
+    // Ignore index errors (e.g., insufficient permissions). The cache will still function without TTL cleanup.
+  }
+};
+
+module.exports = {
+  buildTokenFolderCacheKey,
+  getCachedTokenFolderTree,
+  setCachedTokenFolderTree,
+  getPersistentFolderTreeCacheTtlMs,
+};


### PR DESCRIPTION
## Summary
- add a Mongo-backed cache helper for Cloudinary token folder trees with a 6 hour default TTL
- reuse the persistent cache in the campaign token folder endpoint for both DMs and players while logging cache errors
- exercise the new caching path in the campaign route tests

## Testing
- npm --prefix server test -- campaign

------
https://chatgpt.com/codex/tasks/task_e_68fa639a5e84832e8d0bde18409fe240