### PR TITLE
Lighten background map layer and adjust interactions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -28,10 +28,33 @@
   z-index: 0;
   color: #fff;
   overflow: hidden;
-  background-color: #05070c;
+  background-color: #19273c;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
+}
+
+.map-modal-background::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 45%),
+    radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 52%);
+  opacity: 0.65;
+  mix-blend-mode: screen;
+}
+
+.map-modal-background::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(13, 19, 33, 0.15) 0%, rgba(13, 19, 33, 0.35) 35%, rgba(13, 19, 33, 0.15) 100%),
+    radial-gradient(circle at 50% 100%, rgba(19, 31, 54, 0.45) 0%, rgba(19, 31, 54, 0) 55%);
+  mix-blend-mode: screen;
 }
 
 .map-modal-background__board {
@@ -39,7 +62,7 @@
   inset: 0;
   z-index: 1;
   overflow: hidden;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .map-modal-background__board-inner {
@@ -64,7 +87,7 @@
 }
 
 .map-modal-background__board-inner > .map-modal__empty {
-  background: rgba(10, 12, 18, 0.65);
+  background: rgba(10, 12, 18, 0.42);
   border-radius: var(--bs-border-radius-lg, 0.75rem);
   padding: 1.5rem;
 }
@@ -83,7 +106,9 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: transparent;
+  background: linear-gradient(180deg, rgba(14, 22, 36, 0.35), rgba(14, 22, 36, 0.15));
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   padding: clamp(0.5rem, 1vw, 0.75rem);
   box-shadow: none;
 }
@@ -98,6 +123,11 @@
   width: 100%;
   height: 100%;
   background: transparent;
+}
+
+.map-modal-background__board-inner .campaign-map-board__image {
+  filter: brightness(1.6) contrast(1.12) saturate(1.12);
+  transition: filter 0.3s ease;
 }
 
 .map-modal-background__overlay {
@@ -120,6 +150,11 @@
   gap: 1rem;
   height: 100%;
   pointer-events: auto;
+  background: rgba(18, 28, 45, 0.58);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--bs-border-radius-xl, 1rem);
+  box-shadow: 0 1.25rem 2.75rem rgba(8, 12, 22, 0.4);
+  backdrop-filter: blur(14px);
 }
 
 .map-modal-background__header-inner {
@@ -150,6 +185,23 @@
   justify-content: flex-end;
 }
 
+.map-modal__list .list-group-item-action {
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.map-modal__list .list-group-item-action:not(.active):hover,
+.map-modal__list .list-group-item-action:not(.active):focus-visible {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border-color: rgba(255, 255, 255, 0.25) !important;
+  transform: translateY(-1px);
+  box-shadow: 0 0.75rem 2rem rgba(8, 12, 20, 0.45);
+}
+
+.map-modal__list .list-group-item-action.active {
+  box-shadow: 0 0.5rem 1.5rem rgba(8, 12, 20, 0.35);
+}
+
 .zombies-character-sheet-layout {
   position: relative;
   min-height: 100vh;
@@ -171,20 +223,20 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.48);
   border-radius: inherit;
   background-image:
     linear-gradient(
       to right,
-      rgba(255, 255, 255, 0.35) 0,
-      rgba(255, 255, 255, 0.35) 1px,
+      rgba(255, 255, 255, 0.42) 0,
+      rgba(255, 255, 255, 0.42) 1px,
       transparent 1px,
       transparent 100%
     ),
     linear-gradient(
       to bottom,
-      rgba(255, 255, 255, 0.35) 0,
-      rgba(255, 255, 255, 0.35) 1px,
+      rgba(255, 255, 255, 0.42) 0,
+      rgba(255, 255, 255, 0.42) 1px,
       transparent 1px,
       transparent 100%
     );


### PR DESCRIPTION
## Summary
- soften the background map backdrop with brighter gradients and highlights
- brighten the campaign board layers, grid, and imagery for better legibility
- ensure the background board layer accepts pointer events so it can be dragged

## Testing
- not run (CSS-only changes)

------
https://chatgpt.com/codex/tasks/task_e_6901491f17b0832e9ce2eccac9387e44