### PR TITLE
Allow deleting owned weapons, armor, and accessories

### DIFF
--- a/client/src/components/Accessories/AccessoryList.js
+++ b/client/src/components/Accessories/AccessoryList.js
@@ -60,6 +60,71 @@ const formatSlots = (slots) => {
     .join(', ');
 };
 
+const EMPTY_ARRAY = Object.freeze([]);
+
+const normalizeAccessoryName = (value) => {
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase();
+  }
+  return '';
+};
+
+const extractAccessoryEntryName = (entry) => {
+  if (!entry) return '';
+  if (typeof entry === 'string') {
+    return normalizeAccessoryName(entry);
+  }
+  if (Array.isArray(entry)) {
+    return extractAccessoryEntryName(entry[0]);
+  }
+  if (typeof entry === 'object') {
+    return (
+      normalizeAccessoryName(entry.displayName) ||
+      normalizeAccessoryName(entry.itemName) ||
+      normalizeAccessoryName(entry.accessoryName) ||
+      normalizeAccessoryName(entry.name)
+    );
+  }
+  return '';
+};
+
+const buildMatchKeySet = (accessory, dataKey) => {
+  const keys = new Set();
+  const addKey = (value) => {
+    const normalized = normalizeAccessoryName(value);
+    if (normalized) {
+      keys.add(normalized);
+    }
+  };
+  addKey(dataKey);
+  if (accessory) {
+    addKey(accessory.displayName);
+    addKey(accessory.itemName);
+    addKey(accessory.accessoryName);
+    addKey(accessory.name);
+  }
+  return keys;
+};
+
+const removeFirstMatchingEntry = (entries, accessory, dataKey) => {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return entries;
+  }
+  const matchKeys = buildMatchKeySet(accessory, dataKey);
+  if (matchKeys.size === 0) {
+    return entries;
+  }
+  const index = entries.findIndex((entry) =>
+    matchKeys.has(extractAccessoryEntryName(entry))
+  );
+  if (index === -1) {
+    return entries;
+  }
+  const next = entries.slice();
+  next.splice(index, 1);
+  return next;
+};
+
 const buildAccessoryOwnershipMap = (initialAccessories) => {
   const map = new Map();
   if (!Array.isArray(initialAccessories)) return map;
@@ -128,7 +193,7 @@ function normalizeAccessoryBonuses(bonuses) {
 function AccessoryList({
   campaign,
   onChange,
-  initialAccessories = [],
+  initialAccessories = EMPTY_ARRAY,
   show = true,
   embedded = false,
   onAddToCart = () => {},
@@ -141,15 +206,26 @@ function AccessoryList({
   const [error, setError] = useState(null);
   const [unknownAccessories, setUnknownAccessories] = useState([]);
   const [notesAccessory, setNotesAccessory] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
   const requestIdRef = useRef(0);
 
-  const initialAccessoriesArray = Array.isArray(initialAccessories)
-    ? initialAccessories
-    : [];
+  const initialAccessoriesArray = useMemo(
+    () => (Array.isArray(initialAccessories) ? initialAccessories : EMPTY_ARRAY),
+    [initialAccessories]
+  );
+  const [ownedEntries, setOwnedEntries] = useState(initialAccessoriesArray);
+
+  useEffect(() => {
+    if (Array.isArray(initialAccessories)) {
+      setOwnedEntries((prev) => (prev === initialAccessories ? prev : initialAccessories));
+    } else {
+      setOwnedEntries((prev) => (prev === EMPTY_ARRAY ? prev : EMPTY_ARRAY));
+    }
+  }, [initialAccessories]);
 
   const ownershipMap = useMemo(
-    () => buildAccessoryOwnershipMap(initialAccessoriesArray),
-    [initialAccessoriesArray]
+    () => buildAccessoryOwnershipMap(ownedEntries),
+    [ownedEntries]
   );
 
   const hiddenSet = useMemo(() => {
@@ -351,6 +427,36 @@ function AccessoryList({
   const handleShowNotes = (accessory) => () => setNotesAccessory(accessory);
   const handleCloseNotes = () => setNotesAccessory(null);
 
+  const handleRequestDelete = (dataKey, accessory) => () => {
+    if (!ownedOnly) {
+      return;
+    }
+    setDeleteTarget({ dataKey, accessory });
+  };
+
+  const handleCancelDelete = () => setDeleteTarget(null);
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const { dataKey, accessory } = deleteTarget;
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, accessory, dataKey);
+
+    setDeleteTarget(null);
+
+    if (nextEntries === ownedEntries) {
+      return;
+    }
+
+    setOwnedEntries(nextEntries);
+
+    if (typeof onChange === 'function') {
+      onChange(nextEntries);
+    }
+  };
+
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
 
   const filteredEntries = Object.entries(accessories).filter(([key, accessory]) => {
@@ -419,6 +525,7 @@ function AccessoryList({
         <Row className="row-cols-2 row-cols-lg-3 g-3">
           {expandedEntries.map(({
             reactKey,
+            dataKey,
             accessory,
             copyIndex,
             copyCount,
@@ -481,8 +588,16 @@ function AccessoryList({
                       </div>
                     )}
                   </Card.Body>
-                  {!ownedOnly && (
-                    <Card.Footer className="d-flex justify-content-center">
+                  <Card.Footer className="d-flex justify-content-center">
+                    {ownedOnly ? (
+                      <Button
+                        size="sm"
+                        className="btn-danger action-btn fa-solid fa-trash"
+                        onClick={handleRequestDelete(dataKey, accessory)}
+                        title={`Delete ${accessory.displayName || accessory.name || 'accessory'}`}
+                        aria-label={`Delete ${accessory.displayName || accessory.name || 'accessory'}`}
+                      />
+                    ) : (
                       <div className="d-flex align-items-center gap-2">
                         <Button size="sm" onClick={handleAddToCart(accessory)}>
                           Add to Cart
@@ -493,8 +608,8 @@ function AccessoryList({
                           </Badge>
                         ) : null}
                       </div>
-                    </Card.Footer>
-                  )}
+                    )}
+                  </Card.Footer>
                 </Card>
               </Col>
             );
@@ -510,7 +625,7 @@ function AccessoryList({
     <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
   );
 
-  const modal = (
+  const notesModal = (
     <Modal show={!!notesAccessory} onHide={handleCloseNotes} size="sm">
       <Modal.Header closeButton>
         <Modal.Title>
@@ -521,11 +636,35 @@ function AccessoryList({
     </Modal>
   );
 
+  const deleteAccessoryName =
+    deleteTarget?.accessory?.displayName || deleteTarget?.accessory?.name;
+  const deleteModal = (
+    <Modal show={!!deleteTarget} onHide={handleCancelDelete} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Delete Accessory</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {`Are you sure you want to remove ${
+          deleteAccessoryName ? `${deleteAccessoryName}` : 'this accessory'
+        } from your inventory?`}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" className="action-btn close-btn" onClick={handleCancelDelete}>
+          Cancel
+        </Button>
+        <Button variant="danger" className="action-btn" onClick={handleConfirmDelete}>
+          Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+
   if (embedded) {
     return (
       <>
         {body}
-        {modal}
+        {notesModal}
+        {deleteModal}
       </>
     );
   }
@@ -533,7 +672,8 @@ function AccessoryList({
   return (
     <Card className="item-card">
       {body}
-      {modal}
+      {notesModal}
+      {deleteModal}
     </Card>
   );
 }

--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Card, Form, Alert, Row, Col, Button, Badge } from 'react-bootstrap';
+import { Card, Form, Alert, Row, Col, Button, Badge, Modal } from 'react-bootstrap';
 import {
   GiLeatherArmor,
   GiBreastplate,
@@ -27,6 +27,67 @@ import apiFetch from '../../utils/apiFetch';
  *   hiddenKeys?: Set<string> | string[] | Record<string, boolean> | null,
  * }} props
  */
+const EMPTY_ARRAY = Object.freeze([]);
+
+const normalizeArmorName = (value) => {
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase();
+  }
+  return '';
+};
+
+const extractArmorEntryName = (entry) => {
+  if (!entry) return '';
+  if (typeof entry === 'string') {
+    return normalizeArmorName(entry);
+  }
+  if (Array.isArray(entry)) {
+    return extractArmorEntryName(entry[0]);
+  }
+  if (typeof entry === 'object') {
+    return (
+      normalizeArmorName(entry.displayName) ||
+      normalizeArmorName(entry.armorName) ||
+      normalizeArmorName(entry.name)
+    );
+  }
+  return '';
+};
+
+const buildMatchKeySet = (piece, dataKey) => {
+  const keys = new Set();
+  const addKey = (value) => {
+    const normalized = normalizeArmorName(value);
+    if (normalized) {
+      keys.add(normalized);
+    }
+  };
+  addKey(dataKey);
+  if (piece) {
+    addKey(piece.displayName);
+    addKey(piece.armorName);
+    addKey(piece.name);
+  }
+  return keys;
+};
+
+const removeFirstMatchingEntry = (entries, piece, dataKey) => {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return entries;
+  }
+  const matchKeys = buildMatchKeySet(piece, dataKey);
+  if (matchKeys.size === 0) {
+    return entries;
+  }
+  const index = entries.findIndex((entry) => matchKeys.has(extractArmorEntryName(entry)));
+  if (index === -1) {
+    return entries;
+  }
+  const next = entries.slice();
+  next.splice(index, 1);
+  return next;
+};
+
 const buildArmorOwnershipMap = (initialArmor) => {
   const map = new Map();
   if (!Array.isArray(initialArmor)) return map;
@@ -66,7 +127,7 @@ const buildArmorOwnershipMap = (initialArmor) => {
 function ArmorList({
   campaign,
   onChange,
-  initialArmor = [],
+  initialArmor = EMPTY_ARRAY,
   characterId,
   show = true,
   strength = Number.POSITIVE_INFINITY,
@@ -80,11 +141,25 @@ function ArmorList({
     useState/** @type {Record<string, Armor & { owned?: boolean, ownedCount?: number, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
   const [error, setError] = useState(null);
   const [unknownArmor, setUnknownArmor] = useState([]);
+  const [deleteTarget, setDeleteTarget] = useState(null);
 
-  const initialArmorArray = Array.isArray(initialArmor) ? initialArmor : [];
+  const normalizedInitialArmor = useMemo(
+    () => (Array.isArray(initialArmor) ? initialArmor : EMPTY_ARRAY),
+    [initialArmor]
+  );
+  const [ownedEntries, setOwnedEntries] = useState(normalizedInitialArmor);
+
+  useEffect(() => {
+    if (Array.isArray(initialArmor)) {
+      setOwnedEntries((prev) => (prev === initialArmor ? prev : initialArmor));
+    } else {
+      setOwnedEntries((prev) => (prev === EMPTY_ARRAY ? prev : EMPTY_ARRAY));
+    }
+  }, [initialArmor]);
+
   const ownershipMap = useMemo(
-    () => buildArmorOwnershipMap(initialArmorArray),
-    [initialArmorArray]
+    () => buildArmorOwnershipMap(ownedEntries),
+    [ownedEntries]
   );
 
   const hiddenSet = useMemo(() => {
@@ -180,7 +255,7 @@ function ArmorList({
             }, {})
           : {};
 
-        const invalidInitialArmor = initialArmorArray.filter(
+        const invalidInitialArmor = normalizedInitialArmor.filter(
           (a) => typeof a !== 'string' && typeof a?.name !== 'string'
         );
         if (invalidInitialArmor.length) {
@@ -344,6 +419,36 @@ function ArmorList({
     }
   };
 
+  const handleRequestDelete = (dataKey, piece) => () => {
+    if (!ownedOnly) {
+      return;
+    }
+    setDeleteTarget({ dataKey, piece });
+  };
+
+  const handleCancelDelete = () => setDeleteTarget(null);
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const { dataKey, piece } = deleteTarget;
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, piece, dataKey);
+
+    setDeleteTarget(null);
+
+    if (nextEntries === ownedEntries) {
+      return;
+    }
+
+    setOwnedEntries(nextEntries);
+
+    if (typeof onChange === 'function') {
+      onChange(nextEntries);
+    }
+  };
+
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
   const filteredEntries = Object.entries(armor).filter(([key, piece]) => {
     if (hiddenSet) {
@@ -459,7 +564,15 @@ function ArmorList({
                         : undefined
                     }
                   />
-                  {!ownedOnly && (
+                  {ownedOnly ? (
+                    <Button
+                      size="sm"
+                      className="btn-danger action-btn fa-solid fa-trash"
+                      onClick={handleRequestDelete(dataKey, piece)}
+                      title={`Delete ${piece.displayName || piece.name || 'armor'}`}
+                      aria-label={`Delete ${piece.displayName || piece.name || 'armor'}`}
+                    />
+                  ) : (
                     <>
                       <Button size="sm" onClick={handleAddToCart(piece)}>
                         Add to Cart
@@ -481,17 +594,47 @@ function ArmorList({
     </>
   );
 
+  const deleteArmorName = deleteTarget?.piece?.displayName || deleteTarget?.piece?.name;
+  const deleteModal = (
+    <Modal show={!!deleteTarget} onHide={handleCancelDelete} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Delete Armor</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {`Are you sure you want to remove ${
+          deleteArmorName ? `${deleteArmorName}` : 'this armor'
+        } from your inventory?`}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" className="action-btn close-btn" onClick={handleCancelDelete}>
+          Cancel
+        </Button>
+        <Button variant="danger" className="action-btn" onClick={handleConfirmDelete}>
+          Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+
   if (embedded) {
-    return bodyContent;
+    return (
+      <>
+        {bodyContent}
+        {deleteModal}
+      </>
+    );
   }
 
   return (
-    <Card className="modern-card">
-      <Card.Header className="modal-header">
-        <Card.Title className="modal-title">Armor</Card.Title>
-      </Card.Header>
-      <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
-    </Card>
+    <>
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Armor</Card.Title>
+        </Card.Header>
+        <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
+      </Card>
+      {deleteModal}
+    </>
   );
 }
 

--- a/client/src/components/Armor/ArmorList.test.js
+++ b/client/src/components/Armor/ArmorList.test.js
@@ -355,6 +355,74 @@ test('renders duplicate armor entries when multiple copies are owned', async () 
   expect(screen.getAllByText('Chain Mail')).toHaveLength(1);
 });
 
+test('delete button removes armor after confirmation', async () => {
+  apiFetch
+    .mockResolvedValueOnce({ ok: true, json: async () => armorData })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ allowed: null, proficient: {}, granted: [] }),
+    });
+
+  const onChange = jest.fn();
+  const initialArmor = [
+    { name: 'Leather Armor', displayName: 'Leather Armor', owned: true },
+    { name: 'Leather Armor', displayName: 'Leather Armor', owned: true },
+    { name: 'Chain Mail', displayName: 'Chain Mail', owned: true },
+  ];
+
+  render(
+    <ArmorList
+      ownedOnly
+      embedded
+      campaign="Camp1"
+      characterId="char1"
+      strength={15}
+      initialArmor={initialArmor}
+      onChange={onChange}
+    />
+  );
+
+  const deleteButtons = await screen.findAllByRole('button', {
+    name: /delete leather armor/i,
+  });
+  expect(deleteButtons.length).toBeGreaterThan(0);
+  const deleteButton = deleteButtons[0];
+  const leatherCard = deleteButton.closest('.card');
+  expect(leatherCard).not.toBeNull();
+
+  await act(async () => {
+    await userEvent.click(deleteButton);
+  });
+
+  const confirmationMessage = await screen.findByText(
+    /are you sure you want to remove leather armor from your inventory/i
+  );
+  const confirmationModal = confirmationMessage.closest('.modal');
+  expect(confirmationModal).not.toBeNull();
+
+  const confirmButton = within(confirmationModal).getByRole('button', {
+    name: /delete/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(confirmButton);
+  });
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+  const updatedArmor = onChange.mock.calls[0][0];
+  expect(Array.isArray(updatedArmor)).toBe(true);
+  expect(updatedArmor).toHaveLength(2);
+
+  await waitFor(() =>
+    expect(
+      screen.queryByText(
+        /are you sure you want to remove leather armor from your inventory/i
+      )
+    ).not.toBeInTheDocument()
+  );
+});
+
 test('shows all armor when allowed list is empty', async () => {
   apiFetch.mockResolvedValueOnce({ ok: true, json: async () => armorData });
   apiFetch.mockResolvedValueOnce({

--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -396,6 +396,7 @@ function ItemList({
   const [error, setError] = useState(null);
   const [unknownItems, setUnknownItems] = useState([]);
   const [notesItem, setNotesItem] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
   const [ownedEntries, setOwnedEntries] = useState(() =>
     Array.isArray(initialItems) ? initialItems : EMPTY_ARRAY
   );
@@ -631,6 +632,38 @@ function ItemList({
     }
   };
 
+  const handleRequestDelete = (dataKey, item) => () => {
+    if (!ownedOnly) {
+      return;
+    }
+    setDeleteTarget({ dataKey, item });
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteTarget(null);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const { dataKey, item } = deleteTarget;
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, item, dataKey);
+
+    setDeleteTarget(null);
+
+    if (nextEntries === ownedEntries) {
+      return;
+    }
+
+    setOwnedEntries(nextEntries);
+
+    if (typeof onChange === 'function') {
+      onChange(nextEntries);
+    }
+  };
+
   const getCartCount = (item) => {
     if (!cartCounts) return 0;
     const key = `item::${String(item?.name || '').toLowerCase()}`;
@@ -771,16 +804,27 @@ function ItemList({
                   </Card.Body>
                   <Card.Footer className="d-flex justify-content-center">
                     {ownedOnly ? (
-                      <Button
-                        size="sm"
-                        onClick={handleUseItem(dataKey, item)}
-                        disabled={!canUseItem}
-                        title={
-                          canUseItem ? undefined : 'Only consumable items can be used.'
-                        }
-                      >
-                        Use
-                      </Button>
+                      <div className="d-flex align-items-center gap-2">
+                        <Button
+                          size="sm"
+                          onClick={handleUseItem(dataKey, item)}
+                          disabled={!canUseItem}
+                          title={
+                            canUseItem
+                              ? undefined
+                              : 'Only consumable items can be used.'
+                          }
+                        >
+                          Use
+                        </Button>
+                        <Button
+                          size="sm"
+                          className="btn-danger action-btn fa-solid fa-trash"
+                          onClick={handleRequestDelete(dataKey, item)}
+                          title={`Delete ${item.displayName || item.name || 'item'}`}
+                          aria-label={`Delete ${item.displayName || item.name || 'item'}`}
+                        />
+                      </div>
                     ) : (
                       <div className="d-flex align-items-center gap-2">
                         <Button size="sm" onClick={handleAddToCart(item)}>
@@ -809,7 +853,7 @@ function ItemList({
     <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
   );
 
-  const modal = (
+  const notesModal = (
     <Modal show={!!notesItem} onHide={handleCloseNotes} size="sm">
       <Modal.Header closeButton>
         <Modal.Title>{notesItem?.displayName || notesItem?.name}</Modal.Title>
@@ -818,11 +862,34 @@ function ItemList({
     </Modal>
   );
 
+  const deleteItemName = deleteTarget?.item?.displayName || deleteTarget?.item?.name;
+  const deleteModal = (
+    <Modal show={!!deleteTarget} onHide={handleCancelDelete} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Delete Item</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {`Are you sure you want to remove ${
+          deleteItemName ? `${deleteItemName}` : 'this item'
+        } from your inventory?`}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" className="action-btn close-btn" onClick={handleCancelDelete}>
+          Cancel
+        </Button>
+        <Button variant="danger" className="action-btn" onClick={handleConfirmDelete}>
+          Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+
   if (embedded) {
     return (
       <>
         {body}
-        {modal}
+        {notesModal}
+        {deleteModal}
       </>
     );
   }
@@ -833,7 +900,8 @@ function ItemList({
         <Card.Title className="modal-title">Items</Card.Title>
       </Card.Header>
       {body}
-      {modal}
+      {notesModal}
+      {deleteModal}
     </Card>
   );
 }

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -180,14 +180,16 @@ test('use button removes a consumable item copy and triggers onChange', async ()
     },
   ];
 
-  render(
-    <ItemList
-      ownedOnly
-      embedded
-      initialItems={initialItems}
-      onChange={onChange}
-    />
-  );
+  await act(async () => {
+    render(
+      <ItemList
+        ownedOnly
+        embedded
+        initialItems={initialItems}
+        onChange={onChange}
+      />
+    );
+  });
 
   const potionHeading = await screen.findByText('Potion of healing');
   const potionCard = potionHeading.closest('.card');
@@ -268,5 +270,73 @@ test('using all copies of a consumable potion removes it from the inventory', as
 
   await waitFor(() =>
     expect(screen.queryByText('Potion of healing')).not.toBeInTheDocument()
+  );
+});
+
+test('delete button removes an item after confirmation', async () => {
+  apiFetch.mockResolvedValueOnce({ ok: true, json: async () => itemsData });
+  const onChange = jest.fn();
+  const initialItems = [
+    { name: 'Torch', displayName: 'Torch', owned: true },
+    { name: 'Torch', displayName: 'Torch', owned: true },
+    {
+      name: 'potion-healing',
+      displayName: 'Potion of healing',
+      properties: ['consumable'],
+      owned: true,
+    },
+  ];
+
+  render(
+    <ItemList
+      ownedOnly
+      embedded
+      initialItems={initialItems}
+      onChange={onChange}
+    />
+  );
+
+  const torchHeading = await screen.findByText('Torch');
+  const torchCard = torchHeading.closest('.card');
+  expect(torchCard).not.toBeNull();
+
+  const deleteButton = within(torchCard).getByRole('button', { name: /delete torch/i });
+  await act(async () => {
+    await userEvent.click(deleteButton);
+  });
+
+  const confirmationMessage = await screen.findByText(
+    /are you sure you want to remove torch from your inventory/i
+  );
+  const confirmationModal = confirmationMessage.closest('.modal');
+  expect(confirmationModal).not.toBeNull();
+
+  const confirmButton = within(confirmationModal).getByRole('button', { name: /delete/i });
+  await act(async () => {
+    await userEvent.click(confirmButton);
+  });
+
+  await act(async () => {});
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+  const updatedItems = onChange.mock.calls[0][0];
+  expect(updatedItems).toHaveLength(2);
+
+  const torchCount = updatedItems.filter((entry) => {
+    if (!entry) return false;
+    if (typeof entry === 'string') return entry.toLowerCase() === 'torch';
+    if (Array.isArray(entry)) {
+      return String(entry[0] || '').toLowerCase() === 'torch';
+    }
+    const name = String(entry.name || entry.displayName || '').toLowerCase();
+    return name === 'torch';
+  }).length;
+  expect(torchCount).toBe(1);
+
+  await waitFor(() =>
+    expect(screen.queryByText(/are you sure you want to remove torch/i)).not.toBeInTheDocument()
+  );
+  await waitFor(() =>
+    expect(within(torchCard).queryByText(/×2/)).not.toBeInTheDocument()
   );
 });

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Card, Row, Col, Form, Alert, Button, Badge } from 'react-bootstrap';
+import { Card, Row, Col, Form, Alert, Button, Badge, Modal } from 'react-bootstrap';
 import {
   GiStoneAxe,
   GiBowArrow,
@@ -25,6 +25,67 @@ import apiFetch from '../../utils/apiFetch';
  *   cartCounts?: Record<string, number> | null,
  * }} props
  */
+const EMPTY_ARRAY = Object.freeze([]);
+
+const normalizeWeaponName = (value) => {
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase();
+  }
+  return '';
+};
+
+const extractWeaponEntryName = (entry) => {
+  if (!entry) return '';
+  if (typeof entry === 'string') {
+    return normalizeWeaponName(entry);
+  }
+  if (Array.isArray(entry)) {
+    return extractWeaponEntryName(entry[0]);
+  }
+  if (typeof entry === 'object') {
+    return (
+      normalizeWeaponName(entry.displayName) ||
+      normalizeWeaponName(entry.weaponName) ||
+      normalizeWeaponName(entry.name)
+    );
+  }
+  return '';
+};
+
+const buildMatchKeySet = (weapon, dataKey) => {
+  const keys = new Set();
+  const addKey = (value) => {
+    const normalized = normalizeWeaponName(value);
+    if (normalized) {
+      keys.add(normalized);
+    }
+  };
+  addKey(dataKey);
+  if (weapon) {
+    addKey(weapon.displayName);
+    addKey(weapon.weaponName);
+    addKey(weapon.name);
+  }
+  return keys;
+};
+
+const removeFirstMatchingEntry = (entries, weapon, dataKey) => {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return entries;
+  }
+  const matchKeys = buildMatchKeySet(weapon, dataKey);
+  if (matchKeys.size === 0) {
+    return entries;
+  }
+  const index = entries.findIndex((entry) => matchKeys.has(extractWeaponEntryName(entry)));
+  if (index === -1) {
+    return entries;
+  }
+  const next = entries.slice();
+  next.splice(index, 1);
+  return next;
+};
+
 const buildWeaponOwnershipMap = (initialWeapons) => {
   const map = new Map();
   if (!Array.isArray(initialWeapons)) return map;
@@ -64,7 +125,7 @@ const buildWeaponOwnershipMap = (initialWeapons) => {
 function WeaponList({
   campaign,
   onChange,
-  initialWeapons = [],
+  initialWeapons = EMPTY_ARRAY,
   characterId,
   show = true,
   embedded = false,
@@ -77,10 +138,25 @@ function WeaponList({
     useState/** @type {Record<string, Weapon & { owned?: boolean, ownedCount?: number, proficient?: boolean, granted?: boolean, pending?: boolean, displayName?: string }> | null} */(null);
   const [error, setError] = useState(null);
   const [unknownWeapons, setUnknownWeapons] = useState([]);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+
+  const initialWeaponsArray = useMemo(
+    () => (Array.isArray(initialWeapons) ? initialWeapons : EMPTY_ARRAY),
+    [initialWeapons]
+  );
+  const [ownedEntries, setOwnedEntries] = useState(initialWeaponsArray);
+
+  useEffect(() => {
+    if (Array.isArray(initialWeapons)) {
+      setOwnedEntries((prev) => (prev === initialWeapons ? prev : initialWeapons));
+    } else {
+      setOwnedEntries((prev) => (prev === EMPTY_ARRAY ? prev : EMPTY_ARRAY));
+    }
+  }, [initialWeapons]);
 
   const ownershipMap = useMemo(
-    () => buildWeaponOwnershipMap(initialWeapons),
-    [initialWeapons]
+    () => buildWeaponOwnershipMap(ownedEntries),
+    [ownedEntries]
   );
 
   const hiddenSet = useMemo(() => {
@@ -304,6 +380,36 @@ function WeaponList({
     }
   };
 
+  const handleRequestDelete = (dataKey, weapon) => () => {
+    if (!ownedOnly) {
+      return;
+    }
+    setDeleteTarget({ dataKey, weapon });
+  };
+
+  const handleCancelDelete = () => setDeleteTarget(null);
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    const { dataKey, weapon } = deleteTarget;
+    const nextEntries = removeFirstMatchingEntry(ownedEntries, weapon, dataKey);
+
+    setDeleteTarget(null);
+
+    if (nextEntries === ownedEntries) {
+      return;
+    }
+
+    setOwnedEntries(nextEntries);
+
+    if (typeof onChange === 'function') {
+      onChange(nextEntries);
+    }
+  };
+
   const bodyStyle = embedded ? undefined : { overflowY: 'auto', maxHeight: '70vh' };
   const filteredEntries = Object.entries(weapons).filter(([key, weapon]) => {
     if (hiddenSet) {
@@ -407,7 +513,15 @@ function WeaponList({
                         : undefined
                     }
                   />
-                  {!ownedOnly && (
+                  {ownedOnly ? (
+                    <Button
+                      size="sm"
+                      className="btn-danger action-btn fa-solid fa-trash"
+                      onClick={handleRequestDelete(dataKey, weapon)}
+                      title={`Delete ${weapon.displayName || weapon.name || 'weapon'}`}
+                      aria-label={`Delete ${weapon.displayName || weapon.name || 'weapon'}`}
+                    />
+                  ) : (
                     <>
                       <Button size="sm" onClick={handleAddToCart(weapon)}>
                         Add to Cart
@@ -429,17 +543,47 @@ function WeaponList({
     </>
   );
 
+  const deleteWeaponName = deleteTarget?.weapon?.displayName || deleteTarget?.weapon?.name;
+  const deleteModal = (
+    <Modal show={!!deleteTarget} onHide={handleCancelDelete} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Delete Weapon</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {`Are you sure you want to remove ${
+          deleteWeaponName ? `${deleteWeaponName}` : 'this weapon'
+        } from your inventory?`}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" className="action-btn close-btn" onClick={handleCancelDelete}>
+          Cancel
+        </Button>
+        <Button variant="danger" className="action-btn" onClick={handleConfirmDelete}>
+          Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+
   if (embedded) {
-    return bodyContent;
+    return (
+      <>
+        {bodyContent}
+        {deleteModal}
+      </>
+    );
   }
 
   return (
-    <Card className="modern-card">
-      <Card.Header className="modal-header">
-        <Card.Title className="modal-title">Weapons</Card.Title>
-      </Card.Header>
-      <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
-    </Card>
+    <>
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">Weapons</Card.Title>
+        </Card.Header>
+        <Card.Body style={bodyStyle}>{bodyContent}</Card.Body>
+      </Card>
+      {deleteModal}
+    </>
   );
 }
 

--- a/client/src/components/Weapons/WeaponList.test.js
+++ b/client/src/components/Weapons/WeaponList.test.js
@@ -311,6 +311,73 @@ test('renders duplicate entries when multiple copies are owned', async () => {
   expect(screen.getAllByText('Dagger')).toHaveLength(1);
 });
 
+test('delete button removes a weapon after confirmation', async () => {
+  apiFetch
+    .mockResolvedValueOnce({ ok: true, json: async () => weaponsData })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ allowed: null, proficient: {}, granted: [] }),
+    });
+
+  const onChange = jest.fn();
+  const initialWeapons = [
+    { name: 'dagger', displayName: 'Dagger', owned: true },
+    { name: 'dagger', displayName: 'Dagger', owned: true },
+    { name: 'club', displayName: 'Club', owned: true },
+  ];
+
+  render(
+    <WeaponList
+      ownedOnly
+      embedded
+      campaign="Camp1"
+      characterId="char1"
+      initialWeapons={initialWeapons}
+      onChange={onChange}
+    />
+  );
+
+  const deleteButtons = await screen.findAllByRole('button', {
+    name: /delete dagger/i,
+  });
+  expect(deleteButtons.length).toBeGreaterThan(0);
+  const deleteButton = deleteButtons[0];
+  const daggerCard = deleteButton.closest('.card');
+  expect(daggerCard).not.toBeNull();
+
+  await act(async () => {
+    await userEvent.click(deleteButton);
+  });
+
+  const confirmationMessage = await screen.findByText(
+    /are you sure you want to remove dagger from your inventory/i
+  );
+  const confirmationModal = confirmationMessage.closest('.modal');
+  expect(confirmationModal).not.toBeNull();
+
+  const confirmButton = within(confirmationModal).getByRole('button', {
+    name: /delete/i,
+  });
+
+  await act(async () => {
+    await userEvent.click(confirmButton);
+  });
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+  const updatedWeapons = onChange.mock.calls[0][0];
+  expect(Array.isArray(updatedWeapons)).toBe(true);
+  expect(updatedWeapons).toHaveLength(2);
+
+  await waitFor(() =>
+    expect(
+      screen.queryByText(
+        /are you sure you want to remove dagger from your inventory/i
+      )
+    ).not.toBeInTheDocument()
+  );
+});
+
 test('warns when unknown weapon names are returned', async () => {
   const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
   apiFetch

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -26,6 +26,9 @@ export default function InventoryModal({
   onDockClose,
   onDockChange,
   onItemsChange,
+  onWeaponsChange,
+  onArmorChange,
+  onAccessoriesChange,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -105,6 +108,7 @@ export default function InventoryModal({
               show={isActive}
               embedded
               ownedOnly
+              onChange={onWeaponsChange}
             />
           ),
       },
@@ -124,6 +128,7 @@ export default function InventoryModal({
               show={isActive}
               embedded
               ownedOnly
+              onChange={onArmorChange}
             />
           ),
       },
@@ -164,6 +169,7 @@ export default function InventoryModal({
               show={isActive}
               embedded
               ownedOnly
+              onChange={onAccessoriesChange}
             />
           ),
       },
@@ -176,6 +182,9 @@ export default function InventoryModal({
       normalizedAccessories,
       normalizedWeapons,
       onItemsChange,
+      onWeaponsChange,
+      onArmorChange,
+      onAccessoriesChange,
       handleItemListClose,
     ]
   );

--- a/client/src/components/Zombies/attributes/InventoryModal.test.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.test.js
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 const mockWeaponListProps = { current: null };
 const mockArmorListProps = { current: null };
 const mockItemListProps = { current: null };
+const mockAccessoryListProps = { current: null };
 
 jest.mock('../../Weapons/WeaponList', () => {
   const React = require('react');
@@ -51,6 +52,21 @@ jest.mock('../../Items/ItemList', () => {
   };
 });
 
+jest.mock('../../Accessories/AccessoryList', () => {
+  const React = require('react');
+  return (props) => {
+    mockAccessoryListProps.current = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid="accessory-list">
+        {(props.initialAccessories || []).map((acc) => (
+          <span key={acc.name}>{acc.name}</span>
+        ))}
+      </div>
+    );
+  };
+});
+
 import InventoryModal from './InventoryModal';
 
 describe('InventoryModal', () => {
@@ -58,6 +74,7 @@ describe('InventoryModal', () => {
     mockWeaponListProps.current = null;
     mockArmorListProps.current = null;
     mockItemListProps.current = null;
+    mockAccessoryListProps.current = null;
   });
 
   test('switches tabs between weapons, armor, and items', async () => {
@@ -122,7 +139,15 @@ describe('InventoryModal', () => {
         { name: 'Potion of Healing', owned: true },
         { name: 'Scroll', owned: false },
       ],
+      accessories: [
+        { name: 'Amulet of Swiftness', owned: true },
+        { name: 'Ring of Protection', owned: false },
+      ],
     };
+
+    const onWeaponsChange = jest.fn();
+    const onArmorChange = jest.fn();
+    const onAccessoriesChange = jest.fn();
 
     render(
       <InventoryModal
@@ -130,6 +155,9 @@ describe('InventoryModal', () => {
         onHide={jest.fn()}
         onTabChange={jest.fn()}
         form={form}
+        onWeaponsChange={onWeaponsChange}
+        onArmorChange={onArmorChange}
+        onAccessoriesChange={onAccessoriesChange}
       />
     );
 
@@ -139,6 +167,7 @@ describe('InventoryModal', () => {
     expect(weaponList).not.toHaveTextContent('Great Axe');
 
     expect(mockWeaponListProps.current?.ownedOnly).toBe(true);
+    expect(mockWeaponListProps.current?.onChange).toBe(onWeaponsChange);
 
     await act(async () => {
       await userEvent.click(screen.getByRole('tab', { name: 'Armor' }));
@@ -148,6 +177,7 @@ describe('InventoryModal', () => {
     expect(armorList).toHaveTextContent('Chain Mail');
     expect(armorList).not.toHaveTextContent('Leather Armor');
     expect(mockArmorListProps.current?.ownedOnly).toBe(true);
+    expect(mockArmorListProps.current?.onChange).toBe(onArmorChange);
 
     await act(async () => {
       await userEvent.click(screen.getByRole('tab', { name: 'Items' }));
@@ -158,6 +188,14 @@ describe('InventoryModal', () => {
     expect(itemList).toHaveTextContent('Potion of Healing');
     expect(itemList).not.toHaveTextContent('Scroll');
     expect(mockItemListProps.current?.ownedOnly).toBe(true);
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: 'Accessories' }));
+    });
+    const accessoryList = await screen.findByTestId('accessory-list');
+    expect(accessoryList).toHaveTextContent('Amulet of Swiftness');
+    expect(accessoryList).not.toHaveTextContent('Ring of Protection');
+    expect(mockAccessoryListProps.current?.ownedOnly).toBe(true);
+    expect(mockAccessoryListProps.current?.onChange).toBe(onAccessoriesChange);
   });
 
   test('item list close handler hides the modal when not docked', async () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.accessories.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.accessories.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, screen, within, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../../../utils/apiFetch');
 import apiFetch from '../../../utils/apiFetch';
@@ -119,5 +120,109 @@ describe('AccessoryList request handling', () => {
     ownedAccessory = accessories.find((entry) => entry?.name === 'amulet of swiftness');
     expect(ownedAccessory).toBeTruthy();
     expect(ownedAccessory.owned).toBe(true);
+  });
+
+  test('delete button removes an accessory after confirmation', async () => {
+    apiFetch.mockImplementation((url) => {
+      if (url === '/accessories') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            'amulet of swiftness': {
+              name: 'amulet of swiftness',
+              displayName: 'Amulet of Swiftness',
+              category: 'amulet',
+              targetSlots: ['neck'],
+              weight: 1,
+              cost: '50 gp',
+              statBonuses: {},
+              skillBonuses: {},
+            },
+          }),
+        });
+      }
+      if (url === '/equipment/accessories/Camp1') {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      throw new Error(`Unexpected apiFetch call: ${url}`);
+    });
+
+    const onChange = jest.fn();
+    const initialAccessories = [
+      { name: 'amulet of swiftness', displayName: 'Amulet of Swiftness', owned: true },
+      { name: 'amulet of swiftness', displayName: 'Amulet of Swiftness', owned: true },
+      { name: 'ring of protection', displayName: 'Ring of Protection', owned: true },
+    ];
+
+    render(
+      <AccessoryList
+        campaign="Camp1"
+        initialAccessories={initialAccessories}
+        ownedOnly
+        embedded
+        onChange={onChange}
+        show
+      />
+    );
+
+    const amuletHeadings = await screen.findAllByText('Amulet of Swiftness');
+    const amuletCard = amuletHeadings[0]?.closest('.card');
+    expect(amuletCard).not.toBeNull();
+
+    const deleteButton = within(amuletCard).getByRole('button', {
+      name: /delete amulet of swiftness/i,
+    });
+
+    await act(async () => {
+      await userEvent.click(deleteButton);
+    });
+
+    const confirmationMessage = await screen.findByText(
+      /are you sure you want to remove amulet of swiftness from your inventory/i
+    );
+    const confirmationModal = confirmationMessage.closest('.modal');
+    expect(confirmationModal).not.toBeNull();
+
+    const confirmButton = within(confirmationModal).getByRole('button', {
+      name: /delete/i,
+    });
+
+    await act(async () => {
+      await userEvent.click(confirmButton);
+    });
+
+    await waitFor(() =>
+      expect(
+        onChange.mock.calls.some(([entries]) => {
+          if (!Array.isArray(entries)) {
+            return false;
+          }
+          const amuletCopies = entries.filter(
+            (entry) => entry?.name === 'amulet of swiftness'
+          ).length;
+          return entries.length === 2 && amuletCopies === 1;
+        })
+      ).toBe(true)
+    );
+    const deletionCall = onChange.mock.calls.find(([entries]) => {
+      if (!Array.isArray(entries)) {
+        return false;
+      }
+      const amuletCopies = entries.filter(
+        (entry) => entry?.name === 'amulet of swiftness'
+      ).length;
+      return entries.length === 2 && amuletCopies === 1;
+    });
+    const [updatedAccessories] = deletionCall || [];
+    expect(Array.isArray(updatedAccessories)).toBe(true);
+    expect(updatedAccessories).toHaveLength(2);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          /are you sure you want to remove amulet of swiftness from your inventory/i
+        )
+      ).not.toBeInTheDocument()
+    );
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5303,6 +5303,9 @@ export default function ZombiesCharacterSheet() {
           onTabChange: setInventoryTab,
           characterId,
           onItemsChange: handleItemsChange,
+          onWeaponsChange: handleWeaponsChange,
+          onArmorChange: handleArmorChange,
+          onAccessoriesChange: handleAccessoriesChange,
           onDockChange: (side) => handleDockChange('inventory', side),
         }),
       },
@@ -5840,6 +5843,9 @@ export default function ZombiesCharacterSheet() {
           dockedSide={getDockedSide('inventory')}
           onDockChange={(side) => handleDockChange('inventory', side)}
           onItemsChange={handleItemsChange}
+          onWeaponsChange={handleWeaponsChange}
+          onArmorChange={handleArmorChange}
+          onAccessoriesChange={handleAccessoriesChange}
         />
         <EquipmentModal
           show={showEquipment}


### PR DESCRIPTION
## Summary
- add owned-only delete controls and confirmation modals to the weapon, armor, and accessory lists
- propagate weapon, armor, and accessory inventory updates through the inventory modal into the character sheet
- extend unit tests to cover the new deletion flows and accessory plumbing

## Testing
- npm test -- --runTestsByPath client/src/components/Weapons/WeaponList.test.js
- npm test -- --runTestsByPath client/src/components/Armor/ArmorList.test.js
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.accessories.test.js
- CI=1 npm test -- --runTestsByPath client/src/components/Zombies/attributes/InventoryModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fd6e6de444832ebd28aaddc07818fd