### PR TITLE
Fix elf lineage ability bonuses

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -245,6 +245,17 @@ const attachSelectedAncestryToRace = useCallback((race, {
     updatedRace.__baseSpeed = baseSpeed;
   }
 
+  const hasStoredBaseAbilities = Object.prototype.hasOwnProperty.call(
+    race,
+    "__baseAbilities"
+  );
+  const baseAbilities = hasStoredBaseAbilities ? race.__baseAbilities : race.abilities;
+  if (baseAbilities) {
+    updatedRace.__baseAbilities = { ...baseAbilities };
+  } else {
+    delete updatedRace.__baseAbilities;
+  }
+
   const hasStoredBaseDarkvision = Object.prototype.hasOwnProperty.call(
     race,
     "__baseDarkvisionRange"
@@ -313,6 +324,7 @@ const attachSelectedAncestryToRace = useCallback((race, {
       typeof lineageToApply?.darkvisionRange === "number"
         ? lineageToApply.darkvisionRange
         : null;
+    const lineageAbilities = lineageToApply?.abilities || null;
 
     if (typeof baseSpeed === "number") {
       updatedRace.speed = lineageSpeed ?? baseSpeed;
@@ -328,6 +340,24 @@ const attachSelectedAncestryToRace = useCallback((race, {
       } else {
         updatedRace.darkvisionRange = baseDarkvision;
       }
+    }
+
+    if (baseAbilities || lineageAbilities) {
+      const combinedAbilities = baseAbilities ? { ...baseAbilities } : {};
+
+      if (lineageAbilities) {
+        Object.entries(lineageAbilities).forEach(([abilityKey, bonusValue]) => {
+          const numericBase = Number(combinedAbilities[abilityKey] ?? 0);
+          const numericBonus = Number(bonusValue ?? 0);
+          const safeBase = Number.isNaN(numericBase) ? 0 : numericBase;
+          const safeBonus = Number.isNaN(numericBonus) ? 0 : numericBonus;
+          combinedAbilities[abilityKey] = safeBase + safeBonus;
+        });
+      }
+
+      updatedRace.abilities = combinedAbilities;
+    } else if (updatedRace.abilities) {
+      delete updatedRace.abilities;
     }
   }
 
@@ -741,6 +771,7 @@ useEffect(() => {
     if (raceWithAncestry) {
       newCharacter.race = raceWithAncestry;
       delete newCharacter.race.__baseSpeed;
+      delete newCharacter.race.__baseAbilities;
       delete newCharacter.race.__baseDarkvisionRange;
     } else {
       delete newCharacter.race;
@@ -1714,6 +1745,7 @@ const sendManualToDb = useCallback(async (characterData) => {
   if (raceWithAncestry) {
     newCharacter.race = raceWithAncestry;
     delete newCharacter.race.__baseSpeed;
+    delete newCharacter.race.__baseAbilities;
     delete newCharacter.race.__baseDarkvisionRange;
   } else {
     delete newCharacter.race;

--- a/server/data/races.js
+++ b/server/data/races.js
@@ -52,6 +52,7 @@ const races = {
         description:
           "You know the Dancing Lights cantrip. Starting at 3rd level, you can also cast Faerie Fire once per long rest, and starting at 5th level, you can cast Darkness once per long rest.",
         spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        abilities: { cha: 1 },
         darkvisionRange: 120,
         level1Feature:
           "You know the Dancing Lights cantrip. You can cast it without expending a spell slot.",
@@ -65,6 +66,7 @@ const races = {
         description:
           "You know the Prestidigitation cantrip. Starting at 3rd level, you can also cast Detect Magic once per long rest, and starting at 5th level, you can cast Misty Step once per long rest.",
         spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        abilities: { int: 1 },
         level1Feature:
           "You know the Prestidigitation cantrip. You can cast it without expending a spell slot.",
         level3Feature:
@@ -77,6 +79,7 @@ const races = {
         description:
           "You know the Druidcraft cantrip. Starting at 3rd level, you can also cast Longstrider once per long rest, and starting at 5th level, you can cast Pass without Trace once per long rest.",
         spellcastingAbilities: ["Intelligence", "Wisdom", "Charisma"],
+        abilities: { wis: 1 },
         speed: 35,
         level1Feature:
           "You know the Druidcraft cantrip. You can cast it without expending a spell slot.",


### PR DESCRIPTION
## Summary
- cache the base racial ability scores when attaching a selected ancestry
- merge selected elven lineage ability bonuses into the race data
- strip helper ancestry bookkeeping fields before persisting a character

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68febfcb27b8832392e5258c329064bc