### PR TITLE
Render campaign map as sheet backdrop

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -22,6 +22,85 @@
   object-position: center;
 }
 
+.map-modal-background {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  pointer-events: none;
+  color: #fff;
+}
+
+.map-modal-background__backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(15, 15, 25, 0.75), rgba(6, 6, 10, 0.9));
+  pointer-events: none;
+}
+
+.map-modal-background__content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 100%);
+  padding: clamp(1rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  pointer-events: auto;
+}
+
+.map-modal-background__header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.map-modal-background__title {
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.map-modal-background__body {
+  flex: 1 1 auto;
+  overflow: auto;
+  background: rgba(12, 12, 18, 0.65);
+  border-radius: var(--bs-border-radius-lg, 0.75rem);
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
+}
+
+.map-modal-background__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.zombies-character-sheet-layout {
+  position: relative;
+  min-height: 100vh;
+}
+
+.zombies-character-sheet-layout__map {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  display: none;
+}
+
+.zombies-character-sheet-layout__map--visible {
+  display: block;
+}
+
+.zombies-character-sheet-layout__content {
+  position: relative;
+  z-index: 1;
+}
+
 .map-display__grid-overlay,
 .campaign-map-board__grid-overlay {
   position: absolute;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -152,7 +152,9 @@ const MapModal = ({
   dockedSide = null,
   onDockClose,
   onDockChange,
+  displayMode = 'modal',
 }) => {
+  const isBackground = displayMode === 'background';
   const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
   const normalizedActiveId = useMemo(() => normalizeMapId(activeMapId), [activeMapId]);
   const normalizedActionId = useMemo(
@@ -889,7 +891,7 @@ const MapModal = ({
   };
 
   const dialogClassName = useMemo(() => {
-    if (!isDocked) {
+    if (!isDocked || isBackground) {
       return undefined;
     }
 
@@ -902,6 +904,10 @@ const MapModal = ({
   }, [isDocked, dockedSide]);
 
   const modalClassName = useMemo(() => {
+    if (isBackground) {
+      return undefined;
+    }
+
     const classes = ['dnd-modal', 'modern-modal'];
 
     if (isDocked) {
@@ -922,6 +928,73 @@ const MapModal = ({
     onHide?.();
   }, [isDocked, onDockClose, onHide]);
 
+  const titleContent = <>{title}</>;
+  const backgroundAriaLabel = useMemo(() => {
+    if (typeof title === 'string' && title.trim() !== '') {
+      return title.trim();
+    }
+
+    return 'Campaign map';
+  }, [title]);
+
+  const bodyContent = hasManagementFeatures ? (
+    <div className="d-flex flex-column flex-lg-row gap-4">
+      <div className="flex-grow-1" data-testid="map-modal-sidebar">
+        <h5 className="h6 mb-3">Saved Maps</h5>
+        {renderMapList()}
+      </div>
+      <div className="flex-grow-1" data-testid="map-modal-preview">
+        {previewMap ? renderPreviewContent() : (
+          <p className="text-muted mb-0">No map selected.</p>
+        )}
+      </div>
+    </div>
+  ) : (
+    <div data-testid="map-modal-preview">
+      {previewMap ? renderPreviewContent() : (
+        <p className="text-muted mb-0">No map image available.</p>
+      )}
+    </div>
+  );
+
+  const footerContent = (
+    <Button className="action-btn close-btn" onClick={handleModalHide} data-testid="map-modal-close">
+      Close
+    </Button>
+  );
+
+  if (isBackground) {
+    if (!show) {
+      return null;
+    }
+
+    return (
+      <div
+        className="map-modal-background"
+        data-testid="map-modal-wrapper"
+        role="region"
+        aria-label={backgroundAriaLabel}
+      >
+        <div className="map-modal-background__backdrop" aria-hidden="true" />
+        <div className="map-modal-background__content">
+          <header className="map-modal-background__header">
+            <div className="map-modal-background__header-inner">
+              <h2 className="map-modal-background__title">{titleContent}</h2>
+              <CloseButton
+                variant="white"
+                onClick={handleModalHide}
+                aria-label="Close map"
+                data-testid="map-modal-close-button"
+              />
+            </div>
+          </header>
+          <div className="map-modal-background__body">{bodyContent}</div>
+          <footer className="map-modal-background__footer">{footerContent}</footer>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Modal
       className={modalClassName}
@@ -941,34 +1014,10 @@ const MapModal = ({
           onDockChange={onDockChange}
           isDocked={isDocked}
         />
-        <Modal.Title>{title}</Modal.Title>
+        <Modal.Title>{titleContent}</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        {hasManagementFeatures ? (
-          <div className="d-flex flex-column flex-lg-row gap-4">
-            <div className="flex-grow-1" data-testid="map-modal-sidebar">
-              <h5 className="h6 mb-3">Saved Maps</h5>
-              {renderMapList()}
-            </div>
-            <div className="flex-grow-1" data-testid="map-modal-preview">
-              {previewMap ? renderPreviewContent() : (
-                <p className="text-muted mb-0">No map selected.</p>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div data-testid="map-modal-preview">
-            {previewMap ? renderPreviewContent() : (
-              <p className="text-muted mb-0">No map image available.</p>
-            )}
-          </div>
-        )}
-      </Modal.Body>
-      <Modal.Footer>
-        <Button className="action-btn close-btn" onClick={handleModalHide} data-testid="map-modal-close">
-          Close
-        </Button>
-      </Modal.Footer>
+      <Modal.Body>{bodyContent}</Modal.Body>
+      <Modal.Footer>{footerContent}</Modal.Footer>
     </Modal>
   );
 };
@@ -1009,6 +1058,7 @@ MapModal.propTypes = {
   dockedSide: PropTypes.oneOf(['left', 'right']),
   onDockClose: PropTypes.func,
   onDockChange: PropTypes.func,
+  displayMode: PropTypes.oneOf(['modal', 'background']),
 };
 
 MapModal.defaultProps = {
@@ -1036,6 +1086,7 @@ MapModal.defaultProps = {
   dockedSide: null,
   onDockClose: null,
   onDockChange: null,
+  displayMode: 'modal',
 };
 
 export default MapModal;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5560,22 +5560,48 @@ export default function ZombiesCharacterSheet() {
       .filter(Boolean);
   }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
+  const mapLayerClassName = shouldShowMapModal
+    ? 'zombies-character-sheet-layout__map zombies-character-sheet-layout__map--visible'
+    : 'zombies-character-sheet-layout__map';
+
   return (
-    <div
-      ref={rootContainerRef}
-      className="text-center"
-      style={{
-        fontFamily: 'Raleway, sans-serif',
-        backgroundImage: `url(${loginbg})`,
-        height: "100vh",
-        overflow: "hidden",
-        backgroundSize: "cover",
-        backgroundRepeat: "no-repeat",
-        paddingTop: navHeight + HEADER_PADDING,
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
+    <div className="zombies-character-sheet-layout">
+      <div className={mapLayerClassName}>
+        <MapModal
+          show={shouldShowMapModal}
+          onHide={handleCloseMapModal}
+          map={campaignMap}
+          maps={campaignMaps}
+          activeMapId={campaignActiveMapId}
+          tokensByMapId={modalTokensByMapId}
+          currentCharacterId={resolvedCharacterId}
+          activeCharacterId={activeTurnParticipantId}
+          characterLookup={tokenMetaById}
+          onTokenMove={handleTokenMove}
+          onTokenRemove={handleTokenRemove}
+          dockedSide={getDockedSide('map')}
+          onDockChange={(side) => handleDockChange('map', side)}
+          displayMode="background"
+        />
+      </div>
+      <div
+        ref={rootContainerRef}
+        className="text-center zombies-character-sheet-layout__content"
+        style={{
+          fontFamily: 'Raleway, sans-serif',
+          backgroundImage: shouldShowMapModal ? 'none' : `url(${loginbg})`,
+          backgroundColor: shouldShowMapModal ? 'rgba(10, 12, 18, 0.78)' : undefined,
+          height: '100vh',
+          overflow: 'hidden',
+          backgroundSize: 'cover',
+          backgroundRepeat: 'no-repeat',
+          paddingTop: navHeight + HEADER_PADDING,
+          display: 'flex',
+          flexDirection: 'column',
+          backdropFilter: shouldShowMapModal ? 'blur(8px)' : undefined,
+          position: 'relative',
+        }}
+      >
       <div
         ref={contentColumnRef}
         className="zombies-character-sheet__content"
@@ -6005,22 +6031,8 @@ export default function ZombiesCharacterSheet() {
       errorMessage={tokenPickerError}
       filterScope={tokenPickerFilterScope}
     />
-    <MapModal
-      show={shouldShowMapModal}
-      onHide={handleCloseMapModal}
-      map={campaignMap}
-      maps={campaignMaps}
-      activeMapId={campaignActiveMapId}
-      tokensByMapId={modalTokensByMapId}
-      currentCharacterId={resolvedCharacterId}
-      activeCharacterId={activeTurnParticipantId}
-      characterLookup={tokenMetaById}
-      onTokenMove={handleTokenMove}
-      onTokenRemove={handleTokenRemove}
-      dockedSide={getDockedSide('map')}
-      onDockChange={(side) => handleDockChange('map', side)}
-    />
     {dockedModalElements}
-  </div>
-);
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a fixed layout container to the character sheet so the campaign map renders behind the sheet instead of inside a modal
- update the background mode styling and semantics for MapModal so it only renders when visible and behaves as a background region
- refresh shared SCSS to support the new background layering and preserve token interactions

## Testing
- npm test -- MapModal --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_6901333a1a84832ea23c9461a5c4d3ad