### PR TITLE
Refine dice roller workflow

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2099,6 +2099,45 @@ $rotateX: -$angle;
   justify-content: center;
 }
 
+.damage-roller__overlay-dice {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.damage-roller__dice-button {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(18, 38, 84, 0.78);
+  color: #ffffff;
+  font-size: 1.8rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0.3);
+}
+
+.damage-roller__dice-button i {
+  pointer-events: none;
+}
+
+.damage-roller__dice-button:hover,
+.damage-roller__dice-button:focus-visible {
+  transform: scale(1.1);
+  background: rgba(44, 110, 255, 0.9);
+  box-shadow: 0 0 18px rgba(44, 110, 255, 0.6);
+  outline: none;
+}
+
+.damage-roller__dice-button:active {
+  transform: scale(0.96);
+  box-shadow: 0 0 12px rgba(44, 110, 255, 0.45);
+}
+
 .damage-dice-canvas {
   position: absolute;
   inset: 0;
@@ -2116,6 +2155,10 @@ $rotateX: -$angle;
   opacity: 0;
   transition: opacity 0.3s ease;
   overflow: hidden;
+}
+
+.dice-roller-modal__fields {
+  margin-bottom: 0.5rem;
 }
 
 .damage-dice-canvas__box canvas,

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -18,6 +18,7 @@ import weaponMasteryDefinitions from '../../../data/weaponMasteries';
 import weaponTypeMasteries from '../../../data/weaponTypeMasteries';
 import { rollSkillWithDiceBox } from './Skills';
 import DamageDiceCanvas from './DamageDiceCanvas';
+import DiceRollerModal from '../common/DiceRollerModal';
 import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
 import {
   collectRollValues,
@@ -402,8 +403,47 @@ const PlayerTurnActions = React.forwardRef(
   ) => {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
+  const [showDiceRoller, setShowDiceRoller] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
   const handleShowAttack = () => setShowAttack(true);
+  const handleCloseDiceRoller = () => setShowDiceRoller(false);
+  const handleShowDiceRoller = () => setShowDiceRoller(true);
+
+  const handleDiceRollComplete = ({ total, count, sides, values, usedFallback } = {}) => {
+    if (!Number.isFinite(total)) {
+      setShowDiceRoller(false);
+      return;
+    }
+
+    const sanitizedCount = Number.isInteger(count) ? count : 0;
+    const sanitizedSides = Number.isInteger(sides) ? sides : 0;
+    const expression =
+      sanitizedCount > 0 && sanitizedSides > 0
+        ? `${sanitizedCount}d${sanitizedSides}`
+        : 'Dice Roll';
+
+    const diceRolls = Array.isArray(values)
+      ? values.map((value) => ({
+          value: Number(value) || 0,
+          sides: sanitizedSides || undefined,
+          type: '',
+          category: 'custom',
+        }))
+      : [];
+
+    updateDamageValueWithAnimation(total, '', 'custom', {
+      sourceLabel: 'Dice Roll',
+      expression,
+      diceRolls,
+      rollValues: Array.isArray(values)
+        ? values.map((value) => `${Number(value) || 0}`)
+        : undefined,
+      modifierValues: undefined,
+      usedFallback,
+    });
+
+    setShowDiceRoller(false);
+  };
 
   const [footerHeight, setFooterHeight] = useState(0);
 
@@ -2191,6 +2231,17 @@ const damageAmountStyle = {
                     {damageValue}
                   </span>
                 </div>
+                <div className="damage-roller__overlay-dice">
+                  <button
+                    type="button"
+                    className="damage-roller__dice-button"
+                    onClick={handleShowDiceRoller}
+                    title="Open dice roller"
+                    aria-label="Open dice roller"
+                  >
+                    <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
+                  </button>
+                </div>
                 <div className="damage-roller__overlay-button">
                   {/* Attack Button */}
                   <button
@@ -2365,6 +2416,12 @@ const damageAmountStyle = {
           </ul>
         </Modal.Body>
       </Modal>
+      <DiceRollerModal
+        show={showDiceRoller}
+        onHide={handleCloseDiceRoller}
+        onRollComplete={handleDiceRollComplete}
+        diceColor={diceFaceColor}
+      />
 {/* Attack Modal */}
 
       <Modal size="lg" className="dnd-modal modern-modal" centered show={showAttack} onHide={handleCloseAttack}>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -107,6 +107,48 @@ describe('PlayerTurnActions weapon damage display', () => {
     expect(onPassTurn).not.toHaveBeenCalled();
   });
 
+  test('rolls custom dice from the modal and updates the total display', async () => {
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#112233', equipment: {}, weapon: [], spells: [] }}
+        strMod={0}
+        dexMod={0}
+        onPassTurn={jest.fn()}
+      />
+    );
+
+    const diceButton = screen.getByRole('button', { name: /open dice roller/i });
+    expect(diceButton).toBeInTheDocument();
+
+    fireEvent.click(diceButton);
+
+    const modal = screen.getByRole('dialog', { name: /dice roller/i });
+    const countInput = within(modal).getByLabelText(/number of dice/i);
+    const typeSelect = within(modal).getByLabelText(/dice type/i);
+    fireEvent.change(countInput, { target: { value: '2' } });
+    fireEvent.change(typeSelect, { target: { value: '6' } });
+
+    await act(async () => {
+      fireEvent.click(within(modal).getByRole('button', { name: /^roll$/i }));
+    });
+
+    await waitFor(() => {
+      expect(rollDiceWithBox).toHaveBeenCalledWith([{ count: 2, sides: 6 }]);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /dice roller/i })).not.toBeInTheDocument();
+    });
+
+    const damageTotalButton = screen.getByRole('button', {
+      name: /click to enable a critical damage roll on your next roll/i,
+    });
+
+    await waitFor(() => {
+      expect(damageTotalButton).toHaveTextContent('2');
+    });
+  });
+
   test('weapon damage segments include ability and type classes', async () => {
     const weapon = {
       name: 'Frost Brand',

--- a/client/src/components/Zombies/common/DiceRollerModal.js
+++ b/client/src/components/Zombies/common/DiceRollerModal.js
@@ -1,0 +1,212 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Form, Modal, Row, Col } from 'react-bootstrap';
+import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
+import { DEFAULT_DICE_COLOR, normalizeDiceColor } from '../../../utils/diceColors';
+
+const MAX_DICE_COUNT = 50;
+const MAX_DIE_SIDES = 1000;
+const COMMON_DICE_OPTIONS = [4, 6, 8, 10, 12, 20, 100];
+const DEFAULT_DIE_SIDES = COMMON_DICE_OPTIONS.includes(20)
+  ? 20
+  : COMMON_DICE_OPTIONS[0];
+
+const DiceRollerModal = ({
+  show = false,
+  onHide = () => {},
+  onRollComplete = () => {},
+  diceColor,
+}) => {
+  const [diceCount, setDiceCount] = useState('1');
+  const [selectedSides, setSelectedSides] = useState(DEFAULT_DIE_SIDES);
+  const [customSides, setCustomSides] = useState('');
+  const [rolling, setRolling] = useState(false);
+  const [error, setError] = useState('');
+
+  const normalizedColor = useMemo(
+    () => normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR,
+    [diceColor],
+  );
+
+  const parsedCount = useMemo(() => {
+    const parsed = Number.parseInt(diceCount, 10);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }, [diceCount]);
+
+  const resolvedSides = useMemo(() => {
+    if (selectedSides === 'custom') {
+      const parsed = Number.parseInt(customSides, 10);
+      return Number.isFinite(parsed) ? parsed : NaN;
+    }
+    const parsed = Number(selectedSides);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }, [selectedSides, customSides]);
+
+  const isValidCount = Number.isInteger(parsedCount) && parsedCount >= 1 && parsedCount <= MAX_DICE_COUNT;
+  const isValidSides =
+    Number.isInteger(resolvedSides) && resolvedSides >= 2 && resolvedSides <= MAX_DIE_SIDES;
+
+  useEffect(() => {
+    if (show) {
+      setDiceBoxThemeColor(normalizedColor);
+    }
+  }, [show, normalizedColor]);
+
+  useEffect(() => {
+    if (!show) {
+      setRolling(false);
+      setError('');
+    }
+  }, [show]);
+
+  const handleCountChange = useCallback((event) => {
+    setDiceCount(event.target.value);
+  }, []);
+
+  const handleSidesChange = useCallback((event) => {
+    const value = event.target.value;
+    setSelectedSides(value === 'custom' ? 'custom' : Number.parseInt(value, 10));
+  }, []);
+
+  const handleCustomSidesChange = useCallback((event) => {
+    setCustomSides(event.target.value);
+  }, []);
+
+  const resetAndClose = useCallback(() => {
+    setRolling(false);
+    setError('');
+    onHide();
+  }, [onHide]);
+
+  const handleRoll = useCallback(
+    async (event) => {
+      event?.preventDefault();
+      if (rolling) {
+        return;
+      }
+
+      if (!isValidCount) {
+        setError(`Enter a dice count between 1 and ${MAX_DICE_COUNT}.`);
+        return;
+      }
+
+      if (!isValidSides) {
+        setError(`Choose dice with between 2 and ${MAX_DIE_SIDES} sides.`);
+        return;
+      }
+
+      setError('');
+      setRolling(true);
+
+      try {
+        const response = await rollDiceWithBox([
+          {
+            count: parsedCount,
+            sides: resolvedSides,
+          },
+        ]);
+
+        const values = Array.isArray(response?.rolls?.[0])
+          ? response.rolls[0].map((value) => Number(value) || 0)
+          : [];
+        const total = values.reduce((sum, value) => sum + value, 0);
+
+        onRollComplete({
+          total,
+          count: parsedCount,
+          sides: resolvedSides,
+          values,
+          usedFallback: Boolean(response?.usedFallback),
+        });
+        resetAndClose();
+      } catch (rollError) {
+        setError('Rolling the dice failed. Please try again.');
+        setRolling(false);
+      }
+    },
+    [rolling, isValidCount, isValidSides, parsedCount, resolvedSides, onRollComplete, resetAndClose],
+  );
+
+  const canRoll = isValidCount && isValidSides && !rolling;
+
+  return (
+    <Modal centered show={show} onHide={onHide} aria-label="Dice roller">
+      <Modal.Header closeButton>
+        <Modal.Title>Dice Roller</Modal.Title>
+      </Modal.Header>
+      <Form onSubmit={handleRoll}>
+        <Modal.Body>
+          <Row className="dice-roller-modal__fields g-3" xs={1} sm={2}>
+            <Col>
+              <Form.Group controlId="dice-roller-count">
+                <Form.Label>Number of Dice</Form.Label>
+                <Form.Control
+                  type="number"
+                  min="1"
+                  max={MAX_DICE_COUNT}
+                  value={diceCount}
+                  onChange={handleCountChange}
+                  disabled={rolling}
+                  autoFocus
+                />
+              </Form.Group>
+            </Col>
+            <Col>
+              <Form.Group controlId="dice-roller-type">
+                <Form.Label>Dice Type</Form.Label>
+                <Form.Select
+                  value={selectedSides === 'custom' ? 'custom' : String(selectedSides)}
+                  onChange={handleSidesChange}
+                  disabled={rolling}
+                >
+                  {COMMON_DICE_OPTIONS.map((sides) => (
+                    <option key={`sides-${sides}`} value={String(sides)}>
+                      d{sides}
+                    </option>
+                  ))}
+                  <option value="custom">Custom…</option>
+                </Form.Select>
+              </Form.Group>
+            </Col>
+          </Row>
+          {selectedSides === 'custom' ? (
+            <Form.Group className="mt-3" controlId="dice-roller-custom-sides">
+              <Form.Label>Custom Dice Sides</Form.Label>
+              <Form.Control
+                type="number"
+                min="2"
+                max={MAX_DIE_SIDES}
+                value={customSides}
+                onChange={handleCustomSidesChange}
+                disabled={rolling}
+                placeholder="Enter the number of sides"
+              />
+            </Form.Group>
+          ) : null}
+          {error ? (
+            <div className="text-danger mt-3" role="alert">
+              {error}
+            </div>
+          ) : null}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={onHide} disabled={rolling}>
+            Close
+          </Button>
+          <Button type="submit" variant="primary" disabled={!canRoll}>
+            {rolling ? 'Rolling…' : 'Roll'}
+          </Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+};
+
+DiceRollerModal.propTypes = {
+  show: PropTypes.bool,
+  onHide: PropTypes.func,
+  onRollComplete: PropTypes.func,
+  diceColor: PropTypes.string,
+};
+
+export default DiceRollerModal;


### PR DESCRIPTION
## Summary
- replace the dice expression input with a dice count field and die type selector for the roller modal
- close the modal after rolling and surface the total on the damage display via a new completion callback
- refresh styles and tests around the player turn dice button to reflect the streamlined workflow

## Testing
- CI=true npm test -- PlayerTurnActions.test.js *(fails: RangeError in source-map quick sort during Jest startup)*

------
https://chatgpt.com/codex/tasks/task_e_68fd599a9ad8832e985bf53207e54ca7