### PR TITLE
Add bonus unarmed strike attack card for monks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -531,68 +531,6 @@ const manualCriticalRef = useRef(false);
     () => normalizeEquipmentMap(form.equipment),
     [form.equipment]
   );
-  const equippedWeapons = useMemo(() => {
-    let weapons = [];
-
-    if (equipmentProvided) {
-      weapons = WEAPON_SLOT_KEYS.map((slot) => {
-        const weapon = normalizedEquipment[slot];
-        if (!weapon) return null;
-        if (weapon.source && weapon.source !== 'weapon') return null;
-        const damage =
-          typeof weapon.damage === 'string' ? weapon.damage.trim() : '';
-        if (!damage) return null;
-        return { slot, weapon };
-      }).filter(Boolean);
-    } else {
-      const legacyWeapons = normalizeWeapons(form.weapon || [], {
-        includeUnowned: true,
-      });
-      weapons = legacyWeapons.map((weapon, index) => ({
-        slot: `legacy-${index}`,
-        weapon,
-      }));
-    }
-
-    const hasUnarmedStrike = weapons.some(({ weapon }) => {
-      const name = typeof weapon?.name === 'string' ? weapon.name.trim() : '';
-      return name.toLowerCase() === 'unarmed strike';
-    });
-
-    if (hasUnarmedStrike) {
-      return weapons;
-    }
-
-    return [
-      ...weapons,
-      {
-        slot: 'unarmed-strike',
-        weapon: {
-          name: 'Unarmed Strike',
-          damage: '1d4 Bludgeoning',
-          type: 'Unarmed',
-          category: 'Melee Weapon',
-          properties: [],
-          source: 'weapon',
-        },
-      },
-    ];
-  }, [
-    equipmentProvided,
-    normalizedEquipment,
-    form.weapon,
-  ]);
-
-  const [weaponAbilitySelections, setWeaponAbilitySelections] = useState({});
-  const [weaponHandSelections, setWeaponHandSelections] = useState({});
-
-  const numericStrMod = Number(strMod) || 0;
-  const numericDexMod = Number(dexMod) || 0;
-  const numericSpellAbilityMod = (() => {
-    const parsed = Number(spellAbilityMod);
-    return Number.isFinite(parsed) ? parsed : null;
-  })();
-
   const hasMonkLevels = useMemo(() => {
     if (!Array.isArray(form?.occupation)) {
       return false;
@@ -621,6 +559,141 @@ const manualCriticalRef = useRef(false);
       return Number.isFinite(levelValue) && levelValue > 0;
     });
   }, [form?.occupation]);
+  const bonusUnarmedStrikeFeature = useMemo(() => {
+    const target = 'bonus unarmed strike';
+
+    const searchValue = (value, depth = 0) => {
+      if (!value || depth > 10) {
+        return false;
+      }
+
+      if (typeof value === 'string') {
+        return value.trim().toLowerCase() === target;
+      }
+
+      if (Array.isArray(value)) {
+        return value.some((entry) => searchValue(entry, depth + 1));
+      }
+
+      if (typeof value === 'object') {
+        return Object.entries(value).some(([key, entry]) => {
+          if (typeof key === 'string' && key.trim().toLowerCase() === target) {
+            return true;
+          }
+          return searchValue(entry, depth + 1);
+        });
+      }
+
+      return false;
+    };
+
+    const featureSources = [
+      form?.features,
+      form?.classFeatures,
+      form?.featureList,
+    ];
+
+    return featureSources.some((source) => searchValue(source));
+  }, [form?.classFeatures, form?.featureList, form?.features]);
+
+  const equippedWeapons = useMemo(() => {
+    let weapons = [];
+
+    if (equipmentProvided) {
+      weapons = WEAPON_SLOT_KEYS.map((slot) => {
+        const weapon = normalizedEquipment[slot];
+        if (!weapon) return null;
+        if (weapon.source && weapon.source !== 'weapon') return null;
+        const damage =
+          typeof weapon.damage === 'string' ? weapon.damage.trim() : '';
+        if (!damage) return null;
+        return { slot, weapon };
+      }).filter(Boolean);
+    } else {
+      const legacyWeapons = normalizeWeapons(form.weapon || [], {
+        includeUnowned: true,
+      });
+      weapons = legacyWeapons.map((weapon, index) => ({
+        slot: `legacy-${index}`,
+        weapon,
+      }));
+    }
+
+    const ensureUnarmedStrike = (currentWeapons) => {
+      const hasUnarmedStrike = currentWeapons.some(({ weapon }) => {
+        const name =
+          typeof weapon?.name === 'string' ? weapon.name.trim() : '';
+        return name.toLowerCase() === 'unarmed strike';
+      });
+
+      if (hasUnarmedStrike) {
+        return currentWeapons;
+      }
+
+      return [
+        ...currentWeapons,
+        {
+          slot: 'unarmed-strike',
+          weapon: {
+            name: 'Unarmed Strike',
+            damage: '1d4 Bludgeoning',
+            type: 'Unarmed',
+            category: 'Melee Weapon',
+            properties: [],
+            source: 'weapon',
+          },
+        },
+      ];
+    };
+
+    const withUnarmed = ensureUnarmedStrike(weapons);
+
+    if (hasMonkLevels && bonusUnarmedStrikeFeature) {
+      const baseUnarmed = withUnarmed.find(({ weapon }) => {
+        const name =
+          typeof weapon?.name === 'string' ? weapon.name.trim() : '';
+        return name.toLowerCase() === 'unarmed strike';
+      });
+
+      const baseWeapon = baseUnarmed?.weapon || {
+        name: 'Unarmed Strike',
+        damage: '1d4 Bludgeoning',
+        type: 'Unarmed',
+        category: 'Melee Weapon',
+        properties: [],
+        source: 'weapon',
+      };
+
+      return [
+        ...withUnarmed,
+        {
+          slot: 'bonus-unarmed-strike',
+          weapon: {
+            ...baseWeapon,
+            displayName: 'Bonus Unarmed Strike',
+          },
+        },
+      ];
+    }
+
+    return withUnarmed;
+  }, [
+    bonusUnarmedStrikeFeature,
+    equipmentProvided,
+    form.weapon,
+    hasMonkLevels,
+    normalizedEquipment,
+  ]);
+
+  const [weaponAbilitySelections, setWeaponAbilitySelections] = useState({});
+  const [weaponHandSelections, setWeaponHandSelections] = useState({});
+
+  const numericStrMod = Number(strMod) || 0;
+  const numericDexMod = Number(dexMod) || 0;
+  const numericSpellAbilityMod = (() => {
+    const parsed = Number(spellAbilityMod);
+    return Number.isFinite(parsed) ? parsed : null;
+  })();
 
   const spellAbilityLabel = useMemo(() => {
     if (!spellAbilityKey) {
@@ -1208,6 +1281,13 @@ const manualCriticalRef = useRef(false);
   };
 
   const getWeaponDisplayName = (slot, weapon) => {
+    if (weapon?.displayName && typeof weapon.displayName === 'string') {
+      const trimmed = weapon.displayName.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
     if (weapon?.name && typeof weapon.name === 'string') {
       const trimmed = weapon.name.trim();
       if (trimmed) {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1167,6 +1167,81 @@ describe('PlayerTurnActions weapon damage display', () => {
     const unarmedCards = screen.getAllByText('Unarmed Strike');
     expect(unarmedCards).toHaveLength(1);
   });
+
+  test('includes bonus unarmed strike card for monks with the feature', () => {
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: {},
+          weapon: [],
+          spells: [],
+          occupation: [{ Name: 'Monk', Level: 2 }],
+          features: {
+            class: {
+              monk: [{ name: 'Bonus Unarmed Strike' }],
+            },
+          },
+        }}
+        strMod={5}
+        dexMod={1}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const baseCard = screen.getByText('Unarmed Strike').closest('.attack-card');
+    expect(baseCard).not.toBeNull();
+    if (!baseCard) throw new Error('Base Unarmed Strike card not found');
+
+    const bonusCard = screen
+      .getByText('Bonus Unarmed Strike')
+      .closest('.attack-card');
+    expect(bonusCard).not.toBeNull();
+    if (!bonusCard) throw new Error('Bonus Unarmed Strike card not found');
+
+    const baseDamageRow = within(baseCard)
+      .getByText('Damage')
+      .closest('.attack-card__row');
+    expect(baseDamageRow).not.toBeNull();
+    if (!baseDamageRow) throw new Error('Base damage row not found');
+    expect(
+      within(baseDamageRow).getByText('1d4+1 Bludgeoning')
+    ).toBeInTheDocument();
+
+    const bonusDamageRow = within(bonusCard)
+      .getByText('Damage')
+      .closest('.attack-card__row');
+    expect(bonusDamageRow).not.toBeNull();
+    if (!bonusDamageRow) throw new Error('Bonus damage row not found');
+    expect(
+      within(bonusDamageRow).getByText('1d4+1 Bludgeoning')
+    ).toBeInTheDocument();
+  });
+
+  test('does not include bonus unarmed strike without monk levels', () => {
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: {},
+          weapon: [],
+          spells: [],
+          features: { 'Bonus Unarmed Strike': true },
+        }}
+        strMod={3}
+        dexMod={0}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    expect(screen.queryByText('Bonus Unarmed Strike')).toBeNull();
+  });
 });
 
 describe('PlayerTurnActions critical events', () => {


### PR DESCRIPTION
## Summary
- detect the Bonus Unarmed Strike feature to add an extra unarmed attack card when a monk qualifies
- show the bonus attack with a distinct label while reusing the base unarmed strike calculations
- cover the new behavior with tests and ensure non-monks do not see the bonus card

## Testing
- CI=true npm --prefix client test -- --runInBand PlayerTurnActions *(fails: RangeError from source-map quick-sort when Math.random is stubbed to 0)*

------
https://chatgpt.com/codex/tasks/task_e_68fdb490fc108323bc43892674766cd6