### PR TITLE
Align player figurine picker with enemy token logic

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -485,12 +485,49 @@ const TokenPickerModal = ({
     }
 
     const scoped = baseFilters.filter((filter) => filterMatchesScope(filter, filterScopeSet));
-    if (scoped.length > 0) {
+    if (scoped.length === 0) {
+      return baseFilters;
+    }
+
+    if (isDm) {
       return scoped;
     }
 
-    return baseFilters;
-  }, [baseFilters, filterScopeSet]);
+    const combinedFolderSet = new Set();
+    const combinedAliasSet = new Set();
+
+    scoped.forEach((filter) => {
+      if (Array.isArray(filter.folders)) {
+        filter.folders
+          .map((folder) => (typeof folder === 'string' ? folder.trim() : ''))
+          .filter(Boolean)
+          .forEach((folder) => combinedFolderSet.add(folder));
+      }
+
+      if (Array.isArray(filter.aliases)) {
+        filter.aliases
+          .map((alias) => (typeof alias === 'string' ? alias.trim() : ''))
+          .filter(Boolean)
+          .forEach((alias) => combinedAliasSet.add(alias));
+      }
+    });
+
+    const combinedFolders = Array.from(combinedFolderSet);
+    if (combinedFolders.length === 0) {
+      return scoped;
+    }
+
+    return [
+      {
+        key: '__player_scoped__',
+        label: 'Recommended Tokens',
+        folders: combinedFolders,
+        aliases: Array.from(combinedAliasSet),
+        depth: 0,
+        isCombined: true,
+      },
+    ];
+  }, [baseFilters, filterScopeSet, isDm]);
 
   const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
 
@@ -995,7 +1032,7 @@ const TokenPickerModal = ({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {availableFilters.length > 0 ? (
+        {isDm || availableFilters.length > 1 || fetchingFolders ? (
           <Form.Group className="mb-3" controlId="tokenPickerFilter">
             <Form.Label>Token Library</Form.Label>
             <Form.Select

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -117,14 +117,18 @@ describe('TokenPickerModal', () => {
     });
 
     const select = await screen.findByLabelText(/Token Library/i);
-    const options = within(select).getAllByRole('option');
+    let options;
 
-    expect(options).toHaveLength(4);
-    expect(options[0]).toHaveTextContent('All Tokens');
-    expect(options[1]).toHaveTextContent('Adventurers');
-    expect(options[2]).toHaveTextContent('DM');
-    expect(options[3].textContent.startsWith('\u00A0\u00A0')).toBe(true);
-    expect(options[3]).toHaveTextContent('DM/Dragons');
+    await waitFor(() => {
+      options = within(select).getAllByRole('option');
+
+      expect(options).toHaveLength(4);
+      expect(options[0]).toHaveTextContent('All Tokens');
+      expect(options[1]).toHaveTextContent('Adventurers');
+      expect(options[2]).toHaveTextContent('DM');
+      expect(options[3].textContent.startsWith('\u00A0\u00A0')).toBe(true);
+      expect(options[3]).toHaveTextContent('DM/Dragons');
+    });
 
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];
@@ -372,7 +376,7 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       expect(manifestCalls.length).toBeGreaterThan(0);
       expect(manifestCalls[0]).toBe(
-        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn%2FFighter'
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDragonborn%2FFighter%2CTokens%2FAdventurers%2FCore_Class_Tokens%2FFighter'
       );
     });
 
@@ -380,20 +384,7 @@ describe('TokenPickerModal', () => {
       manifestCalls.includes('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers')
     ).toBe(false);
 
-    const select = await screen.findByLabelText(/Token Library/i);
-    const options = within(select).getAllByRole('option');
-    expect(options).toHaveLength(2);
-    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn/Fighter');
-    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
-
-    await user.selectOptions(select, options[1]);
-
-    await waitFor(() => {
-      const lastCall = manifestCalls[manifestCalls.length - 1];
-      expect(lastCall).toBe(
-        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FCore_Class_Tokens%2FFighter'
-      );
-    });
+    expect(screen.queryByLabelText(/Token Library/i)).not.toBeInTheDocument();
   });
 
   test('player token picker limits folders to scoped race and class combinations', async () => {
@@ -521,12 +512,15 @@ describe('TokenPickerModal', () => {
       totalCount: 0,
     };
 
+    const manifestCalls = [];
+
     apiFetch.mockImplementation((url) => {
       if (url === '/campaigns/Camp1/token-folders') {
         return Promise.resolve({ ok: true, json: async () => folderTree });
       }
 
       if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
         return Promise.resolve({ ok: true, json: async () => manifestPayload });
       }
 
@@ -552,16 +546,14 @@ describe('TokenPickerModal', () => {
       />
     );
 
-    const select = await screen.findByLabelText(/Token Library/i);
+    await waitFor(() => {
+      expect(manifestCalls).toContain(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FDwarves%2FDruid%2CTokens%2FAdventurers%2FCore_Class_Tokens%2FMediumfolk%2FDruid'
+      );
+    });
 
     await waitFor(() => {
-      const options = within(select).getAllByRole('option');
-      const normalizedOptions = options.map((option) => option.textContent.replace(/\u00A0/g, ''));
-
-      expect(normalizedOptions).toEqual([
-        'Dwarves/Druid',
-        'Core_Class_Tokens/Mediumfolk/Druid',
-      ]);
+      expect(screen.queryByLabelText(/Token Library/i)).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -3611,6 +3611,24 @@ export default function ZombiesCharacterSheet() {
     const { nameVariants: raceNameVariants, prefixes: racePrefixList } =
       buildRaceTokenScopeData(form?.race?.name);
 
+    const sizeCandidates = [form?.temporarySize, form?.size, form?.height];
+    const resolvedSize = sizeCandidates
+      .map((value) => (typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''))
+      .find((value) => value);
+
+    const normalizedSize = resolvedSize ? resolvedSize.toLowerCase() : '';
+    const coreClassSizeFolder = (() => {
+      if (!normalizedSize) {
+        return null;
+      }
+
+      if (normalizedSize.includes('small') || normalizedSize.includes('tiny')) {
+        return 'Smallfolk';
+      }
+
+      return 'Mediumfolk';
+    })();
+
     const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
     const seenClasses = new Set();
     occupations.forEach((occupation) => {
@@ -3630,11 +3648,23 @@ export default function ZombiesCharacterSheet() {
       }
       seenClasses.add(classKey);
 
-      addScopeVariants(rawClassName, [
-        'Core_Class_Tokens',
-        'Adventurers/Core_Class_Tokens',
-        'Tokens/Adventurers/Core_Class_Tokens',
-      ]);
+      const coreClassPrefixes = (() => {
+        if (coreClassSizeFolder) {
+          return [
+            `Core_Class_Tokens/${coreClassSizeFolder}`,
+            `Adventurers/Core_Class_Tokens/${coreClassSizeFolder}`,
+            `Tokens/Adventurers/Core_Class_Tokens/${coreClassSizeFolder}`,
+          ];
+        }
+
+        return [
+          'Core_Class_Tokens',
+          'Adventurers/Core_Class_Tokens',
+          'Tokens/Adventurers/Core_Class_Tokens',
+        ];
+      })();
+
+      addScopeVariants(rawClassName, coreClassPrefixes);
 
       if (racePrefixList.length > 0) {
         addScopeVariants(rawClassName, racePrefixList);
@@ -3652,7 +3682,7 @@ export default function ZombiesCharacterSheet() {
     }
 
     return Array.from(scopeSet);
-  }, [form?.occupation, form?.race?.name]);
+  }, [form?.occupation, form?.race?.name, form?.temporarySize, form?.size, form?.height]);
 
   const updateLocalDiceColor = useCallback(
     (incomingCharacterId, nextColor, nextTheme = null) => {


### PR DESCRIPTION
## Summary
- scope player figurine tokens to the character's race, classes, and size-specific core class folders
- merge scoped player folders into a single recommended library so the picker loads all options at once
- update token picker tests to cover the combined folder requests and dropdown visibility

## Testing
- npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68fcf15d8d14832ebfd3edf05001445c