### PR TITLE
Fix TokenPickerModal loop structure

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -775,7 +775,6 @@ const buildPlayerFolderFilters = (folderTree, fallbackFilters = DEFAULT_PLAYER_F
       if (!sanitizedSegment) {
         continue;
       }
-    }
 
       if (KNOWN_CLASS_SEGMENT_SET.has(sanitizedSegment)) {
         classRelativeIndex = index;


### PR DESCRIPTION
## Summary
- fix the TokenPickerModal class segment search loop so break statements are inside the loop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd4a85415c832e981a38f9587f8459