### PR TITLE
Add dice box roller to player actions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2099,6 +2099,45 @@ $rotateX: -$angle;
   justify-content: center;
 }
 
+.damage-roller__overlay-dice {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.damage-roller__dice-button {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(18, 38, 84, 0.78);
+  color: #ffffff;
+  font-size: 1.8rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0.3);
+}
+
+.damage-roller__dice-button i {
+  pointer-events: none;
+}
+
+.damage-roller__dice-button:hover,
+.damage-roller__dice-button:focus-visible {
+  transform: scale(1.1);
+  background: rgba(44, 110, 255, 0.9);
+  box-shadow: 0 0 18px rgba(44, 110, 255, 0.6);
+  outline: none;
+}
+
+.damage-roller__dice-button:active {
+  transform: scale(0.96);
+  box-shadow: 0 0 12px rgba(44, 110, 255, 0.45);
+}
+
 .damage-dice-canvas {
   position: absolute;
   inset: 0;
@@ -2116,6 +2155,36 @@ $rotateX: -$angle;
   opacity: 0;
   transition: opacity 0.3s ease;
   overflow: hidden;
+}
+
+.dice-roller-modal__quick-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.dice-roller-modal__quick-button {
+  min-width: 72px;
+}
+
+.dice-roller-modal__result {
+  background: rgba(12, 22, 50, 0.65);
+  border-radius: 12px;
+  padding: 1rem;
+  color: #f8f9ff;
+}
+
+.dice-roller-modal__result-total {
+  color: #ffffff;
+}
+
+.dice-roller-modal__breakdown li {
+  margin-bottom: 0.35rem;
+}
+
+.dice-roller-modal__breakdown li:last-child {
+  margin-bottom: 0;
 }
 
 .damage-dice-canvas__box canvas,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -18,6 +18,7 @@ import weaponMasteryDefinitions from '../../../data/weaponMasteries';
 import weaponTypeMasteries from '../../../data/weaponTypeMasteries';
 import { rollSkillWithDiceBox } from './Skills';
 import DamageDiceCanvas from './DamageDiceCanvas';
+import DiceRollerModal from '../common/DiceRollerModal';
 import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
 import {
   collectRollValues,
@@ -402,8 +403,11 @@ const PlayerTurnActions = React.forwardRef(
   ) => {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
+  const [showDiceRoller, setShowDiceRoller] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
   const handleShowAttack = () => setShowAttack(true);
+  const handleCloseDiceRoller = () => setShowDiceRoller(false);
+  const handleShowDiceRoller = () => setShowDiceRoller(true);
 
   const [footerHeight, setFooterHeight] = useState(0);
 
@@ -2191,6 +2195,17 @@ const damageAmountStyle = {
                     {damageValue}
                   </span>
                 </div>
+                <div className="damage-roller__overlay-dice">
+                  <button
+                    type="button"
+                    className="damage-roller__dice-button"
+                    onClick={handleShowDiceRoller}
+                    title="Open dice roller"
+                    aria-label="Open dice roller"
+                  >
+                    <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
+                  </button>
+                </div>
                 <div className="damage-roller__overlay-button">
                   {/* Attack Button */}
                   <button
@@ -2365,6 +2380,11 @@ const damageAmountStyle = {
           </ul>
         </Modal.Body>
       </Modal>
+      <DiceRollerModal
+        show={showDiceRoller}
+        onHide={handleCloseDiceRoller}
+        diceColor={diceFaceColor}
+      />
 {/* Attack Modal */}
 
       <Modal size="lg" className="dnd-modal modern-modal" centered show={showAttack} onHide={handleCloseAttack}>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -107,6 +107,24 @@ describe('PlayerTurnActions weapon damage display', () => {
     expect(onPassTurn).not.toHaveBeenCalled();
   });
 
+  test('opens dice roller modal when the dice button is clicked', () => {
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#112233', equipment: {}, weapon: [], spells: [] }}
+        strMod={0}
+        dexMod={0}
+        onPassTurn={jest.fn()}
+      />
+    );
+
+    const diceButton = screen.getByRole('button', { name: /open dice roller/i });
+    expect(diceButton).toBeInTheDocument();
+
+    fireEvent.click(diceButton);
+
+    expect(screen.getByRole('dialog', { name: /dice roller/i })).toBeInTheDocument();
+  });
+
   test('weapon damage segments include ability and type classes', async () => {
     const weapon = {
       name: 'Frost Brand',

--- a/client/src/components/Zombies/common/DiceRollerModal.js
+++ b/client/src/components/Zombies/common/DiceRollerModal.js
@@ -1,0 +1,295 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Form, InputGroup, Modal } from 'react-bootstrap';
+import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
+import { DEFAULT_DICE_COLOR, normalizeDiceColor } from '../../../utils/diceColors';
+
+const COMMON_DICE = [4, 6, 8, 10, 12, 20];
+const MAX_DICE_COUNT = 50;
+const MAX_DIE_SIDES = 1000;
+
+const parseDiceExpression = (expression) => {
+  if (typeof expression !== 'string') {
+    return { error: 'Enter a dice expression such as 2d6 + 1.' };
+  }
+
+  const sanitized = expression.replace(/\s+/g, '').toLowerCase();
+
+  if (!sanitized) {
+    return { error: 'Enter a dice expression such as 2d6 + 1.' };
+  }
+
+  const pattern = /([+-]?)(\d*d\d+|\d+)/g;
+  let match;
+  let lastIndex = 0;
+  const dice = [];
+  const modifiers = [];
+
+  while ((match = pattern.exec(sanitized)) !== null) {
+    if (match.index !== lastIndex) {
+      return { error: 'Invalid characters in dice expression.' };
+    }
+
+    lastIndex = pattern.lastIndex;
+    const token = match[0];
+    const sign = token.startsWith('-') ? -1 : 1;
+    const unsigned = token.replace(/^[-+]/, '');
+
+    if (unsigned.includes('d')) {
+      const [countPart, sidesPart] = unsigned.split('d');
+      const count = countPart ? Number.parseInt(countPart, 10) : 1;
+      const sides = Number.parseInt(sidesPart, 10);
+
+      if (!Number.isFinite(count) || count <= 0 || count > MAX_DICE_COUNT) {
+        return { error: `Dice count must be between 1 and ${MAX_DICE_COUNT}.` };
+      }
+
+      if (!Number.isFinite(sides) || sides <= 1 || sides > MAX_DIE_SIDES) {
+        return { error: `Dice must have between 2 and ${MAX_DIE_SIDES} sides.` };
+      }
+
+      dice.push({
+        count,
+        sides,
+        sign,
+      });
+    } else {
+      const value = Number.parseInt(unsigned, 10);
+      if (!Number.isFinite(value)) {
+        return { error: 'Invalid number in dice expression.' };
+      }
+      modifiers.push(sign * value);
+    }
+  }
+
+  if (lastIndex !== sanitized.length) {
+    return { error: 'Invalid characters in dice expression.' };
+  }
+
+  if (dice.length === 0) {
+    return { error: 'Add at least one dice term such as 1d6.' };
+  }
+
+  const normalizedExpression = [
+    ...dice.map(({ count, sides, sign }, index) => {
+      const prefix = index === 0 && sign === 1 ? '' : sign === 1 ? '+' : '-';
+      return `${prefix}${count}d${sides}`;
+    }),
+    ...modifiers.map((value) => (value >= 0 ? `+${value}` : `${value}`)),
+  ]
+    .join(' ')
+    .trim();
+
+  return { dice, modifiers, normalizedExpression };
+};
+
+const formatDiceValues = (values) =>
+  values.map((value) => Number.isFinite(value) ? value : '?').join(' + ');
+
+const DiceRollerModal = ({ show = false, onHide = () => {}, diceColor }) => {
+  const [expression, setExpression] = useState('1d20');
+  const [error, setError] = useState('');
+  const [rolling, setRolling] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const normalizedColor = useMemo(
+    () => normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR,
+    [diceColor],
+  );
+
+  useEffect(() => {
+    if (show) {
+      setDiceBoxThemeColor(normalizedColor);
+    }
+  }, [show, normalizedColor]);
+
+  useEffect(() => {
+    if (!show) {
+      setError('');
+      setRolling(false);
+    }
+  }, [show]);
+
+  const handleExpressionChange = useCallback((event) => {
+    setExpression(event.target.value);
+  }, []);
+
+  const handleQuickAdd = useCallback((sides) => {
+    setExpression((prev) => {
+      const trimmed = prev.trim();
+      if (!trimmed) {
+        return `1d${sides}`;
+      }
+      if (/[-+\s]$/.test(trimmed)) {
+        return `${trimmed}1d${sides}`;
+      }
+      return `${trimmed}${trimmed.endsWith('+') || trimmed.endsWith('-') ? '' : ' + '}1d${sides}`;
+    });
+  }, []);
+
+  const handleRoll = useCallback(
+    async (event) => {
+      event?.preventDefault();
+      if (rolling) {
+        return;
+      }
+
+      const parsed = parseDiceExpression(expression);
+      if (parsed.error) {
+        setError(parsed.error);
+        return;
+      }
+
+      setError('');
+      setRolling(true);
+
+      try {
+        const { dice, modifiers, normalizedExpression } = parsed;
+        const requests = dice.map(({ count, sides }) => ({ count, sides }));
+        const response = await rollDiceWithBox(requests);
+        const rolls = Array.isArray(response?.rolls) ? response.rolls : [];
+
+        const diceBreakdown = dice.map((group, index) => {
+          const values = Array.isArray(rolls[index]) ? rolls[index] : [];
+          const subtotal = values.reduce((total, value) => total + (Number(value) || 0), 0);
+          const signedTotal = subtotal * group.sign;
+          return {
+            ...group,
+            values,
+            subtotal,
+            signedTotal,
+          };
+        });
+
+        const modifiersTotal = modifiers.reduce((total, value) => total + value, 0);
+        const diceTotal = diceBreakdown.reduce((total, item) => total + item.signedTotal, 0);
+        const total = diceTotal + modifiersTotal;
+
+        setResult({
+          expression: normalizedExpression,
+          diceBreakdown,
+          modifiers,
+          total,
+          usedFallback: Boolean(response?.usedFallback),
+        });
+      } catch (rollError) {
+        setError('Rolling the dice failed. Please try again.');
+      } finally {
+        setRolling(false);
+      }
+    },
+    [expression, rolling],
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        handleRoll(event);
+      }
+    },
+    [handleRoll],
+  );
+
+  return (
+    <Modal centered show={show} onHide={onHide} aria-label="Dice roller">
+      <Modal.Header closeButton>
+        <Modal.Title>Dice Roller</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form onSubmit={handleRoll}>
+          <Form.Group controlId="custom-dice-expression">
+            <Form.Label>Dice Expression</Form.Label>
+            <InputGroup>
+              <Form.Control
+                type="text"
+                value={expression}
+                onChange={handleExpressionChange}
+                onKeyDown={handleKeyDown}
+                placeholder="e.g. 2d6 + 1d8 + 3"
+                aria-describedby="dice-expression-help"
+                disabled={rolling}
+                autoFocus
+              />
+              <Button type="submit" variant="primary" disabled={rolling}>
+                {rolling ? 'Rolling…' : 'Roll'}
+              </Button>
+            </InputGroup>
+            <Form.Text id="dice-expression-help" muted>
+              Use standard dice notation. You can combine multiple dice and modifiers.
+            </Form.Text>
+          </Form.Group>
+        </Form>
+        <div className="dice-roller-modal__quick-buttons" aria-hidden="false">
+          {COMMON_DICE.map((sides) => (
+            <Button
+              key={sides}
+              variant="outline-secondary"
+              size="sm"
+              className="dice-roller-modal__quick-button"
+              onClick={() => handleQuickAdd(sides)}
+              disabled={rolling}
+            >
+              +1d{sides}
+            </Button>
+          ))}
+        </div>
+        {error ? (
+          <div className="text-danger mt-3" role="alert">
+            {error}
+          </div>
+        ) : null}
+        {result ? (
+          <div className="dice-roller-modal__result mt-3">
+            <div className="dice-roller-modal__result-expression text-muted small">
+              Expression: {result.expression || expression}
+            </div>
+            <div className="dice-roller-modal__result-total display-6 fw-bold">
+              Total: {result.total}
+            </div>
+            <ul className="dice-roller-modal__breakdown list-unstyled mb-2">
+              {result.diceBreakdown.map((group, index) => {
+                const prefix =
+                  index === 0 && group.sign > 0 ? '' : group.sign < 0 ? '-' : '+';
+                return (
+                  <li key={`die-${group.count}d${group.sides}-${index}`}>
+                    <strong>
+                      {prefix}
+                      {group.count}d{group.sides}
+                    </strong>{' '}
+                    ({formatDiceValues(group.values)} = {group.subtotal})
+                  </li>
+                );
+              })}
+              {result.modifiers.map((modifier, index) => (
+                <li key={`modifier-${index}`}>
+                  <strong>{modifier >= 0 ? '+' : ''}{modifier}</strong>
+                </li>
+              ))}
+            </ul>
+            {result.usedFallback ? (
+              <div className="text-warning small" role="status">
+                3D dice are unavailable, so a basic roll was used.
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onHide} disabled={rolling}>
+          Close
+        </Button>
+        <Button variant="primary" onClick={handleRoll} disabled={rolling}>
+          {rolling ? 'Rolling…' : 'Roll' }
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+DiceRollerModal.propTypes = {
+  show: PropTypes.bool,
+  onHide: PropTypes.func,
+  diceColor: PropTypes.string,
+};
+
+export default DiceRollerModal;


### PR DESCRIPTION
## Summary
- add a reusable dice roller modal that uses dice-box to roll arbitrary expressions
- expose the roller from the player turn damage overlay with a new dice icon and supporting styles
- cover the new control with a unit test to ensure the modal opens

## Testing
- CI=true npm test -- PlayerTurnActions.test.js *(fails: RangeError in source-map quick sort during Jest startup)*

------
https://chatgpt.com/codex/tasks/task_e_68fd599a9ad8832e985bf53207e54ca7