### PR TITLE
Add bonus unarmed strike attack card for monks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -585,6 +585,25 @@ const manualCriticalRef = useRef(false);
 
     return '1d12 Bludgeoning';
   }, [monkLevel]);
+  const hasBonusUnarmedStrikeFeature = useMemo(() => {
+    const searchValue = 'bonus unarmed strike';
+    const checkValue = (value) => {
+      if (!value) return false;
+      if (Array.isArray(value)) {
+        return value.some((entry) => checkValue(entry));
+      }
+      if (typeof value === 'object') {
+        return Object.values(value).some((entry) => checkValue(entry));
+      }
+      return (
+        typeof value === 'string' &&
+        value.toLowerCase().includes(searchValue)
+      );
+    };
+
+    return checkValue(form?.features);
+  }, [form?.features]);
+
   const equippedWeapons = useMemo(() => {
     let weapons = [];
 
@@ -613,11 +632,30 @@ const manualCriticalRef = useRef(false);
       return name.toLowerCase() === 'unarmed strike';
     });
 
+    const hasBonusUnarmedStrike = weapons.some(({ weapon }) => {
+      const name = typeof weapon?.name === 'string' ? weapon.name.trim() : '';
+      return name.toLowerCase() === 'bonus unarmed strike';
+    });
+
     if (hasUnarmedStrike) {
-      return weapons;
+      const enhancedWeapons = [...weapons];
+      if (hasBonusUnarmedStrikeFeature && !hasBonusUnarmedStrike) {
+        enhancedWeapons.push({
+          slot: 'bonus-unarmed-strike',
+          weapon: {
+            name: 'Bonus Unarmed Strike',
+            damage: unarmedStrikeDamage,
+            type: 'Unarmed Bonus Action',
+            category: 'Bonus Action',
+            properties: ['Bonus Action'],
+            source: 'weapon',
+          },
+        });
+      }
+      return enhancedWeapons;
     }
 
-    return [
+    const nextWeapons = [
       ...weapons,
       {
         slot: 'unarmed-strike',
@@ -631,11 +669,28 @@ const manualCriticalRef = useRef(false);
         },
       },
     ];
+
+    if (hasBonusUnarmedStrikeFeature && !hasBonusUnarmedStrike) {
+      nextWeapons.push({
+        slot: 'bonus-unarmed-strike',
+        weapon: {
+          name: 'Bonus Unarmed Strike',
+          damage: unarmedStrikeDamage,
+          type: 'Unarmed Bonus Action',
+          category: 'Bonus Action',
+          properties: ['Bonus Action'],
+          source: 'weapon',
+        },
+      });
+    }
+
+    return nextWeapons;
   }, [
     equipmentProvided,
     normalizedEquipment,
     form.weapon,
     unarmedStrikeDamage,
+    hasBonusUnarmedStrikeFeature,
   ]);
 
   const [weaponAbilitySelections, setWeaponAbilitySelections] = useState({});

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -354,7 +354,60 @@ describe('PlayerTurnActions weapon damage display', () => {
     const damageRow = within(card).getByText('Damage').closest('.attack-card__row');
     expect(damageRow).not.toBeNull();
     expect(
-      within(damageRow).getByText('1d4+1 Bludgeoning'),
+      within(damageRow).getByText('1d6+1 Bludgeoning'),
+    ).toBeInTheDocument();
+  });
+
+  test('monk with Bonus Unarmed Strike feature gains bonus action attack', () => {
+    render(
+      <PlayerTurnActions
+        form={{
+          diceColor: '#000000',
+          equipment: {},
+          weapon: [],
+          spells: [],
+          occupation: [{ Name: 'Monk', Level: 5 }],
+          features: {
+            monk: {
+              martialArts: ['Bonus Unarmed Strike'],
+            },
+          },
+        }}
+        strMod={1}
+        dexMod={4}
+      />
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Attack'));
+    });
+
+    const bonusCard = screen
+      .getByText('Bonus Unarmed Strike')
+      .closest('.attack-card');
+    expect(bonusCard).not.toBeNull();
+    if (!bonusCard) throw new Error('Bonus Unarmed Strike card not found');
+
+    const bonusDamageRow = within(bonusCard)
+      .getByText('Damage')
+      .closest('.attack-card__row');
+    expect(bonusDamageRow).not.toBeNull();
+    expect(
+      within(bonusDamageRow).getByText('1d8+4 Bludgeoning'),
+    ).toBeInTheDocument();
+
+    const standardCard = screen
+      .getByText('Unarmed Strike')
+      .closest('.attack-card');
+    expect(standardCard).not.toBeNull();
+    if (!standardCard) throw new Error('Unarmed Strike card not found');
+
+    const standardDamageRow = within(standardCard)
+      .getByText('Damage')
+      .closest('.attack-card__row');
+    expect(standardDamageRow).not.toBeNull();
+    expect(
+      within(standardDamageRow).getByText('1d8+4 Bludgeoning'),
     ).toBeInTheDocument();
   });
 
@@ -869,7 +922,9 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Frost Brand').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -922,7 +977,9 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Elemental Blade').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -975,7 +1032,11 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen
+      .getByText('Greatsword of Fire', { exact: false })
+      .closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -1022,7 +1083,9 @@ describe('PlayerTurnActions damage log', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -1311,8 +1374,9 @@ describe('PlayerTurnActions spell casting', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     await act(async () => {
       fireEvent.click(rollButton);
     });
@@ -1355,8 +1419,9 @@ describe('PlayerTurnActions spell casting', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });
@@ -1404,7 +1469,9 @@ describe('PlayerTurnActions spell casting', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     await act(async () => {
       fireEvent.click(rollButton);
     });
@@ -1445,7 +1512,9 @@ describe('PlayerTurnActions spell casting', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Flame Blade').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     await act(async () => {
       fireEvent.click(rollButton);
     });
@@ -1534,7 +1603,9 @@ describe('cantrip scaling', () => {
     act(() => {
       fireEvent.click(screen.getByTitle('Attack'));
     });
-    const rollButton = await screen.findByLabelText(/Roll damage/i);
+    const card = screen.getByText('Fire Bolt').closest('.attack-card');
+    expect(card).not.toBeNull();
+    const rollButton = within(card ?? document.body).getByLabelText(/Roll damage/i);
     act(() => {
       fireEvent.click(rollButton);
     });


### PR DESCRIPTION
## Summary
- detect when characters gain the Bonus Unarmed Strike feature and append a bonus-action unarmed attack card that reuses monk unarmed damage
- extend PlayerTurnActions tests to cover the bonus strike and scope damage roll interactions to the intended cards

## Testing
- CI=true npm test -- PlayerTurnActions *(fails: source-map quick sort error from react-scripts test)*

------
https://chatgpt.com/codex/tasks/task_e_68fe514902cc8323ab6c523bc65dd9d0