### PR TITLE
Filter player token picker assets by scope

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -174,6 +174,146 @@ const filterMatchesScope = (filter, scopeSet) => {
   return false;
 };
 
+const buildNormalizedMatchSet = (values = []) => {
+  const set = new Set();
+
+  values.forEach((value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = value.replace(/\u00A0/g, ' ').trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const lower = trimmed.toLowerCase();
+    const forms = new Set([
+      lower,
+      lower.replace(/[_-]+/g, ' '),
+      lower.replace(/[\\/]+/g, ' '),
+      lower.replace(/[^a-z0-9/]+/g, ' '),
+      lower.replace(/[^a-z0-9]+/g, ''),
+    ]);
+
+    forms.forEach((form) => {
+      if (typeof form !== 'string') {
+        return;
+      }
+
+      const normalized = form.replace(/\s+/g, ' ').trim();
+      if (normalized) {
+        set.add(normalized);
+      }
+    });
+  });
+
+  return set;
+};
+
+const collectAssetMatchValues = (asset, manifestMeta) => {
+  if (!asset || typeof asset !== 'object') {
+    return new Set();
+  }
+
+  const rawValues = [];
+  const addValue = (value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    rawValues.push(trimmed);
+
+    if (!trimmed.toLowerCase().startsWith('folder:')) {
+      rawValues.push(`folder:${trimmed}`);
+    }
+  };
+
+  addValue(asset.relativeFolder);
+  addValue(asset.folder);
+
+  if (Array.isArray(asset.folders)) {
+    asset.folders.forEach(addValue);
+  }
+
+  addValue(asset.publicId);
+  addValue(asset.path);
+  addValue(asset.displayName);
+  addValue(asset.filename);
+  addValue(asset.name);
+
+  if (Array.isArray(asset.tags)) {
+    asset.tags.forEach(addValue);
+  }
+
+  const appliedFolders = Array.isArray(manifestMeta?.appliedFolders)
+    ? manifestMeta.appliedFolders
+    : [];
+  appliedFolders.forEach(addValue);
+
+  return buildNormalizedMatchSet(rawValues);
+};
+
+const collectScopeMatchValues = (scopeSet) => {
+  if (!(scopeSet instanceof Set)) {
+    return new Set();
+  }
+
+  const rawValues = [];
+
+  scopeSet.forEach((value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    rawValues.push(trimmed);
+
+    if (trimmed.toLowerCase().startsWith('folder:')) {
+      rawValues.push(trimmed.slice('folder:'.length));
+    } else {
+      rawValues.push(`folder:${trimmed}`);
+    }
+  });
+
+  return buildNormalizedMatchSet(rawValues);
+};
+
+const assetMatchesScope = (asset, scopeSet, manifestMeta) => {
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return true;
+  }
+
+  const scopeValues = collectScopeMatchValues(scopeSet);
+  if (scopeValues.size === 0) {
+    return true;
+  }
+
+  const assetValues = collectAssetMatchValues(asset, manifestMeta);
+  if (assetValues.size === 0) {
+    return false;
+  }
+
+  for (const scopeValue of scopeValues) {
+    for (const assetValue of assetValues) {
+      if (assetValue.includes(scopeValue)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 const buildDynamicDmFilters = (folderTree, fallbackFilters = DEFAULT_DM_FILTERS) => {
   const fallback = cloneFilters(fallbackFilters);
 
@@ -546,6 +686,18 @@ const TokenPickerModal = ({
   const [nextCursor, setNextCursor] = useState(null);
   const [manifestMeta, setManifestMeta] = useState(null);
 
+  const scopedAssets = useMemo(() => {
+    if (!Array.isArray(assets)) {
+      return [];
+    }
+
+    if (!(filterScopeSet instanceof Set) || filterScopeSet.size === 0) {
+      return assets;
+    }
+
+    return assets.filter((asset) => assetMatchesScope(asset, filterScopeSet, manifestMeta));
+  }, [assets, filterScopeSet, manifestMeta]);
+
   const resetState = useCallback((options = {}) => {
     const { resetFolderLoading = true } = options;
     setAssets([]);
@@ -881,6 +1033,8 @@ const TokenPickerModal = ({
   }, [onClear, onSelect]);
 
   const renderBody = () => {
+    const hasDisplayAssets = scopedAssets.length > 0;
+
     if ((loading || fetchingFolders) && assets.length === 0) {
       return (
         <div className="text-center py-4" role="status" aria-live="polite">
@@ -898,14 +1052,14 @@ const TokenPickerModal = ({
       );
     }
 
-    if (assets.length === 0) {
+    if (!hasDisplayAssets) {
       return <div className="text-center text-muted py-4">No tokens found.</div>;
     }
 
     return (
       <>
         <Row xs={2} sm={3} md={4} className="g-3">
-          {assets.map((asset) => {
+          {scopedAssets.map((asset) => {
             if (!asset || !asset.publicId) {
               return null;
             }

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -396,6 +396,59 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('filters manifest assets based on provided scope', async () => {
+    const folderTree = { folders: [], flatFolders: [] };
+
+    const manifestPayload = {
+      assets: [
+        {
+          publicId: 'Tokens/Adventurers/Dragonborn/Fighter/token-1',
+          filename: 'Dragonborn Fighter',
+          relativeFolder: 'Adventurers/Dragonborn/Fighter',
+        },
+        {
+          publicId: 'Tokens/Adventurers/Elf/Wizard/token-2',
+          filename: 'Elf Wizard',
+          relativeFolder: 'Adventurers/Elf/Wizard',
+        },
+      ],
+      nextCursor: null,
+      appliedFolders: ['Tokens/Adventurers'],
+    };
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={[
+          'Dragonborn/Fighter',
+          'Adventurers/Dragonborn/Fighter',
+          'folder:Tokens/Adventurers/Dragonborn/Fighter',
+        ]}
+      />
+    );
+
+    await screen.findByText('Dragonborn Fighter');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Elf Wizard')).not.toBeInTheDocument();
+    });
+  });
+
   test('player token picker limits folders to scoped race and class combinations', async () => {
     const folderTree = {
       rootFolder: 'Tokens',


### PR DESCRIPTION
## Summary
- add normalized helpers to match token assets against the character's token scope
- display only scope-matching assets in the token picker modal
- cover the scoped asset filtering with a dedicated unit test

## Testing
- CI=1 npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fd1814efd0832e9230548e177035cd