### PR TITLE
Enable interactions on background map overlay

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -211,6 +211,12 @@
   position: fixed;
   inset: 0;
   z-index: 0;
+  pointer-events: none;
+}
+
+.zombies-character-sheet-layout__map--interactive {
+  z-index: 3;
+  pointer-events: auto;
 }
 
 .zombies-character-sheet-layout__content {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -62,6 +62,7 @@ import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
 import buildPlayerTokenFolderScope from '../utils/playerTokenFilters';
+import classNames from '../../../utils/classNames';
 
 const HEADER_PADDING = 16;
 const MIN_DOCKED_MODAL_WIDTH = 320;
@@ -5541,7 +5542,14 @@ export default function ZombiesCharacterSheet() {
       .filter(Boolean);
   }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
-  const mapLayerClassName = 'zombies-character-sheet-layout__map';
+  const mapLayerClassName = useMemo(
+    () =>
+      classNames(
+        'zombies-character-sheet-layout__map',
+        shouldShowMapModal && 'zombies-character-sheet-layout__map--interactive'
+      ),
+    [shouldShowMapModal]
+  );
 
   return (
     <div className="zombies-character-sheet-layout">


### PR DESCRIPTION
## Summary
- raise the background campaign map layer above the sheet when the map modal is shown so pointer interactions work
- gate pointer events on the background map to the modal state so the rest of the UI stays usable when the map is hidden

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690162acd550832e855386b97fa692ba