### PR TITLE
Brighten map modal background and overlay contrast

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -28,10 +28,33 @@
   z-index: 0;
   color: #fff;
   overflow: hidden;
-  background-color: #05070c;
+  background-color: #3f5378;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
+}
+
+.map-modal-background::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.38) 0%, rgba(255, 255, 255, 0) 55%),
+    radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.32) 0%, rgba(255, 255, 255, 0) 62%);
+  opacity: 0.82;
+  mix-blend-mode: screen;
+}
+
+.map-modal-background::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(36, 52, 82, 0.16) 0%, rgba(36, 52, 82, 0.18) 45%, rgba(36, 52, 82, 0.1) 100%),
+    radial-gradient(circle at 50% 100%, rgba(58, 80, 118, 0.4) 0%, rgba(58, 80, 118, 0) 60%);
+  mix-blend-mode: screen;
 }
 
 .map-modal-background__board {
@@ -39,7 +62,7 @@
   inset: 0;
   z-index: 1;
   overflow: hidden;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .map-modal-background__board-inner {
@@ -64,7 +87,7 @@
 }
 
 .map-modal-background__board-inner > .map-modal__empty {
-  background: rgba(10, 12, 18, 0.65);
+  background: rgba(17, 23, 33, 0.28);
   border-radius: var(--bs-border-radius-lg, 0.75rem);
   padding: 1.5rem;
 }
@@ -83,9 +106,11 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: transparent;
+  background: linear-gradient(180deg, rgba(44, 62, 94, 0.2), rgba(44, 62, 94, 0.04));
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.2);
   padding: clamp(0.5rem, 1vw, 0.75rem);
-  box-shadow: none;
+  box-shadow: 0 1.5rem 3rem rgba(6, 10, 20, 0.28);
 }
 
 .map-modal-background__board-inner .campaign-map-board__stage {
@@ -98,6 +123,11 @@
   width: 100%;
   height: 100%;
   background: transparent;
+}
+
+.map-modal-background__board-inner .campaign-map-board__image {
+  filter: brightness(2.15) contrast(1.05) saturate(1.2);
+  transition: filter 0.3s ease;
 }
 
 .map-modal-background__overlay {
@@ -120,6 +150,11 @@
   gap: 1rem;
   height: 100%;
   pointer-events: auto;
+  background: rgba(42, 60, 92, 0.34);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: var(--bs-border-radius-xl, 1rem);
+  box-shadow: 0 1.75rem 3.75rem rgba(8, 12, 24, 0.32);
+  backdrop-filter: blur(20px);
 }
 
 .map-modal-background__header-inner {
@@ -150,6 +185,23 @@
   justify-content: flex-end;
 }
 
+.map-modal__list .list-group-item-action {
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.map-modal__list .list-group-item-action:not(.active):hover,
+.map-modal__list .list-group-item-action:not(.active):focus-visible {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border-color: rgba(255, 255, 255, 0.25) !important;
+  transform: translateY(-1px);
+  box-shadow: 0 0.75rem 2rem rgba(8, 12, 20, 0.45);
+}
+
+.map-modal__list .list-group-item-action.active {
+  box-shadow: 0 0.5rem 1.5rem rgba(8, 12, 20, 0.35);
+}
+
 .zombies-character-sheet-layout {
   position: relative;
   min-height: 100vh;
@@ -171,20 +223,20 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.48);
   border-radius: inherit;
   background-image:
     linear-gradient(
       to right,
-      rgba(255, 255, 255, 0.35) 0,
-      rgba(255, 255, 255, 0.35) 1px,
+      rgba(255, 255, 255, 0.42) 0,
+      rgba(255, 255, 255, 0.42) 1px,
       transparent 1px,
       transparent 100%
     ),
     linear-gradient(
       to bottom,
-      rgba(255, 255, 255, 0.35) 0,
-      rgba(255, 255, 255, 0.35) 1px,
+      rgba(255, 255, 255, 0.42) 0,
+      rgba(255, 255, 255, 0.42) 1px,
       transparent 1px,
       transparent 100%
     );


### PR DESCRIPTION
## Summary
- lighten the campaign map background layers so the backdrop is brighter and more legible
- adjust board chrome and map imagery filters to improve contrast while keeping overlays translucent

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_6901491f17b0832e9ce2eccac9387e44