### PR TITLE
Allow numeric costs and normalize bonus modifiers in inventory updates

### DIFF
--- a/client/src/components/Zombies/attributes/ShopVisibilityManager.js
+++ b/client/src/components/Zombies/attributes/ShopVisibilityManager.js
@@ -1075,13 +1075,10 @@ export default function ShopVisibilityManager({
           filterControl = (
             <Form.Group
               className="d-flex align-items-center gap-2 mb-0"
-              controlId="dm-shop-item-category-filter"
+              controlId="dm-shop-item-category-filter-select"
             >
-              <Form.Label className="mb-0" htmlFor="dm-shop-item-category-filter-select">
-                Category
-              </Form.Label>
+              <Form.Label className="mb-0">Category</Form.Label>
               <Form.Select
-                id="dm-shop-item-category-filter-select"
                 size="sm"
                 value={normalizedItemFilter}
                 onChange={handleItemCategoryFilterChange}

--- a/server/__tests__/equipment.test.js
+++ b/server/__tests__/equipment.test.js
@@ -657,6 +657,71 @@ describe('Equipment routes', () => {
       expect(res.body.message).toBe('Item updated');
     });
 
+    test('update allows textual weights', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({ item: [{ name: 'alchemy jug', weight: 'Varies by form' }] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Item updated');
+    });
+
+    test('update allows numeric costs', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({ item: [{ name: 'alchemy jug', cost: 50 }] });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Item updated');
+    });
+
+    test('update coerces numeric string bonuses', async () => {
+      const updateOne = jest
+        .fn()
+        .mockResolvedValue({ matchedCount: 1 });
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne })
+      });
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({
+          item: [
+            {
+              name: 'alchemy jug',
+              statBonuses: { str: '+1', wis: ' 2 ' },
+              skillBonuses: { stealth: '-0.5', insight: 'abc' },
+            },
+          ],
+        });
+      expect(res.status).toBe(200);
+      expect(updateOne).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          $set: {
+            item: [
+              expect.objectContaining({
+                name: 'alchemy jug',
+                statBonuses: { str: 1, wis: 2 },
+                skillBonuses: { stealth: -0.5 },
+              }),
+            ],
+          },
+        }
+      );
+    });
+
+    test('update rejects invalid cost types', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-item/507f1f77bcf86cd799439011')
+        .send({ item: [{ name: 'alchemy jug', cost: { amount: 50 } }] });
+      expect(res.status).toBe(400);
+    });
+
     test('update not found', async () => {
       dbo.mockResolvedValue({
         collection: () => ({ updateOne: async () => ({ matchedCount: 0 }) })
@@ -747,6 +812,49 @@ describe('Equipment routes', () => {
       expect(res.status).toBe(400);
     });
 
+    test('update accessories coerces numeric string bonuses', async () => {
+      const updateOne = jest
+        .fn()
+        .mockResolvedValue({ matchedCount: 1 });
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [
+            {
+              name: 'Amulet of Insight',
+              targetSlots: [ACCESSORY_SLOT_KEYS[1]],
+              statBonuses: { wis: '+3' },
+              skillBonuses: { history: ' 4 ' },
+            },
+          ],
+        });
+      expect(res.status).toBe(200);
+      expect(updateOne).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          $set: {
+            accessories: [
+              expect.objectContaining({
+                name: 'Amulet of Insight',
+                statBonuses: { wis: 3 },
+                skillBonuses: { history: 4 },
+              }),
+            ],
+            accessory: [
+              expect.objectContaining({
+                name: 'Amulet of Insight',
+                statBonuses: { wis: 3 },
+                skillBonuses: { history: 4 },
+              }),
+            ],
+          },
+        })
+      );
+    });
+
     test('update accessories invalid slot', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
@@ -767,12 +875,48 @@ describe('Equipment routes', () => {
       expect(res.status).toBe(400);
     });
 
-    test('update accessories invalid weight', async () => {
+    test('update accessories allows textual weight', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, weight: 'Feather-light' }],
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Accessories updated');
+    });
+
+    test('update accessories rejects non-string weight', async () => {
       dbo.mockResolvedValue({});
       const res = await request(app)
         .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
         .send({
-          accessories: [{ ...baseAccessory, weight: 'heavy' }],
+          accessories: [{ ...baseAccessory, weight: { amount: 2 } }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    test('update accessories allows numeric costs', async () => {
+      dbo.mockResolvedValue({
+        collection: () => ({ updateOne: async () => ({ matchedCount: 1 }) })
+      });
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, cost: 5000 }],
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Accessories updated');
+    });
+
+    test('update accessories reject invalid cost types', async () => {
+      dbo.mockResolvedValue({});
+      const res = await request(app)
+        .put('/equipment/update-accessories/507f1f77bcf86cd799439011')
+        .send({
+          accessories: [{ ...baseAccessory, cost: { amount: 5000 } }],
         });
       expect(res.status).toBe(400);
     });

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -20,6 +20,113 @@ const SLOT_KEY_LOOKUP = EQUIPMENT_SLOT_KEYS.reduce((lookup, key) => {
   return lookup;
 }, {});
 
+const coerceOptionalString = (value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return String(value);
+};
+
+const coerceOptionalWeight = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const numeric = Number.parseFloat(trimmed);
+    if (!Number.isNaN(numeric) && /^[-+]?\d*(?:\.\d+)?$/.test(trimmed)) {
+      return numeric;
+    }
+    return trimmed;
+  }
+  return value;
+};
+
+const isValidWeight = (value) => {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return false;
+};
+
+const NUMERIC_STRING_PATTERN = /^[-+]?\d+(?:\.\d+)?$/;
+
+const coerceNumericBonusValue = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    if (NUMERIC_STRING_PATTERN.test(trimmed)) {
+      const numeric = Number.parseFloat(trimmed);
+      return Number.isNaN(numeric) ? undefined : numeric;
+    }
+  }
+  return undefined;
+};
+
+const coerceBonusObject = (value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const entries = Object.entries(value).reduce((acc, [key, raw]) => {
+    const coerced = coerceNumericBonusValue(raw);
+    if (coerced !== undefined) {
+      acc[key] = coerced;
+    }
+    return acc;
+  }, {});
+  return entries;
+};
+
+const coerceOptionalCost = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  return value;
+};
+
+const isValidCost = (value) => {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+  return false;
+};
+
 const getSlotString = (value) => {
   if (!value) return '';
   if (typeof value === 'string') {
@@ -415,8 +522,14 @@ module.exports = (router) => {
       body('weight').isFloat().withMessage('weight must be a number').toFloat(),
       body('cost').trim().notEmpty().withMessage('cost is required'),
       body('notes').optional().trim(),
-      body('statBonuses').optional().custom(validateBonusObject),
-      body('skillBonuses').optional().custom(validateBonusObject),
+      body('statBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
+      body('skillBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -443,8 +556,14 @@ module.exports = (router) => {
       body('weight').optional().isFloat().toFloat(),
       body('cost').optional().trim().notEmpty(),
       body('notes').optional().trim(),
-      body('statBonuses').optional().custom(validateBonusObject),
-      body('skillBonuses').optional().custom(validateBonusObject),
+      body('statBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
+      body('skillBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -532,8 +651,14 @@ module.exports = (router) => {
       body('weight').optional().isFloat().toFloat(),
       body('cost').optional().isString().trim(),
       body('notes').optional().isString().trim(),
-      body('statBonuses').optional().custom(validateBonusObject),
-      body('skillBonuses').optional().custom(validateBonusObject),
+      body('statBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
+      body('skillBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -578,8 +703,14 @@ module.exports = (router) => {
       body('weight').optional().isFloat().toFloat(),
       body('cost').optional().isString().trim(),
       body('notes').optional().isString().trim(),
-      body('statBonuses').optional().custom(validateBonusObject),
-      body('skillBonuses').optional().custom(validateBonusObject),
+      body('statBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
+      body('skillBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -631,12 +762,36 @@ module.exports = (router) => {
       body('item').isArray().withMessage('item must be an array'),
       body('item.*').isObject().withMessage('each item must be an object'),
       body('item.*.name').trim().notEmpty().withMessage('name is required'),
-      body('item.*.category').optional().isString().trim(),
-      body('item.*.weight').optional({ checkFalsy: true }).isFloat().toFloat(),
-      body('item.*.cost').optional().isString().trim(),
+      body('item.*.category').optional().isString().bail().customSanitizer(coerceOptionalString),
+      body('item.*.weight')
+        .optional({ values: 'nullish' })
+        .customSanitizer(coerceOptionalWeight)
+        .custom((value) => {
+          if (!isValidWeight(value)) {
+            throw new Error('weight must be a string or number');
+          }
+          return true;
+        }),
+      body('item.*.cost')
+        .optional({ values: 'nullish' })
+        .customSanitizer(coerceOptionalCost)
+        .custom((value) => {
+          if (!isValidCost(value)) {
+            throw new Error('cost must be a string or number');
+          }
+          return true;
+        }),
       body('item.*.notes').optional().isString().trim(),
-      body('item.*.statBonuses').optional().custom(validateBonusObject),
-      body('item.*.skillBonuses').optional().custom(validateBonusObject),
+      body('item.*.statBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
+      body('item.*.skillBonuses')
+        .optional()
+        .customSanitizer(coerceBonusObject)
+        .custom(validateBonusObject),
+      body('item.*.owned').optional().isBoolean().toBoolean(),
+      body('item.*.ownedCount').optional().isInt({ min: 0 }).toInt(),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -686,16 +841,31 @@ module.exports = (router) => {
         }),
       body('accessories.*.rarity').optional().isString().trim(),
       body('accessories.*.weight')
-        .optional({ checkFalsy: true })
-        .isFloat()
-        .toFloat(),
-      body('accessories.*.cost').optional().isString().trim(),
+        .optional({ values: 'nullish' })
+        .customSanitizer(coerceOptionalWeight)
+        .custom((value) => {
+          if (!isValidWeight(value)) {
+            throw new Error('weight must be a string or number');
+          }
+          return true;
+        }),
+      body('accessories.*.cost')
+        .optional({ values: 'nullish' })
+        .customSanitizer(coerceOptionalCost)
+        .custom((value) => {
+          if (!isValidCost(value)) {
+            throw new Error('cost must be a string or number');
+          }
+          return true;
+        }),
       body('accessories.*.notes').optional().isString().trim(),
       body('accessories.*.statBonuses')
         .optional()
+        .customSanitizer(coerceBonusObject)
         .custom(validateBonusObject),
       body('accessories.*.skillBonuses')
         .optional()
+        .customSanitizer(coerceBonusObject)
         .custom(validateBonusObject),
       body('accessories.*.owned').optional().isBoolean().toBoolean(),
       body('accessories.*.ownedCount').optional().isInt().toInt(),


### PR DESCRIPTION
## Summary
- allow numeric item and accessory costs when validating inventory updates by reusing a shared sanitizer
- adjust weight validators to treat only nullish values as absent so zero values persist
- extend equipment route tests to cover numeric costs and ensure invalid types are rejected
- coerce stat and skill bonus maps to numeric values before validation so legacy modifiers save correctly
- expand equipment route tests to confirm numeric string bonuses are sanitized for items and accessories

## Testing
- npm --prefix server test -- --runTestsByPath __tests__/equipment.test.js *(fails: local environment cannot locate the jest binary)*

------
https://chatgpt.com/codex/tasks/task_e_68fec994f894832e93a475ca4ab050e0