### PR TITLE
Fix player token picker selecting generic race folder

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -174,6 +174,116 @@ const filterMatchesScope = (filter, scopeSet) => {
   return false;
 };
 
+const scoreFilterAgainstScope = (filter, scopeSet) => {
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
+
+  if (!filter || typeof filter !== 'object') {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
+
+  const filterValues = [];
+  if (typeof filter.key === 'string') {
+    filterValues.push(filter.key);
+  }
+  if (typeof filter.label === 'string') {
+    filterValues.push(filter.label);
+  }
+  if (Array.isArray(filter.aliases)) {
+    filterValues.push(...filter.aliases);
+  }
+  if (Array.isArray(filter.folders)) {
+    filterValues.push(...filter.folders);
+  }
+
+  const filterVariantSet = buildScopeVariantSet(filterValues);
+  if (filterVariantSet.size === 0) {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
+
+  const scopeVariants = Array.from(scopeSet);
+  const scopeCache = new Map();
+  const filterCache = new Map();
+
+  let bestScore = 0;
+  let bestScopeIndex = Number.POSITIVE_INFINITY;
+
+  scopeVariants.forEach((scopeVariant, scopeIndex) => {
+    const scopeData = normalizeVariantData(scopeVariant, scopeCache);
+    if (!scopeData) {
+      return;
+    }
+
+    const matchSegments = scopeData.segments.length > 0 ? scopeData.segments.length : 1;
+
+    filterVariantSet.forEach((filterVariant) => {
+      const filterData = normalizeVariantData(filterVariant, filterCache);
+      if (!filterData) {
+        return;
+      }
+
+      if (filterData.lower === scopeData.lower || filterData.compact === scopeData.compact) {
+        if (matchSegments > bestScore || (matchSegments === bestScore && scopeIndex < bestScopeIndex)) {
+          bestScore = matchSegments;
+          bestScopeIndex = scopeIndex;
+        }
+        return;
+      }
+
+      if (segmentsContainSubsequence(filterData.segments, scopeData.segments)) {
+        if (matchSegments > bestScore || (matchSegments === bestScore && scopeIndex < bestScopeIndex)) {
+          bestScore = matchSegments;
+          bestScopeIndex = scopeIndex;
+        }
+      }
+    });
+  });
+
+  return { score: bestScore, scopeIndex: bestScopeIndex };
+};
+
+const findBestScopedFilterKey = (filters, scopeSet) => {
+  if (!Array.isArray(filters) || filters.length === 0) {
+    return null;
+  }
+
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return null;
+  }
+
+  let bestKey = null;
+  let bestScore = 0;
+  let bestScopeIndex = Number.POSITIVE_INFINITY;
+  let bestDepth = -1;
+  let bestFilterIndex = Number.POSITIVE_INFINITY;
+
+  filters.forEach((filter, index) => {
+    const { score, scopeIndex } = scoreFilterAgainstScope(filter, scopeSet);
+
+    if (score <= 0) {
+      return;
+    }
+
+    const depth = Number.isInteger(filter?.depth) ? filter.depth : 0;
+
+    if (
+      score > bestScore ||
+      (score === bestScore &&
+        (scopeIndex < bestScopeIndex ||
+          (scopeIndex === bestScopeIndex && (depth > bestDepth || (depth === bestDepth && index < bestFilterIndex)))))
+    ) {
+      bestScore = score;
+      bestScopeIndex = scopeIndex;
+      bestDepth = depth;
+      bestFilterIndex = index;
+      bestKey = filter?.key || null;
+    }
+  });
+
+  return bestKey;
+};
+
 const buildNormalizedMatchSet = (values = []) => {
   const set = new Set();
 
@@ -651,7 +761,12 @@ const TokenPickerModal = ({
 
     let nextKey = null;
 
-    if (defaultFilter) {
+    const scopedKey = findBestScopedFilterKey(availableFilters, filterScopeSet);
+    if (scopedKey && filterLookup.has(scopedKey)) {
+      nextKey = scopedKey;
+    }
+
+    if (!nextKey && defaultFilter) {
       if (filterLookup.has(defaultFilter)) {
         nextKey = defaultFilter;
       } else {
@@ -677,7 +792,7 @@ const TokenPickerModal = ({
     if (nextKey !== selectedFilterKey) {
       setSelectedFilterKey(nextKey);
     }
-  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey]);
+  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey, filterScopeSet]);
 
   const [assets, setAssets] = useState([]);
   const [loading, setLoading] = useState(false);

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import TokenPickerModal from './TokenPickerModal';
 import apiFetch from '../../../utils/apiFetch';
 import { buildEnemyTokenFilterScopeValues } from '../utils/enemyTokenFilters';
+import { buildPlayerTokenFolderScope } from '../utils/playerTokenFilters';
 
 jest.mock('../../../utils/apiFetch');
 
@@ -394,6 +395,128 @@ describe('TokenPickerModal', () => {
         '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FCore_Class_Tokens%2FFighter'
       );
     });
+  });
+
+  test('player token picker prefers most specific matching folder from scope', async () => {
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Humans',
+              path: 'Tokens/Adventurers/Humans',
+              relativePath: 'Adventurers/Humans',
+              children: [
+                {
+                  name: 'Barbarian',
+                  path: 'Tokens/Adventurers/Humans/Barbarian',
+                  relativePath: 'Adventurers/Humans/Barbarian',
+                  children: [],
+                },
+                {
+                  name: 'Paladin',
+                  path: 'Tokens/Adventurers/Humans/Paladin',
+                  relativePath: 'Adventurers/Humans/Paladin',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Humans',
+          path: 'Tokens/Adventurers/Humans',
+          relativePath: 'Adventurers/Humans',
+          depth: 1,
+          displayPath: 'Adventurers/Humans',
+        },
+        {
+          name: 'Barbarian',
+          path: 'Tokens/Adventurers/Humans/Barbarian',
+          relativePath: 'Adventurers/Humans/Barbarian',
+          depth: 2,
+          displayPath: 'Adventurers/Humans/Barbarian',
+        },
+        {
+          name: 'Paladin',
+          path: 'Tokens/Adventurers/Humans/Paladin',
+          relativePath: 'Adventurers/Humans/Paladin',
+          depth: 2,
+          displayPath: 'Adventurers/Humans/Paladin',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    const scope = buildPlayerTokenFolderScope('Human', [{ Occupation: 'Paladin' }]);
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={scope}
+      />
+    );
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FHumans%2FPaladin'
+      );
+    });
+
+    expect(
+      manifestCalls.some((call) =>
+        call.includes('token-manifest?folders=Tokens%2FAdventurers%2FHumans%2FPaladin')
+      )
+    ).toBe(true);
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(3);
+    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Humans');
+    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Humans/Barbarian');
+    expect(options[2].textContent.replace(/\u00A0/g, '')).toBe('Humans/Paladin');
+
+    const selectedOption = options.find((option) => option.selected);
+    expect(selectedOption?.textContent.replace(/\u00A0/g, '')).toBe('Humans/Paladin');
   });
 
   test('filters manifest assets based on provided scope', async () => {


### PR DESCRIPTION
## Summary
- prioritize the most specific folder that matches the token picker scope when auto-selecting player filters
- add coverage to ensure a human paladin scope selects its class folder

## Testing
- npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fd2f600aa4832e9b09368572b7e6bc