### PR TITLE
Handle empty shop visibility responses

### DIFF
--- a/client/src/components/Zombies/attributes/ShopVisibilityManager.js
+++ b/client/src/components/Zombies/attributes/ShopVisibilityManager.js
@@ -113,7 +113,14 @@ const fetchJsonOrThrow = async (url, defaultMessage) => {
 const fetchJsonWithFallback = async (url, fallbackValue = []) => {
   const response = await apiFetch(url);
   if (response.ok) {
-    return response.json();
+    try {
+      return await response.json();
+    } catch (error) {
+      if (response.status === 204 || response.headers.get('Content-Length') === '0') {
+        return fallbackValue;
+      }
+      throw error;
+    }
   }
   if (response.status === 404) {
     return fallbackValue;
@@ -398,9 +405,9 @@ export default function ShopVisibilityManager({ campaign, active, onStatus }) {
           standardAccessories,
           customAccessories,
         ] = await Promise.all([
-          fetchJsonOrThrow(
+          fetchJsonWithFallback(
             `/campaigns/${encodedCampaign}/shop-visibility`,
-            'Failed to load shop visibility.'
+            createEmptyHiddenState()
           ),
           fetchJsonOrThrow('/weapons', 'Failed to load weapons.'),
           fetchJsonWithFallback(`/equipment/weapons/${encodedCampaign}`),


### PR DESCRIPTION
## Summary
- treat missing campaign shop visibility data as an empty configuration so the DM shop tab can load
- make fetchJsonWithFallback resilient to empty JSON responses by returning the provided fallback on 204/no-content replies

## Testing
- CI=true npm test -- ShopVisibilityManager *(fails: no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_68fd2ec1c3d0832eb7f9c72a3f381db9