### PR TITLE
Add Spectator monster data

### DIFF
--- a/server/data/monsters.json
+++ b/server/data/monsters.json
@@ -1311,6 +1311,11 @@
       "url": "/api/monsters/specter"
     },
     {
+      "index": "spectator",
+      "name": "Spectator",
+      "url": "/api/monsters/spectator"
+    },
+    {
       "index": "sphinx-of-lore",
       "name": "Sphinx of Lore",
       "url": "/api/monsters/sphinx-of-lore"
@@ -20326,6 +20331,91 @@
       ],
       "bonus_actions": null,
       "reactions": null,
+      "legendary_actions": null,
+      "lair_actions": null,
+      "regional_effects": null
+    },
+    "spectator": {
+      "index": "spectator",
+      "name": "Spectator",
+      "size": "Medium",
+      "type": "aberration",
+      "alignment": "Lawful Neutral",
+      "armor_class": 14,
+      "hit_points": 39,
+      "hit_dice": "6d8 + 12",
+      "speed": {
+        "walk": "0 ft.",
+        "fly": "30 ft. (hover)"
+      },
+      "strength": 8,
+      "dexterity": 14,
+      "constitution": 14,
+      "intelligence": 13,
+      "wisdom": 14,
+      "charisma": 11,
+      "saving_throws": [
+        {
+          "name": "INT",
+          "value": 3
+        },
+        {
+          "name": "WIS",
+          "value": 4
+        }
+      ],
+      "skills": {
+        "perception": 6
+      },
+      "senses": {
+        "passive_perception": 16,
+        "darkvision": "120 ft."
+      },
+      "languages": "Deep Speech, Undercommon, telepathy 120 ft.",
+      "challenge_rating": 3.0,
+      "xp": 700,
+      "proficiency_bonus": 2,
+      "damage_vulnerabilities": null,
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": [
+        "Prone"
+      ],
+      "special_abilities": null,
+      "actions": [
+        {
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 6 (2d4 + 1) Piercing damage.",
+          "attack_bonus": 1,
+          "damage": [
+            {
+              "damage_dice": "2d4+1",
+              "damage_type": {
+                "name": "piercing"
+              }
+            }
+          ],
+          "damage_dice": "2d4+1",
+          "damage_type": {
+            "name": "piercing"
+          }
+        },
+        {
+          "name": "Eye Rays",
+          "desc": "The spectator shoots up to two of the following magical eye rays at random (rerolling duplicates), choosing one to two targets it can see within 90 feet of it. Each ray has a save DC of 13. 1- Confusion Ray. Wisdom Saving Throw. Failure: The target has the Charmed condition for 1 minute. While Charmed, it can't take reactions, and on its turn it rolls a d10 to determine its behavior: 1-4, the target takes no action or bonus action. 5-6, the target uses all its movement to move in a random direction. 7-8, the target makes one melee attack against a randomly determined creature it can reach. 9-10, the target acts normally. The target can repeat the save at the end of each of its turns, ending the effect on itself on a success. 2- Paralyzing Ray. Constitution Saving Throw. Failure: The target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on itself on a success. 3- Fear Ray. Wisdom Saving Throw. Failure: The target has the Frightened condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on itself on a success. 4- Wounding Ray. The target takes 16 (3d10) Necrotic damage, and it can't regain Hit Points until the start of the spectator's next turn."
+        },
+        {
+          "name": "Create Food and Water (1/Day)",
+          "desc": "The spectator magically creates enough food and water to sustain itself for 24 hours."
+        }
+      ],
+      "bonus_actions": null,
+      "reactions": [
+        {
+          "name": "Spell Reflection",
+          "desc": "If the spectator makes a successful saving throw against a spell, or a spell attack misses it, the spectator can choose another creature (including the spellcaster) it can see within 30 feet of it. The spell targets the chosen creature instead of the spectator. If the spell forced a saving throw, the chosen creature makes its own save. If the spell was an attack, the attack roll is rerolled against the chosen creature."
+        }
+      ],
       "legendary_actions": null,
       "lair_actions": null,
       "regional_effects": null


### PR DESCRIPTION
## Summary
- add Spectator to the monsters index list
- define the Spectator stat block, actions, and reaction details

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68faa2f74b8c8323bdb403b1100b6e15