### PR TITLE
Render campaign map as character sheet background

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -22,6 +22,110 @@
   object-position: center;
 }
 
+.map-modal-background {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  color: #fff;
+  overflow: hidden;
+  background: radial-gradient(circle at center, rgba(8, 10, 16, 0.85), rgba(4, 6, 12, 0.95));
+}
+
+.map-modal-background__board {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 3rem);
+}
+
+.map-modal-background__board > .map-modal__empty {
+  background: rgba(10, 12, 18, 0.8);
+  border-radius: var(--bs-border-radius-lg, 0.75rem);
+  padding: 1.5rem;
+}
+
+.map-modal-background__board .map-modal__board-wrapper {
+  width: min(1200px, 100%);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.map-modal-background__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  z-index: 1;
+}
+
+.map-modal-background__overlay-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 5, 10, 0.65);
+  backdrop-filter: blur(8px);
+}
+
+.map-modal-background__overlay-content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 100%);
+  padding: clamp(1rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  pointer-events: auto;
+}
+
+.map-modal-background__header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.map-modal-background__title {
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.map-modal-background__body {
+  flex: 1 1 auto;
+  overflow: auto;
+  background: rgba(12, 12, 18, 0.65);
+  border-radius: var(--bs-border-radius-lg, 0.75rem);
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
+}
+
+.map-modal-background__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.zombies-character-sheet-layout {
+  position: relative;
+  min-height: 100vh;
+}
+
+.zombies-character-sheet-layout__map {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+}
+
+.zombies-character-sheet-layout__content {
+  position: relative;
+  z-index: 1;
+}
+
 .map-display__grid-overlay,
 .campaign-map-board__grid-overlay {
   position: absolute;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -152,7 +152,9 @@ const MapModal = ({
   dockedSide = null,
   onDockClose,
   onDockChange,
+  displayMode = 'modal',
 }) => {
+  const isBackground = displayMode === 'background';
   const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
   const normalizedActiveId = useMemo(() => normalizeMapId(activeMapId), [activeMapId]);
   const normalizedActionId = useMemo(
@@ -889,7 +891,7 @@ const MapModal = ({
   };
 
   const dialogClassName = useMemo(() => {
-    if (!isDocked) {
+    if (!isDocked || isBackground) {
       return undefined;
     }
 
@@ -902,6 +904,10 @@ const MapModal = ({
   }, [isDocked, dockedSide]);
 
   const modalClassName = useMemo(() => {
+    if (isBackground) {
+      return undefined;
+    }
+
     const classes = ['dnd-modal', 'modern-modal'];
 
     if (isDocked) {
@@ -922,6 +928,98 @@ const MapModal = ({
     onHide?.();
   }, [isDocked, onDockClose, onHide]);
 
+  const handleOverlayBackdropClick = useCallback(
+    (event) => {
+      if (event.target === event.currentTarget) {
+        handleModalHide();
+      }
+    },
+    [handleModalHide]
+  );
+
+  const titleContent = <>{title}</>;
+  const backgroundAriaLabel = useMemo(() => {
+    if (typeof title === 'string' && title.trim() !== '') {
+      return title.trim();
+    }
+
+    return 'Campaign map';
+  }, [title]);
+
+  const emptyBoardMessage = hasManagementFeatures ? (
+    <p className="text-muted mb-0">No map selected.</p>
+  ) : (
+    <p className="text-muted mb-0">No map image available.</p>
+  );
+
+  const boardContent = previewMap ? (
+    renderPreviewContent()
+  ) : (
+    <div className="map-modal__empty" data-testid="map-modal-empty">
+      {emptyBoardMessage}
+    </div>
+  );
+
+  const bodyContent = hasManagementFeatures ? (
+    <div className="d-flex flex-column flex-lg-row gap-4">
+      <div className="flex-grow-1" data-testid="map-modal-sidebar">
+        <h5 className="h6 mb-3">Saved Maps</h5>
+        {renderMapList()}
+      </div>
+      <div className="flex-grow-1" data-testid="map-modal-preview">
+        {boardContent}
+      </div>
+    </div>
+  ) : (
+    <div data-testid="map-modal-preview">{boardContent}</div>
+  );
+
+  const footerContent = (
+    <Button className="action-btn close-btn" onClick={handleModalHide} data-testid="map-modal-close">
+      Close
+    </Button>
+  );
+
+  if (isBackground) {
+    return (
+      <div className="map-modal-background" data-testid="map-modal-wrapper">
+        <div
+          className="map-modal-background__board"
+          role="region"
+          aria-label={backgroundAriaLabel}
+        >
+          {boardContent}
+        </div>
+        {show && (
+          <div
+            className="map-modal-background__overlay"
+            role="dialog"
+            aria-modal="false"
+            aria-label={backgroundAriaLabel}
+            onClick={handleOverlayBackdropClick}
+          >
+            <div className="map-modal-background__overlay-backdrop" aria-hidden="true" />
+            <div className="map-modal-background__overlay-content">
+              <header className="map-modal-background__header">
+                <div className="map-modal-background__header-inner">
+                  <h2 className="map-modal-background__title">{titleContent}</h2>
+                  <CloseButton
+                    variant="white"
+                    onClick={handleModalHide}
+                    aria-label="Close map"
+                    data-testid="map-modal-close-button"
+                  />
+                </div>
+              </header>
+              <div className="map-modal-background__body">{bodyContent}</div>
+              <footer className="map-modal-background__footer">{footerContent}</footer>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <Modal
       className={modalClassName}
@@ -941,34 +1039,10 @@ const MapModal = ({
           onDockChange={onDockChange}
           isDocked={isDocked}
         />
-        <Modal.Title>{title}</Modal.Title>
+        <Modal.Title>{titleContent}</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        {hasManagementFeatures ? (
-          <div className="d-flex flex-column flex-lg-row gap-4">
-            <div className="flex-grow-1" data-testid="map-modal-sidebar">
-              <h5 className="h6 mb-3">Saved Maps</h5>
-              {renderMapList()}
-            </div>
-            <div className="flex-grow-1" data-testid="map-modal-preview">
-              {previewMap ? renderPreviewContent() : (
-                <p className="text-muted mb-0">No map selected.</p>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div data-testid="map-modal-preview">
-            {previewMap ? renderPreviewContent() : (
-              <p className="text-muted mb-0">No map image available.</p>
-            )}
-          </div>
-        )}
-      </Modal.Body>
-      <Modal.Footer>
-        <Button className="action-btn close-btn" onClick={handleModalHide} data-testid="map-modal-close">
-          Close
-        </Button>
-      </Modal.Footer>
+      <Modal.Body>{bodyContent}</Modal.Body>
+      <Modal.Footer>{footerContent}</Modal.Footer>
     </Modal>
   );
 };
@@ -1009,6 +1083,7 @@ MapModal.propTypes = {
   dockedSide: PropTypes.oneOf(['left', 'right']),
   onDockClose: PropTypes.func,
   onDockChange: PropTypes.func,
+  displayMode: PropTypes.oneOf(['modal', 'background']),
 };
 
 MapModal.defaultProps = {
@@ -1036,6 +1111,7 @@ MapModal.defaultProps = {
   dockedSide: null,
   onDockClose: null,
   onDockChange: null,
+  displayMode: 'modal',
 };
 
 export default MapModal;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5,7 +5,6 @@ import apiFetch from '../../../utils/apiFetch';
 import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button } from 'react-bootstrap';
 import '../../../App.scss';
-import loginbg from "../../../images/loginbg.png";
 import CharacterInfo from "../attributes/CharacterInfo";
 import Stats from "../attributes/Stats";
 import Skills from "../attributes/Skills";
@@ -5560,22 +5559,43 @@ export default function ZombiesCharacterSheet() {
       .filter(Boolean);
   }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
+  const mapLayerClassName = 'zombies-character-sheet-layout__map';
+
   return (
-    <div
-      ref={rootContainerRef}
-      className="text-center"
-      style={{
-        fontFamily: 'Raleway, sans-serif',
-        backgroundImage: `url(${loginbg})`,
-        height: "100vh",
-        overflow: "hidden",
-        backgroundSize: "cover",
-        backgroundRepeat: "no-repeat",
-        paddingTop: navHeight + HEADER_PADDING,
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
+    <div className="zombies-character-sheet-layout">
+      <div className={mapLayerClassName}>
+        <MapModal
+          show={shouldShowMapModal}
+          onHide={handleCloseMapModal}
+          map={campaignMap}
+          maps={campaignMaps}
+          activeMapId={campaignActiveMapId}
+          tokensByMapId={modalTokensByMapId}
+          currentCharacterId={resolvedCharacterId}
+          activeCharacterId={activeTurnParticipantId}
+          characterLookup={tokenMetaById}
+          onTokenMove={handleTokenMove}
+          onTokenRemove={handleTokenRemove}
+          dockedSide={getDockedSide('map')}
+          onDockChange={(side) => handleDockChange('map', side)}
+          displayMode="background"
+        />
+      </div>
+      <div
+        ref={rootContainerRef}
+        className="text-center zombies-character-sheet-layout__content"
+        style={{
+          fontFamily: 'Raleway, sans-serif',
+          backgroundColor: 'rgba(10, 12, 18, 0.78)',
+          height: '100vh',
+          overflow: 'hidden',
+          paddingTop: navHeight + HEADER_PADDING,
+          display: 'flex',
+          flexDirection: 'column',
+          backdropFilter: 'blur(8px)',
+          position: 'relative',
+        }}
+      >
       <div
         ref={contentColumnRef}
         className="zombies-character-sheet__content"
@@ -6005,22 +6025,8 @@ export default function ZombiesCharacterSheet() {
       errorMessage={tokenPickerError}
       filterScope={tokenPickerFilterScope}
     />
-    <MapModal
-      show={shouldShowMapModal}
-      onHide={handleCloseMapModal}
-      map={campaignMap}
-      maps={campaignMaps}
-      activeMapId={campaignActiveMapId}
-      tokensByMapId={modalTokensByMapId}
-      currentCharacterId={resolvedCharacterId}
-      activeCharacterId={activeTurnParticipantId}
-      characterLookup={tokenMetaById}
-      onTokenMove={handleTokenMove}
-      onTokenRemove={handleTokenRemove}
-      dockedSide={getDockedSide('map')}
-      onDockChange={(side) => handleDockChange('map', side)}
-    />
     {dockedModalElements}
-  </div>
-);
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- keep the campaign map mounted behind the character sheet so the interactive board replaces the static background
- reuse MapModal in a background mode that always renders the board while showing management controls as an overlay when invoked
- refresh the sheet and map styling to support the persistent backdrop and overlay interaction

## Testing
- npm test -- MapModal --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_6901333a1a84832ea23c9461a5c4d3ad