### PR TITLE
Allow textual inventory weights and fix shop filter label

### DIFF
--- a/client/src/components/Zombies/attributes/ShopVisibilityManager.js
+++ b/client/src/components/Zombies/attributes/ShopVisibilityManager.js
@@ -1075,13 +1075,10 @@ export default function ShopVisibilityManager({
           filterControl = (
             <Form.Group
               className="d-flex align-items-center gap-2 mb-0"
-              controlId="dm-shop-item-category-filter"
+              controlId="dm-shop-item-category-filter-select"
             >
-              <Form.Label className="mb-0" htmlFor="dm-shop-item-category-filter-select">
-                Category
-              </Form.Label>
+              <Form.Label className="mb-0">Category</Form.Label>
               <Form.Select
-                id="dm-shop-item-category-filter-select"
                 size="sm"
                 value={normalizedItemFilter}
                 onChange={handleItemCategoryFilterChange}

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -657,6 +657,17 @@ describe('Equipment routes', () => {
       expect(res.body.message).toBe('Item updated');
     });
 
+    test('update allows textual weights', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({ item: [{ name: 'alchemy jug', weight: 'Varies by form' }] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Item updated');
+    });
+
     test('update not found', async () => {
       dbo.mockResolvedValue({
         collection: () => ({ updateOne: async () => ({ matchedCount: 0 }) })
@@ -767,12 +778,25 @@ describe('Equipment routes', () => {
       expect(res.status).toBe(400);
     });
 
-    test('update accessories invalid weight', async () => {
+    test('update accessories allows textual weight', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, weight: 'Feather-light' }],
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Accessories updated');
+    });
+
+    test('update accessories rejects non-string weight', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
         .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
         .send({
-          accessories: [{ ...baseAccessory, weight: 'heavy' }],
+          accessories: [{ ...baseAccessory, weight: { amount: 2 } }],
         });
       expect(res.status).toBe(400);
     });

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -20,6 +20,50 @@ const SLOT_KEY_LOOKUP = EQUIPMENT_SLOT_KEYS.reduce((lookup, key) => {
   return lookup;
 }, {});
 
+const coerceOptionalString = (value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return String(value);
+};
+
+const coerceOptionalWeight = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const numeric = Number.parseFloat(trimmed);
+    if (!Number.isNaN(numeric) && /^[-+]?\d*(?:\.\d+)?$/.test(trimmed)) {
+      return numeric;
+    }
+    return trimmed;
+  }
+  return value;
+};
+
+const isValidWeight = (value) => {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return false;
+};
+
 const getSlotString = (value) => {
   if (!value) return '';
   if (typeof value === 'string') {
@@ -631,12 +675,22 @@ module.exports = (router) => {
       body('item').isArray().withMessage('item must be an array'),
       body('item.*').isObject().withMessage('each item must be an object'),
       body('item.*.name').trim().notEmpty().withMessage('name is required'),
-      body('item.*.category').optional().isString().trim(),
-      body('item.*.weight').optional({ checkFalsy: true }).isFloat().toFloat(),
+      body('item.*.category').optional().isString().bail().customSanitizer(coerceOptionalString),
+      body('item.*.weight')
+        .optional({ values: 'falsy' })
+        .customSanitizer(coerceOptionalWeight)
+        .custom((value) => {
+          if (!isValidWeight(value)) {
+            throw new Error('weight must be a string or number');
+          }
+          return true;
+        }),
       body('item.*.cost').optional().isString().trim(),
       body('item.*.notes').optional().isString().trim(),
       body('item.*.statBonuses').optional().custom(validateBonusObject),
       body('item.*.skillBonuses').optional().custom(validateBonusObject),
+      body('item.*.owned').optional().isBoolean().toBoolean(),
+      body('item.*.ownedCount').optional().isInt({ min: 0 }).toInt(),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -686,9 +740,14 @@ module.exports = (router) => {
         }),
       body('accessories.*.rarity').optional().isString().trim(),
       body('accessories.*.weight')
-        .optional({ checkFalsy: true })
-        .isFloat()
-        .toFloat(),
+        .optional({ values: 'falsy' })
+        .customSanitizer(coerceOptionalWeight)
+        .custom((value) => {
+          if (!isValidWeight(value)) {
+            throw new Error('weight must be a string or number');
+          }
+          return true;
+        }),
       body('accessories.*.cost').optional().isString().trim(),
       body('accessories.*.notes').optional().isString().trim(),
       body('accessories.*.statBonuses')


### PR DESCRIPTION
## Summary
- relax weight validation so textual weights are accepted when updating character inventories
- expand equipment route tests to cover textual accessory weights while still rejecting invalid types
- tidy the DM shop filter form markup to remove the controlId/htmlFor warning

## Testing
- npm --prefix server test -- --runTestsByPath __tests__/equipment.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fec994f894832e93a475ca4ab050e0