### PR TITLE
Add monk focus indicator to spell slots

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1563,6 +1563,48 @@ body.docked-modal--resizing {
   padding: 2px;
 }
 
+.spell-slot.focus-slot {
+  width: auto;
+  min-width: 48px;
+  height: auto;
+  padding: 6px 12px;
+}
+
+.focus-slot .focus-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.focus-slot .focus-count {
+  position: absolute;
+  top: -0.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #ffa94d;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
+}
+
+.focus-slot .focus-icon {
+  font-size: 2rem;
+  color: #6c757d;
+  transition: transform 0.2s ease, filter 0.2s ease, color 0.2s ease;
+}
+
+.focus-slot .focus-icon--glow {
+  color: #ffa94d;
+  filter: drop-shadow(0 0 6px rgba(255, 153, 0, 0.85))
+    drop-shadow(0 0 16px rgba(255, 153, 0, 0.5));
+}
+
+.focus-slot .focus-icon-wrapper:active .focus-icon {
+  transform: scale(0.95);
+}
+
 .spell-slot .slot-level {
   position: absolute;
   top: -2px;               /* push it near the top */

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { FaHandSparkles } from 'react-icons/fa';
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
+import { getMonkFocusPoints } from '../../../utils/monk';
 
 const SPELLCASTING_CLASSES = {
   bard: 'full',
@@ -44,6 +46,7 @@ export default function SpellSlots({
   const warlockData = pactMagic[warlockLevel] || {};
 
   const features = form.features || {};
+  const monkFocusPoints = getMonkFocusPoints(form);
   const actionCount =
     propActionCount ?? features.actionCount ?? 1;
   const bonusCount =
@@ -93,6 +96,53 @@ export default function SpellSlots({
         );
       });
 
+  const focusUsed = Number(used?.focus) || 0;
+  const focusRemaining = Math.max(monkFocusPoints - focusUsed, 0);
+  const hasMonkFocus = monkFocusPoints > 0;
+
+  const handleFocusActivation = useCallback(
+    (event, action) => {
+      event.preventDefault();
+      if (!onToggleSlot || !hasMonkFocus) {
+        return;
+      }
+      onToggleSlot('focus', action, monkFocusPoints);
+    },
+    [hasMonkFocus, monkFocusPoints, onToggleSlot]
+  );
+
+  const handleFocusClick = useCallback(
+    (event) => {
+      handleFocusActivation(event, event.shiftKey ? 'restore' : 'spend');
+    },
+    [handleFocusActivation]
+  );
+
+  const handleFocusContext = useCallback(
+    (event) => {
+      handleFocusActivation(event, 'restore');
+    },
+    [handleFocusActivation]
+  );
+
+  const handleFocusKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+        handleFocusActivation(event, 'spend');
+      } else if (event.key === 'Backspace' || event.key === 'Delete') {
+        handleFocusActivation(event, 'restore');
+      }
+    },
+    [handleFocusActivation]
+  );
+
+  const handleFocusDoubleClick = useCallback(
+    (event) => {
+      handleFocusActivation(event, 'reset');
+    },
+    [handleFocusActivation]
+  );
+
   return (
     <div style={{ display: 'flex', flexShrink: 0 }}>
       <div className="spell-slot-container">
@@ -134,6 +184,35 @@ export default function SpellSlots({
             })}
           </div>
         </div>
+        {hasMonkFocus && (
+          <div className="spell-slot focus-slot">
+            <div
+              className="focus-icon-wrapper"
+              role="button"
+              tabIndex={0}
+              onClick={handleFocusClick}
+              onContextMenu={handleFocusContext}
+              onDoubleClick={handleFocusDoubleClick}
+              onKeyDown={handleFocusKeyDown}
+              title={
+                "Monk's Focus: " +
+                `${focusRemaining}/${monkFocusPoints} remaining. ` +
+                'Click to spend, Shift+Click or right-click to restore, double-click to reset.'
+              }
+              aria-label={`Monk's Focus: ${focusRemaining} of ${monkFocusPoints} remaining`}
+            >
+              <div className="focus-count" aria-hidden="true">
+                {focusRemaining}
+              </div>
+              <FaHandSparkles
+                aria-hidden="true"
+                className={`focus-icon ${
+                  focusRemaining > 0 ? 'focus-icon--glow' : ''
+                }`}
+              />
+            </div>
+          </div>
+        )}
         {regularLevels.length > 0 && renderGroup(slotData, 'regular')}
         {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
       </div>

--- a/client/src/components/Zombies/attributes/SpellSlots.test.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.test.js
@@ -21,6 +21,40 @@ test('renders only the available number of slots', () => {
   });
 });
 
+test('renders monk focus icon with remaining points', () => {
+  const form = { occupation: [{ Name: 'Monk', Level: 5 }] };
+  const { container } = render(
+    <SpellSlots form={form} used={{ focus: 2 }} />
+  );
+  const focusSlot = container.querySelector('.focus-slot');
+  expect(focusSlot).toBeTruthy();
+  const focusCount = focusSlot.querySelector('.focus-count');
+  expect(focusCount.textContent).toBe('3');
+  const icon = focusSlot.querySelector('.focus-icon');
+  expect(icon.classList.contains('focus-icon--glow')).toBe(true);
+});
+
+test('focus icon removes glow when depleted and triggers callbacks', () => {
+  const form = { occupation: [{ Name: 'Monk', Level: 2 }] };
+  const onToggle = jest.fn();
+  const { container } = render(
+    <SpellSlots form={form} used={{ focus: 2 }} onToggleSlot={onToggle} />
+  );
+  const iconWrapper = container.querySelector('.focus-icon-wrapper');
+  const icon = container.querySelector('.focus-icon');
+  expect(icon.classList.contains('focus-icon--glow')).toBe(false);
+  fireEvent.click(iconWrapper);
+  expect(onToggle).toHaveBeenCalledWith('focus', 'spend', 2);
+  fireEvent.contextMenu(iconWrapper);
+  expect(onToggle).toHaveBeenCalledWith('focus', 'restore', 2);
+});
+
+test('does not render monk focus icon before level two', () => {
+  const form = { occupation: [{ Name: 'Monk', Level: 1 }] };
+  const { container } = render(<SpellSlots form={form} used={{}} />);
+  expect(container.querySelector('.focus-slot')).toBeNull();
+});
+
 test('reflects used slots from props and toggles via callback', () => {
   const form = { occupation: [{ Name: 'Wizard', Level: 1 }] };
   const onToggle = jest.fn();

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -41,6 +41,7 @@ import BackgroundModal from "../attributes/BackgroundModal";
 import Features from "../attributes/Features";
 import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
+import { getMonkFocusPoints } from '../../../utils/monk';
 import hasteIcon from "../../../images/spell-haste-icon.png";
 import largeFormIcon from "../../../images/large-form-icon.png";
 import dragonWingsIcon from "../../../images/dragon-wings-icon.png";
@@ -252,6 +253,7 @@ const createCircleState = () => ({
 const createDefaultUsedSlots = () => ({
   action: createCircleState(),
   bonus: createCircleState(),
+  focus: 0,
 });
 
 const mergeUsedSlotsWithDefaults = (stored) => {
@@ -285,6 +287,20 @@ const mergeUsedSlotsWithDefaults = (stored) => {
       });
 
       result[key] = baseEntry;
+      return;
+    }
+
+    if (key === 'focus') {
+      const parsed =
+        typeof value === 'number'
+          ? value
+          : typeof value === 'string'
+          ? Number.parseFloat(value)
+          : Number(value?.spent ?? value);
+
+      if (Number.isFinite(parsed) && parsed > 0) {
+        result.focus = Math.max(0, Math.floor(parsed));
+      }
       return;
     }
 
@@ -335,6 +351,14 @@ const serializeUsedSlotsForStorage = (slots) => {
         payload[key] = usedEntries;
       }
 
+      return;
+    }
+
+    if (key === 'focus') {
+      const numericValue = Number(value);
+      if (Number.isFinite(numericValue) && numericValue > 0) {
+        payload.focus = Math.floor(numericValue);
+      }
       return;
     }
 
@@ -1164,6 +1188,7 @@ export default function ZombiesCharacterSheet() {
       return total + (Number.isFinite(level) ? level : 0);
     }, 0);
   }, [occupations]);
+  const monkFocusPoints = useMemo(() => getMonkFocusPoints(form), [form]);
   const baseActionCount = form?.features?.actionCount ?? 1;
   const [actionCount, setActionCount] = useState(baseActionCount);
   const [usedSlots, setUsedSlots] = useState(() =>
@@ -2019,7 +2044,12 @@ export default function ZombiesCharacterSheet() {
     }
 
     setUsedSlots((prev) => {
-      const updated = { ...prev, action: createCircleState(), bonus: createCircleState() };
+      const updated = {
+        ...prev,
+        action: createCircleState(),
+        bonus: createCircleState(),
+        focus: 0,
+      };
       Object.keys(updated).forEach((key) => {
         if (key.startsWith('warlock-')) delete updated[key];
       });
@@ -2027,6 +2057,33 @@ export default function ZombiesCharacterSheet() {
     });
     setActionCount(baseActionCount);
   }, [shortRestCount, baseActionCount]);
+
+  useEffect(() => {
+    setUsedSlots((prev) => {
+      const maxFocus = Math.max(0, monkFocusPoints);
+      const rawCurrent = prev?.focus;
+      const numericCurrent = Number(rawCurrent);
+      const normalizedCurrent =
+        Number.isFinite(numericCurrent) && numericCurrent > 0
+          ? Math.floor(numericCurrent)
+          : 0;
+      const clamped = Math.min(normalizedCurrent, maxFocus);
+
+      if (rawCurrent === clamped) {
+        return prev;
+      }
+
+      if (rawCurrent === undefined && clamped === 0) {
+        return prev;
+      }
+
+      if (clamped === normalizedCurrent && normalizedCurrent === 0 && rawCurrent === 0) {
+        return prev;
+      }
+
+      return { ...prev, focus: clamped };
+    });
+  }, [monkFocusPoints]);
 
   useEffect(() => {
     const handler = () => {
@@ -3043,6 +3100,40 @@ export default function ZombiesCharacterSheet() {
         if (arg === 'action') {
           speakWithAnimalsPendingRef.current = false;
         }
+        return;
+      }
+      if (arg === 'focus') {
+        const operation = typeof lvl === 'string' ? lvl : 'spend';
+        const providedMax = Number(idx);
+        const maxFocus = Number.isFinite(providedMax)
+          ? Math.max(0, Math.floor(providedMax))
+          : getMonkFocusPoints(form);
+
+        setUsedSlots((prev) => {
+          const numericCurrent = Number(prev?.focus);
+          const current =
+            Number.isFinite(numericCurrent) && numericCurrent > 0
+              ? Math.floor(numericCurrent)
+              : 0;
+          let next = current;
+
+          if (operation === 'restore') {
+            next = Math.max(0, current - 1);
+          } else if (operation === 'reset') {
+            next = 0;
+          } else if (operation === 'spend') {
+            if (current >= maxFocus) {
+              return prev;
+            }
+            next = Math.min(maxFocus, current + 1);
+          }
+
+          if (next === current) {
+            return prev;
+          }
+
+          return { ...prev, focus: next };
+        });
         return;
       }
       const consumeSlot = (level, preferredType) => {

--- a/client/src/utils/monk.js
+++ b/client/src/utils/monk.js
@@ -1,0 +1,46 @@
+export const getMonkLevel = (form) => {
+  if (!form || typeof form !== 'object' || !Array.isArray(form.occupation)) {
+    return 0;
+  }
+
+  return form.occupation.reduce((total, occupationEntry) => {
+    if (!occupationEntry || typeof occupationEntry !== 'object') {
+      return total;
+    }
+
+    const name = String(
+      occupationEntry.Name ??
+        occupationEntry.Occupation ??
+        occupationEntry.name ??
+        occupationEntry.occupation ??
+        ''
+    ).toLowerCase();
+
+    if (name !== 'monk') {
+      return total;
+    }
+
+    const levelValue = Number(
+      occupationEntry.Level ??
+        occupationEntry.level ??
+        occupationEntry.Levels ??
+        occupationEntry.levels ??
+        0
+    );
+
+    if (!Number.isFinite(levelValue) || levelValue <= 0) {
+      return total;
+    }
+
+    return total + levelValue;
+  }, 0);
+};
+
+export const getMonkFocusPoints = (form) => {
+  const monkLevel = getMonkLevel(form);
+  if (monkLevel < 2) {
+    return 0;
+  }
+
+  return monkLevel;
+};


### PR DESCRIPTION
## Summary
- add a Monk's Focus indicator to the spell slot bar that shows remaining points with an orange glow
- persist monk focus usage alongside other slot data and reset it on rests
- cover the new focus indicator behavior with unit tests

## Testing
- CI=1 npm test -- SpellSlots.test

------
https://chatgpt.com/codex/tasks/task_e_68fe730cf9948323b6457732dca878c7