### PR TITLE
Improve player figurine token selection scope

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -492,7 +492,98 @@ const TokenPickerModal = ({
     return baseFilters;
   }, [baseFilters, filterScopeSet]);
 
-  const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
+  const playerScopedFilters = useMemo(() => {
+    if (isDm) {
+      return [];
+    }
+
+    if (!(filterScopeSet instanceof Set) || filterScopeSet.size === 0) {
+      return [];
+    }
+
+    return availableFilters.filter((filter) => filterMatchesScope(filter, filterScopeSet));
+  }, [availableFilters, filterScopeSet, isDm]);
+
+  const combinedPlayerFilter = useMemo(() => {
+    if (!Array.isArray(playerScopedFilters) || playerScopedFilters.length <= 1) {
+      return null;
+    }
+
+    const folderSet = new Set();
+    const aliasSet = new Set([
+      'scope:auto',
+      'scope:recommended',
+      'recommended',
+      'recommended tokens',
+      'recommendedtokens',
+    ]);
+
+    playerScopedFilters.forEach((filter) => {
+      if (!filter || typeof filter !== 'object') {
+        return;
+      }
+
+      if (Array.isArray(filter.folders)) {
+        filter.folders.forEach((folder) => {
+          if (typeof folder !== 'string') {
+            return;
+          }
+          const trimmed = folder.trim();
+          if (!trimmed) {
+            return;
+          }
+          folderSet.add(trimmed);
+          aliasSet.add(trimmed);
+          aliasSet.add(trimmed.toLowerCase());
+        });
+      }
+
+      if (Array.isArray(filter.aliases)) {
+        filter.aliases.forEach((alias) => {
+          if (typeof alias === 'string' && alias.trim() !== '') {
+            aliasSet.add(alias.trim());
+            aliasSet.add(alias.trim().toLowerCase());
+          }
+        });
+      }
+
+      if (typeof filter.label === 'string' && filter.label.trim() !== '') {
+        const normalizedLabel = filter.label.replace(/\u00A0/g, ' ').trim();
+        if (normalizedLabel) {
+          aliasSet.add(normalizedLabel);
+          aliasSet.add(normalizedLabel.toLowerCase());
+        }
+      }
+    });
+
+    const combinedFolders = Array.from(folderSet);
+    if (combinedFolders.length === 0) {
+      return null;
+    }
+
+    combinedFolders.sort((a, b) => a.localeCompare(b));
+
+    return {
+      key: 'scope:recommended',
+      label: 'Recommended Tokens',
+      folders: combinedFolders,
+      aliases: Array.from(aliasSet).filter(Boolean),
+      depth: 0,
+    };
+  }, [playerScopedFilters]);
+
+  const effectiveFilters = useMemo(() => {
+    if (combinedPlayerFilter) {
+      const existing = availableFilters.filter(
+        (filter) => filter && filter.key !== combinedPlayerFilter.key
+      );
+      return [combinedPlayerFilter, ...existing];
+    }
+
+    return availableFilters;
+  }, [availableFilters, combinedPlayerFilter]);
+
+  const filterLookup = useMemo(() => buildFilterMap(effectiveFilters), [effectiveFilters]);
 
   const [selectedFilterKey, setSelectedFilterKey] = useState(null);
 
@@ -510,11 +601,13 @@ const TokenPickerModal = ({
 
     let nextKey = null;
 
-    if (defaultFilter) {
+    if (combinedPlayerFilter && filterLookup.has(combinedPlayerFilter.key)) {
+      nextKey = combinedPlayerFilter.key;
+    } else if (defaultFilter) {
       if (filterLookup.has(defaultFilter)) {
         nextKey = defaultFilter;
       } else {
-        const aliasMatch = availableFilters.find(
+        const aliasMatch = effectiveFilters.find(
           (filter) =>
             filter &&
             typeof filter === 'object' &&
@@ -536,7 +629,13 @@ const TokenPickerModal = ({
     if (nextKey !== selectedFilterKey) {
       setSelectedFilterKey(nextKey);
     }
-  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey]);
+  }, [
+    filterLookup,
+    effectiveFilters,
+    defaultFilter,
+    selectedFilterKey,
+    combinedPlayerFilter,
+  ]);
 
   const [assets, setAssets] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -995,7 +1094,7 @@ const TokenPickerModal = ({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {availableFilters.length > 0 ? (
+        {effectiveFilters.length > 0 ? (
           <Form.Group className="mb-3" controlId="tokenPickerFilter">
             <Form.Label>Token Library</Form.Label>
             <Form.Select
@@ -1009,7 +1108,7 @@ const TokenPickerModal = ({
                   Loading token folders…
                 </option>
               ) : null}
-              {availableFilters.map((filter) => (
+              {effectiveFilters.map((filter) => (
                 <option key={filter.key} value={filter.key}>
                   {filter.label}
                 </option>

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -371,8 +371,16 @@ describe('TokenPickerModal', () => {
 
     await waitFor(() => {
       expect(manifestCalls.length).toBeGreaterThan(0);
-      expect(manifestCalls[0]).toBe(
-        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn%2FFighter'
+      expect(manifestCalls[0].startsWith('/campaigns/Camp1/token-manifest')).toBe(true);
+      const firstUrl = new URL(`http://example.com${manifestCalls[0]}`);
+      const folderParam = firstUrl.searchParams.get('folders');
+      expect(folderParam).toBeTruthy();
+      const folderList = folderParam.split(',').map((entry) => entry.trim());
+      expect(new Set(folderList)).toEqual(
+        new Set([
+          'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+          'Tokens/Adventurers/Dragonborn/Fighter',
+        ])
       );
     });
 
@@ -382,11 +390,12 @@ describe('TokenPickerModal', () => {
 
     const select = await screen.findByLabelText(/Token Library/i);
     const options = within(select).getAllByRole('option');
-    expect(options).toHaveLength(2);
-    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn/Fighter');
-    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
+    expect(options).toHaveLength(3);
+    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Recommended Tokens');
+    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn/Fighter');
+    expect(options[2].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
 
-    await user.selectOptions(select, options[1]);
+    await user.selectOptions(select, options[2]);
 
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];
@@ -559,6 +568,7 @@ describe('TokenPickerModal', () => {
       const normalizedOptions = options.map((option) => option.textContent.replace(/\u00A0/g, ''));
 
       expect(normalizedOptions).toEqual([
+        'Recommended Tokens',
         'Dwarves/Druid',
         'Core_Class_Tokens/Mediumfolk/Druid',
       ]);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -3568,6 +3568,35 @@ export default function ZombiesCharacterSheet() {
 
   const characterFigurine = useMemo(() => resolveFigurineImageData(form), [form]);
 
+  const resolveTokenSizeFolder = useCallback(() => {
+    const rawSize = (() => {
+      if (typeof form?.temporarySize === 'string' && form.temporarySize.trim() !== '') {
+        return form.temporarySize.trim();
+      }
+
+      if (typeof form?.size === 'string' && form.size.trim() !== '') {
+        return form.size.trim();
+      }
+
+      return '';
+    })()
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+
+    if (!rawSize) {
+      return 'Mediumfolk';
+    }
+
+    switch (rawSize) {
+      case 'tiny':
+      case 'small':
+      case 'little':
+        return 'Smallfolk';
+      default:
+        return 'Mediumfolk';
+    }
+  }, [form?.size, form?.temporarySize]);
+
   const tokenPickerFilterScope = useMemo(() => {
     const scopeSet = new Set();
 
@@ -3612,6 +3641,12 @@ export default function ZombiesCharacterSheet() {
       buildRaceTokenScopeData(form?.race?.name);
 
     const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
+    const sizeFolder = resolveTokenSizeFolder();
+    const sizePrefixes = [
+      `Core_Class_Tokens/${sizeFolder}`,
+      `Adventurers/Core_Class_Tokens/${sizeFolder}`,
+      `Tokens/Adventurers/Core_Class_Tokens/${sizeFolder}`,
+    ];
     const seenClasses = new Set();
     occupations.forEach((occupation) => {
       if (!occupation || typeof occupation !== 'object') {
@@ -3636,6 +3671,8 @@ export default function ZombiesCharacterSheet() {
         'Tokens/Adventurers/Core_Class_Tokens',
       ]);
 
+      addScopeVariants(rawClassName, sizePrefixes);
+
       if (racePrefixList.length > 0) {
         addScopeVariants(rawClassName, racePrefixList);
       }
@@ -3652,7 +3689,7 @@ export default function ZombiesCharacterSheet() {
     }
 
     return Array.from(scopeSet);
-  }, [form?.occupation, form?.race?.name]);
+  }, [form?.occupation, form?.race?.name, resolveTokenSizeFolder]);
 
   const updateLocalDiceColor = useCallback(
     (incomingCharacterId, nextColor, nextTheme = null) => {


### PR DESCRIPTION
## Summary
- derive size-aware scope hints so player figurine searches include Core_Class_Tokens size folders
- expose a combined "Recommended Tokens" option that loads all scoped player folders at once
- update token picker tests to cover the new combined behaviour

## Testing
- npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68fcd9a4f958832e975d83fe1c3a33f6