### PR TITLE
Add fallback race scopes to player token class filters

### DIFF
--- a/client/src/components/Zombies/utils/playerTokenFilters.js
+++ b/client/src/components/Zombies/utils/playerTokenFilters.js
@@ -344,7 +344,10 @@ export const buildPlayerTokenFolderScope = (raceName, occupations) => {
   });
 
   if (classCollector.values.length > 0) {
-    return classCollector.values;
+    raceCollector.values.forEach((raceValue) => {
+      classCollector.add(raceValue);
+    });
+    return classCollector.values.length > 0 ? classCollector.values : null;
   }
 
   return raceCollector.values.length > 0 ? raceCollector.values : null;

--- a/client/src/components/Zombies/utils/playerTokenFilters.test.js
+++ b/client/src/components/Zombies/utils/playerTokenFilters.test.js
@@ -34,11 +34,10 @@ describe('buildPlayerTokenFolderScope', () => {
         'folder:Tokens/Adventurers/Dragonborn/Fighters',
       ])
     );
-    expect(scope.some((value) => value === 'Tokens/Adventurers/Dragonborn')).toBe(false);
-    expect(scope.filter((value) => value === 'Dragonborn/Fighter').length).toBe(1);
-    expect(scope.some((value) => value === 'Tokens/Adventurers/Dragonborn')).toBe(
-      false
+    expect(scope).toEqual(
+      expect.arrayContaining(['Tokens/Adventurers/Dragonborn', 'Dragonborn'])
     );
+    expect(scope.filter((value) => value === 'Dragonborn/Fighter').length).toBe(1);
   });
 
   it('creates class variants when subclasses are provided', () => {
@@ -55,7 +54,7 @@ describe('buildPlayerTokenFolderScope', () => {
         'Tokens/Adventurers/Elves',
       ])
     );
-    expect(scope.some((value) => value === 'Tokens/Adventurers/Elves')).toBe(false);
+    expect(scope).toEqual(expect.arrayContaining(['Tokens/Adventurers/Elves', 'Elf']));
   });
 
   it('handles multi-class characters', () => {
@@ -73,8 +72,8 @@ describe('buildPlayerTokenFolderScope', () => {
         'Tokens/Adventurers/Half-Orcs',
       ])
     );
-    expect(scope.some((value) => value === 'Tokens/Adventurers/Half-Orcs')).toBe(
-      false
+    expect(scope).toEqual(
+      expect.arrayContaining(['Tokens/Adventurers/Half-Orcs', 'Half-Orc'])
     );
   });
 
@@ -90,8 +89,8 @@ describe('buildPlayerTokenFolderScope', () => {
         'Tokens/Adventurers/Goliaths',
       ])
     );
-    expect(scope.some((value) => value === 'Tokens/Adventurers/Goliaths')).toBe(
-      false
+    expect(scope).toEqual(
+      expect.arrayContaining(['Tokens/Adventurers/Goliaths', 'Goliath'])
     );
   });
 
@@ -106,7 +105,7 @@ describe('buildPlayerTokenFolderScope', () => {
         'folder:Tokens/Adventurers/Elves/Rangers',
       ])
     );
-    expect(scope.some((value) => value === 'Tokens/Adventurers/Elves')).toBe(false);
+    expect(scope).toEqual(expect.arrayContaining(['Tokens/Adventurers/Elves', 'Elf']));
   });
 
   it('avoids runaway pluralization variants', () => {


### PR DESCRIPTION
## Summary
- include race-level token folders when class-specific scopes are present so characters still see base tokens
- update player token filter tests to validate race folder fallback behavior

## Testing
- CI=true npm test -- playerTokenFilters

------
https://chatgpt.com/codex/tasks/task_e_68fd2d7f5758832ea0d1d08ee0296a82