### PR TITLE
Sync Large Form size changes across campaign maps

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -120,6 +120,19 @@ const normalizeCreatureSize = (value) => {
   return null;
 };
 
+const resolveCharacterTokenSize = (form) =>
+  normalizeCreatureSize(
+    form?.temporarySize ??
+      form?.size ??
+      form?.characterSize ??
+      form?.character?.size ??
+      form?.creature?.size ??
+      form?.profile?.size ??
+      form?.race?.size ??
+      form?.attributes?.size ??
+      form?.displayType
+  );
+
 const normalizeCombatState = (state) => {
   if (!state || typeof state !== "object") {
     return createEmptyCombatState();
@@ -375,7 +388,25 @@ const sanitizeToken = (tokenValue, fallbackId) => {
     return null;
   }
 
-  return { ...candidate, characterId: candidateId, x, y };
+  const sanitized = { ...candidate, characterId: candidateId, x, y };
+
+  if (Object.prototype.hasOwnProperty.call(candidate, 'rotation')) {
+    const normalizedRotation = normalizeRotation(candidate.rotation);
+    if (normalizedRotation === null) {
+      delete sanitized.rotation;
+    } else {
+      sanitized.rotation = normalizedRotation;
+    }
+  }
+
+  const normalizedSize = normalizeCreatureSize(candidate.size);
+  if (normalizedSize) {
+    sanitized.size = normalizedSize;
+  } else if (Object.prototype.hasOwnProperty.call(candidate, 'size')) {
+    delete sanitized.size;
+  }
+
+  return sanitized;
 };
 
 const sanitizeTokenDictionary = (tokens) => {
@@ -1182,6 +1213,7 @@ export default function ZombiesCharacterSheet() {
   const campaignMapRef = useRef(null);
   const campaignMapsRef = useRef([]);
   const campaignActiveMapIdRef = useRef(null);
+  const appliedLargeFormMapsRef = useRef(new Set());
   const [dockedModals, setDockedModals] = useState({ left: null, right: null });
   const [dockedModalWidths, setDockedModalWidths] = useState({ left: null, right: null });
 
@@ -1300,6 +1332,253 @@ export default function ZombiesCharacterSheet() {
         ? campaignActiveMapId.trim()
         : null;
   }, [campaignActiveMapId]);
+
+  useEffect(() => {
+    const normalizedCampaign =
+      typeof campaignId === 'string' && campaignId.trim() !== '' ? campaignId.trim() : null;
+    const normalizedCharacterId =
+      typeof resolvedCharacterId === 'string' && resolvedCharacterId.trim() !== ''
+        ? resolvedCharacterId.trim()
+        : null;
+
+    if (!normalizedCampaign || !normalizedCharacterId) {
+      return;
+    }
+
+    const tokensByMap = campaignMapTokensRef.current || {};
+    const updates = Object.entries(tokensByMap).reduce((acc, [mapId, tokens]) => {
+      if (typeof mapId !== 'string') {
+        return acc;
+      }
+
+      const trimmedMapId = mapId.trim();
+      if (!trimmedMapId) {
+        return acc;
+      }
+
+      if (!tokens || typeof tokens !== 'object') {
+        return acc;
+      }
+
+      const token = tokens[normalizedCharacterId];
+      if (!token || typeof token !== 'object') {
+        return acc;
+      }
+
+      const clampedX = clamp01(token.x);
+      const clampedY = clamp01(token.y);
+      if (clampedX === null || clampedY === null) {
+        return acc;
+      }
+
+      const currentSize = normalizeCreatureSize(token.size);
+      if (largeFormActive) {
+        if (currentSize === 'large') {
+          return acc;
+        }
+
+        acc.push({ mapId: trimmedMapId, token, x: clampedX, y: clampedY, nextSize: 'large' });
+        return acc;
+      }
+
+      if (currentSize === 'large' && desiredTokenSize !== 'large') {
+        const appliedMaps = appliedLargeFormMapsRef.current;
+        if (!(appliedMaps instanceof Set) || !appliedMaps.has(trimmedMapId)) {
+          return acc;
+        }
+
+        acc.push({ mapId: trimmedMapId, token, x: clampedX, y: clampedY, nextSize: null });
+      }
+
+      return acc;
+    }, []);
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    const previousAppliedLargeMaps =
+      appliedLargeFormMapsRef.current instanceof Set
+        ? new Set(appliedLargeFormMapsRef.current)
+        : new Set();
+    const nextAppliedLargeMaps = new Set(previousAppliedLargeMaps);
+    updates.forEach(({ mapId, nextSize }) => {
+      if (nextSize === 'large') {
+        nextAppliedLargeMaps.add(mapId);
+      } else {
+        nextAppliedLargeMaps.delete(mapId);
+      }
+    });
+    appliedLargeFormMapsRef.current = nextAppliedLargeMaps;
+
+    const encodedCampaign = encodeURIComponent(normalizedCampaign);
+    const encodedCharacterId = encodeURIComponent(normalizedCharacterId);
+    const previousCampaignTokens = campaignMapTokensRef.current || {};
+    const previousActiveTokens = activeMapTokensRef.current || {};
+    const previousCampaignMap = campaignMapRef.current || null;
+    const timestamp = new Date().toISOString();
+
+    const applySizeToToken = (baseToken = {}, nextSize) => {
+      const nextToken = {
+        ...baseToken,
+        characterId: normalizedCharacterId,
+        updatedAt: timestamp,
+      };
+
+      if (nextSize) {
+        nextToken.size = nextSize;
+      } else if (Object.prototype.hasOwnProperty.call(nextToken, 'size')) {
+        delete nextToken.size;
+      }
+
+      return nextToken;
+    };
+
+    setCampaignMapTokens((prev) => {
+      const next = { ...(prev || {}) };
+      updates.forEach(({ mapId, token, nextSize }) => {
+        const existing = { ...(next[mapId] || {}) };
+        const baseToken = {
+          ...(existing[normalizedCharacterId] || {}),
+          ...(token || {}),
+        };
+        existing[normalizedCharacterId] = applySizeToToken(baseToken, nextSize);
+        next[mapId] = existing;
+      });
+      return next;
+    });
+
+    const activeMapId = campaignActiveMapIdRef.current;
+    const activeUpdate = activeMapId
+      ? updates.find((update) => update.mapId === activeMapId) || null
+      : null;
+    const shouldUpdateActiveTokens =
+      !activeMapId ||
+      Boolean(activeUpdate) ||
+      Boolean(activeMapTokensRef.current?.[normalizedCharacterId]);
+
+    if (shouldUpdateActiveTokens) {
+      const fallbackToken =
+        (activeUpdate && activeUpdate.token) ||
+        activeMapTokensRef.current?.[normalizedCharacterId] ||
+        updates[0]?.token ||
+        {};
+      const fallbackSize =
+        (activeUpdate && activeUpdate.nextSize) ||
+        (updates[0] && updates[0].nextSize) ||
+        null;
+
+      setActiveMapTokens((prev) => ({
+        ...(prev || {}),
+        [normalizedCharacterId]: applySizeToToken({
+          ...(prev?.[normalizedCharacterId] || {}),
+          ...fallbackToken,
+        }, fallbackSize),
+      }));
+    }
+
+    setCampaignMap((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const prevMapId =
+        typeof prev.mapId === 'string' && prev.mapId.trim() !== '' ? prev.mapId.trim() : null;
+      if (!prevMapId) {
+        return prev;
+      }
+
+      const update = updates.find((entry) => entry.mapId === prevMapId);
+      if (!update) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        tokens: {
+          ...(prev.tokens || {}),
+          [normalizedCharacterId]: applySizeToToken({
+            ...(prev.tokens?.[normalizedCharacterId] || {}),
+            ...(update.token || {}),
+          }, update.nextSize),
+        },
+      };
+    });
+
+    let isCancelled = false;
+    let didPersist = false;
+
+    const persist = async () => {
+      try {
+        for (const update of updates) {
+          if (isCancelled) {
+            return;
+          }
+
+          const encodedMapId = encodeURIComponent(update.mapId);
+          const payload = {
+            x: update.x,
+            y: update.y,
+            size: update.nextSize || '',
+          };
+
+          if (Object.prototype.hasOwnProperty.call(update.token, 'rotation')) {
+            const normalizedRotation = normalizeRotation(update.token.rotation);
+            if (normalizedRotation !== null) {
+              payload.rotation = normalizedRotation;
+            }
+          }
+
+          const response = await apiFetch(
+            `/campaigns/${encodedCampaign}/maps/${encodedMapId}/tokens/${encodedCharacterId}`,
+            {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            }
+          );
+
+          if (!response.ok) {
+            const message = await parseErrorMessage(
+              response,
+              'Failed to update figurine size.'
+            );
+            throw new Error(message);
+          }
+        }
+
+        didPersist = true;
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        console.error(error);
+        setCampaignMapTokens(previousCampaignTokens || {});
+        setActiveMapTokens(previousActiveTokens || {});
+        setCampaignMap(previousCampaignMap || null);
+        appliedLargeFormMapsRef.current = previousAppliedLargeMaps;
+      }
+    };
+
+    persist();
+
+    return () => {
+      isCancelled = true;
+      if (!didPersist) {
+        appliedLargeFormMapsRef.current = previousAppliedLargeMaps;
+      }
+    };
+  }, [
+    campaignId,
+    campaignMapTokens,
+    desiredTokenSize,
+    largeFormActive,
+    resolvedCharacterId,
+    setActiveMapTokens,
+    setCampaignMap,
+    setCampaignMapTokens,
+  ]);
 
   const applyMapPayload = useCallback(
     (payload = {}) => {
@@ -1676,6 +1955,11 @@ export default function ZombiesCharacterSheet() {
     });
   }, [baseActionCount, activeEffects]);
 
+  const largeFormActive = useMemo(
+    () => activeEffects.some((effect) => effect?.name === 'Large Form'),
+    [activeEffects]
+  );
+
   const adrenalineRushActive = useMemo(
     () => activeEffects.some((effect) => effect?.name === 'Adrenaline Rush'),
     [activeEffects]
@@ -1688,17 +1972,14 @@ export default function ZombiesCharacterSheet() {
 
   const temporarySize = form?.temporarySize;
   const temporarySpeedBonus = form?.temporarySpeedBonus;
+  const desiredTokenSize = useMemo(() => resolveCharacterTokenSize(form), [form]);
 
   useEffect(() => {
     if (!form) {
       return;
     }
 
-    const hasLargeForm = activeEffects.some(
-      (effect) => effect && effect.name === 'Large Form'
-    );
-
-    if (hasLargeForm) {
+    if (largeFormActive) {
       const desiredSize = 'Large';
       const desiredSpeedBonus = 10;
       const nextSize = form.temporarySize;
@@ -1766,7 +2047,7 @@ export default function ZombiesCharacterSheet() {
       } = prev;
       return rest;
     });
-  }, [activeEffects, form]);
+  }, [form, largeFormActive]);
 
   const consumeCircle = useCallback(
     (type, index) => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -908,7 +908,25 @@ const sanitizeToken = (tokenValue, fallbackId) => {
     return null;
   }
 
-  return { ...candidate, characterId: candidateId, x, y };
+  const sanitized = { ...candidate, characterId: candidateId, x, y };
+
+  if (Object.prototype.hasOwnProperty.call(candidate, 'rotation')) {
+    const normalizedRotation = normalizeRotation(candidate.rotation);
+    if (normalizedRotation === null) {
+      delete sanitized.rotation;
+    } else {
+      sanitized.rotation = normalizedRotation;
+    }
+  }
+
+  const normalizedSize = normalizeCreatureSize(candidate.size);
+  if (normalizedSize) {
+    sanitized.size = normalizedSize;
+  } else if (Object.prototype.hasOwnProperty.call(candidate, 'size')) {
+    delete sanitized.size;
+  }
+
+  return sanitized;
 };
 
 const sanitizeTokenDictionary = (tokens) => {

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -14,6 +14,7 @@ const {
   buildCampaignMapPayload,
   normalizeMapTokens,
   normalizeTokenRotation,
+  normalizeTokenSize,
 } = require('../utils/campaignMaps');
 const {
   uploadMapImage,
@@ -1192,6 +1193,7 @@ module.exports = (router) => {
           .isFloat()
           .withMessage('rotation must be a number')
           .toFloat(),
+        body('size').optional().isString().withMessage('size must be a string').trim(),
       ],
       handleValidationErrors,
       async (req, res, next) => {
@@ -1272,6 +1274,15 @@ module.exports = (router) => {
               delete nextTokens[mapId][trimmedCharacterId].rotation;
             } else {
               nextTokens[mapId][trimmedCharacterId].rotation = normalizedRotation;
+            }
+          }
+
+          if (Object.prototype.hasOwnProperty.call(req.body, 'size')) {
+            const normalizedSize = normalizeTokenSize(req.body.size);
+            if (normalizedSize) {
+              nextTokens[mapId][trimmedCharacterId].size = normalizedSize;
+            } else {
+              delete nextTokens[mapId][trimmedCharacterId].size;
             }
           }
 

--- a/server/utils/campaignMaps.js
+++ b/server/utils/campaignMaps.js
@@ -63,6 +63,7 @@ const clampPercentage = (value) => {
 };
 
 const FIGURINE_STRING_FIELDS = ['imageUrl', 'cloudinaryPublicId', 'folder'];
+const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
 
 const normalizeTokenRotation = (value) => {
   if (value === null || value === undefined || value === '') {
@@ -81,6 +82,34 @@ const normalizeTokenRotation = (value) => {
   // noise from repeated normalization. Three decimal places is more than
   // enough granularity for visual rotations.
   return Math.round(resolved * 1000) / 1000;
+};
+
+const normalizeTokenSize = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (CREATURE_SIZE_KEYS.includes(trimmed)) {
+    return trimmed;
+  }
+
+  const tokens = trimmed.split(/[^a-z]+/).filter(Boolean);
+  const tokenMatch = CREATURE_SIZE_KEYS.find((size) => tokens.includes(size));
+  if (tokenMatch) {
+    return tokenMatch;
+  }
+
+  const prefixMatch = CREATURE_SIZE_KEYS.find((size) => trimmed.startsWith(size));
+  if (prefixMatch) {
+    return prefixMatch;
+  }
+
+  return null;
 };
 
 const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
@@ -186,6 +215,18 @@ const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
         }
       }
 
+      if ('size' in candidate) {
+        const normalizedSize = normalizeTokenSize(candidate.size);
+        if (normalizedSize) {
+          sanitizedToken.size = normalizedSize;
+          if (normalizedSize !== candidate.size) {
+            didMutate = true;
+          }
+        } else if (candidate.size !== undefined) {
+          didMutate = true;
+        }
+      }
+
       FIGURINE_STRING_FIELDS.forEach((field) => {
         if (!(field in candidate)) {
           return;
@@ -222,6 +263,9 @@ const normalizeMapTokens = ({ mapTokens, validMapIds = new Set(), now }) => {
         }, {}),
         ...(rawValue && Object.prototype.hasOwnProperty.call(rawValue, 'rotation')
           ? { rotation: rawValue.rotation }
+          : {}),
+        ...(rawValue && Object.prototype.hasOwnProperty.call(rawValue, 'size')
+          ? { size: rawValue.size }
           : {}),
       });
       const sanitizedComparable = JSON.stringify(sanitizedToken);
@@ -551,4 +595,5 @@ module.exports = {
   getMapSchemas,
   normalizeMapTokens,
   normalizeTokenRotation,
+  normalizeTokenSize,
 };


### PR DESCRIPTION
## Summary
- normalize map token sanitization on the player and DM clients so rotation and size metadata persist
- push Large Form size changes to the campaign map tokens and track affected maps for cleanup when the effect ends
- extend the campaign token endpoint and token normalizer to accept and normalize figurine size updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd6281bfe4832e9ae70ca703b89a9e