### PR TITLE
Adjust character sheet background map layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3611,25 +3611,33 @@ h1 {
     color: inherit;
     width: 100%;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     .campaign-map-board__stage {
       height: 100%;
+      width: 100%;
       display: flex;
       align-items: center;
       justify-content: center;
     }
 
     .campaign-map-board__image-wrapper {
-      height: 100%;
+      height: auto;
       max-height: 100%;
       max-width: 100%;
       border-radius: 0;
       aspect-ratio: auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .campaign-map-board__image {
-      height: 100%;
       width: 100%;
+      height: auto;
+      max-height: 100%;
       object-fit: contain;
       object-position: center;
     }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1506,6 +1506,21 @@ const CampaignMapBoard = ({
     };
   }, [lastDraggedTokenId, lockRotation, rotateTokenBy]);
 
+  const boardStyle = useMemo(() => {
+    if (!hasBackgroundVariant) {
+      return undefined;
+    }
+
+    return {
+      width: '100%',
+      height: '100%',
+      flex: '1 1 auto',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    };
+  }, [hasBackgroundVariant]);
+
   return (
     <div
       ref={boardRef}
@@ -1514,6 +1529,7 @@ const CampaignMapBoard = ({
         className,
         interactionDisabled && 'campaign-map-board--disabled'
       )}
+      style={boardStyle}
     >
       {title && <h5 className="campaign-map-board__title">{title}</h5>}
       {imageSrc ? (

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5928,12 +5928,19 @@ export default function ZombiesCharacterSheet() {
           inset: 0,
           zIndex: 0,
           overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'stretch',
+          justifyContent: 'center',
         }}
       >
         {mapBoardMap ? (
           <div
             className="zombies-character-sheet__map-backdrop-board"
-            style={{ position: 'absolute', inset: 0 }}
+            style={{
+              position: 'relative',
+              flex: '1 1 auto',
+              display: 'flex',
+            }}
           >
             <CampaignMapBoard
               map={mapBoardMap}


### PR DESCRIPTION
## Summary
- ensure the background campaign map board stretches to the viewport while keeping the grid centered
- update the background styling so the map image remains contained instead of stretching
- adjust the character sheet backdrop container to flex the embedded board across the full screen

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_69012a742ab8832e84e22306ad6aec0e