### PR TITLE
Implement monk unarmored movement speed scaling

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -125,13 +125,13 @@ export default function HealthDefense({
     return checkValue(form?.features);
   }, [form?.features]);
 
-  const hasMonkLevels = useMemo(() => {
+  const monkLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) {
-      return false;
+      return 0;
     }
-    return form.occupation.some((occupationEntry) => {
+    return form.occupation.reduce((total, occupationEntry) => {
       if (!occupationEntry || typeof occupationEntry !== 'object') {
-        return false;
+        return total;
       }
       const name = String(
         occupationEntry.Name ??
@@ -141,7 +141,7 @@ export default function HealthDefense({
           ''
       ).toLowerCase();
       if (name !== 'monk') {
-        return false;
+        return total;
       }
       const levelValue = Number(
         occupationEntry.Level ??
@@ -150,9 +150,14 @@ export default function HealthDefense({
           occupationEntry.levels ??
           0
       );
-      return Number.isFinite(levelValue) && levelValue > 0;
-    });
+      if (!Number.isFinite(levelValue) || levelValue <= 0) {
+        return total;
+      }
+      return total + levelValue;
+    }, 0);
   }, [form?.occupation]);
+
+  const hasMonkLevels = monkLevel > 0;
 
   const shouldApplyUnarmoredDefenseWisBonus = useMemo(() => {
     if (hasArmorEquipped || hasShieldEquipped) {
@@ -324,10 +329,33 @@ export default function HealthDefense({
       ? numericSpeedMultiplier
       : 1;
 
+  const unarmoredMovementBonus = useMemo(() => {
+    if (hasArmorEquipped || hasShieldEquipped) {
+      return 0;
+    }
+    if (monkLevel < 2) {
+      return 0;
+    }
+    if (monkLevel <= 5) {
+      return 10;
+    }
+    if (monkLevel <= 9) {
+      return 15;
+    }
+    if (monkLevel <= 13) {
+      return 20;
+    }
+    if (monkLevel <= 17) {
+      return 25;
+    }
+    return 30;
+  }, [hasArmorEquipped, hasShieldEquipped, monkLevel]);
+
   const baseSpeed =
     Number(form?.speed ?? 0) +
     Number(speed ?? 0) +
-    Number(form?.temporarySpeedBonus ?? 0);
+    Number(form?.temporarySpeedBonus ?? 0) +
+    unarmoredMovementBonus;
 
   const totalSpeed = baseSpeed * safeSpeedMultiplier;
 

--- a/client/src/components/Zombies/attributes/HealthDefense.test.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.test.js
@@ -214,3 +214,91 @@ test('does not add wisdom modifier to AC when a shield is equipped', () => {
   const acDisplay = screen.getByText('AC:', { selector: 'strong' }).parentElement;
   expect(acDisplay).toHaveTextContent('AC: 14');
 });
+
+test.each([
+  { level: 2, expectedSpeed: 40 },
+  { level: 5, expectedSpeed: 40 },
+  { level: 6, expectedSpeed: 45 },
+  { level: 10, expectedSpeed: 50 },
+  { level: 14, expectedSpeed: 55 },
+  { level: 18, expectedSpeed: 60 },
+])('applies monk unarmored movement bonus at level $level', ({ level, expectedSpeed }) => {
+  const monkForm = {
+    ...baseForm,
+    occupation: [{ Name: 'Monk', Level: level }],
+    equipment: {},
+    armor: [],
+  };
+
+  render(
+    <HealthDefense
+      form={monkForm}
+      conMod={0}
+      dexMod={2}
+      wisMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+
+  const speedDisplay = screen.getByText('Speed:', { selector: 'strong' }).parentElement;
+  expect(speedDisplay).toHaveTextContent(`Speed: ${expectedSpeed}`);
+});
+
+test('does not apply monk unarmored movement bonus when armor or a shield is equipped', () => {
+  const armoredMonk = {
+    ...baseForm,
+    occupation: [{ Name: 'Monk', Level: 12 }],
+    armor: [['Chain Shirt', 13, 2]],
+    equipment: null,
+  };
+
+  const { rerender } = render(
+    <HealthDefense
+      form={armoredMonk}
+      conMod={0}
+      dexMod={2}
+      wisMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+
+  let speedDisplay = screen.getByText('Speed:', { selector: 'strong' }).parentElement;
+  expect(speedDisplay).toHaveTextContent('Speed: 30');
+
+  rerender(
+    <HealthDefense
+      form={{
+        ...armoredMonk,
+        armor: [],
+        equipment: {
+          offHand: {
+            name: 'Shield',
+            source: 'armor',
+            category: 'shield',
+            ac: 12,
+            acBonus: 2,
+          },
+        },
+      }}
+      conMod={0}
+      dexMod={2}
+      wisMod={0}
+      ac={0}
+      hpMaxBonus={0}
+      hpMaxBonusPerLevel={0}
+      initiative={0}
+      speed={0}
+    />
+  );
+
+  speedDisplay = screen.getByText('Speed:', { selector: 'strong' }).parentElement;
+  expect(speedDisplay).toHaveTextContent('Speed: 30');
+});

--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -721,7 +721,8 @@ const monkFeatures = {
     },
     {
       name: 'Unarmored Movement',
-      description: 'Your speed increases while you are not wearing armor or wielding a shield.'
+      description:
+        'Your speed increases by 10 feet while you are not wearing armor or wielding a shield. This bonus improves to 15 feet at 6th level, 20 feet at 10th level, 25 feet at 14th level, and 30 feet at 18th level.'
     }
   ],
   3: [


### PR DESCRIPTION
## Summary
- calculate total monk levels so unarmored movement speed bonuses scale with level
- extend HealthDefense tests to cover the scaling bonus and armor/shield restrictions
- document the scaling values in the monk Unarmored Movement feature description

## Testing
- npm test -- --runTestsByPath client/src/components/Zombies/attributes/HealthDefense.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fdaa0cfc248323860ab8299d8646c6