### PR TITLE
Add detailed martial arts feature breakdown for monks

### DIFF
--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -3,7 +3,7 @@
 // keyed by level.
 
 /**
- * @typedef {{ name: string, description: string }} Feature
+ * @typedef {{ name: string, description: string, meta?: string }} Feature
  * @typedef {{
  *   featuresByLevel: Record<number, Feature[]>,
  *   spellSlots?: Record<number, Record<number, number>>,
@@ -676,7 +676,24 @@ const monkFeatures = {
     {
       name: 'Martial Arts',
       description:
-        'Your practice of martial arts gives you mastery of combat styles using unarmed strikes and monk weapons.'
+        'Your practice of martial arts gives you mastery of combat styles that use your Unarmed Strike and monk weapons. Monk weapons include simple melee weapons and martial melee weapons that have the Light property. You gain the following benefits while you are unarmed or wielding only monk weapons and you aren’t wearing armor or wielding a shield.'
+    },
+    {
+      name: 'Bonus Unarmed Strike',
+      meta: 'Martial Arts',
+      description: 'You can make an Unarmed Strike as a Bonus Action.'
+    },
+    {
+      name: 'Martial Arts Die',
+      meta: 'Martial Arts',
+      description:
+        'You can roll 1d6 in place of the normal damage of your Unarmed Strike or monk weapons. This die changes as you gain monk levels, as shown in the Martial Arts column of the Monk Features table.'
+    },
+    {
+      name: 'Dexterous Attacks',
+      meta: 'Martial Arts',
+      description:
+        'You can use your Dexterity modifier instead of your Strength modifier for the attack and damage rolls of your Unarmed Strikes and monk weapons. When you use the Grapple or Shove option of your Unarmed Strike, you can use your Dexterity modifier instead of your Strength modifier to determine the save DC.'
     }
   ],
   2: [


### PR DESCRIPTION
## Summary
- expand the Monk martial arts feature with a fuller description
- add individual cards for Bonus Unarmed Strike, Martial Arts Die, and Dexterous Attacks with a Martial Arts subheading
- document the optional `meta` field in the class feature data model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fda1692c3c8323958a297be98d26ef