### PR TITLE
Restore health to full on long rest

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1650,8 +1650,15 @@ export default function ZombiesCharacterSheet() {
 
     // Clear effects on rest
     setActiveEffects([]);
+    if (didLongRestIncrement) {
+      const { maxHp } = calculateCharacterHitPoints(form);
+      const nextHealth = Number.isFinite(maxHp) ? maxHp : 0;
+      handleHealthChange(nextHealth);
+      return;
+    }
+
     handleHealthChange(0);
-  }, [handleHealthChange, longRestCount, shortRestCount]);
+  }, [form, handleHealthChange, longRestCount, shortRestCount]);
 
   useEffect(() => {
     const hasteActive = activeEffects.some((e) => e.name === 'Haste');


### PR DESCRIPTION
## Summary
- ensure characters regain full hit points when a long rest is triggered
- continue clearing active effects on rest while maintaining existing short rest behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcd188d180832ea51119a478b171cd