### PR TITLE
Allow players to pass combat turns

### DIFF
--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -1500,6 +1500,141 @@ describe('Campaign routes', () => {
     expect(res.body.message).toBe('Forbidden');
   });
 
+  test('player controlling active participant can pass turn', async () => {
+    mockUser = { username: 'PlayerOne' };
+    const campaignDoc = {
+      campaignName: 'Test',
+      dm: 'DM',
+      players: ['PlayerOne'],
+      enemies: [],
+      combat: {
+        participants: [
+          { characterId: 'char-1', initiative: 15 },
+          { characterId: 'char-2', initiative: 12 },
+        ],
+        activeTurn: 0,
+      },
+    };
+
+    const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+    const campaignCollection = {
+      findOne: jest.fn().mockResolvedValue(campaignDoc),
+      updateOne,
+    };
+    const characterCollection = {
+      findOne: jest
+        .fn()
+        .mockResolvedValue({
+          campaign: 'Test',
+          characterId: 'char-1',
+          token: 'PlayerOne',
+        }),
+    };
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return campaignCollection;
+        }
+        if (name === 'Characters') {
+          return characterCollection;
+        }
+        return {};
+      },
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/combat')
+      .send({
+        participants: [
+          { characterId: 'char-1', initiative: 15 },
+          { characterId: 'char-2', initiative: 12 },
+        ],
+        activeTurn: 1,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      participants: [
+        { characterId: 'char-1', initiative: 15 },
+        { characterId: 'char-2', initiative: 12 },
+      ],
+      activeTurn: 1,
+    });
+    expect(updateOne).toHaveBeenCalledWith(
+      { campaignName: 'Test' },
+      {
+        $set: {
+          combat: {
+            participants: [
+              { characterId: 'char-1', initiative: 15 },
+              { characterId: 'char-2', initiative: 12 },
+            ],
+            activeTurn: 1,
+          },
+        },
+      }
+    );
+  });
+
+  test('player cannot skip ahead when passing turn', async () => {
+    mockUser = { username: 'PlayerOne' };
+    const campaignDoc = {
+      campaignName: 'Test',
+      dm: 'DM',
+      players: ['PlayerOne'],
+      enemies: [],
+      combat: {
+        participants: [
+          { characterId: 'char-1', initiative: 15 },
+          { characterId: 'char-2', initiative: 12 },
+        ],
+        activeTurn: 0,
+      },
+    };
+
+    const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+    const campaignCollection = {
+      findOne: jest.fn().mockResolvedValue(campaignDoc),
+      updateOne,
+    };
+    const characterCollection = {
+      findOne: jest
+        .fn()
+        .mockResolvedValue({
+          campaign: 'Test',
+          characterId: 'char-1',
+          token: 'PlayerOne',
+        }),
+    };
+
+    dbo.mockResolvedValue({
+      collection: (name) => {
+        if (name === 'Campaigns') {
+          return campaignCollection;
+        }
+        if (name === 'Characters') {
+          return characterCollection;
+        }
+        return {};
+      },
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/combat')
+      .send({
+        participants: [
+          { characterId: 'char-1', initiative: 15 },
+          { characterId: 'char-2', initiative: 12 },
+        ],
+        activeTurn: 0,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('Forbidden');
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+
   test('update combat validation failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1747,8 +1747,38 @@ module.exports = (router) => {
             return res.status(404).json({ message: 'Campaign not found' });
           }
 
-          if (!req.user || campaign.dm !== req.user.username) {
-            return res.status(403).json({ message: 'Forbidden' });
+          const normalizedCampaign = withDefaultCombat(campaign);
+          const isDm = req.user && campaign.dm === req.user.username;
+          const username =
+            typeof req.user?.username === 'string'
+              ? req.user.username.trim()
+              : null;
+          const normalizedPlayers = Array.isArray(campaign.players)
+            ? campaign.players
+                .map((player) => {
+                  if (typeof player === 'string') {
+                    const trimmed = player.trim();
+                    return trimmed || null;
+                  }
+
+                  if (
+                    player &&
+                    typeof player === 'object' &&
+                    typeof player.username === 'string'
+                  ) {
+                    const trimmed = player.username.trim();
+                    return trimmed || null;
+                  }
+
+                  return null;
+                })
+                .filter(Boolean)
+            : [];
+
+          if (!isDm) {
+            if (!username || !normalizedPlayers.includes(username)) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
           }
 
           const enemyLookup = createEnemyLookup(campaign.enemies);
@@ -1767,6 +1797,84 @@ module.exports = (router) => {
             req.body.activeTurn === null || req.body.activeTurn === undefined
               ? null
               : req.body.activeTurn;
+
+          if (!isDm) {
+            const currentParticipants = Array.isArray(
+              normalizedCampaign?.combat?.participants
+            )
+              ? normalizedCampaign.combat.participants
+              : [];
+
+            const currentTurnIndex = Number.isInteger(
+              normalizedCampaign?.combat?.activeTurn
+            )
+              ? normalizedCampaign.combat.activeTurn
+              : null;
+
+            const participantsMatch =
+              participants.length === currentParticipants.length &&
+              participants.every((participant, index) => {
+                const current = currentParticipants[index];
+                return (
+                  current &&
+                  current.characterId === participant.characterId &&
+                  current.initiative === participant.initiative
+                );
+              });
+
+            if (!participantsMatch) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+
+            if (
+              currentTurnIndex === null ||
+              currentTurnIndex < 0 ||
+              currentTurnIndex >= currentParticipants.length ||
+              currentParticipants.length === 0
+            ) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+
+            const activeParticipant = currentParticipants[currentTurnIndex];
+            if (!activeParticipant) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+
+            const characterFilters = [
+              { characterId: activeParticipant.characterId },
+            ];
+
+            if (ObjectId.isValid(activeParticipant.characterId)) {
+              characterFilters.push({ _id: new ObjectId(activeParticipant.characterId) });
+            }
+
+            const charactersCollection = db_connect.collection('Characters');
+            const activeCharacter = await charactersCollection.findOne({
+              campaign: campaign.campaignName,
+              $or: characterFilters,
+            });
+
+            const ownerCandidates = [
+              activeCharacter?.token,
+              activeCharacter?.player,
+              activeCharacter?.owner,
+              activeCharacter?.username,
+            ]
+              .filter((value) => typeof value === 'string')
+              .map((value) => value.trim())
+              .filter(Boolean);
+
+            if (!ownerCandidates.includes(username)) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+
+            const expectedNextTurn =
+              (currentTurnIndex + 1) % currentParticipants.length;
+
+            if (activeTurn !== expectedNextTurn) {
+              return res.status(403).json({ message: 'Forbidden' });
+            }
+          }
 
           if (
             activeTurn !== null &&


### PR DESCRIPTION
## Summary
- allow non-DM players who own the active combatant to advance the turn while preserving participant order
- guard player pass requests by verifying ownership and the requested next turn index
- add server campaign route tests covering successful and rejected player pass attempts

## Testing
- npm --prefix server test -- server/__tests__/campaigns.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fcd46fd140832eafe95cf5fc822373