### PR TITLE
Expand race token scope to class folders

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -61,6 +61,7 @@ import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
 import buildRaceTokenScopeData from '../utils/raceTokenFilters';
+import { buildTokenPickerScope } from '../utils/tokenPickerScope';
 
 const HEADER_PADDING = 16;
 const MIN_DOCKED_MODAL_WIDTH = 320;
@@ -3598,104 +3599,13 @@ export default function ZombiesCharacterSheet() {
   }, [form?.size, form?.temporarySize]);
 
   const tokenPickerFilterScope = useMemo(() => {
-    const scopeSet = new Set();
-
-    const addScopeVariants = (rawValue, prefixes = [], options = {}) => {
-      if (typeof rawValue !== 'string') {
-        return;
-      }
-
-      const normalizedValue = rawValue.replace(/\s+/g, ' ').trim();
-      if (!normalizedValue) {
-        return;
-      }
-
-      const lowerValue = normalizedValue.toLowerCase();
-      const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
-
-      const normalizedPrefixes = Array.isArray(prefixes)
-        ? prefixes.map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
-        : [];
-
-      const includeStandalone =
-        options.includeStandalone ?? normalizedPrefixes.filter(Boolean).length === 0;
-
-      if (includeStandalone) {
-        [normalizedValue, lowerValue, compactValue]
-          .filter(Boolean)
-          .forEach((entry) => scopeSet.add(entry));
-      }
-
-      normalizedPrefixes
-        .filter(Boolean)
-        .forEach((prefix) => {
-          scopeSet.add(`${prefix}/${normalizedValue}`);
-          scopeSet.add(`${prefix}/${lowerValue}`);
-          if (compactValue) {
-            scopeSet.add(`${prefix}/${compactValue}`);
-          }
-        });
-    };
-
-    const { nameVariants: raceNameVariants, prefixes: racePrefixList } =
-      buildRaceTokenScopeData(form?.race?.name);
-
-    const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
     const sizeFolder = resolveTokenSizeFolder();
-    const sizePrefixes = [
-      `Core_Class_Tokens/${sizeFolder}`,
-      `Adventurers/Core_Class_Tokens/${sizeFolder}`,
-      `Tokens/Adventurers/Core_Class_Tokens/${sizeFolder}`,
-    ];
-    const seenClasses = new Set();
-    occupations.forEach((occupation) => {
-      if (!occupation || typeof occupation !== 'object') {
-        return;
-      }
-
-      const rawClassName =
-        typeof occupation.Occupation === 'string' ? occupation.Occupation.replace(/\s+/g, ' ').trim() : '';
-      if (!rawClassName) {
-        return;
-      }
-
-      const classKey = rawClassName.toLowerCase();
-      if (seenClasses.has(classKey)) {
-        return;
-      }
-      seenClasses.add(classKey);
-
-      addScopeVariants(rawClassName, [
-        'Core_Class_Tokens',
-        'Adventurers/Core_Class_Tokens',
-        'Tokens/Adventurers/Core_Class_Tokens',
-      ]);
-
-      addScopeVariants(rawClassName, sizePrefixes);
-
-      if (racePrefixList.length > 0) {
-        addScopeVariants(rawClassName, racePrefixList);
-      }
+    return buildTokenPickerScope({
+      raceName: form?.race?.name,
+      occupations: form?.occupation,
+      sizeFolder,
+      buildRaceScopeData: buildRaceTokenScopeData,
     });
-
-    raceNameVariants.forEach((variant) => {
-      addScopeVariants(variant, [
-        'Adventurers',
-        'Tokens/Adventurers',
-      ]);
-    });
-
-    if (scopeSet.size === 0 && raceNameVariants.length > 0) {
-      const fallbackRace = raceNameVariants.find((variant) => typeof variant === 'string' && variant.trim() !== '');
-      if (fallbackRace) {
-        addScopeVariants(fallbackRace, [
-          'Adventurers',
-          'Tokens/Adventurers',
-        ]);
-      }
-    }
-
-    return Array.from(scopeSet);
   }, [form?.occupation, form?.race?.name, resolveTokenSizeFolder]);
 
   const updateLocalDiceColor = useCallback(

--- a/client/src/components/Zombies/utils/tokenPickerScope.js
+++ b/client/src/components/Zombies/utils/tokenPickerScope.js
@@ -1,0 +1,155 @@
+import buildRaceTokenScopeData from './raceTokenFilters';
+
+const addScopeVariantsToSet = (scopeSet, rawValue, prefixes = [], options = {}) => {
+  if (!scopeSet || typeof scopeSet.add !== 'function') {
+    return;
+  }
+
+  if (typeof rawValue !== 'string') {
+    return;
+  }
+
+  const normalizedValue = rawValue.replace(/\s+/g, ' ').trim();
+  if (!normalizedValue) {
+    return;
+  }
+
+  const lowerValue = normalizedValue.toLowerCase();
+  const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
+
+  const normalizedPrefixes = Array.isArray(prefixes)
+    ? prefixes.map((prefix) =>
+        typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''
+      )
+    : [];
+
+  const includeStandalone =
+    options.includeStandalone ?? normalizedPrefixes.filter(Boolean).length === 0;
+
+  if (includeStandalone) {
+    [normalizedValue, lowerValue, compactValue]
+      .filter(Boolean)
+      .forEach((entry) => scopeSet.add(entry));
+  }
+
+  normalizedPrefixes
+    .filter(Boolean)
+    .forEach((prefix) => {
+      scopeSet.add(`${prefix}/${normalizedValue}`);
+      scopeSet.add(`${prefix}/${lowerValue}`);
+      if (compactValue) {
+        scopeSet.add(`${prefix}/${compactValue}`);
+      }
+    });
+};
+
+export const buildTokenPickerScope = ({
+  raceName,
+  occupations,
+  sizeFolder,
+  buildRaceScopeData = buildRaceTokenScopeData,
+} = {}) => {
+  const scopeSet = new Set();
+
+  const raceScopeResult =
+    typeof buildRaceScopeData === 'function'
+      ? buildRaceScopeData(raceName)
+      : buildRaceTokenScopeData(raceName);
+  const raceNameVariants = Array.isArray(raceScopeResult?.nameVariants)
+    ? raceScopeResult.nameVariants
+    : [];
+  const racePrefixList = Array.isArray(raceScopeResult?.prefixes)
+    ? raceScopeResult.prefixes
+    : [];
+
+  const normalizedSizeFolder =
+    typeof sizeFolder === 'string' && sizeFolder.trim() !== ''
+      ? sizeFolder.trim()
+      : 'Mediumfolk';
+
+  const sizePrefixes = [
+    `Core_Class_Tokens/${normalizedSizeFolder}`,
+    `Adventurers/Core_Class_Tokens/${normalizedSizeFolder}`,
+    `Tokens/Adventurers/Core_Class_Tokens/${normalizedSizeFolder}`,
+  ];
+
+  const seenClasses = new Set();
+  let hasRaceSpecificClassScope = false;
+
+  (Array.isArray(occupations) ? occupations : []).forEach((occupation) => {
+    if (!occupation || typeof occupation !== 'object') {
+      return;
+    }
+
+    const rawClassName =
+      typeof occupation.Occupation === 'string'
+        ? occupation.Occupation.replace(/\s+/g, ' ').trim()
+        : '';
+    if (!rawClassName) {
+      return;
+    }
+
+    const classKey = rawClassName.toLowerCase();
+    if (seenClasses.has(classKey)) {
+      return;
+    }
+    seenClasses.add(classKey);
+
+    addScopeVariantsToSet(scopeSet, rawClassName, [
+      'Core_Class_Tokens',
+      'Adventurers/Core_Class_Tokens',
+      'Tokens/Adventurers/Core_Class_Tokens',
+    ]);
+
+    addScopeVariantsToSet(scopeSet, rawClassName, sizePrefixes);
+
+    if (Array.isArray(racePrefixList) && racePrefixList.length > 0) {
+      addScopeVariantsToSet(scopeSet, rawClassName, racePrefixList);
+
+      const raceClassPrefixes = racePrefixList.map((prefix) =>
+        typeof prefix === 'string' && prefix.trim() !== ''
+          ? `${prefix.trim()}/Core_Class_Tokens`
+          : ''
+      );
+      addScopeVariantsToSet(scopeSet, rawClassName, raceClassPrefixes, {
+        includeStandalone: false,
+      });
+
+      const raceSizePrefixes = raceClassPrefixes.map((prefix) =>
+        typeof prefix === 'string' && prefix.trim() !== ''
+          ? `${prefix.trim()}/${normalizedSizeFolder}`
+          : ''
+      );
+      addScopeVariantsToSet(scopeSet, rawClassName, raceSizePrefixes, {
+        includeStandalone: false,
+      });
+
+      hasRaceSpecificClassScope = true;
+    }
+  });
+
+  if (!hasRaceSpecificClassScope) {
+    raceNameVariants.forEach((variant) => {
+      addScopeVariantsToSet(scopeSet, variant, [
+        'Adventurers',
+        'Tokens/Adventurers',
+      ]);
+    });
+  }
+
+  if (scopeSet.size === 0 && raceNameVariants.length > 0) {
+    const fallbackRace = raceNameVariants.find(
+      (variant) => typeof variant === 'string' && variant.trim() !== ''
+    );
+    if (fallbackRace) {
+      addScopeVariantsToSet(scopeSet, fallbackRace, [
+        'Adventurers',
+        'Tokens/Adventurers',
+      ]);
+    }
+  }
+
+  return Array.from(scopeSet);
+};
+
+export default buildTokenPickerScope;

--- a/client/src/components/Zombies/utils/tokenPickerScope.test.js
+++ b/client/src/components/Zombies/utils/tokenPickerScope.test.js
@@ -1,0 +1,49 @@
+import { buildTokenPickerScope } from './tokenPickerScope';
+
+describe('buildTokenPickerScope', () => {
+  it('includes race-specific class folders without including the base race folder', () => {
+    const scope = buildTokenPickerScope({
+      raceName: 'Dragonborn',
+      occupations: [{ Occupation: 'Fighter' }],
+      sizeFolder: 'Mediumfolk',
+    });
+
+    expect(scope).toEqual(expect.arrayContaining([
+      'Core_Class_Tokens/Fighter',
+      'Adventurers/Core_Class_Tokens/Fighter',
+      'Tokens/Adventurers/Core_Class_Tokens/Fighter',
+      'Core_Class_Tokens/Mediumfolk/Fighter',
+      'Adventurers/Core_Class_Tokens/Mediumfolk/Fighter',
+      'Tokens/Adventurers/Core_Class_Tokens/Mediumfolk/Fighter',
+      'Dragonborn/Fighter',
+      'Dragonborn/fighter',
+      'Tokens/Adventurers/Dragonborn/Fighter',
+      'Dragonborn/Core_Class_Tokens/Fighter',
+      'Adventurers/Dragonborn/Core_Class_Tokens/Fighter',
+      'Tokens/Adventurers/Dragonborn/Core_Class_Tokens/Fighter',
+      'Dragonborn/Core_Class_Tokens/Mediumfolk/Fighter',
+      'Adventurers/Dragonborn/Core_Class_Tokens/Mediumfolk/Fighter',
+      'Tokens/Adventurers/Dragonborn/Core_Class_Tokens/Mediumfolk/Fighter',
+    ]));
+
+    expect(scope).not.toContain('Dragonborn');
+    expect(scope).not.toContain('dragonborn');
+    expect(scope).not.toContain('Tokens/Adventurers/Dragonborn');
+  });
+
+  it('falls back to race folders when no occupations are provided', () => {
+    const scope = buildTokenPickerScope({
+      raceName: 'Dragonborn',
+      occupations: [],
+      sizeFolder: 'Mediumfolk',
+    });
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Adventurers/Dragonborn',
+        'Adventurers/dragonborn',
+        'Tokens/Adventurers/Dragonborn',
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extend the race-specific token scope to include Core_Class_Tokens paths for each occupation
- cover the new folder combinations in token picker scope tests to prevent regressions

## Testing
- CI=true npm test -- tokenPickerScope.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fce243e518832e98e8157ce20740cc