### PR TITLE
Default DM token picker to Dungeon Master library

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -598,7 +598,7 @@ const TokenPickerModal = ({
   campaignId,
   onSelect,
   isDm = false,
-  defaultFilter = 'adventurers',
+  defaultFilter = null,
   dmFilters = DEFAULT_DM_FILTERS,
   title = 'Choose Figurine Token',
   allowClear = false,
@@ -653,6 +653,14 @@ const TokenPickerModal = ({
 
   const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
 
+  const resolvedDefaultFilter = useMemo(() => {
+    if (defaultFilter && typeof defaultFilter === 'string') {
+      return defaultFilter;
+    }
+
+    return isDm ? 'dm' : 'adventurers';
+  }, [defaultFilter, isDm]);
+
   const [selectedFilterKey, setSelectedFilterKey] = useState(null);
 
   useEffect(() => {
@@ -669,16 +677,16 @@ const TokenPickerModal = ({
 
     let nextKey = null;
 
-    if (defaultFilter) {
-      if (filterLookup.has(defaultFilter)) {
-        nextKey = defaultFilter;
+    if (resolvedDefaultFilter) {
+      if (filterLookup.has(resolvedDefaultFilter)) {
+        nextKey = resolvedDefaultFilter;
       } else {
         const aliasMatch = availableFilters.find(
           (filter) =>
             filter &&
             typeof filter === 'object' &&
             Array.isArray(filter.aliases) &&
-            filter.aliases.includes(defaultFilter)
+            filter.aliases.includes(resolvedDefaultFilter)
         );
 
         if (aliasMatch) {
@@ -695,7 +703,7 @@ const TokenPickerModal = ({
     if (nextKey !== selectedFilterKey) {
       setSelectedFilterKey(nextKey);
     }
-  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey]);
+  }, [filterLookup, availableFilters, resolvedDefaultFilter, selectedFilterKey]);
 
   const [assets, setAssets] = useState([]);
   const [loading, setLoading] = useState(false);

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -128,7 +128,7 @@ describe('TokenPickerModal', () => {
 
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];
-      expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers');
+      expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FDM');
     });
 
     await user.selectOptions(select, options[3]);


### PR DESCRIPTION
## Summary
- default the DM token picker to the Dungeon Master library when no explicit filter is supplied
- update the token picker test expectation to reflect the new default manifest query

## Testing
- CI=true npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fac2557308832e9245860081aed32d