### PR TITLE
Allow nullish optional item fields during inventory updates

### DIFF
--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -114,6 +114,34 @@ const coerceOptionalCost = (value) => {
   return value;
 };
 
+const coerceOptionalBoolean = (value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed;
+  }
+  return value;
+};
+
+const coerceOptionalInteger = (value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed;
+  }
+  return value;
+};
+
 const isValidCost = (value) => {
   if (value === undefined) {
     return true;
@@ -762,7 +790,11 @@ module.exports = (router) => {
       body('item').isArray().withMessage('item must be an array'),
       body('item.*').isObject().withMessage('each item must be an object'),
       body('item.*.name').trim().notEmpty().withMessage('name is required'),
-      body('item.*.category').optional().isString().bail().customSanitizer(coerceOptionalString),
+      body('item.*.category')
+        .optional({ values: 'nullish' })
+        .isString()
+        .bail()
+        .customSanitizer(coerceOptionalString),
       body('item.*.weight')
         .optional({ values: 'nullish' })
         .customSanitizer(coerceOptionalWeight)
@@ -781,17 +813,25 @@ module.exports = (router) => {
           }
           return true;
         }),
-      body('item.*.notes').optional().isString().trim(),
+      body('item.*.notes').optional({ values: 'nullish' }).isString().trim(),
       body('item.*.statBonuses')
-        .optional()
+        .optional({ values: 'nullish' })
         .customSanitizer(coerceBonusObject)
         .custom(validateBonusObject),
       body('item.*.skillBonuses')
-        .optional()
+        .optional({ values: 'nullish' })
         .customSanitizer(coerceBonusObject)
         .custom(validateBonusObject),
-      body('item.*.owned').optional().isBoolean().toBoolean(),
-      body('item.*.ownedCount').optional().isInt({ min: 0 }).toInt(),
+      body('item.*.owned')
+        .customSanitizer(coerceOptionalBoolean)
+        .optional()
+        .isBoolean()
+        .toBoolean(),
+      body('item.*.ownedCount')
+        .customSanitizer(coerceOptionalInteger)
+        .optional()
+        .isInt({ min: 0 })
+        .toInt(),
     ],
     handleValidationErrors,
     async (req, res, next) => {
@@ -867,8 +907,16 @@ module.exports = (router) => {
         .optional()
         .customSanitizer(coerceBonusObject)
         .custom(validateBonusObject),
-      body('accessories.*.owned').optional().isBoolean().toBoolean(),
-      body('accessories.*.ownedCount').optional().isInt().toInt(),
+      body('accessories.*.owned')
+        .customSanitizer(coerceOptionalBoolean)
+        .optional()
+        .isBoolean()
+        .toBoolean(),
+      body('accessories.*.ownedCount')
+        .customSanitizer(coerceOptionalInteger)
+        .optional()
+        .isInt()
+        .toInt(),
     ],
     handleValidationErrors,
     async (req, res, next) => {


### PR DESCRIPTION
## Summary
- allow optional category and note fields in inventory items to accept nullish values
- ignore nullish stat and skill bonus payloads so existing records with null metadata do not fail validation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff9619db8c832ebb8a738486044916