### PR TITLE
Close dice roller modal immediately after roll

### DIFF
--- a/client/src/components/Zombies/common/DiceRollerModal.js
+++ b/client/src/components/Zombies/common/DiceRollerModal.js
@@ -72,12 +72,6 @@ const DiceRollerModal = ({
     setCustomSides(event.target.value);
   }, []);
 
-  const resetAndClose = useCallback(() => {
-    setRolling(false);
-    setError('');
-    onHide();
-  }, [onHide]);
-
   const handleRoll = useCallback(
     async (event) => {
       event?.preventDefault();
@@ -97,6 +91,7 @@ const DiceRollerModal = ({
 
       setError('');
       setRolling(true);
+      onHide();
 
       try {
         const response = await rollDiceWithBox([
@@ -118,13 +113,21 @@ const DiceRollerModal = ({
           values,
           usedFallback: Boolean(response?.usedFallback),
         });
-        resetAndClose();
       } catch (rollError) {
-        setError('Rolling the dice failed. Please try again.');
+        console.error('Rolling the dice failed.', rollError);
+      } finally {
         setRolling(false);
       }
     },
-    [rolling, isValidCount, isValidSides, parsedCount, resolvedSides, onRollComplete, resetAndClose],
+    [
+      rolling,
+      isValidCount,
+      isValidSides,
+      parsedCount,
+      resolvedSides,
+      onHide,
+      onRollComplete,
+    ],
   );
 
   const canRoll = isValidCount && isValidSides && !rolling;


### PR DESCRIPTION
## Summary
- close the dice roller modal as soon as a roll is triggered so the UI gets out of the way immediately
- ensure the rolling state resets even if the dice roll request fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd5ef15758832e8f34ee641c6a7c67