### PR TITLE
Add inventory item deletion with confirmation

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -396,6 +396,7 @@ function ItemList({
   const [error, setError] = useState(null);
   const [unknownItems, setUnknownItems] = useState([]);
   const [notesItem, setNotesItem] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
   const [ownedEntries, setOwnedEntries] = useState(() =>
     Array.isArray(initialItems) ? initialItems : EMPTY_ARRAY
   );
@@ -631,6 +632,38 @@ function ItemList({
     }
   };
 
+  const handleRequestDelete = (dataKey, item) => () => {
+    if (!ownedOnly) {
+      return;
+    }
+    setDeleteTarget({ dataKey, item });
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteTarget(null);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const { dataKey, item } = deleteTarget;
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
+
+    setDeleteTarget(null);
+
+    if (nextEntries === ownedEntries) {
+      return;
+    }
+
+    setOwnedEntries(nextEntries);
+
+    if (typeof onChange === 'function') {
+      onChange(nextEntries);
+    }
+  };
+
   const getCartCount = (item) => {
     if (!cartCounts) return 0;
     const key = `item::${String(item?.name || '').toLowerCase()}`;
@@ -771,16 +804,27 @@ function ItemList({
                   </Card.Body>
                   <Card.Footer className="d-flex justify-content-center">
                     {ownedOnly ? (
-                      <Button
-                        size="sm"
-                        onClick={handleUseItem(dataKey, item)}
-                        disabled={!canUseItem}
-                        title={
-                          canUseItem ? undefined : 'Only consumable items can be used.'
-                        }
-                      >
-                        Use
-                      </Button>
+                      <div className="d-flex align-items-center gap-2">
+                        <Button
+                          size="sm"
+                          onClick={handleUseItem(dataKey, item)}
+                          disabled={!canUseItem}
+                          title={
+                            canUseItem
+                              ? undefined
+                              : 'Only consumable items can be used.'
+                          }
+                        >
+                          Use
+                        </Button>
+                        <Button
+                          size="sm"
+                          className="btn-danger action-btn fa-solid fa-trash"
+                          onClick={handleRequestDelete(dataKey, item)}
+                          title={`Delete ${item.displayName || item.name || 'item'}`}
+                          aria-label={`Delete ${item.displayName || item.name || 'item'}`}
+                        />
+                      </div>
                     ) : (
                       <div className="d-flex align-items-center gap-2">
                         <Button size="sm" onClick={handleAddToCart(item)}>
@@ -809,7 +853,7 @@ function ItemList({
     <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
   );
 
-  const modal = (
+  const notesModal = (
     <Modal show={!!notesItem} onHide={handleCloseNotes} size="sm">
       <Modal.Header closeButton>
         <Modal.Title>{notesItem?.displayName || notesItem?.name}</Modal.Title>
@@ -818,11 +862,34 @@ function ItemList({
     </Modal>
   );
 
+  const deleteItemName = deleteTarget?.item?.displayName || deleteTarget?.item?.name;
+  const deleteModal = (
+    <Modal show={!!deleteTarget} onHide={handleCancelDelete} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Delete Item</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {`Are you sure you want to remove ${
+          deleteItemName ? `${deleteItemName}` : 'this item'
+        } from your inventory?`}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" className="action-btn close-btn" onClick={handleCancelDelete}>
+          Cancel
+        </Button>
+        <Button variant="danger" className="action-btn" onClick={handleConfirmDelete}>
+          Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+
   if (embedded) {
     return (
       <>
         {body}
-        {modal}
+        {notesModal}
+        {deleteModal}
       </>
     );
   }
@@ -833,7 +900,8 @@ function ItemList({
         <Card.Title className="modal-title">Items</Card.Title>
       </Card.Header>
       {body}
-      {modal}
+      {notesModal}
+      {deleteModal}
     </Card>
   );
 }

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -180,14 +180,16 @@ test('use button removes a consumable item copy and triggers onChange', async ()
     },
   ];
 
-  render(
-    <ItemList
-      ownedOnly
-      embedded
-      initialItems={initialItems}
-      onChange={onChange}
-    />
-  );
+  await act(async () => {
+    render(
+      <ItemList
+        ownedOnly
+        embedded
+        initialItems={initialItems}
+        onChange={onChange}
+      />
+    );
+  });
 
   const potionHeading = await screen.findByText('Potion of healing');
   const potionCard = potionHeading.closest('.card');
@@ -268,5 +270,73 @@ test('using all copies of a consumable potion removes it from the inventory', as
 
   await waitFor(() =>
     expect(screen.queryByText('Potion of healing')).not.toBeInTheDocument()
+  );
+});
+
+test('delete button removes an item after confirmation', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => itemsData });
+  const onChange = jest.fn();
+  const initialItems = [
+    { name: 'Torch', displayName: 'Torch', owned: true },
+    { name: 'Torch', displayName: 'Torch', owned: true },
+    {
+      name: 'potion-healing',
+      displayName: 'Potion of healing',
+      properties: ['consumable'],
+      owned: true,
+    },
+  ];
+
+  render(
+    <ItemList
+      ownedOnly
+      embedded
+      initialItems={initialItems}
+      onChange={onChange}
+    />
+  );
+
+  const torchHeading = await screen.findByText('Torch');
+  const torchCard = torchHeading.closest('.card');
+  expect(torchCard).not.toBeNull();
+
+  const deleteButton = within(torchCard).getByRole('button', { name: /delete torch/i });
+  await act(async () => {
+    await userEvent.click(deleteButton);
+  });
+
+  const confirmationMessage = await screen.findByText(
+    /are you sure you want to remove torch from your inventory/i
+  );
+  const confirmationModal = confirmationMessage.closest('.modal');
+  expect(confirmationModal).not.toBeNull();
+
+  const confirmButton = within(confirmationModal).getByRole('button', { name: /delete/i });
+  await act(async () => {
+    await userEvent.click(confirmButton);
+  });
+
+  await act(async () => {});
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+  const updatedItems = onChange.mock.calls[0][0];
+  expect(updatedItems).toHaveLength(2);
+
+  const torchCount = updatedItems.filter((entry) => {
+    if (!entry) return false;
+    if (typeof entry === 'string') return entry.toLowerCase() === 'torch';
+    if (Array.isArray(entry)) {
+      return String(entry[0] || '').toLowerCase() === 'torch';
+    }
+    const name = String(entry.name || entry.displayName || '').toLowerCase();
+    return name === 'torch';
+  }).length;
+  expect(torchCount).toBe(1);
+
+  await waitFor(() =>
+    expect(screen.queryByText(/are you sure you want to remove torch/i)).not.toBeInTheDocument()
+  );
+  await waitFor(() =>
+    expect(within(torchCard).queryByText(/×2/)).not.toBeInTheDocument()
   );
 });


### PR DESCRIPTION
## Summary
- add delete controls to inventory item cards with a shared trash icon
- persist removals by updating owned entries and triggering the existing change callback
- expand ItemList tests to cover the delete confirmation flow

## Testing
- npm test -- --runTestsByPath src/components/Items/ItemList.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fd6e6de444832ebd28aaddc07818fd