### PR TITLE
Add Cloudinary usage endpoint and cache figurine suggestions

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -26,6 +26,7 @@ const monsters = require('./monsters');
 const weaponProficiency = require('./weaponProficiency');
 const armorProficiency = require('./armorProficiency');
 const ai = require('./ai');
+const usage = require('./usage');
 
 routes.use(async (req, res, next) => {
   try {
@@ -49,6 +50,7 @@ items(routes);
 accessories(routes);
 monsters(routes);
 ai(routes);
+usage(routes);
 // Register occupations routes before generic ID-based routes to ensure
 // "/characters/occupations" is matched correctly.
 characterOccupations(routes);

--- a/server/routes/usage.js
+++ b/server/routes/usage.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const logger = require('../utils/logger');
+const { getUsage } = require('../utils/cloudinary');
+
+module.exports = (router) => {
+  const usageRouter = express.Router();
+
+  usageRouter.get('/', async (req, res) => {
+    try {
+      const usage = await getUsage();
+      return res.json({ usage });
+    } catch (error) {
+      if (error && error.message === 'Cloudinary environment variables are not configured') {
+        return res.status(503).json({ message: 'Cloudinary is not configured' });
+      }
+
+      logger.warn('Failed to retrieve Cloudinary usage', {
+        route: 'GET /usage',
+        error: error?.message,
+      });
+
+      if (error && error.message === 'Cloudinary usage API is unavailable') {
+        return res.status(503).json({ message: 'Cloudinary usage API is unavailable' });
+      }
+
+      return res.status(500).json({ message: 'Failed to retrieve Cloudinary usage' });
+    }
+  });
+
+  router.use('/usage', usageRouter);
+};

--- a/server/utils/cloudinary.js
+++ b/server/utils/cloudinary.js
@@ -7,9 +7,11 @@ const DEFAULT_TOKEN_CACHE_TTL_MS = 60_000;
 const DEFAULT_FOLDER_TREE_CACHE_TTL_MS = 120_000;
 const DEFAULT_FOLDER_TREE_CONCURRENCY = 4;
 const MAX_FOLDER_TREE_CONCURRENCY = 12;
+const DEFAULT_FIGURINE_SUGGESTION_CACHE_TTL_MS = 300_000;
 
 const tokenListCache = new Map();
 const folderTreeCache = new Map();
+const figurineSuggestionCache = new Map();
 
 const parseCacheTtl = (value, fallback) => {
   const numericValue = Number(value);
@@ -26,6 +28,12 @@ const getFolderTreeCacheTtlMs = () =>
   parseCacheTtl(
     process.env.CLOUDINARY_FOLDER_TREE_CACHE_TTL_MS,
     DEFAULT_FOLDER_TREE_CACHE_TTL_MS
+  );
+
+const getFigurineSuggestionCacheTtlMs = () =>
+  parseCacheTtl(
+    process.env.CLOUDINARY_FIGURINE_SUGGESTION_CACHE_TTL_MS,
+    DEFAULT_FIGURINE_SUGGESTION_CACHE_TTL_MS
   );
 
 const parsePositiveInteger = (value, fallback, max) => {
@@ -321,6 +329,17 @@ const deleteMapImage = async (publicId, options = {}) => {
     resource_type: 'image',
     ...options,
   });
+};
+
+const getUsage = async () => {
+  configure();
+  const sdk = resolveCloudinary();
+
+  if (!sdk?.api || typeof sdk.api.usage !== 'function') {
+    throw new Error('Cloudinary usage API is unavailable');
+  }
+
+  return sdk.api.usage();
 };
 
 const listTokenFolderTree = async ({ folders = null, rootFolder: inputRootFolder } = {}) => {
@@ -688,6 +707,20 @@ const collectMonsterKeys = (monsterDetail = {}) => {
   return Array.from(sanitized).filter(Boolean);
 };
 
+const buildFigurineSuggestionCacheKey = ({ keys, includeGeneralSearch }) => {
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return null;
+  }
+
+  const normalizedKeys = Array.from(new Set(keys.filter(Boolean))).sort();
+  if (normalizedKeys.length === 0) {
+    return null;
+  }
+
+  const scope = includeGeneralSearch ? 'general' : 'dm-only';
+  return `${scope}::${normalizedKeys.join('|')}`;
+};
+
 const collectCandidateTokens = (resource) => {
   const tokens = new Set();
 
@@ -936,9 +969,23 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
     return null;
   }
 
+  const cacheTtlMs = getFigurineSuggestionCacheTtlMs();
+  clearCacheWhenDisabled(figurineSuggestionCache, cacheTtlMs);
+  const cacheKey = buildFigurineSuggestionCacheKey({ keys, includeGeneralSearch });
+
+  if (cacheTtlMs > 0 && cacheKey) {
+    const cached = getCacheEntry(figurineSuggestionCache, cacheKey);
+    if (cached !== null || figurineSuggestionCache.has(cacheKey)) {
+      return cached;
+    }
+  }
+
   try {
     configure();
   } catch (error) {
+    if (cacheTtlMs > 0 && cacheKey) {
+      setCacheEntry(figurineSuggestionCache, cacheKey, null, cacheTtlMs);
+    }
     return null;
   }
 
@@ -961,8 +1008,15 @@ const suggestEnemyFigurine = async (monsterDetail, { includeGeneralSearch = true
     });
 
     if (suggestion) {
+      if (cacheTtlMs > 0 && cacheKey) {
+        setCacheEntry(figurineSuggestionCache, cacheKey, suggestion, cacheTtlMs);
+      }
       return suggestion;
     }
+  }
+
+  if (cacheTtlMs > 0 && cacheKey) {
+    setCacheEntry(figurineSuggestionCache, cacheKey, null, cacheTtlMs);
   }
 
   return null;
@@ -976,4 +1030,5 @@ module.exports = {
   listTokenAssets,
   listTokenFolderTree,
   suggestEnemyFigurine,
+  getUsage,
 };


### PR DESCRIPTION
## Summary
- expose a GET /usage endpoint to report Cloudinary account usage with helpful errors
- add a Cloudinary utility for retrieving usage data and wire the new route into the router
- cache figurine suggestion lookups to avoid repeated Cloudinary searches

## Testing
- npm test -- --runTestsByPath __tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fad328f5fc832ea4f11d8776a7d6f3