### PR TITLE
Restrict player token filters to class directories

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -543,11 +543,30 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
         .filter(Boolean)
     : [];
 
-  const inferredRootPath =
-    typeof folderTree?.folders?.[0]?.path === 'string' &&
-    folderTree.folders[0].path.trim() !== ''
-      ? folderTree.folders[0].path.trim()
+  const inferredRootPath = (() => {
+    const flatRoot = Array.isArray(folderTree?.flatFolders)
+      ? folderTree.flatFolders.find(
+          (entry) =>
+            entry &&
+            typeof entry.path === 'string' &&
+            entry.path.trim() !== '' &&
+            (entry.depth === 0 || entry.depth === null || entry.depth === undefined)
+        )
       : null;
+
+    if (flatRoot) {
+      return flatRoot.path.trim();
+    }
+
+    if (
+      typeof folderTree?.folders?.[0]?.path === 'string' &&
+      folderTree.folders[0].path.trim() !== ''
+    ) {
+      return folderTree.folders[0].path.trim();
+    }
+
+    return null;
+  })();
 
   const resolvedRootFolders =
     inferredRootPath && inferredRootPath.trim() !== ''
@@ -572,13 +591,14 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
   });
 
   const playerRootPath = resolvedRootFolders[0] || null;
-  const rootLeaf = playerRootPath
+  const rootSegments = playerRootPath
     ? playerRootPath
         .split('/')
         .map((segment) => segment.trim())
         .filter(Boolean)
-        .pop()
-    : null;
+    : [];
+  const rootLeaf = rootSegments.length > 0 ? rootSegments[rootSegments.length - 1] : null;
+  const rootLeafLower = rootLeaf ? rootLeaf.toLowerCase() : null;
 
   const flatFolders = Array.isArray(folderTree?.flatFolders)
     ? folderTree.flatFolders
@@ -601,19 +621,58 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
     const depth = Number.isInteger(entry.depth) ? entry.depth : 0;
     const indent = depth > 0 ? NBSP.repeat(depth * 2) : '';
 
-    const relativePath =
-      typeof entry.relativePath === 'string' && entry.relativePath.trim() !== ''
-        ? entry.relativePath.trim()
-        : '';
+    const normalizedRelativePath = (() => {
+      if (playerRootPath && normalizedPath.startsWith(playerRootPath)) {
+        return normalizedPath
+          .slice(playerRootPath.length)
+          .replace(/^\/+/, '')
+          .trim();
+      }
 
-    const relativeSegments = relativePath
-      ? relativePath.split('/').map((segment) => segment.trim()).filter(Boolean)
-      : [];
+      if (typeof entry.relativePath === 'string' && entry.relativePath.trim() !== '') {
+        return entry.relativePath.trim();
+      }
 
-    const trimmedSegments =
-      rootLeaf && relativeSegments.length > 0 && relativeSegments[0] === rootLeaf
-        ? relativeSegments.slice(1)
-        : relativeSegments;
+      return '';
+    })();
+
+    const pathSegments = normalizedPath
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    const rootIndex = rootLeafLower
+      ? pathSegments.findIndex((segment) => segment.toLowerCase() === rootLeafLower)
+      : -1;
+
+    if (rootIndex === -1) {
+      return;
+    }
+
+    if (rootSegments.length > 0) {
+      const expectedRootStart = rootIndex - (rootSegments.length - 1);
+      if (expectedRootStart < 0) {
+        return;
+      }
+
+      const matchesRoot = rootSegments.every((segment, segmentIndex) => {
+        const targetSegment = pathSegments[expectedRootStart + segmentIndex];
+        return (
+          typeof targetSegment === 'string' &&
+          targetSegment.trim().toLowerCase() === segment.trim().toLowerCase()
+        );
+      });
+
+      if (!matchesRoot) {
+        return;
+      }
+    }
+
+    const trimmedSegments = pathSegments.slice(rootIndex + 1);
+
+    if (trimmedSegments.length < 2) {
+      return;
+    }
 
     const trimmedRelativePath = trimmedSegments.join('/');
 
@@ -632,9 +691,9 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
       aliasSet.add(trimmedRelativePath.toLowerCase());
     }
 
-    if (relativePath) {
-      aliasSet.add(relativePath);
-      aliasSet.add(relativePath.toLowerCase());
+    if (normalizedRelativePath) {
+      aliasSet.add(normalizedRelativePath);
+      aliasSet.add(normalizedRelativePath.toLowerCase());
     }
 
     if (displayCandidate) {

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -233,12 +233,10 @@ describe('TokenPickerModal', () => {
     await waitFor(() => {
       options = within(select).getAllByRole('option');
 
-      expect(options).toHaveLength(3);
+      expect(options).toHaveLength(2);
       expect(options[0]).toHaveTextContent('Adventurers');
-      expect(options[1].textContent.startsWith('\u00A0\u00A0')).toBe(true);
-      expect(options[1]).toHaveTextContent('Heroes');
-      expect(options[2].textContent.startsWith('\u00A0\u00A0\u00A0\u00A0')).toBe(true);
-      expect(options[2]).toHaveTextContent('Heroes/Rogues');
+      expect(options[1].textContent.startsWith('\u00A0\u00A0\u00A0\u00A0')).toBe(true);
+      expect(options[1]).toHaveTextContent('Heroes/Rogues');
     });
 
     await waitFor(() => {
@@ -246,7 +244,7 @@ describe('TokenPickerModal', () => {
       expect(lastCall).toBe('/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers');
     });
 
-    await user.selectOptions(select, options[2]);
+    await user.selectOptions(select, options[1]);
 
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];


### PR DESCRIPTION
## Summary
- validate that discovered folders belong to the Adventurers root before adding them to the player picker
- require at least a race and class segment after the Adventurers root so race-only folders are excluded

## Testing
- npm test -- TokenPickerModal

------
https://chatgpt.com/codex/tasks/task_e_68fd3af77bcc832eb5d911022741c19a