### PR TITLE
Remove excessive blur from map overlay

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -67,7 +67,6 @@
   position: absolute;
   inset: 0;
   background: rgba(3, 5, 10, 0.65);
-  backdrop-filter: blur(8px);
 }
 
 .map-modal-background__overlay-content {
@@ -101,7 +100,6 @@
   background: rgba(12, 12, 18, 0.65);
   border-radius: var(--bs-border-radius-lg, 0.75rem);
   padding: clamp(1rem, 2.5vw, 1.5rem);
-  backdrop-filter: blur(4px);
   box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
 }
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5592,7 +5592,6 @@ export default function ZombiesCharacterSheet() {
           paddingTop: navHeight + HEADER_PADDING,
           display: 'flex',
           flexDirection: 'column',
-          backdropFilter: 'blur(8px)',
           position: 'relative',
         }}
       >


### PR DESCRIPTION
## Summary
- remove the backdrop blur from the map modal overlay so the background map remains sharp
- drop the inline blur filter on the character sheet container to prevent the entire interface from appearing fuzzy

## Testing
- npm start *(fails: Module not found: Can't resolve '@3d-dice/dice-box')*

------
https://chatgpt.com/codex/tasks/task_e_69013ce35cd4832ea8f1e1ec8f98760c