### PR TITLE
Fix enemy token picker scope ordering

### DIFF
--- a/client/src/components/Zombies/utils/enemyTokenFilters.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.js
@@ -253,8 +253,27 @@ export const buildEnemyTokenFilterScopeValues = (monsterIndex, monsterDetail) =>
     (monsterDetail && ENEMY_ADVERSARY_TOKEN_CONFIG[monsterDetail?.index]);
 
   if (config) {
-    const folders = Array.isArray(config.folders) ? config.folders : config.folder ? [config.folder] : [];
-    folders.forEach((folder) => addEnemyFolderVariantsToScope(scopeSet, folder));
+    const folders = Array.isArray(config.folders)
+      ? config.folders
+      : config.folder
+        ? [config.folder]
+        : [];
+
+    folders.forEach((folder) => {
+      addEnemyFolderVariantsToScope(scopeSet, folder);
+
+      if (primaryFolderVariant === null) {
+        const normalized = normalizeAdversaryFolderPath(folder);
+
+        if (normalized) {
+          const withoutPrefix = normalized.replace(/^Tokens\/Adversaries\/?/i, '');
+
+          if (withoutPrefix) {
+            primaryFolderVariant = withoutPrefix;
+          }
+        }
+      }
+    });
   }
 
   const folderNameCandidates = new Set();

--- a/client/src/components/Zombies/utils/enemyTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.test.js
@@ -5,14 +5,14 @@ describe('buildEnemyTokenFilterScopeValues', () => {
     const scope = buildEnemyTokenFilterScopeValues('cultist', { index: 'cultist', name: 'Cultist' });
 
     expect(scope).toBeInstanceOf(Array);
-    expect(scope[0]).toBe('folder:Tokens/Adversaries/Cultist');
-    expect(scope[1]).toBe('Tokens/Adversaries/Cultist');
+    expect(scope[0]).toBe('folder:Tokens/Adversaries/Cultists');
+    expect(scope[1]).toBe('Tokens/Adversaries/Cultists');
     expect(scope).toEqual(
       expect.arrayContaining([
-        'folder:Tokens/Adversaries/Cultist',
-        'Tokens/Adversaries/Cultist',
         'folder:Tokens/Adversaries/Cultists',
         'Tokens/Adversaries/Cultists',
+        'folder:Tokens/Adversaries/Cultist',
+        'Tokens/Adversaries/Cultist',
       ])
     );
   });
@@ -36,14 +36,14 @@ describe('buildEnemyTokenFilterScopeValues', () => {
       name: 'Giant Wolf Spider',
     });
 
-    expect(scope[0]).toBe('folder:Tokens/Adversaries/Giant_Wolf_Spider');
-    expect(scope[1]).toBe('Tokens/Adversaries/Giant_Wolf_Spider');
+    expect(scope[0]).toBe('folder:Tokens/Adversaries/Giant Wolf Spiders');
+    expect(scope[1]).toBe('Tokens/Adversaries/Giant Wolf Spiders');
     expect(scope).toEqual(
       expect.arrayContaining([
-        'folder:Tokens/Adversaries/Giant Wolf Spider',
-        'Tokens/Adversaries/Giant Wolf Spider',
         'folder:Tokens/Adversaries/Giant Wolf Spiders',
         'Tokens/Adversaries/Giant Wolf Spiders',
+        'folder:Tokens/Adversaries/Giant Wolf Spider',
+        'Tokens/Adversaries/Giant Wolf Spider',
       ])
     );
     expect(scope.map((value) => value.toLowerCase())).toEqual(


### PR DESCRIPTION
## Summary
- ensure configured adversary folders are prioritized when building enemy token scope hints so the token picker fetches existing assets
- update scope unit tests to reflect the new ordering

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/utils/enemyTokenFilters.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68faa61184ec832eb586435bfc8d983e