### PR TITLE
Add deselect-all toggle to DM shop visibility manager

### DIFF
--- a/client/src/components/Accessories/AccessoryList.js
+++ b/client/src/components/Accessories/AccessoryList.js
@@ -122,6 +122,7 @@ function normalizeAccessoryBonuses(bonuses) {
  *   onAddToCart?: (accessory: any) => void,
  *   ownedOnly?: boolean,
  *   cartCounts?: Record<string, number> | null,
+ *   hiddenKeys?: Set<string> | string[] | Record<string, boolean> | null,
  * }} props
  */
 function AccessoryList({
@@ -133,6 +134,7 @@ function AccessoryList({
   onAddToCart = () => {},
   ownedOnly = false,
   cartCounts = null,
+  hiddenKeys = null,
 }) {
   const [accessories, setAccessories] =
     useState/** @type {Record<string, any & { owned?: boolean, ownedCount?: number, displayName?: string }> | null} */(null);
@@ -149,6 +151,26 @@ function AccessoryList({
     () => buildAccessoryOwnershipMap(initialAccessoriesArray),
     [initialAccessoriesArray]
   );
+
+  const hiddenSet = useMemo(() => {
+    if (!hiddenKeys) {
+      return null;
+    }
+    if (hiddenKeys instanceof Set) {
+      return new Set(Array.from(hiddenKeys, (value) => String(value).toLowerCase()));
+    }
+    if (Array.isArray(hiddenKeys)) {
+      return new Set(hiddenKeys.map((value) => String(value).toLowerCase()));
+    }
+    if (hiddenKeys && typeof hiddenKeys === 'object') {
+      return new Set(
+        Object.entries(hiddenKeys)
+          .filter(([, hidden]) => Boolean(hidden))
+          .map(([key]) => String(key).toLowerCase())
+      );
+    }
+    return null;
+  }, [hiddenKeys]);
 
   useEffect(() => {
     if (!show) return undefined;
@@ -331,9 +353,16 @@ function AccessoryList({
 
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
 
-  const filteredEntries = Object.entries(accessories).filter(([, accessory]) =>
-    ownedOnly ? (accessory.ownedCount ?? 0) > 0 : true
-  );
+  const filteredEntries = Object.entries(accessories).filter(([key, accessory]) => {
+    if (hiddenSet) {
+      const normalizedKey = String(key || '').toLowerCase();
+      const displayKey = String(accessory.displayName || accessory.name || '').toLowerCase();
+      if (hiddenSet.has(normalizedKey) || (displayKey && hiddenSet.has(displayKey))) {
+        return false;
+      }
+    }
+    return ownedOnly ? (accessory.ownedCount ?? 0) > 0 : true;
+  });
 
   const expandedEntries = ownedOnly
     ? filteredEntries.flatMap(([key, accessory]) => {

--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -24,6 +24,7 @@ import apiFetch from '../../utils/apiFetch';
  *   onAddToCart?: (armor: Armor & { type?: string }) => void,
  *   ownedOnly?: boolean,
  *   cartCounts?: Record<string, number> | null,
+ *   hiddenKeys?: Set<string> | string[] | Record<string, boolean> | null,
  * }} props
  */
 const buildArmorOwnershipMap = (initialArmor) => {
@@ -73,6 +74,7 @@ function ArmorList({
   onAddToCart = () => {},
   ownedOnly = false,
   cartCounts = null,
+  hiddenKeys = null,
 }) {
   const [armor, setArmor] =
     useState/** @type {Record<string, Armor & { owned?: boolean, ownedCount?: number, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
@@ -84,6 +86,26 @@ function ArmorList({
     () => buildArmorOwnershipMap(initialArmorArray),
     [initialArmorArray]
   );
+
+  const hiddenSet = useMemo(() => {
+    if (!hiddenKeys) {
+      return null;
+    }
+    if (hiddenKeys instanceof Set) {
+      return new Set(Array.from(hiddenKeys, (value) => String(value).toLowerCase()));
+    }
+    if (Array.isArray(hiddenKeys)) {
+      return new Set(hiddenKeys.map((value) => String(value).toLowerCase()));
+    }
+    if (hiddenKeys && typeof hiddenKeys === 'object') {
+      return new Set(
+        Object.entries(hiddenKeys)
+          .filter(([, hidden]) => Boolean(hidden))
+          .map(([key]) => String(key).toLowerCase())
+      );
+    }
+    return null;
+  }, [hiddenKeys]);
 
   useEffect(() => {
     if (!show) return;
@@ -323,9 +345,16 @@ function ArmorList({
   };
 
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
-  const filteredEntries = Object.entries(armor).filter(([, piece]) =>
-    ownedOnly ? (piece.ownedCount ?? 0) > 0 : true
-  );
+  const filteredEntries = Object.entries(armor).filter(([key, piece]) => {
+    if (hiddenSet) {
+      const normalizedKey = String(key || '').toLowerCase();
+      const displayKey = String(piece.displayName || piece.name || '').toLowerCase();
+      if (hiddenSet.has(normalizedKey) || (displayKey && hiddenSet.has(displayKey))) {
+        return false;
+      }
+    }
+    return ownedOnly ? (piece.ownedCount ?? 0) > 0 : true;
+  });
   const expandedEntries = ownedOnly
     ? filteredEntries.flatMap(([key, piece]) => {
         const count = piece.ownedCount ?? 0;

--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -157,6 +157,7 @@ const dispatchConsumablePotionUsed = (item) => {
  *   onAddToCart?: (item: Item & { type?: string }) => void,
  *   ownedOnly?: boolean,
  *   cartCounts?: Record<string, number> | null,
+ *   hiddenKeys?: Set<string> | string[] | Record<string, boolean> | null,
  * }} props
  */
 const buildItemOwnershipMap = (initialItems) => {
@@ -388,6 +389,7 @@ function ItemList({
   ownedOnly = false,
   cartCounts = null,
   diceColor,
+  hiddenKeys = null,
 }) {
   const [items, setItems] =
     useState/** @type {Record<string, Item & { owned?: boolean, ownedCount?: number, displayName?: string }> | null} */(null);
@@ -456,6 +458,26 @@ function ItemList({
     () => buildItemOwnershipMap(ownedEntries),
     [ownedEntries]
   );
+
+  const hiddenSet = useMemo(() => {
+    if (!hiddenKeys) {
+      return null;
+    }
+    if (hiddenKeys instanceof Set) {
+      return new Set(Array.from(hiddenKeys, (value) => String(value).toLowerCase()));
+    }
+    if (Array.isArray(hiddenKeys)) {
+      return new Set(hiddenKeys.map((value) => String(value).toLowerCase()));
+    }
+    if (hiddenKeys && typeof hiddenKeys === 'object') {
+      return new Set(
+        Object.entries(hiddenKeys)
+          .filter(([, hidden]) => Boolean(hidden))
+          .map(([key]) => String(key).toLowerCase())
+      );
+    }
+    return null;
+  }, [hiddenKeys]);
 
   useEffect(() => {
     if (!show) return;
@@ -619,7 +641,14 @@ function ItemList({
   const handleShowNotes = (item) => () => setNotesItem(item);
 
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
-  const filteredEntries = Object.entries(items).filter(([, item]) => {
+  const filteredEntries = Object.entries(items).filter(([key, item]) => {
+    if (hiddenSet) {
+      const normalizedKey = String(key || '').toLowerCase();
+      const displayKey = String(item.displayName || item.name || '').toLowerCase();
+      if (hiddenSet.has(normalizedKey) || (displayKey && hiddenSet.has(displayKey))) {
+        return false;
+      }
+    }
     if (ownedOnly && (item.ownedCount ?? 0) <= 0) {
       return false;
     }

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -71,6 +71,7 @@ function WeaponList({
   onAddToCart = () => {},
   ownedOnly = false,
   cartCounts = null,
+  hiddenKeys = null,
 }) {
   const [weapons, setWeapons] =
     useState/** @type {Record<string, Weapon & { owned?: boolean, ownedCount?: number, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
@@ -81,6 +82,26 @@ function WeaponList({
     () => buildWeaponOwnershipMap(initialWeapons),
     [initialWeapons]
   );
+
+  const hiddenSet = useMemo(() => {
+    if (!hiddenKeys) {
+      return null;
+    }
+    if (hiddenKeys instanceof Set) {
+      return new Set(Array.from(hiddenKeys, (value) => String(value).toLowerCase()));
+    }
+    if (Array.isArray(hiddenKeys)) {
+      return new Set(hiddenKeys.map((value) => String(value).toLowerCase()));
+    }
+    if (hiddenKeys && typeof hiddenKeys === 'object') {
+      return new Set(
+        Object.entries(hiddenKeys)
+          .filter(([, hidden]) => Boolean(hidden))
+          .map(([key]) => String(key).toLowerCase())
+      );
+    }
+    return null;
+  }, [hiddenKeys]);
 
   useEffect(() => {
     if (!show) return;
@@ -284,9 +305,16 @@ function WeaponList({
   };
 
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
-  const filteredEntries = Object.entries(weapons).filter(([, weapon]) =>
-    ownedOnly ? (weapon.ownedCount ?? 0) > 0 : true
-  );
+  const filteredEntries = Object.entries(weapons).filter(([key, weapon]) => {
+    if (hiddenSet) {
+      const normalizedKey = String(key || '').toLowerCase();
+      const displayKey = String(weapon.displayName || weapon.name || '').toLowerCase();
+      if (hiddenSet.has(normalizedKey) || (displayKey && hiddenSet.has(displayKey))) {
+        return false;
+      }
+    }
+    return ownedOnly ? (weapon.ownedCount ?? 0) > 0 : true;
+  });
   const expandedEntries = ownedOnly
     ? filteredEntries.flatMap(([key, weapon]) => {
         const count = weapon.ownedCount ?? 0;

--- a/client/src/components/Zombies/attributes/ShopModal.js
+++ b/client/src/components/Zombies/attributes/ShopModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Modal, Card, Tab, Button, Nav, Badge } from 'react-bootstrap';
 import { FaShoppingCart } from 'react-icons/fa';
 import WeaponList from '../../Weapons/WeaponList';
@@ -6,8 +6,51 @@ import ArmorList from '../../Armor/ArmorList';
 import ItemList from '../../Items/ItemList';
 import AccessoryList from '../../Accessories/AccessoryList';
 import DockControls from '../components/DockControls';
+import apiFetch from '../../../utils/apiFetch';
 
 const DEFAULT_TAB = 'weapons';
+
+const SHOP_VISIBILITY_KEYS = ['weapons', 'armor', 'items', 'accessories'];
+
+const buildHiddenSet = (value) => {
+  const set = new Set();
+  if (Array.isArray(value)) {
+    value.forEach((entry) => {
+      if (typeof entry !== 'string') {
+        return;
+      }
+      const normalized = entry.trim().toLowerCase();
+      if (normalized) {
+        set.add(normalized);
+      }
+    });
+  } else if (value && typeof value === 'object') {
+    Object.entries(value).forEach(([key, hidden]) => {
+      if (!hidden || typeof key !== 'string') {
+        return;
+      }
+      const normalized = key.trim().toLowerCase();
+      if (normalized) {
+        set.add(normalized);
+      }
+    });
+  }
+  return set;
+};
+
+const createEmptyVisibilitySets = () =>
+  SHOP_VISIBILITY_KEYS.reduce((acc, key) => {
+    acc[key] = new Set();
+    return acc;
+  }, {});
+
+const convertVisibilityResponse = (data) => {
+  const result = createEmptyVisibilitySets();
+  SHOP_VISIBILITY_KEYS.forEach((key) => {
+    result[key] = buildHiddenSet(data?.[key]);
+  });
+  return result;
+};
 
 const COIN_VALUES = {
   cp: 1,
@@ -422,6 +465,10 @@ export default function ShopModal({
   onDockClose,
   onDockChange,
 }) {
+  const [shopVisibility, setShopVisibility] = useState(() =>
+    createEmptyVisibilitySets()
+  );
+  const visibilityCampaignRef = useRef(null);
   const [cart, setCart] = useState([]);
   const [showCart, setShowCart] = useState(false);
   const [insufficientFunds, setInsufficientFunds] = useState('');
@@ -518,6 +565,58 @@ export default function ShopModal({
   }, [cart, cp, gp, sp, pp]);
 
   useEffect(() => {
+    const campaignName =
+      typeof form?.campaign === 'string' ? form.campaign.trim() : '';
+    if (!campaignName) {
+      setShopVisibility(createEmptyVisibilitySets());
+      visibilityCampaignRef.current = null;
+    }
+  }, [form?.campaign]);
+
+  useEffect(() => {
+    const campaignName =
+      typeof form?.campaign === 'string' ? form.campaign.trim() : '';
+    if (!show || !campaignName) {
+      return;
+    }
+
+    if (visibilityCampaignRef.current === campaignName) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadVisibility = async () => {
+      try {
+        const response = await apiFetch(
+          `/campaigns/${encodeURIComponent(campaignName)}/shop-visibility`
+        );
+        if (!response.ok) {
+          throw new Error('Failed to load shop visibility');
+        }
+        const data = await response.json();
+        if (isMounted) {
+          setShopVisibility(convertVisibilityResponse(data));
+          visibilityCampaignRef.current = campaignName;
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to load shop visibility', error);
+        if (isMounted) {
+          setShopVisibility(createEmptyVisibilitySets());
+          visibilityCampaignRef.current = null;
+        }
+      }
+    };
+
+    loadVisibility();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [form?.campaign, show]);
+
+  useEffect(() => {
     if (totalCostCp > availableCp) {
       setInsufficientFunds('Insufficient funds to complete purchase.');
     }
@@ -570,6 +669,7 @@ export default function ShopModal({
               embedded
               onAddToCart={handleAddToCart}
               cartCounts={cartCounts}
+              hiddenKeys={shopVisibility.weapons}
             />
           ) : null,
       },
@@ -588,6 +688,7 @@ export default function ShopModal({
               embedded
               onAddToCart={handleAddToCart}
               cartCounts={cartCounts}
+              hiddenKeys={shopVisibility.armor}
             />
           ) : null,
       },
@@ -607,6 +708,7 @@ export default function ShopModal({
               onAddToCart={handleAddToCart}
               cartCounts={cartCounts}
               diceColor={form?.diceColor}
+              hiddenKeys={shopVisibility.items}
             />
           ) : null,
       },
@@ -623,8 +725,9 @@ export default function ShopModal({
               embedded
               onAddToCart={handleAddAccessoryToCart}
               cartCounts={cartCounts}
+              hiddenKeys={shopVisibility.accessories}
             />
-          ) : null,
+        ) : null,
       },
     ],
     [
@@ -643,6 +746,7 @@ export default function ShopModal({
       onAccessoriesChange,
       onWeaponsChange,
       strength,
+      shopVisibility,
     ]
   );
 

--- a/client/src/components/Zombies/attributes/ShopModal.test.js
+++ b/client/src/components/Zombies/attributes/ShopModal.test.js
@@ -9,6 +9,22 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+jest.mock('../../../utils/apiFetch', () =>
+  jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: async () => ({
+        weapons: [],
+        armor: [],
+        items: [],
+        accessories: [],
+      }),
+    })
+  )
+);
+
+const apiFetch = require('../../../utils/apiFetch');
+
 const mockWeaponListFetch = jest.fn();
 const mockArmorListFetch = jest.fn();
 const mockItemListFetch = jest.fn();
@@ -221,6 +237,16 @@ const renderShopModal = (props = {}) =>
   );
 
 beforeEach(() => {
+  apiFetch.mockClear();
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      weapons: [],
+      armor: [],
+      items: [],
+      accessories: [],
+    }),
+  });
   mockWeaponListFetch.mockClear();
   mockArmorListFetch.mockClear();
   mockItemListFetch.mockClear();

--- a/client/src/components/Zombies/attributes/ShopVisibilityManager.js
+++ b/client/src/components/Zombies/attributes/ShopVisibilityManager.js
@@ -1,0 +1,755 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Col,
+  Form,
+  Nav,
+  Row,
+  Spinner,
+  Tab,
+} from 'react-bootstrap';
+import apiFetch from '../../../utils/apiFetch';
+
+const SHOP_TABS = [
+  { key: 'weapons', title: 'Weapons' },
+  { key: 'armor', title: 'Armor' },
+  { key: 'items', title: 'Items' },
+  { key: 'accessories', title: 'Accessories' },
+];
+
+const createEmptyHiddenState = () => ({
+  weapons: [],
+  armor: [],
+  items: [],
+  accessories: [],
+});
+
+const normalizeKey = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().toLowerCase();
+};
+
+const toHtmlId = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.replace(/[^a-z0-9_-]/g, '-');
+};
+
+const collectHiddenEntries = (value) => {
+  const normalized = new Set();
+  if (Array.isArray(value)) {
+    value.forEach((entry) => {
+      const key = normalizeKey(entry);
+      if (key) {
+        normalized.add(key);
+      }
+    });
+  } else if (value && typeof value === 'object') {
+    Object.entries(value).forEach(([entryKey, hidden]) => {
+      if (hidden === true) {
+        const key = normalizeKey(entryKey);
+        if (key) {
+          normalized.add(key);
+        }
+      }
+    });
+  }
+  return Array.from(normalized).sort();
+};
+
+const normalizeHiddenState = (input) => {
+  const state = createEmptyHiddenState();
+  SHOP_TABS.forEach(({ key }) => {
+    state[key] = collectHiddenEntries(input?.[key]);
+  });
+  return state;
+};
+
+const hiddenStatesEqual = (stateA, stateB) =>
+  SHOP_TABS.every(({ key }) => {
+    const setA = new Set(Array.isArray(stateA[key]) ? stateA[key] : []);
+    const setB = new Set(Array.isArray(stateB[key]) ? stateB[key] : []);
+    if (setA.size !== setB.size) {
+      return false;
+    }
+    for (const entry of setA) {
+      if (!setB.has(entry)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+const fetchJsonOrThrow = async (url, defaultMessage) => {
+  const response = await apiFetch(url);
+  if (response.ok) {
+    return response.json();
+  }
+  let message = defaultMessage || response.statusText || 'Request failed';
+  try {
+    const errorBody = await response.json();
+    if (errorBody && typeof errorBody.message === 'string') {
+      message = errorBody.message;
+    }
+  } catch (error) {
+    // ignore JSON parse errors
+  }
+  const error = new Error(message);
+  error.status = response.status;
+  throw error;
+};
+
+const fetchJsonWithFallback = async (url, fallbackValue = []) => {
+  const response = await apiFetch(url);
+  if (response.ok) {
+    return response.json();
+  }
+  if (response.status === 404) {
+    return fallbackValue;
+  }
+  let message = response.statusText || 'Request failed';
+  try {
+    const errorBody = await response.json();
+    if (errorBody && typeof errorBody.message === 'string') {
+      message = errorBody.message;
+    }
+  } catch (error) {
+    // ignore JSON parse errors
+  }
+  const error = new Error(message);
+  error.status = response.status;
+  throw error;
+};
+
+const toTitleCase = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value
+    .split(/\s+|_/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const normalizeArrayField = (value) => {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const buildWeaponCatalog = (standard, custom) => {
+  const map = new Map();
+  if (standard && typeof standard === 'object') {
+    Object.entries(standard).forEach(([key, weapon]) => {
+      if (!weapon) {
+        return;
+      }
+      const normalizedKey = normalizeKey(key || weapon.name);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: weapon.displayName || weapon.name || key,
+        category: weapon.category || '',
+        cost: weapon.cost ?? '',
+        damage: weapon.damage ?? '',
+        properties: normalizeArrayField(weapon.properties),
+        source: 'Standard',
+      });
+    });
+  }
+  if (Array.isArray(custom)) {
+    custom.forEach((weapon) => {
+      if (!weapon) {
+        return;
+      }
+      const rawName = weapon.name || weapon.weaponName;
+      const normalizedKey = normalizeKey(rawName);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: weapon.displayName || weapon.name || weapon.weaponName || rawName,
+        category: weapon.category || weapon.type || 'custom',
+        cost: weapon.cost ?? '',
+        damage: weapon.damage ?? '',
+        properties: normalizeArrayField(weapon.properties),
+        source: 'Custom',
+      });
+    });
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
+};
+
+const buildArmorCatalog = (standard, custom) => {
+  const map = new Map();
+  if (standard && typeof standard === 'object') {
+    Object.entries(standard).forEach(([key, armor]) => {
+      if (!armor) {
+        return;
+      }
+      const normalizedKey = normalizeKey(key || armor.name);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: armor.displayName || armor.name || key,
+        category: armor.category || '',
+        cost: armor.cost ?? '',
+        armorClass: armor.acBonus ?? armor.ac ?? '',
+        maxDex: armor.maxDex ?? null,
+        strength: armor.strength ?? null,
+        stealth: armor.stealth ?? false,
+        source: 'Standard',
+      });
+    });
+  }
+  if (Array.isArray(custom)) {
+    custom.forEach((armor) => {
+      if (!armor) {
+        return;
+      }
+      const rawName = armor.name || armor.armorName;
+      const normalizedKey = normalizeKey(rawName);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: armor.name || armor.armorName || rawName,
+        category: armor.category || armor.type || 'custom',
+        cost: armor.cost ?? '',
+        armorClass: armor.acBonus ?? armor.armorBonus ?? armor.ac ?? '',
+        maxDex: armor.maxDex ?? null,
+        strength: armor.strength ?? null,
+        stealth: armor.stealth ?? false,
+        source: 'Custom',
+      });
+    });
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
+};
+
+const buildItemCatalog = (standard, custom) => {
+  const map = new Map();
+  if (standard && typeof standard === 'object') {
+    Object.entries(standard).forEach(([key, item]) => {
+      if (!item) {
+        return;
+      }
+      const normalizedKey = normalizeKey(key || item.name);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: item.displayName || item.name || key,
+        category: item.category || '',
+        cost: item.cost ?? '',
+        weight: item.weight ?? '',
+        notes: item.notes || '',
+        source: 'Standard',
+      });
+    });
+  }
+  if (Array.isArray(custom)) {
+    custom.forEach((item) => {
+      if (!item) {
+        return;
+      }
+      const normalizedKey = normalizeKey(item.name);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: item.name,
+        category: item.category || 'custom',
+        cost: item.cost ?? '',
+        weight: item.weight ?? '',
+        notes: item.notes || '',
+        source: 'Custom',
+      });
+    });
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
+};
+
+const buildAccessoryCatalog = (standard, custom) => {
+  const map = new Map();
+  if (standard && typeof standard === 'object') {
+    Object.entries(standard).forEach(([key, accessory]) => {
+      if (!accessory) {
+        return;
+      }
+      const normalizedKey = normalizeKey(key || accessory.name);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: accessory.displayName || accessory.name || key,
+        category: accessory.category || '',
+        cost: accessory.cost ?? '',
+        targetSlots: normalizeArrayField(accessory.targetSlots),
+        rarity: accessory.rarity || '',
+        source: 'Standard',
+      });
+    });
+  }
+  if (Array.isArray(custom)) {
+    custom.forEach((accessory) => {
+      if (!accessory) {
+        return;
+      }
+      const normalizedKey = normalizeKey(accessory.name);
+      if (!normalizedKey) {
+        return;
+      }
+      map.set(normalizedKey, {
+        key: normalizedKey,
+        name: accessory.name,
+        category: accessory.category || 'custom',
+        cost: accessory.cost ?? '',
+        targetSlots: normalizeArrayField(accessory.targetSlots),
+        rarity: accessory.rarity || '',
+        source: 'Custom',
+      });
+    });
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
+};
+
+export default function ShopVisibilityManager({ campaign, active, onStatus }) {
+  const [activeTabKey, setActiveTabKey] = useState('weapons');
+  const [hiddenState, setHiddenState] = useState(() => createEmptyHiddenState());
+  const [initialHiddenState, setInitialHiddenState] = useState(() =>
+    createEmptyHiddenState()
+  );
+  const [inventory, setInventory] = useState({
+    weapons: [],
+    armor: [],
+    items: [],
+    accessories: [],
+  });
+  const [loading, setLoading] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setHiddenState(createEmptyHiddenState());
+    setInitialHiddenState(createEmptyHiddenState());
+    setInventory({ weapons: [], armor: [], items: [], accessories: [] });
+    setInitialized(false);
+    setError(null);
+  }, [campaign]);
+
+  useEffect(() => {
+    if (!active || !campaign || initialized || loading) {
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const encodedCampaign = encodeURIComponent(campaign);
+        const [
+          visibilityData,
+          standardWeapons,
+          customWeapons,
+          standardArmor,
+          customArmor,
+          standardItems,
+          customItems,
+          standardAccessories,
+          customAccessories,
+        ] = await Promise.all([
+          fetchJsonOrThrow(
+            `/campaigns/${encodedCampaign}/shop-visibility`,
+            'Failed to load shop visibility.'
+          ),
+          fetchJsonOrThrow('/weapons', 'Failed to load weapons.'),
+          fetchJsonWithFallback(`/equipment/weapons/${encodedCampaign}`),
+          fetchJsonOrThrow('/armor', 'Failed to load armor.'),
+          fetchJsonWithFallback(`/equipment/armor/${encodedCampaign}`),
+          fetchJsonOrThrow('/items', 'Failed to load items.'),
+          fetchJsonWithFallback(`/equipment/items/${encodedCampaign}`),
+          fetchJsonOrThrow('/accessories', 'Failed to load accessories.'),
+          fetchJsonWithFallback(`/equipment/accessories/${encodedCampaign}`),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        setInventory({
+          weapons: buildWeaponCatalog(standardWeapons, customWeapons),
+          armor: buildArmorCatalog(standardArmor, customArmor),
+          items: buildItemCatalog(standardItems, customItems),
+          accessories: buildAccessoryCatalog(standardAccessories, customAccessories),
+        });
+
+        const normalizedHidden = normalizeHiddenState(visibilityData);
+        setHiddenState(normalizedHidden);
+        setInitialHiddenState(normalizedHidden);
+        setError(null);
+        setInitialized(true);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        // eslint-disable-next-line no-console
+        console.error('Failed to load shop visibility', err);
+        const message = err?.message || 'Failed to load shop inventory.';
+        setError({ message });
+        if (typeof onStatus === 'function') {
+          onStatus({ type: 'danger', message });
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [active, campaign, initialized, loading, onStatus]);
+
+  const hiddenSets = useMemo(() => {
+    const sets = {};
+    SHOP_TABS.forEach(({ key }) => {
+      sets[key] = new Set(Array.isArray(hiddenState[key]) ? hiddenState[key] : []);
+    });
+    return sets;
+  }, [hiddenState]);
+
+  const hasChanges = useMemo(
+    () => !hiddenStatesEqual(hiddenState, initialHiddenState),
+    [hiddenState, initialHiddenState]
+  );
+
+  const handleToggleItem = useCallback((category, key, visible) => {
+    const normalizedKey = normalizeKey(key);
+    if (!normalizedKey) {
+      return;
+    }
+    setHiddenState((prev) => {
+      const current = Array.isArray(prev[category]) ? prev[category] : [];
+      const set = new Set(current);
+      if (visible) {
+        set.delete(normalizedKey);
+      } else {
+        set.add(normalizedKey);
+      }
+      return { ...prev, [category]: Array.from(set).sort() };
+    });
+  }, []);
+
+  const handleToggleAll = useCallback((category, shouldShowAll, keys) => {
+    setHiddenState((prev) => ({
+      ...prev,
+      [category]: shouldShowAll
+        ? []
+        : keys
+            .map((entry) => normalizeKey(entry))
+            .filter(Boolean)
+            .sort(),
+    }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!campaign) {
+      return;
+    }
+    const encodedCampaign = encodeURIComponent(campaign);
+    const payload = SHOP_TABS.reduce((acc, { key }) => {
+      acc[key] = Array.isArray(hiddenState[key])
+        ? Array.from(new Set(hiddenState[key])).filter(Boolean)
+        : [];
+      return acc;
+    }, {});
+
+    setSaving(true);
+    try {
+      const response = await apiFetch(
+        `/campaigns/${encodedCampaign}/shop-visibility`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }
+      );
+      if (!response.ok) {
+        let message = response.statusText || 'Failed to update shop visibility.';
+        try {
+          const errorBody = await response.json();
+          if (errorBody && typeof errorBody.message === 'string') {
+            message = errorBody.message;
+          }
+        } catch (error) {
+          // ignore JSON parse errors
+        }
+        throw new Error(message);
+      }
+      const data = await response.json();
+      const normalized = normalizeHiddenState(data);
+      setHiddenState(normalized);
+      setInitialHiddenState(normalized);
+      setError(null);
+      if (typeof onStatus === 'function') {
+        onStatus({ type: 'success', message: 'Shop visibility updated.' });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to save shop visibility', err);
+      const message = err?.message || 'Failed to update shop visibility.';
+      setError({ message });
+      if (typeof onStatus === 'function') {
+        onStatus({ type: 'danger', message });
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [campaign, hiddenState, onStatus]);
+
+  const renderCategory = useCallback(
+    (category) => {
+    const entries = Array.isArray(inventory[category]) ? inventory[category] : [];
+    const hiddenSet = hiddenSets[category] || new Set();
+    const total = entries.length;
+    const visibleCount = entries.reduce(
+      (count, entry) => (hiddenSet.has(entry.key) ? count : count + 1),
+      0
+    );
+    const allVisible = total > 0 && visibleCount === total;
+    const noneVisible = total > 0 && visibleCount === 0;
+    const allKeys = entries.map((entry) => entry.key);
+
+      if (loading && total === 0) {
+        return (
+          <div className="d-flex justify-content-center py-4">
+            <Spinner animation="border" role="status" />
+            <span className="visually-hidden">Loading shop inventory…</span>
+          </div>
+        );
+      }
+
+      if (!loading && total === 0) {
+        return <div className="text-center text-muted py-4">No items available.</div>;
+      }
+
+      return (
+        <>
+          <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+            <div className="d-flex align-items-center flex-wrap gap-3">
+              <Form.Check
+                type="checkbox"
+                id={`${category}-select-all`}
+                label="Select All"
+                checked={allVisible}
+                onChange={(event) =>
+                  handleToggleAll(category, event.target.checked, allKeys)
+                }
+                disabled={loading || saving || total === 0}
+              />
+              <Form.Check
+                type="checkbox"
+                id={`${category}-deselect-all`}
+                label="Deselect All"
+                checked={noneVisible}
+                onChange={(event) =>
+                  handleToggleAll(category, !event.target.checked, allKeys)
+                }
+                disabled={loading || saving || total === 0}
+              />
+            </div>
+            <div className="text-muted small">
+              Showing {visibleCount} of {total}
+            </div>
+          </div>
+          <Row className="row-cols-1 row-cols-md-2 row-cols-xl-3 g-3">
+            {entries.map((item) => {
+              const visible = !hiddenSet.has(item.key);
+              return (
+                <Col key={`${category}-${item.key}`} className="d-flex">
+                  <Card className="flex-grow-1 h-100 bg-dark bg-opacity-75 border border-secondary text-light">
+                    <Card.Body className="d-flex flex-column gap-2">
+                      <div>
+                        <div className="d-flex justify-content-between align-items-start gap-2">
+                          <div>
+                            <Card.Title className="h5 mb-1">{item.name}</Card.Title>
+                            <Card.Subtitle className="text-muted text-uppercase small">
+                              {item.category ? toTitleCase(item.category) : '—'}
+                            </Card.Subtitle>
+                          </div>
+                          <Badge bg={item.source === 'Custom' ? 'info' : 'secondary'}>
+                            {item.source}
+                          </Badge>
+                        </div>
+                        {item.damage !== undefined && (
+                          <Card.Text className="mb-1">Damage: {item.damage || '—'}</Card.Text>
+                        )}
+                        {item.properties !== undefined && (
+                          <Card.Text className="mb-1">
+                            Properties:{' '}
+                            {item.properties && item.properties.length > 0
+                              ? item.properties.join(', ')
+                              : '—'}
+                          </Card.Text>
+                        )}
+                        {item.armorClass !== undefined && (
+                          <Card.Text className="mb-1">
+                            AC Bonus: {item.armorClass || '—'}
+                          </Card.Text>
+                        )}
+                        {item.maxDex !== undefined && (
+                          <Card.Text className="mb-1">
+                            Max Dex: {item.maxDex === null ? '—' : item.maxDex}
+                          </Card.Text>
+                        )}
+                        {item.strength !== undefined && (
+                          <Card.Text className="mb-1">
+                            Strength: {item.strength === null ? '—' : item.strength}
+                          </Card.Text>
+                        )}
+                        {item.stealth !== undefined && (
+                          <Card.Text className="mb-1">
+                            Stealth: {item.stealth ? 'Disadvantage' : '—'}
+                          </Card.Text>
+                        )}
+                        {item.weight !== undefined && (
+                          <Card.Text className="mb-1">
+                            Weight: {item.weight === '' || item.weight === null ? '—' : item.weight}
+                          </Card.Text>
+                        )}
+                        {item.targetSlots !== undefined && (
+                          <Card.Text className="mb-1">
+                            Slots:{' '}
+                            {item.targetSlots && item.targetSlots.length > 0
+                              ? item.targetSlots.map(toTitleCase).join(', ')
+                              : '—'}
+                          </Card.Text>
+                        )}
+                        {item.rarity !== undefined && (
+                          <Card.Text className="mb-1">
+                            Rarity: {item.rarity ? toTitleCase(item.rarity) : '—'}
+                          </Card.Text>
+                        )}
+                        <Card.Text className="mb-1">Cost: {item.cost || '—'}</Card.Text>
+                        {item.notes ? (
+                          <Card.Text className="small text-muted mb-0">
+                            {item.notes}
+                          </Card.Text>
+                        ) : null}
+                      </div>
+                      <div className="mt-auto">
+                        <Form.Check
+                          type="checkbox"
+                          id={`${category}-visibility-${toHtmlId(item.key)}`}
+                          label="Visible in player shop"
+                          checked={visible}
+                          onChange={(event) =>
+                            handleToggleItem(category, item.key, event.target.checked)
+                          }
+                          disabled={saving}
+                        />
+                      </div>
+                    </Card.Body>
+                  </Card>
+                </Col>
+              );
+            })}
+          </Row>
+        </>
+      );
+    },
+    [handleToggleAll, handleToggleItem, hiddenSets, inventory, loading, saving]
+  );
+
+  return (
+    <div>
+      {error ? <Alert variant="danger">{error.message}</Alert> : null}
+      <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <div className="text-muted small">
+          Choose which items are available to players in the shop.
+        </div>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={!initialized || saving || !hasChanges}
+        >
+          {saving ? (
+            <span className="d-flex align-items-center gap-2">
+              <Spinner animation="border" size="sm" role="status" />
+              <span>Saving…</span>
+            </span>
+          ) : (
+            'Save Visibility'
+          )}
+        </Button>
+      </div>
+      <Tab.Container activeKey={activeTabKey} onSelect={(key) => key && setActiveTabKey(key)}>
+        <div className="d-flex justify-content-center mb-3">
+          <Nav variant="tabs" className="flex-wrap">
+            {SHOP_TABS.map(({ key, title }) => (
+              <Nav.Item key={key}>
+                <Nav.Link eventKey={key}>{title}</Nav.Link>
+              </Nav.Item>
+            ))}
+          </Nav>
+        </div>
+        <Tab.Content>
+          {SHOP_TABS.map(({ key }) => (
+            <Tab.Pane eventKey={key} key={key}>
+              {renderCategory(key)}
+            </Tab.Pane>
+          ))}
+        </Tab.Content>
+      </Tab.Container>
+    </div>
+  );
+}
+
+ShopVisibilityManager.defaultProps = {
+  campaign: '',
+  active: false,
+  onStatus: () => {},
+};

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -31,6 +31,7 @@ import MapModal from '../attributes/MapModal';
 import { calculateDamage } from '../attributes/PlayerTurnActions';
 import D20RollerModal, { DEFAULT_DICE_COLOR } from '../common/D20RollerModal';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
+import ShopVisibilityManager from '../attributes/ShopVisibilityManager';
 import {
   GiCharacter,
   GiStoneAxe,
@@ -3958,6 +3959,7 @@ export default function ZombiesDM() {
         { key: 'armor', title: 'Armor' },
         { key: 'items', title: 'Items' },
         { key: 'accessories', title: 'Accessories' },
+        { key: 'shop', title: 'Shop' },
       ],
       [calculateCharacterInitiative]
     );
@@ -8055,6 +8057,35 @@ const resolveIcon = (category, iconMap, fallback) => {
                   />
                 )}
               </div>
+            </Card.Body>
+          </Card>
+        </div>
+      )}
+    </Tab.Pane>
+    <Tab.Pane eventKey="shop">
+      {activeResourceTab === 'shop' && (
+        <div className="text-center">
+          <Card className="modern-card" data-testid="resource-shop-card">
+            <Card.Header className="modal-header">
+              <div className="d-flex align-items-center justify-content-center w-100">
+                <div className="flex-grow-1" />
+                <CloseButton
+                  className="ms-auto"
+                  variant="white"
+                  onClick={() => handleCloseResourceTab('shop')}
+                  aria-label="Close shop tab"
+                />
+              </div>
+            </Card.Header>
+            <Card.Body
+              className="resource-tab-safe-area text-start"
+              style={{ overflowY: 'auto', maxHeight: '70vh' }}
+            >
+              <ShopVisibilityManager
+                campaign={currentCampaign}
+                active={activeResourceTab === 'shop'}
+                onStatus={setStatus}
+              />
             </Card.Body>
           </Card>
         </div>

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -209,6 +209,91 @@ const parseFolderFilters = (input) => {
   return Array.from(new Set(sanitized));
 };
 
+const SHOP_VISIBILITY_CATEGORIES = ['weapons', 'armor', 'items', 'accessories'];
+
+const normalizeShopVisibilityValue = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    const normalizedSet = new Set();
+    value.forEach((entry) => {
+      if (typeof entry !== 'string') {
+        return;
+      }
+      const normalized = entry.trim().toLowerCase();
+      if (normalized) {
+        normalizedSet.add(normalized);
+      }
+    });
+    return Array.from(normalizedSet);
+  }
+
+  if (typeof value === 'object') {
+    const normalizedSet = new Set();
+    Object.entries(value).forEach(([key, hidden]) => {
+      if (typeof key !== 'string') {
+        return;
+      }
+      const normalized = key.trim().toLowerCase();
+      if (!normalized) {
+        return;
+      }
+      if (hidden === true) {
+        normalizedSet.add(normalized);
+      }
+    });
+    return Array.from(normalizedSet);
+  }
+
+  return [];
+};
+
+const normalizeShopVisibility = (input) => {
+  const visibility = {};
+  SHOP_VISIBILITY_CATEGORIES.forEach((category) => {
+    visibility[category] = normalizeShopVisibilityValue(input?.[category]);
+  });
+  return visibility;
+};
+
+const validateShopVisibilityPayload = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('visibility must be an object');
+  }
+
+  for (const [category, entries] of Object.entries(value)) {
+    if (!SHOP_VISIBILITY_CATEGORIES.includes(category)) {
+      throw new Error(`invalid category: ${category}`);
+    }
+
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        if (typeof entry !== 'string') {
+          throw new Error(`category ${category} must be an array of strings`);
+        }
+      }
+      continue;
+    }
+
+    if (entries && typeof entries === 'object') {
+      for (const hidden of Object.values(entries)) {
+        if (typeof hidden !== 'boolean') {
+          throw new Error(`category ${category} must map keys to boolean values`);
+        }
+      }
+      continue;
+    }
+
+    if (entries !== undefined && entries !== null) {
+      throw new Error(`category ${category} must be an array or object`);
+    }
+  }
+
+  return true;
+};
+
 const sanitizeSingleFolder = (folder) => {
   const sanitized = parseFolderFilters(
     Array.isArray(folder) ? folder : folder ? [folder] : []
@@ -1366,6 +1451,81 @@ module.exports = (router) => {
           emitMapUpdate(campaignName, tokenPayload);
 
           return res.json(tokenPayload);
+        } catch (err) {
+          next(err);
+        }
+      }
+    );
+
+  campaignRouter
+    .route('/:campaign/shop-visibility')
+    .get(
+      [param('campaign').trim().notEmpty().withMessage('campaign is required')],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const db_connect = req.db;
+          const campaign = await db_connect.collection('Campaigns').findOne(
+            { campaignName },
+            { projection: { dm: 1, players: 1, shopVisibility: 1 } }
+          );
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const username = typeof req.user?.username === 'string' ? req.user.username : null;
+          const isDm = username && campaign.dm === username;
+          const isPlayer =
+            username &&
+            Array.isArray(campaign.players) &&
+            campaign.players.includes(username);
+
+          if (!isDm && !isPlayer) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const visibility = normalizeShopVisibility(campaign.shopVisibility || {});
+          return res.json(visibility);
+        } catch (err) {
+          next(err);
+        }
+      }
+    )
+    .put(
+      [
+        param('campaign').trim().notEmpty().withMessage('campaign is required'),
+        body().custom(validateShopVisibilityPayload),
+      ],
+      handleValidationErrors,
+      async (req, res, next) => {
+        try {
+          const campaignName = req.params.campaign;
+          const db_connect = req.db;
+          const collection = db_connect.collection('Campaigns');
+          const campaign = await collection.findOne(
+            { campaignName },
+            { projection: { dm: 1 } }
+          );
+
+          if (!campaign) {
+            return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          if (!req.user || campaign.dm !== req.user.username) {
+            return res.status(403).json({ message: 'Forbidden' });
+          }
+
+          const visibility = normalizeShopVisibility(req.body || {});
+
+          await collection.updateOne(
+            { campaignName },
+            { $set: { shopVisibility: visibility } },
+            { upsert: false }
+          );
+
+          return res.json(visibility);
         } catch (err) {
           next(err);
         }


### PR DESCRIPTION
## Summary
- add an explicit deselect-all checkbox alongside the existing select-all control in the DM shop visibility manager
- keep the visibility summary messaging intact while supporting full hide/show actions

## Testing
- npm test -- ShopModal

------
https://chatgpt.com/codex/tasks/task_e_68fd1f905a98832e8844cb98d6807b15