### PR TITLE
Prioritize spaced adversary folder variants

### DIFF
--- a/client/src/components/Zombies/utils/enemyTokenFilters.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.js
@@ -203,6 +203,16 @@ const addEnemyFolderVariantsToScope = (set, folderPath) => {
 
   const variants = new Set([pathWithTokens, pathWithTokens.replace(/^Tokens\//i, '')]);
 
+  const segments = pathWithTokens.split('/');
+  if (segments.length >= 3 && segments[0] === 'Tokens' && segments[1] === 'Adversaries') {
+    const dmSegments = [...segments];
+    dmSegments.splice(1, 0, 'DM');
+    const dmPath = dmSegments.join('/');
+
+    variants.add(dmPath);
+    variants.add(dmPath.replace(/^Tokens\//i, ''));
+  }
+
   variants.forEach((variant) => {
     addEnemyScopeValue(set, variant);
     addEnemyScopeValue(set, `folder:${variant}`);
@@ -218,12 +228,12 @@ const buildOrderedNameVariants = (words) => {
   const lowerWords = words.map((word) => word.toLowerCase());
 
   const candidates = [
-    titleWords.join('_'),
-    titleWords.join('-'),
     titleWords.join(' '),
-    lowerWords.join('_'),
-    lowerWords.join('-'),
     lowerWords.join(' '),
+    titleWords.join('_'),
+    lowerWords.join('_'),
+    titleWords.join('-'),
+    lowerWords.join('-'),
     titleWords.join(''),
     lowerWords.join(''),
   ];
@@ -244,6 +254,44 @@ const buildOrderedNameVariants = (words) => {
   return unique;
 };
 
+const extractNormalizedWords = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .split(/[\\/]+/g)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .join(' ')
+    .split(/[^A-Za-z0-9]+/g)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+};
+
+const derivePreferredAdversaryFolderName = (folderPath) => {
+  const normalized = normalizeAdversaryFolderPath(folderPath);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const withoutPrefix = normalized.replace(/^Tokens\/Adversaries\/?/i, '');
+
+  if (!withoutPrefix) {
+    return null;
+  }
+
+  const normalizedWords = extractNormalizedWords(withoutPrefix);
+  const ordered = buildOrderedNameVariants(normalizedWords);
+
+  if (ordered.length > 0) {
+    return ordered[0];
+  }
+
+  return withoutPrefix;
+};
+
 export const buildEnemyTokenFilterScopeValues = (monsterIndex, monsterDetail) => {
   const scopeSet = new Set();
   let primaryFolderVariant = null;
@@ -253,8 +301,28 @@ export const buildEnemyTokenFilterScopeValues = (monsterIndex, monsterDetail) =>
     (monsterDetail && ENEMY_ADVERSARY_TOKEN_CONFIG[monsterDetail?.index]);
 
   if (config) {
-    const folders = Array.isArray(config.folders) ? config.folders : config.folder ? [config.folder] : [];
-    folders.forEach((folder) => addEnemyFolderVariantsToScope(scopeSet, folder));
+    const folders = Array.isArray(config.folders)
+      ? config.folders
+      : config.folder
+        ? [config.folder]
+        : [];
+
+    folders.forEach((folder) => {
+      addEnemyFolderVariantsToScope(scopeSet, folder);
+
+      const preferredFolderName = derivePreferredAdversaryFolderName(folder);
+
+      if (preferredFolderName) {
+        addEnemyFolderVariantsToScope(
+          scopeSet,
+          `Tokens/Adversaries/${preferredFolderName}`
+        );
+
+        if (primaryFolderVariant === null) {
+          primaryFolderVariant = preferredFolderName;
+        }
+      }
+    });
   }
 
   const folderNameCandidates = new Set();
@@ -284,20 +352,7 @@ export const buildEnemyTokenFilterScopeValues = (monsterIndex, monsterDetail) =>
       return;
     }
 
-    const baseSegments = trimmed
-      .split(/[\\/]+/g)
-      .map((segment) => segment.trim())
-      .filter(Boolean);
-
-    if (baseSegments.length === 0) {
-      return;
-    }
-
-    const normalizedWords = baseSegments
-      .join(' ')
-      .split(/[^A-Za-z0-9]+/g)
-      .map((segment) => segment.trim())
-      .filter(Boolean);
+    const normalizedWords = extractNormalizedWords(trimmed);
 
     if (normalizedWords.length === 0) {
       return;

--- a/client/src/components/Zombies/utils/enemyTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/enemyTokenFilters.test.js
@@ -5,14 +5,14 @@ describe('buildEnemyTokenFilterScopeValues', () => {
     const scope = buildEnemyTokenFilterScopeValues('cultist', { index: 'cultist', name: 'Cultist' });
 
     expect(scope).toBeInstanceOf(Array);
-    expect(scope[0]).toBe('folder:Tokens/Adversaries/Cultist');
-    expect(scope[1]).toBe('Tokens/Adversaries/Cultist');
+    expect(scope[0]).toBe('folder:Tokens/Adversaries/Cultists');
+    expect(scope[1]).toBe('Tokens/Adversaries/Cultists');
     expect(scope).toEqual(
       expect.arrayContaining([
-        'folder:Tokens/Adversaries/Cultist',
-        'Tokens/Adversaries/Cultist',
         'folder:Tokens/Adversaries/Cultists',
         'Tokens/Adversaries/Cultists',
+        'folder:Tokens/Adversaries/Cultist',
+        'Tokens/Adversaries/Cultist',
       ])
     );
   });
@@ -36,14 +36,16 @@ describe('buildEnemyTokenFilterScopeValues', () => {
       name: 'Giant Wolf Spider',
     });
 
-    expect(scope[0]).toBe('folder:Tokens/Adversaries/Giant_Wolf_Spider');
-    expect(scope[1]).toBe('Tokens/Adversaries/Giant_Wolf_Spider');
+    expect(scope[0]).toBe('folder:Tokens/Adversaries/Giant Wolf Spiders');
+    expect(scope[1]).toBe('Tokens/Adversaries/Giant Wolf Spiders');
     expect(scope).toEqual(
       expect.arrayContaining([
-        'folder:Tokens/Adversaries/Giant Wolf Spider',
-        'Tokens/Adversaries/Giant Wolf Spider',
         'folder:Tokens/Adversaries/Giant Wolf Spiders',
         'Tokens/Adversaries/Giant Wolf Spiders',
+        'folder:Tokens/Adversaries/Giant_Wolf_Spiders',
+        'Tokens/Adversaries/Giant_Wolf_Spiders',
+        'folder:Tokens/Adversaries/Giant Wolf Spider',
+        'Tokens/Adversaries/Giant Wolf Spider',
       ])
     );
     expect(scope.map((value) => value.toLowerCase())).toEqual(
@@ -65,8 +67,21 @@ describe('buildEnemyTokenFilterScopeValues', () => {
       .map((value) => value.toLowerCase())
       .forEach((value) => {
         expect(value).toContain('adversaries');
-        expect(value).not.toContain('adventurers');
-      });
+      expect(value).not.toContain('adventurers');
+    });
+  });
+
+  it('adds dm folder variants so the dungeon master filter matches', () => {
+    const scope = buildEnemyTokenFilterScopeValues('orc', { index: 'orc', name: 'Orc' });
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'folder:Tokens/DM/Adversaries/Orc',
+        'Tokens/DM/Adversaries/Orc',
+        'folder:DM/Adversaries/Orc',
+        'DM/Adversaries/Orc',
+      ])
+    );
   });
 
   it('does not include unrelated wolf spider folders when selecting wolf', () => {
@@ -78,6 +93,24 @@ describe('buildEnemyTokenFilterScopeValues', () => {
     lowerScope.forEach((value) => {
       expect(value).not.toContain('wolf spider');
     });
+  });
+
+  it('prefers monster name folders when no config is provided', () => {
+    const scope = buildEnemyTokenFilterScopeValues('giant-badger', {
+      index: 'giant-badger',
+      name: 'Giant Badger',
+    });
+
+    expect(scope[0]).toBe('folder:Tokens/Adversaries/Giant Badger');
+    expect(scope[1]).toBe('Tokens/Adversaries/Giant Badger');
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'folder:Tokens/Adversaries/Giant Badger',
+        'Tokens/Adversaries/Giant Badger',
+        'folder:Tokens/Adversaries/Giant_Badger',
+        'Tokens/Adversaries/Giant_Badger',
+      ])
+    );
   });
 
   it('returns null when no identifying information is provided', () => {


### PR DESCRIPTION
## Summary
- prefer space-delimited monster folder names when deriving enemy token scopes so the picker targets Tokens/Adversaries/<Monster Name>
- keep underscore-based folder variants as fallbacks to continue supporting legacy naming
- update adversary scope tests to assert the new folder ordering

## Testing
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/utils/enemyTokenFilters.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68faa61184ec832eb586435bfc8d983e