### PR TITLE
Prevent DM shop visibility spinner from stalling

### DIFF
--- a/client/src/components/Zombies/attributes/ShopVisibilityManager.js
+++ b/client/src/components/Zombies/attributes/ShopVisibilityManager.js
@@ -113,7 +113,14 @@ const fetchJsonOrThrow = async (url, defaultMessage) => {
 const fetchJsonWithFallback = async (url, fallbackValue = []) => {
   const response = await apiFetch(url);
   if (response.ok) {
-    return response.json();
+    try {
+      return await response.json();
+    } catch (error) {
+      if (response.status === 204 || response.headers.get('Content-Length') === '0') {
+        return fallbackValue;
+      }
+      throw error;
+    }
   }
   if (response.status === 404) {
     return fallbackValue;
@@ -373,12 +380,13 @@ export default function ShopVisibilityManager({ campaign, active, onStatus }) {
     setHiddenState(createEmptyHiddenState());
     setInitialHiddenState(createEmptyHiddenState());
     setInventory({ weapons: [], armor: [], items: [], accessories: [] });
+    setLoading(false);
     setInitialized(false);
     setError(null);
   }, [campaign]);
 
   useEffect(() => {
-    if (!active || !campaign || initialized || loading) {
+    if (!active || !campaign || initialized) {
       return;
     }
 
@@ -398,9 +406,9 @@ export default function ShopVisibilityManager({ campaign, active, onStatus }) {
           standardAccessories,
           customAccessories,
         ] = await Promise.all([
-          fetchJsonOrThrow(
+          fetchJsonWithFallback(
             `/campaigns/${encodedCampaign}/shop-visibility`,
-            'Failed to load shop visibility.'
+            createEmptyHiddenState()
           ),
           fetchJsonOrThrow('/weapons', 'Failed to load weapons.'),
           fetchJsonWithFallback(`/equipment/weapons/${encodedCampaign}`),
@@ -451,7 +459,7 @@ export default function ShopVisibilityManager({ campaign, active, onStatus }) {
     return () => {
       cancelled = true;
     };
-  }, [active, campaign, initialized, loading, onStatus]);
+  }, [active, campaign, initialized, onStatus]);
 
   const hiddenSets = useMemo(() => {
     const sets = {};


### PR DESCRIPTION
## Summary
- reset the DM shop visibility manager when the campaign changes so the loading flag clears cleanly
- avoid cancelling the active visibility load when the loading state updates, preventing the spinner from sticking forever

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd2ec1c3d0832eb7f9c72a3f381db9