### PR TITLE
Expand player token filter scope to include class variants

### DIFF
--- a/client/src/components/Zombies/utils/playerTokenFilters.js
+++ b/client/src/components/Zombies/utils/playerTokenFilters.js
@@ -37,6 +37,68 @@ const capitalizeTokenWord = (word) => {
   return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
 };
 
+const pluralizeTokenWord = (word) => {
+  if (typeof word !== 'string' || word.length === 0) {
+    return word;
+  }
+
+  const lower = word.toLowerCase();
+
+  if (lower.endsWith('person')) {
+    return `${lower.slice(0, -6)}people`;
+  }
+
+  if (lower === 'human') {
+    return 'humans';
+  }
+
+  if (lower.endsWith('man')) {
+    return `${lower.slice(0, -3)}men`;
+  }
+
+  if (lower.endsWith('child')) {
+    return `${lower.slice(0, -5)}children`;
+  }
+
+  if (lower.endsWith('tooth')) {
+    return `${lower.slice(0, -5)}teeth`;
+  }
+
+  if (lower.endsWith('foot')) {
+    return `${lower.slice(0, -4)}feet`;
+  }
+
+  if (lower.endsWith('mouse')) {
+    return `${lower.slice(0, -5)}mice`;
+  }
+
+  if (lower.endsWith('goose')) {
+    return `${lower.slice(0, -5)}geese`;
+  }
+
+  if (lower.endsWith('lf')) {
+    return `${lower.slice(0, -1)}ves`;
+  }
+
+  if (lower.endsWith('fe')) {
+    return `${lower.slice(0, -2)}ves`;
+  }
+
+  if (lower.endsWith('f')) {
+    return `${lower.slice(0, -1)}ves`;
+  }
+
+  if (lower.endsWith('y') && !/[aeiou]y$/.test(lower)) {
+    return `${lower.slice(0, -1)}ies`;
+  }
+
+  if (/([sxz]|ch|sh)$/.test(lower)) {
+    return `${lower}es`;
+  }
+
+  return `${lower}s`;
+};
+
 const normalizeTokenWords = (value) => {
   if (typeof value !== 'string') {
     return [];
@@ -121,6 +183,33 @@ const buildTokenNameVariantSet = (rawValue) => {
         }
       });
     });
+
+    const pluralWords = [...words];
+    const lastIndex = pluralWords.length - 1;
+
+    if (lastIndex >= 0) {
+      const pluralLower = pluralizeTokenWord(pluralWords[lastIndex]);
+
+      if (pluralLower && pluralLower !== pluralWords[lastIndex].toLowerCase()) {
+        pluralWords[lastIndex] = pluralLower;
+
+        const pluralTitleWords = pluralWords.map(capitalizeTokenWord);
+        const pluralLowerWords = pluralWords.map((word) => word.toLowerCase());
+
+        [pluralTitleWords, pluralLowerWords].forEach((wordList) => {
+          const spaceVariant = wordList.join(' ').trim();
+          const hyphenVariant = wordList.join('-').trim();
+          const underscoreVariant = wordList.join('_').trim();
+          const compactVariant = wordList.join('').trim();
+
+          [spaceVariant, hyphenVariant, underscoreVariant, compactVariant].forEach((entry) => {
+            if (entry) {
+              variants.add(entry);
+            }
+          });
+        });
+      }
+    }
   });
 
   return variants;

--- a/client/src/components/Zombies/utils/playerTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/playerTokenFilters.test.js
@@ -34,6 +34,8 @@ describe('buildPlayerTokenFolderScope', () => {
         'Adventurers/Dragonborn/Fighter',
         'Tokens/Adventurers/Dragonborn/Fighter',
         'folder:Tokens/Adventurers/Dragonborn/Fighter',
+        'Tokens/Adventurers/Dragonborn/Fighters',
+        'folder:Tokens/Adventurers/Dragonborn/Fighters',
       ])
     );
     expect(scope.filter((value) => value === 'Dragonborn/Fighter').length).toBe(1);
@@ -94,6 +96,8 @@ describe('buildPlayerTokenFolderScope', () => {
       expect.arrayContaining([
         'Tokens/Adventurers/Elves/Ranger',
         'folder:Tokens/Adventurers/Elves/Ranger',
+        'Tokens/Adventurers/Elves/Rangers',
+        'folder:Tokens/Adventurers/Elves/Rangers',
       ])
     );
   });


### PR DESCRIPTION
## Summary
- add pluralization logic when building player token name variants so class folders like Fighters are matched
- extend the player token scope tests to cover pluralized race/class folder paths

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/utils/playerTokenFilters.test.js --watch=false *(fails: Node.js OOM while running react-scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1ee73f0c832e82d0b8b01375f3ab