### PR TITLE
Limit DM token picker to scoped adversary folder

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -908,6 +908,12 @@ const TokenPickerModal = ({
         ? cloneFilters(dmFilters)
         : cloneFilters(DEFAULT_DM_FILTERS);
 
+    if (scopeFolderHints.length > 0) {
+      setDmFolderOptions(fallbackFilters);
+      hasLoadedDmFoldersRef.current = true;
+      return;
+    }
+
     if (!campaignId) {
       setDmFolderOptions(fallbackFilters);
       hasLoadedDmFoldersRef.current = false;
@@ -955,7 +961,7 @@ const TokenPickerModal = ({
     return () => {
       isCancelled = true;
     };
-  }, [show, isDm, campaignId, dmFilters]);
+  }, [show, isDm, campaignId, dmFilters, scopeFolderHints]);
 
   useEffect(() => {
     if (isDm) {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -200,16 +200,16 @@ describe('TokenPickerModal', () => {
     );
 
     await waitFor(() => {
-      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
-    });
-
-    await waitFor(() => {
       expect(manifestCalls.length).toBeGreaterThan(0);
       const lastCall = manifestCalls[manifestCalls.length - 1];
       expect(lastCall).toContain('folders=');
       expect(lastCall).toContain('Tokens%2FAdversaries%2F');
       expect(lastCall).not.toContain('Tokens%2FAdventurers');
     });
+
+    expect(
+      apiFetch.mock.calls.some(([url]) => url === '/campaigns/Camp1/token-folders')
+    ).toBe(false);
   });
 
   test('players see Adventurers folders and scope manifest requests to selections', async () => {


### PR DESCRIPTION
## Summary
- skip Cloudinary folder tree fetch when DM token picker already has scoped folder hints
- ensure DM manifest requests immediately target the adversary-specific Tokens/Adversaries/<Monster> path
- adjust tests to reflect that scoped DM pickers no longer hit the token-folders endpoint

## Testing
- npm test -- TokenPickerModal --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68fa83a25090832e878263ce2437218f