### PR TITLE
Add unarmed strike option to player attacks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -532,8 +532,10 @@ const manualCriticalRef = useRef(false);
     [form.equipment]
   );
   const equippedWeapons = useMemo(() => {
+    let weapons = [];
+
     if (equipmentProvided) {
-      return WEAPON_SLOT_KEYS.map((slot) => {
+      weapons = WEAPON_SLOT_KEYS.map((slot) => {
         const weapon = normalizedEquipment[slot];
         if (!weapon) return null;
         if (weapon.source && weapon.source !== 'weapon') return null;
@@ -542,16 +544,44 @@ const manualCriticalRef = useRef(false);
         if (!damage) return null;
         return { slot, weapon };
       }).filter(Boolean);
+    } else {
+      const legacyWeapons = normalizeWeapons(form.weapon || [], {
+        includeUnowned: true,
+      });
+      weapons = legacyWeapons.map((weapon, index) => ({
+        slot: `legacy-${index}`,
+        weapon,
+      }));
     }
 
-    const legacyWeapons = normalizeWeapons(form.weapon || [], {
-      includeUnowned: true,
+    const hasUnarmedStrike = weapons.some(({ weapon }) => {
+      const name = typeof weapon?.name === 'string' ? weapon.name.trim() : '';
+      return name.toLowerCase() === 'unarmed strike';
     });
-    return legacyWeapons.map((weapon, index) => ({
-      slot: `legacy-${index}`,
-      weapon,
-    }));
-  }, [equipmentProvided, normalizedEquipment, form.weapon]);
+
+    if (hasUnarmedStrike) {
+      return weapons;
+    }
+
+    return [
+      ...weapons,
+      {
+        slot: 'unarmed-strike',
+        weapon: {
+          name: 'Unarmed Strike',
+          damage: '1d4 Bludgeoning',
+          type: 'Unarmed',
+          category: 'Melee Weapon',
+          properties: [],
+          source: 'weapon',
+        },
+      },
+    ];
+  }, [
+    equipmentProvided,
+    normalizedEquipment,
+    form.weapon,
+  ]);
 
   const [weaponAbilitySelections, setWeaponAbilitySelections] = useState({});
   const [weaponHandSelections, setWeaponHandSelections] = useState({});

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -999,6 +999,53 @@ describe('PlayerTurnActions weapon damage display', () => {
     expect(fire).toHaveClass('damage-fire');
     expect(fire.textContent).toBe('1d10 Fire');
   });
+
+  test('includes an unarmed strike attack when no weapons are equipped', () => {
+    render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', equipment: {}, spells: [] }}
+        strMod={3}
+        dexMod={0}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const card = screen.getByText('Unarmed Strike').closest('.attack-card');
+    expect(card).not.toBeNull();
+    expect(within(card).getByText('1d4+3 Bludgeoning')).toBeInTheDocument();
+  });
+
+  test('does not duplicate unarmed strike when other weapons are equipped', () => {
+    const rapier = {
+      name: 'Rapier',
+      damage: '1d8 piercing',
+      category: 'melee',
+      source: 'weapon',
+    };
+
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: rapier },
+          spells: [],
+        }}
+        strMod={2}
+        dexMod={0}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    expect(screen.getByText('Rapier')).toBeInTheDocument();
+    const unarmedCards = screen.getAllByText('Unarmed Strike');
+    expect(unarmedCards).toHaveLength(1);
+  });
 });
 
 describe('PlayerTurnActions critical events', () => {


### PR DESCRIPTION
## Summary
- always append an Unarmed Strike attack option with 1d4 bludgeoning damage to player actions
- add tests covering the default unarmed strike and ensuring it does not duplicate existing weapons

## Testing
- CI=true npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/PlayerTurnActions.test.js *(fails: RangeError from jsdom quick sort while running react-scripts test)*

------
https://chatgpt.com/codex/tasks/task_e_68fda42f38a4832398b50c89d6c889e0