### PR TITLE
Sanitize DM shop item payloads before updating inventory

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -121,6 +121,168 @@ const normalizeCreatureSize = (value) => {
   return null;
 };
 
+const parseNumericValue = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const sanitizeBonusRecord = (bonuses) => {
+  if (!bonuses || typeof bonuses !== 'object' || Array.isArray(bonuses)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(bonuses).reduce((acc, [key, value]) => {
+    const normalizedKey = typeof key === 'string' ? key.trim() : String(key);
+    if (!normalizedKey) {
+      return acc;
+    }
+
+    const parsed = parseNumericValue(value);
+    if (parsed === null) {
+      return acc;
+    }
+
+    acc[normalizedKey] = parsed;
+    return acc;
+  }, {});
+
+  return Object.keys(entries).length ? entries : undefined;
+};
+
+const coerceInventoryItem = (entry) => {
+  if (!entry) {
+    return null;
+  }
+
+  if (Array.isArray(entry)) {
+    const [name, category, weight, cost, notes, statBonuses, skillBonuses] = entry;
+    const base = {};
+    if (name !== undefined) base.name = name;
+    if (category !== undefined) base.category = category;
+    if (weight !== undefined) base.weight = weight;
+    if (cost !== undefined) base.cost = cost;
+    if (notes !== undefined) base.notes = notes;
+    if (statBonuses !== undefined) base.statBonuses = statBonuses;
+    if (skillBonuses !== undefined) base.skillBonuses = skillBonuses;
+    return base;
+  }
+
+  if (typeof entry === 'string') {
+    return { name: entry };
+  }
+
+  if (typeof entry === 'object') {
+    return { ...entry };
+  }
+
+  return null;
+};
+
+const sanitizeInventoryItem = (entry) => {
+  const base = coerceInventoryItem(entry);
+  if (!base) {
+    return null;
+  }
+
+  const sanitized = { ...base };
+
+  const resolvedName =
+    typeof base.name === 'string' && base.name.trim()
+      ? base.name.trim()
+      : typeof base.displayName === 'string' && base.displayName.trim()
+        ? base.displayName.trim()
+        : typeof base.itemName === 'string' && base.itemName.trim()
+          ? base.itemName.trim()
+          : '';
+
+  if (!resolvedName) {
+    return null;
+  }
+
+  sanitized.name = resolvedName;
+
+  if (typeof sanitized.category === 'string') {
+    const trimmedCategory = sanitized.category.trim();
+    if (trimmedCategory) {
+      sanitized.category = trimmedCategory;
+    } else {
+      delete sanitized.category;
+    }
+  } else {
+    delete sanitized.category;
+  }
+
+  const weightValue = parseNumericValue(sanitized.weight);
+  if (weightValue === null) {
+    delete sanitized.weight;
+  } else {
+    sanitized.weight = weightValue;
+  }
+
+  if (typeof sanitized.cost === 'string') {
+    const trimmedCost = sanitized.cost.trim();
+    if (trimmedCost) {
+      sanitized.cost = trimmedCost;
+    } else {
+      delete sanitized.cost;
+    }
+  } else if (typeof sanitized.cost === 'number' && Number.isFinite(sanitized.cost)) {
+    sanitized.cost = `${sanitized.cost}`;
+  } else if (sanitized.cost !== undefined) {
+    delete sanitized.cost;
+  }
+
+  if (typeof sanitized.notes === 'string') {
+    sanitized.notes = sanitized.notes.trim();
+    if (!sanitized.notes) {
+      delete sanitized.notes;
+    }
+  } else if (sanitized.notes !== undefined) {
+    delete sanitized.notes;
+  }
+
+  const statBonuses = sanitizeBonusRecord(base.statBonuses);
+  if (statBonuses !== undefined) {
+    sanitized.statBonuses = statBonuses;
+  } else {
+    delete sanitized.statBonuses;
+  }
+
+  const skillBonuses = sanitizeBonusRecord(base.skillBonuses);
+  if (skillBonuses !== undefined) {
+    sanitized.skillBonuses = skillBonuses;
+  } else {
+    delete sanitized.skillBonuses;
+  }
+
+  if (typeof base.owned === 'boolean') {
+    sanitized.owned = base.owned;
+  }
+
+  return sanitized;
+};
+
+const sanitizeInventoryItemsForUpdate = (items) => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items.map(sanitizeInventoryItem).filter(Boolean);
+};
+
 const resolveCharacterTokenSize = (form) =>
   normalizeCreatureSize(
     form?.temporarySize ??
@@ -3701,12 +3863,13 @@ export default function ZombiesCharacterSheet() {
 
   const handleItemsChange = useCallback(
     async (items) => {
-      setForm((prev) => ({ ...prev, item: items }));
+      const sanitizedItems = sanitizeInventoryItemsForUpdate(items);
+      setForm((prev) => ({ ...prev, item: sanitizedItems }));
       try {
         await apiFetch(`/equipment/update-item/${characterId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ item: items }),
+          body: JSON.stringify({ item: sanitizedItems }),
         });
       } catch (err) {
         // eslint-disable-next-line no-console

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -1808,12 +1808,14 @@ test('normalizes legacy inventory entries before updating items', async () => {
     {
       name: 'Spyglass',
       category: 'Adventuring Gear',
-      weight: '1',
+      weight: ' 1 ',
       cost: '1,000 gp',
-      notes: 'Expensive',
+      notes: 'Expensive ',
       owned: false,
       displayName: 'Spyglass',
       rarity: 'rare',
+      statBonuses: { wis: '2', str: 'not-a-number' },
+      skillBonuses: { perception: '3', stealth: '' },
     },
   ];
 
@@ -1888,29 +1890,23 @@ test('normalizes legacy inventory entries before updating items', async () => {
     )
   ).toBe(true);
 
-  expect(payload.item).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: 'Rope (hempen)',
-        category: '',
-        weight: '',
-        statBonuses: {},
-        skillBonuses: {},
-      }),
-      expect.objectContaining({
-        name: 'Lantern',
-        category: 'Adventuring Gear',
-        notes: 'Brass lantern',
-        statBonuses: { wis: 1 },
-        skillBonuses: { perception: 2 },
-      }),
-      expect.objectContaining({
-        name: 'Alchemy Jug',
-        type: 'gear',
-        owned: true,
-      }),
-    ])
-  );
+  const rope = payload.item.find((entry) => entry.name === 'Rope (hempen)');
+  expect(rope).toEqual({ name: 'Rope (hempen)' });
+
+  const lantern = payload.item.find((entry) => entry.name === 'Lantern');
+  expect(lantern).toMatchObject({
+    category: 'Adventuring Gear',
+    notes: 'Brass lantern',
+    statBonuses: { wis: 1 },
+    skillBonuses: { perception: 2 },
+    weight: 2,
+  });
+
+  const newPurchase = payload.item.find((entry) => entry.name === 'Alchemy Jug');
+  expect(newPurchase).toMatchObject({
+    type: 'gear',
+    owned: true,
+  });
 
   const preserved = payload.item.find((entry) => entry.name === 'Spyglass');
   expect(preserved).toMatchObject({
@@ -1918,6 +1914,10 @@ test('normalizes legacy inventory entries before updating items', async () => {
     owned: false,
     rarity: 'rare',
     notes: 'Expensive',
+    category: 'Adventuring Gear',
+    weight: 1,
+    statBonuses: { wis: 2 },
+    skillBonuses: { perception: 3 },
   });
 });
 


### PR DESCRIPTION
## Summary
- sanitize item payloads before submitting inventory updates so invalid values no longer trigger 400 responses
- normalize numeric fields, trim strings, and drop empty bonus values when preparing inventory items
- extend the ZombiesCharacterSheet item normalization test to cover the new sanitization behavior

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --testNamePattern "normalizes legacy inventory"

------
https://chatgpt.com/codex/tasks/task_e_68ffb0d6d748832e811b68783ddcd334