### PR TITLE
Improve clarity of map modal background

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -52,7 +52,7 @@
   align-items: center;
   justify-content: center;
   transform: translate(-50%, -50%)
-    scale(var(--map-modal-background-scale, 1.35));
+    scale(var(--map-modal-background-scale, 1));
   transform-origin: center center;
   cursor: grab;
   touch-action: none;
@@ -83,9 +83,9 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: rgba(18, 16, 14, 0.85);
+  background: transparent;
   padding: clamp(0.5rem, 1vw, 0.75rem);
-  box-shadow: 0 1.25rem 3.25rem rgba(0, 0, 0, 0.55);
+  box-shadow: none;
 }
 
 .map-modal-background__board-inner .campaign-map-board__stage {
@@ -138,11 +138,11 @@
 .map-modal-background__body {
   flex: 1 1 auto;
   overflow: auto;
-  background: rgba(10, 12, 20, 0.28);
+  background: transparent;
   border-radius: var(--bs-border-radius-lg, 0.75rem);
   padding: clamp(1rem, 2.5vw, 1.5rem);
-  backdrop-filter: saturate(140%) blur(2px);
-  box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.4);
+  backdrop-filter: none;
+  box-shadow: none;
 }
 
 .map-modal-background__footer {

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -150,7 +150,7 @@ const areSetsEqual = (a, b) => {
   return true;
 };
 
-const BACKGROUND_DEFAULT_SCALE = 1.35;
+const BACKGROUND_DEFAULT_SCALE = 1;
 const BACKGROUND_DRAG_THRESHOLD = 4;
 
 const MapModal = ({


### PR DESCRIPTION
## Summary
- reduce the default zoom on the map modal background so the map renders at its original scale
- remove dark overlays and blur from the background board to keep the background map fully visible

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690147b48c00832e993765dfc8f36d7f