### PR TITLE
Limit DM token folder scope to primary adversary path

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -159,7 +159,54 @@ const buildFolderHintsFromScope = (scopeValues) => {
     hints.push(normalized);
   });
 
-  return hints;
+  const getSegments = (value) =>
+    typeof value === 'string'
+      ? value
+          .split('/')
+          .map((segment) => segment.trim())
+          .filter(Boolean)
+      : [];
+
+  const sortedHints = hints.sort((a, b) => {
+    const aSegments = getSegments(a);
+    const bSegments = getSegments(b);
+
+    const aIsDm = aSegments.length > 1 && aSegments[1].toLowerCase() === 'dm';
+    const bIsDm = bSegments.length > 1 && bSegments[1].toLowerCase() === 'dm';
+
+    if (aIsDm !== bIsDm) {
+      return aIsDm ? -1 : 1;
+    }
+
+    if (aSegments.length !== bSegments.length) {
+      return bSegments.length - aSegments.length;
+    }
+
+    if (a.length !== b.length) {
+      return b.length - a.length;
+    }
+
+    return a.localeCompare(b);
+  });
+
+  const dmHints = sortedHints.filter((value) => {
+    if (typeof value !== 'string') {
+      return false;
+    }
+
+    const segments = value
+      .split('/')
+      .map((segment) => segment.trim().toLowerCase())
+      .filter(Boolean);
+
+    return segments.length > 1 && segments[1] === 'dm';
+  });
+
+  if (dmHints.length > 0) {
+    return [dmHints[0]];
+  }
+
+  return sortedHints;
 };
 
 const normalizeVariantData = (value, cache) => {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -202,9 +202,12 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       expect(manifestCalls.length).toBeGreaterThan(0);
       const lastCall = manifestCalls[manifestCalls.length - 1];
-      expect(lastCall).toContain('folders=');
-      expect(lastCall).toContain('Tokens%2FAdversaries%2F');
-      expect(lastCall).not.toContain('Tokens%2FAdventurers');
+      const [, foldersParam = ''] = /folders=([^&]+)/.exec(lastCall) || [];
+      const decodedFolders = decodeURIComponent(foldersParam).split(',');
+
+      expect(decodedFolders).toHaveLength(1);
+      expect(decodedFolders[0]).toMatch(/^Tokens\/DM\/Adversaries\//);
+      expect(decodedFolders[0]).not.toContain('Adventurers');
     });
 
     expect(


### PR DESCRIPTION
## Summary
- filter scoped folder hints down to the highest-priority DM adversary path before requesting the manifest
- tighten the token picker unit test to expect a single DM adversary folder when scoped

## Testing
- CI=1 npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68faaf5d08e4832eb13e3bc89884b419