### PR TITLE
Scope token picker to class-specific folders

### DIFF
--- a/client/src/components/Zombies/components/TokenPickerModal.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.js
@@ -288,6 +288,110 @@ const collectScopeMatchValues = (scopeSet) => {
   return buildNormalizedMatchSet(rawValues);
 };
 
+const buildScopedFallbackFilters = (scope) => {
+  const values = Array.isArray(scope) ? scope : [scope];
+  const filters = [];
+  const seen = new Set();
+
+  const normalizeFolderPath = (folderPath) => {
+    if (typeof folderPath !== 'string') {
+      return null;
+    }
+
+    const normalized = folderPath
+      .replace(/\u00A0/g, ' ')
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter(Boolean)
+      .join('/');
+
+    return normalized || null;
+  };
+
+  const resolveFolderPath = (value) => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const trimmed = value.replace(/\u00A0/g, ' ').trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const lower = trimmed.toLowerCase();
+
+    if (lower.startsWith('folder:')) {
+      return resolveFolderPath(trimmed.slice('folder:'.length));
+    }
+
+    if (lower.startsWith('tokens/')) {
+      const normalized = normalizeFolderPath(trimmed);
+      if (normalized && normalized.toLowerCase().includes('adventurers/')) {
+        return normalized;
+      }
+      return null;
+    }
+
+    if (lower.startsWith('adventurers/')) {
+      const normalized = normalizeFolderPath(`Tokens/${trimmed}`);
+      if (normalized && normalized.toLowerCase().includes('adventurers/')) {
+        return normalized;
+      }
+      return null;
+    }
+
+    return null;
+  };
+
+  const addFolderFilter = (folderPath) => {
+    const normalizedFolder = normalizeFolderPath(folderPath);
+    if (!normalizedFolder || seen.has(normalizedFolder)) {
+      return;
+    }
+
+    seen.add(normalizedFolder);
+
+    const segments = normalizedFolder.split('/');
+    let displaySegments = segments;
+
+    if (displaySegments.length > 0 && displaySegments[0].toLowerCase() === 'tokens') {
+      displaySegments = displaySegments.slice(1);
+    }
+
+    if (displaySegments.length > 0 && displaySegments[0].toLowerCase() === 'adventurers') {
+      displaySegments = displaySegments.slice(1);
+    }
+
+    const rawLabel = displaySegments.join('/') || normalizedFolder;
+    const depth = Math.max(0, displaySegments.length - 1);
+    const indent = depth > 0 ? NBSP.repeat(depth * 2) : '';
+    const aliases = new Set([
+      normalizedFolder,
+      normalizedFolder.toLowerCase(),
+      rawLabel,
+      rawLabel.toLowerCase(),
+      `folder:${normalizedFolder}`,
+    ]);
+
+    filters.push({
+      key: `scope:${normalizedFolder}`,
+      label: `${indent}${rawLabel}`,
+      folders: [normalizedFolder],
+      aliases: Array.from(aliases).filter(Boolean),
+      depth,
+    });
+  };
+
+  values.forEach((scopeValue) => {
+    const folderPath = resolveFolderPath(scopeValue);
+    if (folderPath) {
+      addFolderFilter(folderPath);
+    }
+  });
+
+  return filters;
+};
+
 const assetMatchesScope = (asset, scopeSet, manifestMeta) => {
   if (!(scopeSet instanceof Set) || scopeSet.size === 0) {
     return true;
@@ -614,24 +718,79 @@ const TokenPickerModal = ({
     return cloneFilters(DEFAULT_PLAYER_FILTERS);
   }, [isDm, dmFolderOptions, playerFolderOptions]);
 
+  const scopeFallbackFilters = useMemo(
+    () => buildScopedFallbackFilters(filterScope),
+    [filterScope]
+  );
+
   const filterScopeSet = useMemo(() => buildScopeVariantSet(filterScope), [filterScope]);
 
   const { availableFilters, hasScopedFilterMatch } = useMemo(() => {
-    if (!Array.isArray(baseFilters)) {
-      return { availableFilters: [], hasScopedFilterMatch: false };
-    }
+    const baseList = Array.isArray(baseFilters) ? [...baseFilters] : [];
+    const mergedFilters = [...baseList];
+    const existingKeys = new Set(mergedFilters.map((filter) => filter?.key).filter(Boolean));
+    const existingFolderPaths = new Set();
+
+    mergedFilters.forEach((filter) => {
+      if (!filter || typeof filter !== 'object' || !Array.isArray(filter.folders)) {
+        return;
+      }
+
+      filter.folders.forEach((folder) => {
+        if (typeof folder === 'string' && folder.trim() !== '') {
+          existingFolderPaths.add(folder.trim());
+        }
+      });
+    });
+
+    scopeFallbackFilters.forEach((filter) => {
+      if (!filter || typeof filter !== 'object' || !filter.key) {
+        return;
+      }
+
+      if (existingKeys.has(filter.key)) {
+        return;
+      }
+
+      const fallbackFolder = Array.isArray(filter.folders)
+        ? filter.folders.find((folder) => typeof folder === 'string' && folder.trim() !== '')
+        : null;
+
+      if (fallbackFolder && existingFolderPaths.has(fallbackFolder.trim())) {
+        return;
+      }
+
+      mergedFilters.push({
+        ...filter,
+        ...(Array.isArray(filter.folders) ? { folders: [...filter.folders] } : {}),
+        ...(Array.isArray(filter.aliases)
+          ? { aliases: Array.from(new Set(filter.aliases.filter(Boolean))) }
+          : {}),
+      });
+
+      existingKeys.add(filter.key);
+      if (fallbackFolder && fallbackFolder.trim() !== '') {
+        existingFolderPaths.add(fallbackFolder.trim());
+      }
+    });
 
     if (!(filterScopeSet instanceof Set) || filterScopeSet.size === 0) {
-      return { availableFilters: baseFilters, hasScopedFilterMatch: false };
+      return {
+        availableFilters: mergedFilters,
+        hasScopedFilterMatch: scopeFallbackFilters.length > 0,
+      };
     }
 
-    const scoped = baseFilters.filter((filter) => filterMatchesScope(filter, filterScopeSet));
+    const scoped = mergedFilters.filter((filter) => filterMatchesScope(filter, filterScopeSet));
     if (scoped.length > 0) {
       return { availableFilters: scoped, hasScopedFilterMatch: true };
     }
 
-    return { availableFilters: baseFilters, hasScopedFilterMatch: false };
-  }, [baseFilters, filterScopeSet]);
+    return {
+      availableFilters: mergedFilters,
+      hasScopedFilterMatch: scopeFallbackFilters.length > 0,
+    };
+  }, [baseFilters, filterScopeSet, scopeFallbackFilters]);
 
   const filterLookup = useMemo(() => buildFilterMap(availableFilters), [availableFilters]);
 

--- a/client/src/components/Zombies/components/TokenPickerModal.test.js
+++ b/client/src/components/Zombies/components/TokenPickerModal.test.js
@@ -382,11 +382,12 @@ describe('TokenPickerModal', () => {
 
     const select = await screen.findByLabelText(/Token Library/i);
     const options = within(select).getAllByRole('option');
-    expect(options).toHaveLength(2);
-    expect(options[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn/Fighter');
-    expect(options[1].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
+    const actualOptions = options.filter((option) => option.value !== '');
+    expect(actualOptions).toHaveLength(2);
+    expect(actualOptions[0].textContent.replace(/\u00A0/g, '')).toBe('Dragonborn/Fighter');
+    expect(actualOptions[1].textContent.replace(/\u00A0/g, '')).toBe('Core_Class_Tokens/Fighter');
 
-    await user.selectOptions(select, options[1]);
+    await user.selectOptions(select, actualOptions[1]);
 
     await waitFor(() => {
       const lastCall = manifestCalls[manifestCalls.length - 1];
@@ -394,6 +395,62 @@ describe('TokenPickerModal', () => {
         '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FCore_Class_Tokens%2FFighter'
       );
     });
+  });
+
+  test('uses scoped fallback filters when folder tree lacks matching entries', async () => {
+    const folderTree = {
+      folders: [],
+      flatFolders: [],
+    };
+
+    const manifestPayload = {
+      assets: [],
+      nextCursor: null,
+      appliedFolders: [],
+      totalCount: 0,
+    };
+
+    const manifestCalls = [];
+
+    apiFetch.mockImplementation((url) => {
+      if (url === '/campaigns/Camp1/token-folders') {
+        return Promise.resolve({ ok: true, json: async () => folderTree });
+      }
+
+      if (url.startsWith('/campaigns/Camp1/token-manifest')) {
+        manifestCalls.push(url);
+        return Promise.resolve({ ok: true, json: async () => manifestPayload });
+      }
+
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <TokenPickerModal
+        show
+        campaignId="Camp1"
+        onHide={jest.fn()}
+        onSelect={jest.fn()}
+        filterScope="Tokens/Adventurers/Goliaths/Warlock"
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/campaigns/Camp1/token-folders');
+    });
+
+    await waitFor(() => {
+      expect(manifestCalls.length).toBeGreaterThan(0);
+      expect(manifestCalls[0]).toBe(
+        '/campaigns/Camp1/token-manifest?folders=Tokens%2FAdventurers%2FGoliaths%2FWarlock'
+      );
+    });
+
+    const select = await screen.findByLabelText(/Token Library/i);
+    const options = within(select).getAllByRole('option');
+    const actualOptions = options.filter((option) => option.value !== '');
+    expect(actualOptions).toHaveLength(1);
+    expect(actualOptions[0].textContent.replace(/\u00A0/g, '')).toBe('Goliaths/Warlock');
   });
 
   test('filters manifest assets based on provided scope', async () => {
@@ -609,11 +666,15 @@ describe('TokenPickerModal', () => {
 
     await waitFor(() => {
       const options = within(select).getAllByRole('option');
-      const normalizedOptions = options.map((option) => option.textContent.replace(/\u00A0/g, ''));
+      const actualOptions = options.filter((option) => option.value !== '');
+      const normalizedOptions = actualOptions.map((option) =>
+        option.textContent.replace(/\u00A0/g, '')
+      );
 
       expect(normalizedOptions).toEqual([
         'Dwarves/Druid',
         'Core_Class_Tokens/Mediumfolk/Druid',
+        'Core_Class_Tokens/Druid',
       ]);
     });
   });
@@ -821,9 +882,10 @@ describe('TokenPickerModal', () => {
 
     const select = await screen.findByLabelText(/Token Library/i);
     const options = within(select).getAllByRole('option');
+    const actualOptions = options.filter((option) => option.value !== '');
 
-    expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent('Adversaries/Cultist');
+    expect(actualOptions).toHaveLength(1);
+    expect(actualOptions[0]).toHaveTextContent('Adversaries/Cultist');
   });
 
   test('does not include parent adversary filters when scope targets specific adversary', async () => {
@@ -859,8 +921,9 @@ describe('TokenPickerModal', () => {
 
     const select = await screen.findByLabelText(/Token Library/i);
     const options = within(select).getAllByRole('option');
+    const actualOptions = options.filter((option) => option.value !== '');
 
-    expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent('Adversaries/Cultists');
+    expect(actualOptions).toHaveLength(1);
+    expect(actualOptions[0]).toHaveTextContent('Adversaries/Cultists');
   });
 });


### PR DESCRIPTION
## Summary
- derive scoped fallback filters from player token scope values so we can target class-specific folders even when the tree response is shallow
- avoid duplicating existing folder options and limit fallback filters to adventurer folders to keep DM views unchanged
- expand TokenPickerModal tests to cover the new scoped fallback behaviour and updated option rendering

## Testing
- npm test -- TokenPickerModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fd4c68691c832e9168246a678732c8