### PR TITLE
Add Uncanny Metabolism to monk level 2 features

### DIFF
--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -723,6 +723,11 @@ const monkFeatures = {
       name: 'Unarmored Movement',
       description:
         'Your speed increases by 10 feet while you are not wearing armor or wielding a shield. This bonus improves to 15 feet at 6th level, 20 feet at 10th level, 25 feet at 14th level, and 30 feet at 18th level.'
+    },
+    {
+      name: 'Uncanny Metabolism',
+      description:
+        'When you roll Initiative, you can regain all expended Focus Points. When you do so, roll your Martial Arts die, and regain a number of Hit Points equal to your Monk level plus the number rolled. Once you use this feature, you can’t use it again until you finish a Long Rest.'
     }
   ],
   3: [


### PR DESCRIPTION
## Summary
- add the Uncanny Metabolism entry to the monk's level 2 class features data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe7ac7ecb08323807cf1034f6a7b31