### PR TITLE
Allow monks to use Dexterity for monk weapons

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -593,6 +593,35 @@ const manualCriticalRef = useRef(false);
     return Number.isFinite(parsed) ? parsed : null;
   })();
 
+  const hasMonkLevels = useMemo(() => {
+    if (!Array.isArray(form?.occupation)) {
+      return false;
+    }
+    return form.occupation.some((occupationEntry) => {
+      if (!occupationEntry || typeof occupationEntry !== 'object') {
+        return false;
+      }
+      const name = String(
+        occupationEntry.Name ??
+          occupationEntry.Occupation ??
+          occupationEntry.name ??
+          occupationEntry.occupation ??
+          '',
+      ).toLowerCase();
+      if (name !== 'monk') {
+        return false;
+      }
+      const levelValue = Number(
+        occupationEntry.Level ??
+          occupationEntry.level ??
+          occupationEntry.Levels ??
+          occupationEntry.levels ??
+          0,
+      );
+      return Number.isFinite(levelValue) && levelValue > 0;
+    });
+  }, [form?.occupation]);
+
   const spellAbilityLabel = useMemo(() => {
     if (!spellAbilityKey) {
       return 'Spellcasting Ability Modifier';
@@ -607,13 +636,6 @@ const manualCriticalRef = useRef(false);
     [],
   );
 
-  const isRangedWeapon = (weapon) => {
-    const category = weapon?.category;
-    return (
-      typeof category === 'string' && category.toLowerCase().includes('ranged')
-    );
-  };
-
   const isFinesseWeapon = useCallback(
     (weapon) =>
       Array.isArray(weapon?.properties) &&
@@ -623,7 +645,122 @@ const manualCriticalRef = useRef(false);
     []
   );
 
+  const getWeaponCategoryString = useCallback((weapon) => {
+    if (!weapon || typeof weapon !== 'object') {
+      return '';
+    }
+    const candidates = [
+      weapon.category,
+      weapon.weaponCategory,
+      weapon.weaponType,
+      weapon.type,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate !== 'string') continue;
+      const normalized = candidate.trim().toLowerCase();
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return '';
+  }, []);
+
+  const isRangedWeapon = useCallback(
+    (weapon) => getWeaponCategoryString(weapon).includes('ranged'),
+    [getWeaponCategoryString],
+  );
+
+  const hasWeaponProperty = useCallback((weapon, property) => {
+    if (!Array.isArray(weapon?.properties)) {
+      return false;
+    }
+    const normalizedSearch = String(property || '').toLowerCase();
+    if (!normalizedSearch) {
+      return false;
+    }
+    return weapon.properties.some((prop) => {
+      if (typeof prop !== 'string') {
+        return false;
+      }
+      return prop.toLowerCase().includes(normalizedSearch);
+    });
+  }, []);
+
+  const isMeleeWeapon = useCallback(
+    (weapon) => getWeaponCategoryString(weapon).includes('melee'),
+    [getWeaponCategoryString],
+  );
+
+  const isSimpleMeleeWeapon = useCallback(
+    (weapon) => {
+      const category = getWeaponCategoryString(weapon);
+      return category.includes('simple') && category.includes('melee');
+    },
+    [getWeaponCategoryString],
+  );
+
+  const isMartialMeleeWeapon = useCallback(
+    (weapon) => {
+      const category = getWeaponCategoryString(weapon);
+      return category.includes('martial') && category.includes('melee');
+    },
+    [getWeaponCategoryString],
+  );
+
+  const isUnarmedAttack = useCallback((weapon) => {
+    if (!weapon || typeof weapon !== 'object') {
+      return false;
+    }
+    const nameCandidates = [
+      weapon.name,
+      weapon.label,
+      weapon.title,
+      weapon.displayName,
+    ];
+    for (const candidate of nameCandidates) {
+      if (typeof candidate !== 'string') continue;
+      if (candidate.trim().toLowerCase() === 'unarmed strike') {
+        return true;
+      }
+    }
+    const typeString = getWeaponCategoryString(weapon);
+    if (typeString.includes('unarmed')) {
+      return true;
+    }
+    const rawType = String(weapon?.type || '').toLowerCase();
+    return rawType.includes('unarmed');
+  }, [getWeaponCategoryString]);
+
+  const qualifiesForMonkDexterity = useCallback(
+    (weapon) => {
+      if (!hasMonkLevels) {
+        return false;
+      }
+      if (isUnarmedAttack(weapon)) {
+        return true;
+      }
+      if (!isMeleeWeapon(weapon)) {
+        return false;
+      }
+      if (isSimpleMeleeWeapon(weapon)) {
+        return true;
+      }
+      return isMartialMeleeWeapon(weapon) && hasWeaponProperty(weapon, 'light');
+    },
+    [
+      hasMonkLevels,
+      hasWeaponProperty,
+      isMartialMeleeWeapon,
+      isMeleeWeapon,
+      isSimpleMeleeWeapon,
+      isUnarmedAttack,
+    ],
+  );
+
   const getAbilityKeyForWeapon = (slot, weapon) => {
+    if (qualifiesForMonkDexterity(weapon)) {
+      return 'dex';
+    }
     if (isFinesseWeapon(weapon)) {
       const stored = weaponAbilitySelections[slot];
       if (stored === 'str' || stored === 'dex') {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -280,6 +280,127 @@ describe('PlayerTurnActions weapon damage display', () => {
     });
   });
 
+  test('monk uses dexterity for simple melee weapon attacks', () => {
+    const weapon = {
+      name: 'Quarterstaff',
+      damage: '1d6 bludgeoning',
+      category: 'Simple Melee Weapon',
+      source: 'weapon',
+      properties: [],
+    };
+
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          weapon: [],
+          spells: [],
+          occupation: [{ Name: 'Monk', Level: 2 }],
+        }}
+        strMod={5}
+        dexMod={1}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const card = screen.getByText('Quarterstaff').closest('.attack-card');
+    expect(card).not.toBeNull();
+    if (!card) throw new Error('Quarterstaff card not found');
+
+    const attackRow = within(card).getByText('Attack Bonus').closest('.attack-card__row');
+    expect(attackRow).not.toBeNull();
+    const attackValue = attackRow?.querySelector('.attack-card__value');
+    expect(attackValue?.textContent).toBe(String(3));
+
+    const damageRow = within(card).getByText('Damage').closest('.attack-card__row');
+    expect(damageRow).not.toBeNull();
+    expect(
+      within(damageRow).getByText('1d6+1 Bludgeoning'),
+    ).toBeInTheDocument();
+  });
+
+  test('monk uses dexterity for unarmed strikes', () => {
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: {},
+          weapon: [],
+          spells: [],
+          occupation: [{ Name: 'Monk', Level: 2 }],
+        }}
+        strMod={5}
+        dexMod={1}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const card = screen.getByText('Unarmed Strike').closest('.attack-card');
+    expect(card).not.toBeNull();
+    if (!card) throw new Error('Unarmed Strike card not found');
+
+    const attackRow = within(card).getByText('Attack Bonus').closest('.attack-card__row');
+    expect(attackRow).not.toBeNull();
+    const attackValue = attackRow?.querySelector('.attack-card__value');
+    expect(attackValue?.textContent).toBe(String(3));
+
+    const damageRow = within(card).getByText('Damage').closest('.attack-card__row');
+    expect(damageRow).not.toBeNull();
+    expect(
+      within(damageRow).getByText('1d4+1 Bludgeoning'),
+    ).toBeInTheDocument();
+  });
+
+  test('monk uses strength for non-light martial melee weapons', () => {
+    const weapon = {
+      name: 'Glaive',
+      damage: '1d10 slashing',
+      category: 'Martial Melee Weapon',
+      source: 'weapon',
+      properties: ['Heavy', 'Reach'],
+    };
+
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: { mainHand: weapon },
+          weapon: [],
+          spells: [],
+          occupation: [{ Name: 'Monk', Level: 2 }],
+        }}
+        strMod={5}
+        dexMod={1}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const card = screen.getByText('Glaive').closest('.attack-card');
+    expect(card).not.toBeNull();
+    if (!card) throw new Error('Glaive card not found');
+
+    const attackRow = within(card).getByText('Attack Bonus').closest('.attack-card__row');
+    expect(attackRow).not.toBeNull();
+    const attackValue = attackRow?.querySelector('.attack-card__value');
+    expect(attackValue?.textContent).toBe(String(7));
+
+    const damageRow = within(card).getByText('Damage').closest('.attack-card__row');
+    expect(damageRow).not.toBeNull();
+    expect(
+      within(damageRow).getByText('1d10+5 Slashing'),
+    ).toBeInTheDocument();
+  });
+
   test('multi-part weapon damage applies ability modifier once', () => {
     const weapon = {
       name: 'Storm Blade',


### PR DESCRIPTION
## Summary
- update the player turn actions component to detect monk characters and use Dexterity for unarmed strikes and qualifying monk weapons
- add helpers to classify weapon categories and properties when determining attack ability modifiers
- add tests covering Dexterity usage for monk weapons, unarmed strikes, and Strength fallback for heavy martial weapons

## Testing
- `CI=true npm test -- PlayerTurnActions --testNamePattern="monk uses dexterity for simple melee weapon attacks"`
- `CI=true npm test -- PlayerTurnActions --testNamePattern="monk uses dexterity for unarmed strikes"`
- `CI=true npm test -- PlayerTurnActions --testNamePattern="monk uses strength for non-light martial melee weapons"`


------
https://chatgpt.com/codex/tasks/task_e_68fdaaa775a48323a7e33cf1280fb491