### PR TITLE
Fix token picker fallback manifest loading

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -455,6 +455,7 @@ const TokenPickerModal = ({
   const [playerFolderOptions, setPlayerFolderOptions] = useState(() =>
     cloneFilters(DEFAULT_PLAYER_FILTERS)
   );
+  const [playerFoldersLoaded, setPlayerFoldersLoaded] = useState(false);
   const [fetchingFolders, setFetchingFolders] = useState(false);
 
   const baseFilters = useMemo(() => {
@@ -678,8 +679,19 @@ const TokenPickerModal = ({
       return false;
     }
 
-    return filterMatchesScope(activeFilter, filterScopeSet);
-  }, [activeFilter, filterScopeSet]);
+    const matches = filterMatchesScope(activeFilter, filterScopeSet);
+
+    if (
+      !matches &&
+      !isDm &&
+      playerFoldersLoaded &&
+      (!Array.isArray(playerScopedFilters) || playerScopedFilters.length === 0)
+    ) {
+      return true;
+    }
+
+    return matches;
+  }, [activeFilter, filterScopeSet, isDm, playerFoldersLoaded, playerScopedFilters]);
 
   const manifestFilterKey = useMemo(() => {
     if (!activeFilter) {
@@ -797,6 +809,7 @@ const TokenPickerModal = ({
         setDmFolderOptions(null);
       } else {
         setPlayerFolderOptions(cloneFilters(DEFAULT_PLAYER_FILTERS));
+        setPlayerFoldersLoaded(false);
       }
       return;
     }
@@ -895,6 +908,7 @@ const TokenPickerModal = ({
 
     if (!campaignId) {
       setPlayerFolderOptions(fallbackFilters);
+      setPlayerFoldersLoaded(true);
       return;
     }
 
@@ -902,6 +916,7 @@ const TokenPickerModal = ({
 
     const fetchFolders = async () => {
       setFetchingFolders(true);
+      setPlayerFoldersLoaded(false);
       try {
         const encodedCampaignId = encodeURIComponent(campaignId);
         const response = await apiFetch(`/campaigns/${encodedCampaignId}/token-folders`);
@@ -916,10 +931,12 @@ const TokenPickerModal = ({
         }
 
         setPlayerFolderOptions(buildPlayerFolderFilters(data, fallbackFilters));
+        setPlayerFoldersLoaded(true);
       } catch (err) {
         console.error(err);
         if (!isCancelled) {
           setPlayerFolderOptions(fallbackFilters);
+          setPlayerFoldersLoaded(true);
         }
       } finally {
         if (!isCancelled) {
@@ -929,6 +946,7 @@ const TokenPickerModal = ({
     };
 
     setPlayerFolderOptions(fallbackFilters);
+    setPlayerFoldersLoaded(false);
     fetchFolders();
 
     return () => {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -577,6 +577,76 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('falls back to default folders when scoped recommendations are unavailable', async () => {
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+      ],
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={[
+          'Tokens/Adventurers/Core_Class_Tokens/Mediumfolk/Fighter',
+          'Adventurers/Core_Class_Tokens/Mediumfolk/Fighter',
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
+    });
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+    });
+
+    expect(manifestCalls[manifestCalls.length - 1]).toBe(
+      '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers'
+    );
+  });
+
   test('player library dropdown stays disabled until folders finish loading', async () => {
     const folderTree = {
       rootFolder: 'Tokens',


### PR DESCRIPTION
## Summary
- ensure the token picker only defers manifest requests when scoped folders exist
- add tracking for player token folder loading so players still see tokens when no scoped folders are available
- cover the fallback behaviour with a dedicated unit test

## Testing
- `npm test -- TokenPickerModal`


------
https://chatgpt.com/codex/tasks/task_e_68fcecda8af0832e9e7f92b9871ed050