### PR TITLE
Keep dice theme state in sync after attack rolls

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1514,6 +1514,7 @@ const manualCriticalRef = useRef(false);
     const { result, d20 } = await rollSkillWithDiceBox(bonus, {
       diceColor: diceFaceColor,
     });
+    diceBoxThemeRef.current = diceFaceColor;
     const weaponLabel = getWeaponDisplayName(slot, weapon);
     const segments = [`${d20} (d20)`];
     if (bonus) {
@@ -1553,6 +1554,7 @@ const manualCriticalRef = useRef(false);
       const { result, d20 } = await rollSkillWithDiceBox(total, {
         diceColor: diceFaceColor,
       });
+      diceBoxThemeRef.current = diceFaceColor;
       const segments = [`${d20} (d20)`];
       segments.push(`${formatModifier(abilityBonus)} ${spellAbilityLabel}`);
       segments.push(


### PR DESCRIPTION
## Summary
- update attack roll handlers to record the dice theme currently applied
- ensure subsequent damage rolls detect theme changes and reapply the appropriate effect color

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcd6d88b6c832e8699f9c15e347910