### PR TITLE
Improve token scope selection for player tokens

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -174,10 +174,123 @@ const filterMatchesScope = (filter, scopeSet) => {
   return false;
 };
 
-const buildNormalizedMatchSet = (values = []) => {
-  const set = new Set();
+const scoreFilterAgainstScope = (filter, scopeSet) => {
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
 
-  values.forEach((value) => {
+  if (!filter || typeof filter !== 'object') {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
+
+  const filterValues = [];
+  if (typeof filter.key === 'string') {
+    filterValues.push(filter.key);
+  }
+  if (typeof filter.label === 'string') {
+    filterValues.push(filter.label);
+  }
+  if (Array.isArray(filter.aliases)) {
+    filterValues.push(...filter.aliases);
+  }
+  if (Array.isArray(filter.folders)) {
+    filterValues.push(...filter.folders);
+  }
+
+  const filterVariantSet = buildScopeVariantSet(filterValues);
+  if (filterVariantSet.size === 0) {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
+
+  const scopeVariants = Array.from(scopeSet);
+  const scopeCache = new Map();
+  const filterCache = new Map();
+
+  let bestScore = 0;
+  let bestScopeIndex = Number.POSITIVE_INFINITY;
+
+  scopeVariants.forEach((scopeVariant, scopeIndex) => {
+    const scopeData = normalizeVariantData(scopeVariant, scopeCache);
+    if (!scopeData) {
+      return;
+    }
+
+    const matchSegments = scopeData.segments.length > 0 ? scopeData.segments.length : 1;
+
+    filterVariantSet.forEach((filterVariant) => {
+      const filterData = normalizeVariantData(filterVariant, filterCache);
+      if (!filterData) {
+        return;
+      }
+
+      if (filterData.lower === scopeData.lower || filterData.compact === scopeData.compact) {
+        if (matchSegments > bestScore || (matchSegments === bestScore && scopeIndex < bestScopeIndex)) {
+          bestScore = matchSegments;
+          bestScopeIndex = scopeIndex;
+        }
+        return;
+      }
+
+      if (segmentsContainSubsequence(filterData.segments, scopeData.segments)) {
+        if (matchSegments > bestScore || (matchSegments === bestScore && scopeIndex < bestScopeIndex)) {
+          bestScore = matchSegments;
+          bestScopeIndex = scopeIndex;
+        }
+      }
+    });
+  });
+
+  return { score: bestScore, scopeIndex: bestScopeIndex };
+};
+
+const findBestScopedFilterKey = (filters, scopeSet) => {
+  if (!Array.isArray(filters) || filters.length === 0) {
+    return null;
+  }
+
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return null;
+  }
+
+  let bestKey = null;
+  let bestScore = 0;
+  let bestScopeIndex = Number.POSITIVE_INFINITY;
+  let bestDepth = -1;
+  let bestFilterIndex = Number.POSITIVE_INFINITY;
+
+  filters.forEach((filter, index) => {
+    const { score, scopeIndex } = scoreFilterAgainstScope(filter, scopeSet);
+
+    if (score <= 0) {
+      return;
+    }
+
+    const depth = Number.isInteger(filter?.depth) ? filter.depth : 0;
+
+    if (
+      score > bestScore ||
+      (score === bestScore &&
+        (scopeIndex < bestScopeIndex ||
+          (scopeIndex === bestScopeIndex && (depth > bestDepth || (depth === bestDepth && index < bestFilterIndex)))))
+    ) {
+      bestScore = score;
+      bestScopeIndex = scopeIndex;
+      bestDepth = depth;
+      bestFilterIndex = index;
+      bestKey = filter?.key || null;
+    }
+  });
+
+  return bestKey;
+};
+
+const collectAssetScopeCandidates = (asset, manifestMeta) => {
+  if (!asset || typeof asset !== 'object') {
+    return [];
+  }
+
+  const values = new Set();
+  const addValue = (value) => {
     if (typeof value !== 'string') {
       return;
     }
@@ -187,50 +300,10 @@ const buildNormalizedMatchSet = (values = []) => {
       return;
     }
 
-    const lower = trimmed.toLowerCase();
-    const forms = new Set([
-      lower,
-      lower.replace(/[_-]+/g, ' '),
-      lower.replace(/[\\/]+/g, ' '),
-      lower.replace(/[^a-z0-9/]+/g, ' '),
-      lower.replace(/[^a-z0-9]+/g, ''),
-    ]);
-
-    forms.forEach((form) => {
-      if (typeof form !== 'string') {
-        return;
-      }
-
-      const normalized = form.replace(/\s+/g, ' ').trim();
-      if (normalized) {
-        set.add(normalized);
-      }
-    });
-  });
-
-  return set;
-};
-
-const collectAssetMatchValues = (asset, manifestMeta) => {
-  if (!asset || typeof asset !== 'object') {
-    return new Set();
-  }
-
-  const rawValues = [];
-  const addValue = (value) => {
-    if (typeof value !== 'string') {
-      return;
-    }
-
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return;
-    }
-
-    rawValues.push(trimmed);
+    values.add(trimmed);
 
     if (!trimmed.toLowerCase().startsWith('folder:')) {
-      rawValues.push(`folder:${trimmed}`);
+      values.add(`folder:${trimmed}`);
     }
   };
 
@@ -256,62 +329,67 @@ const collectAssetMatchValues = (asset, manifestMeta) => {
     : [];
   appliedFolders.forEach(addValue);
 
-  return buildNormalizedMatchSet(rawValues);
+  return Array.from(values);
 };
 
-const collectScopeMatchValues = (scopeSet) => {
-  if (!(scopeSet instanceof Set)) {
-    return new Set();
+const scoreAssetAgainstScope = (asset, scopeSet, manifestMeta) => {
+  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
   }
 
-  const rawValues = [];
+  const candidates = collectAssetScopeCandidates(asset, manifestMeta);
+  if (candidates.length === 0) {
+    return { score: 0, scopeIndex: Number.POSITIVE_INFINITY };
+  }
 
-  scopeSet.forEach((value) => {
-    if (typeof value !== 'string') {
+  const scopeVariants = Array.from(scopeSet);
+  const scopeCache = new Map();
+  const candidateCache = new Map();
+
+  let bestScore = 0;
+  let bestScopeIndex = Number.POSITIVE_INFINITY;
+
+  scopeVariants.forEach((scopeVariant, scopeIndex) => {
+    const scopeData = normalizeVariantData(scopeVariant, scopeCache);
+    if (!scopeData) {
       return;
     }
 
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return;
-    }
+    const matchSegments = scopeData.segments.length > 0 ? scopeData.segments.length : 1;
 
-    rawValues.push(trimmed);
+    candidates.forEach((candidate) => {
+      const candidateData = normalizeVariantData(candidate, candidateCache);
+      if (!candidateData) {
+        return;
+      }
 
-    if (trimmed.toLowerCase().startsWith('folder:')) {
-      rawValues.push(trimmed.slice('folder:'.length));
-    } else {
-      rawValues.push(`folder:${trimmed}`);
-    }
+      if (
+        candidateData.lower === scopeData.lower ||
+        candidateData.compact === scopeData.compact
+      ) {
+        if (
+          matchSegments > bestScore ||
+          (matchSegments === bestScore && scopeIndex < bestScopeIndex)
+        ) {
+          bestScore = matchSegments;
+          bestScopeIndex = scopeIndex;
+        }
+        return;
+      }
+
+      if (segmentsContainSubsequence(candidateData.segments, scopeData.segments)) {
+        if (
+          matchSegments > bestScore ||
+          (matchSegments === bestScore && scopeIndex < bestScopeIndex)
+        ) {
+          bestScore = matchSegments;
+          bestScopeIndex = scopeIndex;
+        }
+      }
+    });
   });
 
-  return buildNormalizedMatchSet(rawValues);
-};
-
-const assetMatchesScope = (asset, scopeSet, manifestMeta) => {
-  if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
-    return true;
-  }
-
-  const scopeValues = collectScopeMatchValues(scopeSet);
-  if (scopeValues.size === 0) {
-    return true;
-  }
-
-  const assetValues = collectAssetMatchValues(asset, manifestMeta);
-  if (assetValues.size === 0) {
-    return false;
-  }
-
-  for (const scopeValue of scopeValues) {
-    for (const assetValue of assetValues) {
-      if (assetValue.includes(scopeValue)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  return { score: bestScore, scopeIndex: bestScopeIndex };
 };
 
 const buildDynamicDmFilters = (folderTree, fallbackFilters = DEFAULT_DM_FILTERS) => {
@@ -651,7 +729,12 @@ const TokenPickerModal = ({
 
     let nextKey = null;
 
-    if (defaultFilter) {
+    const scopedKey = findBestScopedFilterKey(availableFilters, filterScopeSet);
+    if (scopedKey && filterLookup.has(scopedKey)) {
+      nextKey = scopedKey;
+    }
+
+    if (!nextKey && defaultFilter) {
       if (filterLookup.has(defaultFilter)) {
         nextKey = defaultFilter;
       } else {
@@ -677,7 +760,7 @@ const TokenPickerModal = ({
     if (nextKey !== selectedFilterKey) {
       setSelectedFilterKey(nextKey);
     }
-  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey]);
+  }, [filterLookup, availableFilters, defaultFilter, selectedFilterKey, filterScopeSet]);
 
   const [assets, setAssets] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -695,7 +778,43 @@ const TokenPickerModal = ({
       return assets;
     }
 
-    return assets.filter((asset) => assetMatchesScope(asset, filterScopeSet, manifestMeta));
+    const matchDetails = assets.map((asset) => ({
+      asset,
+      ...scoreAssetAgainstScope(asset, filterScopeSet, manifestMeta),
+    }));
+
+    const positiveMatches = matchDetails.filter((entry) => entry.score > 0);
+    if (positiveMatches.length === 0) {
+      return assets;
+    }
+
+    let bestScore = 0;
+    let bestScopeIndex = Number.POSITIVE_INFINITY;
+
+    positiveMatches.forEach(({ score, scopeIndex }) => {
+      const normalizedScopeIndex = Number.isFinite(scopeIndex)
+        ? scopeIndex
+        : Number.POSITIVE_INFINITY;
+
+      if (score > bestScore || (score === bestScore && normalizedScopeIndex < bestScopeIndex)) {
+        bestScore = score;
+        bestScopeIndex = normalizedScopeIndex;
+      }
+    });
+
+    return positiveMatches
+      .filter(({ score, scopeIndex }) => {
+        if (score !== bestScore) {
+          return false;
+        }
+
+        const normalizedScopeIndex = Number.isFinite(scopeIndex)
+          ? scopeIndex
+          : Number.POSITIVE_INFINITY;
+
+        return normalizedScopeIndex === bestScopeIndex;
+      })
+      .map(({ asset }) => asset);
   }, [assets, filterScopeSet, manifestMeta]);
 
   const resetState = useCallback((options = {}) => {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import TokenPickerModal from './TokenPickerModal';
 import apiFetch from '../../../utils/apiFetch';
 import { buildEnemyTokenFilterScopeValues } from '../utils/enemyTokenFilters';
+import { buildPlayerTokenFolderScope } from '../utils/playerTokenFilters';
 
 jest.mock('../../../utils/apiFetch');
 
@@ -396,6 +397,128 @@ describe('TokenPickerModal', () => {
     });
   });
 
+  test('player token picker prefers most specific matching folder from scope', async () => {
+    const folderTree = {
+      rootFolder: 'Tokens',
+      folders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          children: [
+            {
+              name: 'Humans',
+              path: 'Tokens/Adventurers/Humans',
+              relativePath: 'Adventurers/Humans',
+              children: [
+                {
+                  name: 'Barbarian',
+                  path: 'Tokens/Adventurers/Humans/Barbarian',
+                  relativePath: 'Adventurers/Humans/Barbarian',
+                  children: [],
+                },
+                {
+                  name: 'Paladin',
+                  path: 'Tokens/Adventurers/Humans/Paladin',
+                  relativePath: 'Adventurers/Humans/Paladin',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      flatFolders: [
+        {
+          name: 'Adventurers',
+          path: 'Tokens/Adventurers',
+          relativePath: 'Adventurers',
+          depth: 0,
+          displayPath: 'Adventurers',
+        },
+        {
+          name: 'Humans',
+          path: 'Tokens/Adventurers/Humans',
+          relativePath: 'Adventurers/Humans',
+          depth: 1,
+          displayPath: 'Adventurers/Humans',
+        },
+        {
+          name: 'Barbarian',
+          path: 'Tokens/Adventurers/Humans/Barbarian',
+          relativePath: 'Adventurers/Humans/Barbarian',
+          depth: 2,
+          displayPath: 'Adventurers/Humans/Barbarian',
+        },
+        {
+          name: 'Paladin',
+          path: 'Tokens/Adventurers/Humans/Paladin',
+          relativePath: 'Adventurers/Humans/Paladin',
+          depth: 2,
+          displayPath: 'Adventurers/Humans/Paladin',
+        },
+      ],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    const scope = buildPlayerTokenFolderScope('Human', [{ Occupation: 'Paladin' }]);
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={scope}
+      />
+    );
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      const lastCall = manifestCalls[manifestCalls.length - 1];
+      expect(lastCall).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FHumans%2FPaladin'
+      );
+    });
+
+    expect(
+      manifestCalls.some((call) =>
+        call.includes('token-manifest?folders=Tokens%2FAdventurers%2FHumans%2FPaladin')
+      )
+    ).toBe(true);
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(3);
+    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Humans');
+    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Humans/Barbarian');
+    expect(options[2].textContent.replace(/\u00A0/g, '')).toBe('Humans/Paladin');
+
+    const selectedOption = options.find((option) => option.selected);
+    expect(selectedOption?.textContent.replace(/\u00A0/g, '')).toBe('Humans/Paladin');
+  });
+
   test('filters manifest assets based on provided scope', async () => {
     const folderTree = { folders: [], flatFolders: [] };
 
@@ -407,7 +530,12 @@ describe('TokenPickerModal', () => {
           relativeFolder: 'Adventurers/Dragonborn/Fighter',
         },
         {
-          publicId: 'Tokens/Adventurers/Elf/Wizard/token-2',
+          publicId: 'Tokens/Adventurers/Dragonborn/Wizard/token-2',
+          filename: 'Dragonborn Wizard',
+          relativeFolder: 'Adventurers/Dragonborn/Wizard',
+        },
+        {
+          publicId: 'Tokens/Adventurers/Elf/Wizard/token-3',
           filename: 'Elf Wizard',
           relativeFolder: 'Adventurers/Elf/Wizard',
         },
@@ -445,7 +573,64 @@ describe('TokenPickerModal', () => {
     await screen.findByText('Dragonborn Fighter');
 
     await waitFor(() => {
+      expect(screen.queryByText('Dragonborn Wizard')).not.toBeInTheDocument();
       expect(screen.queryByText('Elf Wizard')).not.toBeInTheDocument();
+    });
+  });
+
+  test('falls back to race tokens when class-specific tokens are unavailable', async () => {
+    const folderTree = { folders: [], flatFolders: [] };
+
+    const manifestPayload = {
+      assets: [
+        {
+          publicId: 'Tokens/Adventurers/Dragonborn/token-1',
+          filename: 'Dragonborn Adventurer',
+          relativeFolder: 'Adventurers/Dragonborn',
+        },
+        {
+          publicId: 'Tokens/Adventurers/Human/Fighter/token-2',
+          filename: 'Human Fighter',
+          relativeFolder: 'Adventurers/Human/Fighter',
+        },
+      ],
+      nextCursor: null,
+      appliedFolders: ['Tokens/Adventurers'],
+    };
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope={[
+          'Dragonborn/Warlock',
+          'Adventurers/Dragonborn/Warlock',
+          'folder:Tokens/Adventurers/Dragonborn/Warlock',
+          'Dragonborn',
+          'Adventurers/Dragonborn',
+          'folder:Tokens/Adventurers/Dragonborn',
+        ]}
+      />
+    );
+
+    await screen.findByText('Dragonborn Adventurer');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Human Fighter')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- score manifest assets against the provided scope so the token picker favors the most specific matching folders
- ensure scoped asset filtering falls back to race folders only when no class-specific tokens are found
- add regression tests covering class-specific and fallback asset filtering scenarios

## Testing
- npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fd2f600aa4832e9b09368572b7e6bc