### PR TITLE
Limit player token picker to class folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -584,6 +584,30 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
     ? folderTree.flatFolders
     : [];
 
+  const descendantLookup = flatFolders.reduce((acc, entry) => {
+    if (!entry || typeof entry.path !== 'string') {
+      return acc;
+    }
+
+    const normalizedPath = entry.path.trim();
+    if (!normalizedPath) {
+      return acc;
+    }
+
+    const segments = normalizedPath.split('/');
+    while (segments.length > 1) {
+      segments.pop();
+      const parentPath = segments.join('/');
+      if (!parentPath) {
+        break;
+      }
+
+      acc.set(parentPath, true);
+    }
+
+    return acc;
+  }, new Map());
+
   flatFolders.forEach((entry) => {
     if (!entry || typeof entry.path !== 'string') {
       return;
@@ -616,6 +640,11 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
         : relativeSegments;
 
     const trimmedRelativePath = trimmedSegments.join('/');
+
+    const hasDescendants = descendantLookup.get(normalizedPath) === true;
+    if (hasDescendants && trimmedSegments.length <= 1) {
+      return;
+    }
 
     const displayCandidate =
       trimmedRelativePath ||

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -233,12 +233,10 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       options = within(select).getAllByRole('option');
 
-      expect(options).toHaveLength(3);
+      expect(options).toHaveLength(2);
       expect(options[0]).toHaveTextContent('Adventurers');
-      expect(options[1].textContent.startsWith('\u00A0\u00A0')).toBe(true);
-      expect(options[1]).toHaveTextContent('Heroes');
-      expect(options[2].textContent.startsWith('\u00A0\u00A0\u00A0\u00A0')).toBe(true);
-      expect(options[2]).toHaveTextContent('Heroes/Rogues');
+      expect(options[1].textContent.startsWith('\u00A0\u00A0\u00A0\u00A0')).toBe(true);
+      expect(options[1]).toHaveTextContent('Heroes/Rogues');
     });
 
     await waitFor(() => {
@@ -246,7 +244,7 @@ describe('TokenPickerModal', () => {
       expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers');
     });
 
-    await user.selectOptions(select, options[2]);
+    await user.selectOptions(select, options[1]);
 
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];


### PR DESCRIPTION
## Summary
- prevent player token filters from listing race-level folders when class folders are available
- update the player token picker test to reflect the refined folder list

## Testing
- npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68fd3af77bcc832eb5d911022741c19a