### PR TITLE
Fix Worg monster data

### DIFF
--- a/server/data/monsters.json
+++ b/server/data/monsters.json
@@ -25020,25 +25020,24 @@
       "type": "fey",
       "alignment": "Neutral Evil",
       "armor_class": 13,
-      "hit_points": 67,
-      "hit_dice": "9d8 + 27",
+      "hit_points": 26,
+      "hit_dice": "4d10 + 4",
       "speed": {
-        "walk": "5 ft.",
-        "fly": "60 ft. (hover)"
+        "walk": "50 ft."
       },
-      "strength": 6,
-      "dexterity": 16,
-      "constitution": 16,
-      "intelligence": 12,
-      "wisdom": 14,
-      "charisma": 15,
+      "strength": 16,
+      "dexterity": 13,
+      "constitution": 13,
+      "intelligence": 7,
+      "wisdom": 11,
+      "charisma": 8,
       "saving_throws": [],
       "skills": {
-        "perception": 5,
-        "stealth": 5
+        "perception": 4,
+        "stealth": 3
       },
       "senses": {
-        "passive_perception": 12,
+        "passive_perception": 14,
         "darkvision": "60 ft."
       },
       "languages": "Goblin, Worg",
@@ -25046,61 +25045,27 @@
       "xp": 100,
       "proficiency_bonus": 2,
       "damage_vulnerabilities": null,
-      "damage_resistances": [
-        "Acid",
-        "Bludgeoning",
-        "Cold",
-        "Fire",
-        "Piercing",
-        "Slashing"
-      ],
-      "damage_immunities": [
-        "Cold",
-        "Necrotic",
-        "Poison"
-      ],
-      "condition_immunities": [
-        "Charmed",
-        "Exhaustion",
-        "Grappled",
-        "Paralyzed",
-        "Petrified",
-        "Poisoned",
-        "Prone",
-        "Restrained",
-        "Unconscious"
-      ],
-      "special_abilities": [
-        {
-          "name": "Incorporeal Movement",
-          "desc": "The wraith can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object."
-        },
-        {
-          "name": "Sunlight Sensitivity",
-          "desc": "While in sunlight, the wraith has Disadvantage on ability checks and attack rolls."
-        }
-      ],
+      "damage_resistances": null,
+      "damage_immunities": null,
+      "condition_immunities": null,
+      "special_abilities": null,
       "actions": [
         {
-          "name": "Life Drain",
-          "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (4d8 + 3) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken.",
-          "attack_bonus": 6,
+          "name": "Bite",
+          "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the next attack roll made against the target before the start of the worg's next turn has Advantage.",
+          "attack_bonus": 5,
           "damage": [
             {
-              "damage_dice": "4d8+3",
+              "damage_dice": "1d8+3",
               "damage_type": {
-                "name": "necrotic"
+                "name": "piercing"
               }
             }
           ],
-          "damage_dice": "4d8+3",
+          "damage_dice": "1d8+3",
           "damage_type": {
-            "name": "necrotic"
+            "name": "piercing"
           }
-        },
-        {
-          "name": "Create Specter",
-          "desc": "The wraith targets a Humanoid corpse within 10 feet of itself that has been dead for no longer than 1 minute. The target’s spirit rises as a Specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith’s control. The wraith can have no more than seven specters under its control at a time."
         }
       ],
       "bonus_actions": null,


### PR DESCRIPTION
## Summary
- replace the incorrect wraith stat block stored under the Worg entry with the proper Worg statistics and bite attack details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fec40dc924832395c1314b5cb85ce0