### PR TITLE
Add Wisdom bonus to unarmored defense AC

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -10,6 +10,7 @@ export default function HealthDefense({
   form,
   conMod,
   dexMod,
+  wisMod = 0,
   totalLevel,
   ac = 0,
   hpMaxBonus = 0,
@@ -63,13 +64,115 @@ export default function HealthDefense({
     Number(ac);
   let filteredMaxDexArray = armorMaxDexBonus.filter((e) => e !== 0);
   let armorMaxDexMin = Math.min(...filteredMaxDexArray);
-    
+
      let armorMaxDex;
      if (Number(armorMaxDexMin) < Number(dexMod) && Number(armorMaxDexMin > 0)) {
         armorMaxDex = armorMaxDexMin;
      } else {
       armorMaxDex = dexMod;
      }
+
+  const numericWisMod = Number(wisMod);
+  const safeWisMod = Number.isFinite(numericWisMod) ? numericWisMod : 0;
+
+  const isShieldItem = (item) => {
+    if (!item) return false;
+    if (Array.isArray(item)) {
+      const [name] = item;
+      return typeof name === 'string' && name.toLowerCase().includes('shield');
+    }
+    const category = String(item.category ?? item.type ?? '').toLowerCase();
+    if (category.includes('shield')) {
+      return true;
+    }
+    const name = String(item.name ?? item.title ?? item.displayName ?? item.label ?? '').toLowerCase();
+    return name.includes('shield');
+  };
+
+  const hasShieldEquipped = useMemo(
+    () => armorItems.some((item) => isShieldItem(item)),
+    [armorItems]
+  );
+
+  const hasArmorEquipped = useMemo(
+    () =>
+      armorItems.some((item) => {
+        if (!item) return false;
+        if (isShieldItem(item)) return false;
+        if (Array.isArray(item)) return true;
+        const source = String(item.__source ?? item.source ?? '').toLowerCase();
+        if (source === 'armor') {
+          return true;
+        }
+        return false;
+      }),
+    [armorItems]
+  );
+
+  const hasUnarmoredDefenseFeature = useMemo(() => {
+    const searchValue = 'unarmored defense';
+    const checkValue = (value) => {
+      if (!value) return false;
+      if (Array.isArray(value)) {
+        return value.some((entry) => checkValue(entry));
+      }
+      if (typeof value === 'object') {
+        return Object.values(value).some((entry) => checkValue(entry));
+      }
+      return typeof value === 'string' && value.toLowerCase().includes(searchValue);
+    };
+
+    return checkValue(form?.features);
+  }, [form?.features]);
+
+  const hasMonkLevels = useMemo(() => {
+    if (!Array.isArray(form?.occupation)) {
+      return false;
+    }
+    return form.occupation.some((occupationEntry) => {
+      if (!occupationEntry || typeof occupationEntry !== 'object') {
+        return false;
+      }
+      const name = String(
+        occupationEntry.Name ??
+          occupationEntry.Occupation ??
+          occupationEntry.name ??
+          occupationEntry.occupation ??
+          ''
+      ).toLowerCase();
+      if (name !== 'monk') {
+        return false;
+      }
+      const levelValue = Number(
+        occupationEntry.Level ??
+          occupationEntry.level ??
+          occupationEntry.Levels ??
+          occupationEntry.levels ??
+          0
+      );
+      return Number.isFinite(levelValue) && levelValue > 0;
+    });
+  }, [form?.occupation]);
+
+  const shouldApplyUnarmoredDefenseWisBonus = useMemo(() => {
+    if (hasArmorEquipped || hasShieldEquipped) {
+      return false;
+    }
+    if (!Number.isFinite(numericWisMod)) {
+      return false;
+    }
+    return hasUnarmoredDefenseFeature || hasMonkLevels;
+  }, [
+    hasArmorEquipped,
+    hasShieldEquipped,
+    hasMonkLevels,
+    hasUnarmoredDefenseFeature,
+    numericWisMod,
+  ]);
+
+  const wisdomBonusToAc = shouldApplyUnarmoredDefenseWisBonus ? safeWisMod : 0;
+
+  const totalArmorClass = Number(totalArmorAcBonus) + 10 + Number(armorMaxDex) + wisdomBonusToAc;
     
   const derivedTotalLevel = useMemo(() => {
     if (Number.isFinite(totalLevel)) {
@@ -427,7 +530,7 @@ return (
 <div style={{ color: "#FFFFFF", display: "flex", flexDirection: "column", alignItems: "center", gap: "10px" }}>
   {/* First row */}
   <div style={{ display: "flex", gap: "20px", justifyContent: "center", flexWrap: "nowrap" }}>
-    <div><strong>AC:</strong> {Number(totalArmorAcBonus) + 10 + Number(armorMaxDex)}</div>
+    <div><strong>AC:</strong> {totalArmorClass}</div>
     <div><strong>Initiative:</strong> {Number(dexMod) + Number(initiative)}</div>
     <div><strong>Speed:</strong> {totalSpeed}</div>
   </div>

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -24,6 +24,7 @@ test('renders only proficiency bonus when no spellcasting', () => {
       form={baseForm}
       conMod={0}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -41,6 +42,7 @@ test('renders spell save dc and proficiency bonus when spellAbilityMod provided'
       form={baseForm}
       conMod={0}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -60,6 +62,7 @@ test('uses provided proficiency bonus when supplied', () => {
       form={formWithProf}
       conMod={0}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -78,6 +81,7 @@ test('allows health adjustment by dragging the bar', () => {
       form={baseForm}
       conMod={0}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -96,6 +100,7 @@ test('places range input above fill bar and label', () => {
       form={baseForm}
       conMod={0}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -117,6 +122,7 @@ test('updates health when slider is dragged', () => {
       form={baseForm}
       conMod={0}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -144,6 +150,7 @@ test('includes racial hp bonus when feat overrides are zero', () => {
       form={dwarfForm}
       conMod={2}
       dexMod={0}
+      wisMod={0}
       ac={0}
       hpMaxBonus={0}
       hpMaxBonusPerLevel={0}
@@ -153,4 +160,57 @@ test('includes racial hp bonus when feat overrides are zero', () => {
   );
 
   expect(screen.getByText('10/25')).toBeInTheDocument();
+});
+
+test('adds wisdom modifier to AC when unarmored defense is available and no armor or shield equipped', () => {
+  const monkForm = {
+    ...baseForm,
+    occupation: [{ Name: 'Monk', Level: 2 }],
+    equipment: {},
+    armor: [],
+  };
+
+  render(
+    <HealthDefense
+      form={monkForm}
+      conMod={0}
+      dexMod={2}
+      wisMod={3}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+
+  const acDisplay = screen.getByText('AC:', { selector: 'strong' }).parentElement;
+  expect(acDisplay).toHaveTextContent('AC: 15');
+});
+
+test('does not add wisdom modifier to AC when a shield is equipped', () => {
+  const monkWithShield = {
+    ...baseForm,
+    occupation: [{ Name: 'Monk', Level: 2 }],
+    equipment: {
+      offHand: { name: 'Shield', source: 'armor', category: 'shield', ac: 12, acBonus: 2 },
+    },
+  };
+
+  render(
+    <HealthDefense
+      form={monkWithShield}
+      conMod={0}
+      dexMod={2}
+      wisMod={3}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+
+  const acDisplay = screen.getByText('AC:', { selector: 'strong' }).parentElement;
+  expect(acDisplay).toHaveTextContent('AC: 14');
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5267,6 +5267,7 @@ export default function ZombiesCharacterSheet() {
               totalLevel={totalLevel}
               dexMod={statMods.dex}
               conMod={statMods.con}
+              wisMod={statMods.wis}
               initiative={featBonuses.initiative}
               speed={featBonuses.speed}
               ac={featBonuses.ac}


### PR DESCRIPTION
## Summary
- add Wisdom modifier to the HealthDefense AC calculation when Unarmored Defense applies and the character is unarmored
- detect shields or armor to gate the bonus and accept Wisdom modifier from the sheet
- cover the monk scenario with new unit tests

## Testing
- CI=true npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/HealthDefense.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fda6ef789c8323bad29b629d1edafd