### PR TITLE
Brighten campaign map overlay and remove legacy modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -28,7 +28,7 @@
   z-index: 0;
   color: #fff;
   overflow: hidden;
-  background: radial-gradient(circle at center, rgba(8, 10, 16, 0.85), rgba(4, 6, 12, 0.95));
+  background: radial-gradient(circle at center, rgba(8, 10, 16, 0.55), rgba(4, 6, 12, 0.75));
 }
 
 .map-modal-background__board {
@@ -61,13 +61,7 @@
   justify-content: center;
   align-items: stretch;
   z-index: 1;
-}
-
-.map-modal-background__overlay-backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(3, 5, 10, 0.65);
-  backdrop-filter: blur(8px);
+  pointer-events: none;
 }
 
 .map-modal-background__overlay-content {
@@ -98,11 +92,10 @@
 .map-modal-background__body {
   flex: 1 1 auto;
   overflow: auto;
-  background: rgba(12, 12, 18, 0.65);
+  background: rgba(12, 12, 18, 0.45);
   border-radius: var(--bs-border-radius-lg, 0.75rem);
   padding: clamp(1rem, 2.5vw, 1.5rem);
-  backdrop-filter: blur(4px);
-  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.35);
 }
 
 .map-modal-background__footer {

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -928,15 +928,6 @@ const MapModal = ({
     onHide?.();
   }, [isDocked, onDockClose, onHide]);
 
-  const handleOverlayBackdropClick = useCallback(
-    (event) => {
-      if (event.target === event.currentTarget) {
-        handleModalHide();
-      }
-    },
-    [handleModalHide]
-  );
-
   const titleContent = <>{title}</>;
   const backgroundAriaLabel = useMemo(() => {
     if (typeof title === 'string' && title.trim() !== '') {
@@ -996,9 +987,7 @@ const MapModal = ({
             role="dialog"
             aria-modal="false"
             aria-label={backgroundAriaLabel}
-            onClick={handleOverlayBackdropClick}
           >
-            <div className="map-modal-background__overlay-backdrop" aria-hidden="true" />
             <div className="map-modal-background__overlay-content">
               <header className="map-modal-background__header">
                 <div className="map-modal-background__header-inner">

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -76,7 +76,6 @@ const DOCKABLE_MODAL_DEFINITIONS = {
   equipment: { label: 'Equipment', component: EquipmentModal },
   inventory: { label: 'Inventory', component: InventoryModal },
   shop: { label: 'Shop', component: ShopModal },
-  map: { label: 'Campaign Map', component: MapModal },
   help: { label: 'Help', component: Help },
 };
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
@@ -5425,23 +5424,6 @@ export default function ZombiesCharacterSheet() {
           onDockChange: (side) => handleDockChange('shop', side),
         }),
       },
-      map: {
-        ...DOCKABLE_MODAL_DEFINITIONS.map,
-        showProp: 'show',
-        isEnabled: true,
-        getBaseProps: () => ({
-          map: campaignMap,
-          maps: campaignMaps,
-          activeMapId: campaignActiveMapId,
-          tokensByMapId: modalTokensByMapId,
-          currentCharacterId: resolvedCharacterId,
-          activeCharacterId: activeTurnParticipantId,
-          characterLookup: tokenMetaById,
-          onTokenMove: handleTokenMove,
-          onHide: handleCloseMapModal,
-          onDockChange: (side) => handleDockChange('map', side),
-        }),
-      },
       help: {
         ...DOCKABLE_MODAL_DEFINITIONS.help,
         showProp: 'showHelpModal',
@@ -5592,7 +5574,6 @@ export default function ZombiesCharacterSheet() {
           paddingTop: navHeight + HEADER_PADDING,
           display: 'flex',
           flexDirection: 'column',
-          backdropFilter: 'blur(8px)',
           position: 'relative',
         }}
       >


### PR DESCRIPTION
## Summary
- soften the campaign map background overlay so the board art stays clear while the modal is open
- remove the blocking backdrop in background mode so figurine hover and token drag interactions reach the board
- drop the dockable legacy map modal from the character sheet so only the new background presentation is available

## Testing
- Not run (npm start fails: Module not found: Can't resolve '@3d-dice/dice-box')

------
https://chatgpt.com/codex/tasks/task_e_69013ce35cd4832ea8f1e1ec8f98760c