### PR TITLE
Enable campaign map panning and hover labels

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3827,6 +3827,12 @@ h1 {
     height: 100%;
     object-fit: contain;
     object-position: center;
+    transform: translate(
+      var(--campaign-map-pan-x, 0),
+      var(--campaign-map-pan-y, 0)
+    );
+    transition: transform 0.08s ease-out;
+    will-change: transform;
   }
 
   &__tokens-layer {
@@ -3840,6 +3846,12 @@ h1 {
     inset: 0;
     pointer-events: auto;
     z-index: 2;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  &__tokens-layer--panning {
+    cursor: grabbing;
   }
 
   &__token {
@@ -4326,12 +4338,14 @@ h1 {
   }
 
   &__token--label-active,
+  &__token--hovered,
   &__token:hover,
   &__token:focus-visible {
     z-index: 50;
   }
 
   &__token--label-active .campaign-map-board__figurine-label,
+  &__token--hovered .campaign-map-board__figurine-label,
   &__token:hover .campaign-map-board__figurine-label,
   &__token:focus-visible .campaign-map-board__figurine-label {
     opacity: 1;
@@ -4350,6 +4364,10 @@ h1 {
   }
 
   &--disabled &__token--draggable {
+    cursor: default;
+  }
+
+  &--disabled &__tokens-layer {
     cursor: default;
   }
 }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -427,6 +427,28 @@ const ROTATION_STEP_DEGREES = 15;
 
 const TWO_PI = Math.PI * 2;
 
+const MAP_PAN_DRAG_THRESHOLD_PX = 5;
+const MAP_PAN_DRAG_THRESHOLD_SQUARED = MAP_PAN_DRAG_THRESHOLD_PX ** 2;
+
+const resolvePointerValue = (primary, fallback) => {
+  const primaryNumber = Number(primary);
+  if (Number.isFinite(primaryNumber)) {
+    return primaryNumber;
+  }
+
+  const fallbackNumber = Number(fallback);
+  if (Number.isFinite(fallbackNumber)) {
+    return fallbackNumber;
+  }
+
+  return null;
+};
+
+const resolvePointerCoordinates = (event) => ({
+  x: resolvePointerValue(event?.clientX, event?.pageX),
+  y: resolvePointerValue(event?.clientY, event?.pageY),
+});
+
 const normalizeDegrees = (value) => {
   if (value === null || value === undefined || value === '') {
     return 0;
@@ -478,6 +500,10 @@ const CampaignMapBoard = ({
   const [rotationOverrides, setRotationOverrides] = useState({});
   const rotationOverridesRef = useRef({});
   const [draggingRotationTokenId, setDraggingRotationTokenId] = useState(null);
+  const [mapPanOffset, setMapPanOffset] = useState({ x: 0, y: 0 });
+  const mapPanOffsetRef = useRef(mapPanOffset);
+  const mapPanStateRef = useRef(null);
+  const [isMapPanning, setIsMapPanning] = useState(false);
   const tokenPositionsRef = useRef([]);
   const [layerNode, setLayerNode] = useState(null);
   const [figurineImageMetrics, setFigurineImageMetrics] = useState({});
@@ -525,6 +551,43 @@ const CampaignMapBoard = ({
     [map]
   );
   const metadataSquareSize = useMemo(() => resolveSquareSizeFromMetadata(map), [map]);
+
+  useEffect(() => {
+    mapPanOffsetRef.current = mapPanOffset;
+  }, [mapPanOffset]);
+
+  useEffect(() => {
+    const boardElement = boardRef.current;
+    if (!boardElement) {
+      return () => {};
+    }
+
+    boardElement.style.setProperty(
+      '--campaign-map-pan-x',
+      `${mapPanOffset.x}px`
+    );
+    boardElement.style.setProperty(
+      '--campaign-map-pan-y',
+      `${mapPanOffset.y}px`
+    );
+
+    return () => {
+      boardElement.style.removeProperty('--campaign-map-pan-x');
+      boardElement.style.removeProperty('--campaign-map-pan-y');
+    };
+  }, [mapPanOffset]);
+
+  useEffect(() => {
+    mapPanStateRef.current = null;
+    setIsMapPanning(false);
+    setMapPanOffset((prev) => {
+      if (prev.x === 0 && prev.y === 0) {
+        return prev;
+      }
+      return { x: 0, y: 0 };
+    });
+    mapPanOffsetRef.current = { x: 0, y: 0 };
+  }, [imageSrc]);
 
   useEffect(() => {
     const boardElement = boardRef.current;
@@ -858,7 +921,8 @@ const CampaignMapBoard = ({
     (event) => {
       setActiveLabelTokenId(null);
       setLastDraggedTokenId(null);
-      if (interactionDisabled || typeof onBackgroundClick !== 'function') {
+      setHoveredTokenId(null);
+      if (interactionDisabled) {
         return;
       }
 
@@ -866,7 +930,135 @@ const CampaignMapBoard = ({
         return;
       }
 
-      const coords = getNormalizedCoordinates(event.clientX, event.clientY);
+      if (typeof event?.button === 'number' && event.button !== 0) {
+        return;
+      }
+
+      const { x: startX, y: startY } = resolvePointerCoordinates(event);
+      const resolvedStartX = Number.isFinite(startX) ? startX : 0;
+      const resolvedStartY = Number.isFinite(startY) ? startY : 0;
+      const initialCoords =
+        Number.isFinite(startX) && Number.isFinite(startY)
+          ? getNormalizedCoordinates(startX, startY)
+          : null;
+
+      mapPanStateRef.current = {
+        pointerId: event.pointerId,
+        startClientX: resolvedStartX,
+        startClientY: resolvedStartY,
+        originX: mapPanOffsetRef.current.x,
+        originY: mapPanOffsetRef.current.y,
+        initialCoords: initialCoords || null,
+        hasDragged: false,
+        allowBackgroundClick: typeof onBackgroundClick === 'function',
+      };
+
+      if (event.currentTarget.setPointerCapture) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch (error) {
+          // Ignore pointer capture errors (e.g., when unsupported)
+        }
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [getNormalizedCoordinates, interactionDisabled, onBackgroundClick]
+  );
+
+  const handleLayerPointerMove = useCallback((event) => {
+    const panState = mapPanStateRef.current;
+    if (!panState) {
+      return;
+    }
+
+    const { x: currentX, y: currentY } = resolvePointerCoordinates(event);
+    if (!Number.isFinite(currentX) || !Number.isFinite(currentY)) {
+      return;
+    }
+
+    if (
+      panState.pointerId !== undefined &&
+      event.pointerId !== undefined &&
+      panState.pointerId !== event.pointerId
+    ) {
+      return;
+    }
+
+    const deltaX = currentX - panState.startClientX;
+    const deltaY = currentY - panState.startClientY;
+
+    if (!panState.hasDragged) {
+      const distanceSquared = deltaX * deltaX + deltaY * deltaY;
+      if (distanceSquared < MAP_PAN_DRAG_THRESHOLD_SQUARED) {
+        return;
+      }
+
+      panState.hasDragged = true;
+      setIsMapPanning(true);
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const nextX = panState.originX + deltaX;
+    const nextY = panState.originY + deltaY;
+
+    if (
+      nextX === mapPanOffsetRef.current.x &&
+      nextY === mapPanOffsetRef.current.y
+    ) {
+      return;
+    }
+
+    mapPanOffsetRef.current = { x: nextX, y: nextY };
+    setMapPanOffset({ x: nextX, y: nextY });
+  }, []);
+
+  const handleLayerPointerUp = useCallback(
+    (event) => {
+      const panState = mapPanStateRef.current;
+      if (!panState) {
+        return;
+      }
+
+      if (
+        panState.pointerId !== undefined &&
+        event.pointerId !== undefined &&
+        panState.pointerId !== event.pointerId
+      ) {
+        return;
+      }
+
+      if (event.currentTarget.releasePointerCapture) {
+        try {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch (error) {
+          // Ignore release errors – capturing might not be active or supported
+        }
+      }
+
+      mapPanStateRef.current = null;
+      mapPanOffsetRef.current = mapPanOffset;
+      setIsMapPanning(false);
+
+      if (panState.hasDragged) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (!panState.allowBackgroundClick) {
+        return;
+      }
+
+      const { x: upX, y: upY } = resolvePointerCoordinates(event);
+      const resolvedClientX = Number.isFinite(upX) ? upX : panState.startClientX;
+      const resolvedClientY = Number.isFinite(upY) ? upY : panState.startClientY;
+      const coords =
+        getNormalizedCoordinates(resolvedClientX, resolvedClientY) ||
+        panState.initialCoords;
       if (!coords) {
         return;
       }
@@ -875,12 +1067,36 @@ const CampaignMapBoard = ({
       event.stopPropagation();
       onBackgroundClick(coords);
     },
-    [
-      getNormalizedCoordinates,
-      interactionDisabled,
-      onBackgroundClick,
-      setActiveLabelTokenId,
-    ]
+    [getNormalizedCoordinates, mapPanOffset, onBackgroundClick]
+  );
+
+  const handleLayerPointerCancel = useCallback(
+    (event) => {
+      const panState = mapPanStateRef.current;
+      if (!panState) {
+        return;
+      }
+
+      if (
+        panState.pointerId !== undefined &&
+        event.pointerId !== undefined &&
+        panState.pointerId !== event.pointerId
+      ) {
+        return;
+      }
+
+      if (event.currentTarget.releasePointerCapture) {
+        try {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch (error) {
+          // Ignore release errors – capturing might not be active or supported
+        }
+      }
+
+      mapPanStateRef.current = null;
+      setIsMapPanning(false);
+    },
+    []
   );
 
   const getResolvedRotationForToken = useCallback(
@@ -1385,9 +1601,15 @@ const CampaignMapBoard = ({
             <img src={imageSrc} alt={altText} className="campaign-map-board__image" />
             <div className="campaign-map-board__grid-overlay" aria-hidden="true" />
             <div
-              className="campaign-map-board__tokens-layer"
+              className={classNames(
+                'campaign-map-board__tokens-layer',
+                isMapPanning && 'campaign-map-board__tokens-layer--panning'
+              )}
               ref={handleLayerRef}
               onPointerDown={handleLayerPointerDown}
+              onPointerMove={handleLayerPointerMove}
+              onPointerUp={handleLayerPointerUp}
+              onPointerCancel={handleLayerPointerCancel}
             >
               {tokenPositions.map((token, tokenIndex) => {
                 const {
@@ -1482,6 +1704,8 @@ const CampaignMapBoard = ({
                       'campaign-map-board__token',
                       draggable && 'campaign-map-board__token--draggable',
                       isLabelActive && 'campaign-map-board__token--label-active',
+                      hoveredTokenId === characterId &&
+                        'campaign-map-board__token--hovered',
                       isActiveTurn && 'campaign-map-board__token--active-turn',
                       `campaign-map-board__token--size-${sizeKey}`,
                       isRotationActive && 'lastDragged',

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -27,6 +27,7 @@ describe('CampaignMapBoard pointer interactions', () => {
         onTokenDrag={overrides.onTokenDrag}
         onTokenDragEnd={overrides.onTokenDragEnd}
         onTokenPositionChange={overrides.onTokenPositionChange}
+        onBackgroundClick={overrides.onBackgroundClick}
         onTokenRemove={overrides.onTokenRemove}
       />
     );
@@ -92,6 +93,62 @@ describe('CampaignMapBoard pointer interactions', () => {
     fireEvent(tokenElement, pointerUpEvent);
 
     expect(pointerUpEvent.defaultPrevented).toBe(false);
+  });
+
+  it('fires onBackgroundClick when the background is clicked without dragging', () => {
+    const onBackgroundClick = jest.fn();
+    const { container } = renderBoard({ onBackgroundClick });
+
+    const layer = container.querySelector('.campaign-map-board__tokens-layer');
+    expect(layer).not.toBeNull();
+    if (!layer) {
+      return;
+    }
+
+    layer.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 400,
+    });
+
+    const pointerDownEvent = createEvent.pointerDown(layer, {
+      button: 0,
+      pointerId: 10,
+      clientX: 200,
+      clientY: 200,
+      pageX: 200,
+      pageY: 200,
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(layer, pointerDownEvent);
+
+    const pointerUpEvent = createEvent.pointerUp(layer, {
+      button: 0,
+      pointerId: 10,
+      clientX: 200,
+      clientY: 200,
+      pageX: 200,
+      pageY: 200,
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(layer, pointerUpEvent);
+
+    expect(onBackgroundClick).toHaveBeenCalledTimes(1);
+    const [coords] = onBackgroundClick.mock.calls[0];
+    expect(coords).toEqual(
+      expect.objectContaining({
+        x: expect.any(Number),
+        y: expect.any(Number),
+      })
+    );
+    expect(coords.x).toBeGreaterThanOrEqual(0);
+    expect(coords.x).toBeLessThanOrEqual(1);
+    expect(coords.y).toBeGreaterThanOrEqual(0);
+    expect(coords.y).toBeLessThanOrEqual(1);
+    expect(pointerUpEvent.defaultPrevented).toBe(true);
   });
 
   it('supports dragging with the primary pointer button', () => {


### PR DESCRIPTION
## Summary
- allow campaign map background to pan with pointer dragging and reset offsets when the image changes
- surface figurine names on hover with a dedicated state class and update board styling with grab cursors
- add a regression test that covers background click behavior

## Testing
- CI=true npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js

------
https://chatgpt.com/codex/tasks/task_e_69015ac8ce50832ea257dcf679f35766