### PR TITLE
Prefer most specific DM scope hint

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -159,7 +159,76 @@ const buildFolderHintsFromScope = (scopeValues) => {
     hints.push(normalized);
   });
 
-  return hints;
+  const getSegments = (value) =>
+    typeof value === 'string'
+      ? value
+          .split('/')
+          .map((segment) => segment.trim())
+          .filter(Boolean)
+      : [];
+
+  const sortedHints = hints.sort((a, b) => {
+    const aSegments = getSegments(a);
+    const bSegments = getSegments(b);
+
+    const aIsDm = aSegments.length > 1 && aSegments[1].toLowerCase() === 'dm';
+    const bIsDm = bSegments.length > 1 && bSegments[1].toLowerCase() === 'dm';
+
+    if (aIsDm !== bIsDm) {
+      return aIsDm ? -1 : 1;
+    }
+
+    if (aSegments.length !== bSegments.length) {
+      return bSegments.length - aSegments.length;
+    }
+
+    if (a.length !== b.length) {
+      return b.length - a.length;
+    }
+
+    return a.localeCompare(b);
+  });
+
+  const compareFolderSpecificity = (a, b) => {
+    const aSegments = getSegments(a);
+    const bSegments = getSegments(b);
+
+    if (aSegments.length !== bSegments.length) {
+      return aSegments.length - bSegments.length;
+    }
+
+    if (a.length !== b.length) {
+      return a.length - b.length;
+    }
+
+    return a.localeCompare(b);
+  };
+
+  const dmHints = sortedHints.filter((value) => {
+    if (typeof value !== 'string') {
+      return false;
+    }
+
+    const segments = value
+      .split('/')
+      .map((segment) => segment.trim().toLowerCase())
+      .filter(Boolean);
+
+    return segments.length > 1 && segments[1] === 'dm';
+  });
+
+  if (dmHints.length > 0) {
+    const sortedDmHints = [...dmHints].sort(compareFolderSpecificity);
+    const mostSpecificHint = sortedDmHints[sortedDmHints.length - 1];
+
+    if (mostSpecificHint) {
+      return [mostSpecificHint];
+    }
+
+    return sortedDmHints;
+  }
+
+  return sortedHints;
 };
 
 const normalizeVariantData = (value, cache) => {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -202,14 +202,61 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       expect(manifestCalls.length).toBeGreaterThan(0);
       const lastCall = manifestCalls[manifestCalls.length - 1];
-      expect(lastCall).toContain('folders=');
-      expect(lastCall).toContain('Tokens%2FAdversaries%2F');
-      expect(lastCall).not.toContain('Tokens%2FAdventurers');
+      const [, foldersParam = ''] = /folders=([^&]+)/.exec(lastCall) || [];
+      const decodedFolders = decodeURIComponent(foldersParam).split(',');
+
+      expect(decodedFolders).toHaveLength(1);
+      expect(decodedFolders[0]).toMatch(/^Tokens\/DM\/Adversaries(?:\/|$)/);
+      expect(decodedFolders[0]).not.toContain('Adventurers');
     });
 
     expect(
       apiFetch.mock.calls.some(([url]) => url === '/campaigns/Camp1/token-folders')
     ).toBe(false);
+  });
+
+  test('prefers the most specific DM scope folder when requesting manifest', async () => {
+    const scope = [
+      'folder:Tokens/DM/Adversaries',
+      'Tokens/DM/Adversaries',
+      'folder:Tokens/DM/Adversaries/Cultists',
+      'Tokens/DM/Adversaries/Cultists',
+    ];
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        isDm
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={scope}
+      />
+    );
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toContain('folders=Tokens%2FDM%2FAdversaries%2FCultists');
+    });
   });
 
   test('players see Adventurers folders and scope manifest requests to selections', async () => {


### PR DESCRIPTION
## Summary
- ensure the DM scope hint selection chooses the most specific folder before requesting manifests
- add a regression test verifying manifest calls use the scoped DM adversary folder

## Testing
- npm test -- TokenPickerModal.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68faaf5d08e4832eb13e3bc89884b419