### PR TITLE
Fix player figurine scope extraction for race and class data

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -60,7 +60,7 @@ import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
-import buildRaceTokenScopeData from '../utils/raceTokenFilters';
+import buildPlayerTokenFolderScope from '../utils/playerTokenFilters';
 
 const HEADER_PADDING = 16;
 const MIN_DOCKED_MODAL_WIDTH = 320;
@@ -3569,90 +3569,13 @@ export default function ZombiesCharacterSheet() {
   const characterFigurine = useMemo(() => resolveFigurineImageData(form), [form]);
 
   const tokenPickerFilterScope = useMemo(() => {
-    const scopeSet = new Set();
+    const raceValue =
+      form?.race !== undefined && form?.race !== null && form?.race !== ''
+        ? form.race
+        : form?.raceName ?? form?.Race ?? null;
 
-    const addScopeVariants = (rawValue, prefixes = [], options = {}) => {
-      if (typeof rawValue !== 'string') {
-        return;
-      }
-
-      const normalizedValue = rawValue.replace(/\s+/g, ' ').trim();
-      if (!normalizedValue) {
-        return;
-      }
-
-      const lowerValue = normalizedValue.toLowerCase();
-      const compactValue = lowerValue.replace(/[^a-z0-9]/g, '');
-
-      const normalizedPrefixes = Array.isArray(prefixes)
-        ? prefixes.map((prefix) => (typeof prefix === 'string' ? prefix.replace(/\s+/g, ' ').trim() : ''))
-        : [];
-
-      const includeStandalone =
-        options.includeStandalone ?? normalizedPrefixes.filter(Boolean).length === 0;
-
-      if (includeStandalone) {
-        [normalizedValue, lowerValue, compactValue]
-          .filter(Boolean)
-          .forEach((entry) => scopeSet.add(entry));
-      }
-
-      normalizedPrefixes
-        .filter(Boolean)
-        .forEach((prefix) => {
-          scopeSet.add(`${prefix}/${normalizedValue}`);
-          scopeSet.add(`${prefix}/${lowerValue}`);
-          if (compactValue) {
-            scopeSet.add(`${prefix}/${compactValue}`);
-          }
-        });
-    };
-
-    const { nameVariants: raceNameVariants, prefixes: racePrefixList } =
-      buildRaceTokenScopeData(form?.race?.name);
-
-    const occupations = Array.isArray(form?.occupation) ? form.occupation : [];
-    const seenClasses = new Set();
-    occupations.forEach((occupation) => {
-      if (!occupation || typeof occupation !== 'object') {
-        return;
-      }
-
-      const rawClassName =
-        typeof occupation.Occupation === 'string' ? occupation.Occupation.replace(/\s+/g, ' ').trim() : '';
-      if (!rawClassName) {
-        return;
-      }
-
-      const classKey = rawClassName.toLowerCase();
-      if (seenClasses.has(classKey)) {
-        return;
-      }
-      seenClasses.add(classKey);
-
-      addScopeVariants(rawClassName, [
-        'Core_Class_Tokens',
-        'Adventurers/Core_Class_Tokens',
-        'Tokens/Adventurers/Core_Class_Tokens',
-      ]);
-
-      if (racePrefixList.length > 0) {
-        addScopeVariants(rawClassName, racePrefixList);
-      }
-    });
-
-    if (scopeSet.size === 0 && raceNameVariants.length > 0) {
-      const fallbackRace = raceNameVariants.find((variant) => typeof variant === 'string' && variant.trim() !== '');
-      if (fallbackRace) {
-        addScopeVariants(fallbackRace, [
-          'Adventurers',
-          'Tokens/Adventurers',
-        ]);
-      }
-    }
-
-    return Array.from(scopeSet);
-  }, [form?.occupation, form?.race?.name]);
+    return buildPlayerTokenFolderScope(raceValue, form?.occupation);
+  }, [form?.occupation, form?.race, form?.raceName, form?.Race, form?.race?.name]);
 
   const updateLocalDiceColor = useCallback(
     (incomingCharacterId, nextColor, nextTheme = null) => {

--- a/client/src/components/Zombies/utils/playerTokenFilters.js
+++ b/client/src/components/Zombies/utils/playerTokenFilters.js
@@ -1,0 +1,232 @@
+import { buildRaceTokenNameVariants } from './raceTokenFilters';
+
+const RACE_NAME_KEYS = ['name', 'Name', 'race', 'Race', 'raceName', 'RaceName', 'race_name'];
+const OCCUPATION_NAME_KEYS = [
+  'Occupation',
+  'Name',
+  'occupation',
+  'name',
+  'Class',
+  'class',
+];
+
+const extractRaceName = (input) => {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return '';
+  }
+
+  for (const key of RACE_NAME_KEYS) {
+    const value = input[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+
+  return '';
+};
+
+const capitalizeTokenWord = (word) => {
+  if (typeof word !== 'string' || word.length === 0) {
+    return '';
+  }
+
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+};
+
+const normalizeTokenWords = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const cleaned = trimmed
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/[\\/]+/g, ' ')
+    .replace(/[_-]+/g, ' ')
+    .replace(/&/g, ' ')
+    .replace(/[^a-z0-9\s]/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) {
+    return [];
+  }
+
+  return cleaned
+    .split(' ')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+};
+
+const buildTokenNameVariantSet = (rawValue) => {
+  const variants = new Set();
+
+  if (typeof rawValue !== 'string') {
+    return variants;
+  }
+
+  const trimmed = rawValue.replace(/\s+/g, ' ').trim();
+  if (!trimmed) {
+    return variants;
+  }
+
+  variants.add(trimmed);
+
+  const noParens = trimmed.replace(/\([^)]*\)/g, ' ').replace(/\s+/g, ' ').trim();
+  if (noParens) {
+    variants.add(noParens);
+  }
+
+  const slashNormalized = trimmed.replace(/[\\/]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (slashNormalized) {
+    variants.add(slashNormalized);
+  }
+
+  const underscoreNormalized = trimmed.replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+  if (underscoreNormalized) {
+    variants.add(underscoreNormalized);
+  }
+
+  const hyphenNormalized = trimmed.replace(/-/g, ' ').replace(/\s+/g, ' ').trim();
+  if (hyphenNormalized) {
+    variants.add(hyphenNormalized);
+  }
+
+  variants.forEach((variant) => {
+    const words = normalizeTokenWords(variant);
+    if (words.length === 0) {
+      return;
+    }
+
+    const titleWords = words.map(capitalizeTokenWord);
+    const lowerWords = words.map((word) => word.toLowerCase());
+
+    [titleWords, lowerWords].forEach((wordList) => {
+      const spaceVariant = wordList.join(' ').trim();
+      const hyphenVariant = wordList.join('-').trim();
+      const underscoreVariant = wordList.join('_').trim();
+      const compactVariant = wordList.join('').trim();
+
+      [spaceVariant, hyphenVariant, underscoreVariant, compactVariant].forEach((entry) => {
+        if (entry) {
+          variants.add(entry);
+        }
+      });
+    });
+  });
+
+  return variants;
+};
+
+const collectOccupationNames = (occupations) => {
+  const names = new Set();
+
+  const addName = (value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmedValue = value.replace(/\s+/g, ' ').trim();
+    if (trimmedValue) {
+      names.add(trimmedValue);
+    }
+  };
+
+  const entries = Array.isArray(occupations) ? occupations : [occupations];
+
+  entries.forEach((occupation) => {
+    if (!occupation) {
+      return;
+    }
+
+    if (typeof occupation === 'string') {
+      addName(occupation);
+      return;
+    }
+
+    if (typeof occupation !== 'object') {
+      return;
+    }
+
+    for (const key of OCCUPATION_NAME_KEYS) {
+      const candidate = occupation[key];
+      if (typeof candidate === 'string' && candidate.trim()) {
+        addName(candidate);
+        return;
+      }
+    }
+
+    if (typeof occupation.title === 'string') {
+      addName(occupation.title);
+    }
+  });
+
+  return Array.from(names);
+};
+
+const addScopeValue = (set, value) => {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed) {
+    return;
+  }
+
+  set.add(trimmed);
+};
+
+export const buildPlayerTokenFolderScope = (raceName, occupations) => {
+  const normalizedRaceName = extractRaceName(raceName);
+  const raceVariantSet = new Set();
+  buildRaceTokenNameVariants(normalizedRaceName).forEach((variant) => {
+    if (typeof variant === 'string' && variant.trim()) {
+      buildTokenNameVariantSet(variant).forEach((entry) => raceVariantSet.add(entry));
+    }
+  });
+
+  if (raceVariantSet.size === 0) {
+    return null;
+  }
+
+  const classVariantSet = new Set();
+  collectOccupationNames(occupations).forEach((name) => {
+    buildTokenNameVariantSet(name).forEach((entry) => classVariantSet.add(entry));
+  });
+
+  const scopeSet = new Set();
+
+  if (classVariantSet.size === 0) {
+    raceVariantSet.forEach((raceVariant) => {
+      addScopeValue(scopeSet, raceVariant);
+      addScopeValue(scopeSet, `Adventurers/${raceVariant}`);
+      addScopeValue(scopeSet, `Tokens/Adventurers/${raceVariant}`);
+      addScopeValue(scopeSet, `folder:Tokens/Adventurers/${raceVariant}`);
+    });
+
+    return scopeSet.size > 0 ? Array.from(scopeSet) : null;
+  }
+
+  raceVariantSet.forEach((raceVariant) => {
+    classVariantSet.forEach((classVariant) => {
+      const base = `${raceVariant}/${classVariant}`;
+      addScopeValue(scopeSet, base);
+      addScopeValue(scopeSet, `Adventurers/${base}`);
+      addScopeValue(scopeSet, `Tokens/Adventurers/${base}`);
+      addScopeValue(scopeSet, `folder:Tokens/Adventurers/${base}`);
+    });
+  });
+
+  return scopeSet.size > 0 ? Array.from(scopeSet) : null;
+};
+
+export default buildPlayerTokenFolderScope;

--- a/client/src/components/Zombies/utils/playerTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/playerTokenFilters.test.js
@@ -1,0 +1,92 @@
+import { buildPlayerTokenFolderScope } from './playerTokenFilters';
+
+describe('buildPlayerTokenFolderScope', () => {
+  it('returns null when race name is missing', () => {
+    expect(buildPlayerTokenFolderScope(null, [])).toBeNull();
+    expect(buildPlayerTokenFolderScope('', [])).toBeNull();
+  });
+
+  it('returns race folders when no classes are provided', () => {
+    const scope = buildPlayerTokenFolderScope('Human', []);
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Human',
+        'Adventurers/Human',
+        'Tokens/Adventurers/Human',
+        'folder:Tokens/Adventurers/Human',
+      ])
+    );
+  });
+
+  it('builds scoped folders for race and class combinations', () => {
+    const scope = buildPlayerTokenFolderScope('Dragonborn', [
+      { Occupation: 'Fighter' },
+      { Occupation: 'fighter' },
+    ]);
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Dragonborn/Fighter',
+        'Adventurers/Dragonborn/Fighter',
+        'Tokens/Adventurers/Dragonborn/Fighter',
+        'folder:Tokens/Adventurers/Dragonborn/Fighter',
+      ])
+    );
+    expect(scope.filter((value) => value === 'Dragonborn/Fighter').length).toBe(1);
+  });
+
+  it('creates class variants when subclasses are provided', () => {
+    const scope = buildPlayerTokenFolderScope('Elf', [
+      { Occupation: 'Wizard (Evocation)' },
+    ]);
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Elf/Wizard',
+        'Adventurers/Elf/Wizard',
+        'Tokens/Adventurers/Elf/Wizard',
+        'folder:Tokens/Adventurers/Elf/Wizard',
+      ])
+    );
+  });
+
+  it('handles multi-class characters', () => {
+    const scope = buildPlayerTokenFolderScope('Half-Orc', [
+      { Occupation: 'Barbarian' },
+      { Occupation: 'Cleric' },
+    ]);
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Half-Orc/Barbarian',
+        'Half-Orc/Cleric',
+        'Tokens/Adventurers/Half-Orc/Barbarian',
+        'Tokens/Adventurers/Half-Orc/Cleric',
+      ])
+    );
+  });
+
+  it('supports race objects and occupation name properties', () => {
+    const scope = buildPlayerTokenFolderScope({ name: 'Goliath' }, [
+      { name: 'Cleric' },
+    ]);
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Tokens/Adventurers/Goliaths/Cleric',
+        'folder:Tokens/Adventurers/Goliaths/Cleric',
+      ])
+    );
+  });
+
+  it('collects class names from string entries', () => {
+    const scope = buildPlayerTokenFolderScope('Elf', ['Ranger']);
+
+    expect(scope).toEqual(
+      expect.arrayContaining([
+        'Tokens/Adventurers/Elves/Ranger',
+        'folder:Tokens/Adventurers/Elves/Ranger',
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow the player token scope helper to resolve race names from objects and occupation names from additional properties
- update the character sheet to pass through legacy race values when building the figurine picker scope
- extend the helper tests to cover race objects and string-based class entries

## Testing
- CI=true npm test -- playerTokenFilters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fcfceca7dc832e8dd8707f2d904f70