### PR TITLE
Restore interactions on background campaign map

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -211,6 +211,11 @@
   position: fixed;
   inset: 0;
   z-index: 0;
+  pointer-events: auto;
+}
+
+.zombies-character-sheet-layout__map--overlay-visible {
+  z-index: 3;
 }
 
 .zombies-character-sheet-layout__content {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -62,6 +62,7 @@ import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
 import buildPlayerTokenFolderScope from '../utils/playerTokenFilters';
+import classNames from '../../../utils/classNames';
 
 const HEADER_PADDING = 16;
 const MIN_DOCKED_MODAL_WIDTH = 320;
@@ -5541,7 +5542,14 @@ export default function ZombiesCharacterSheet() {
       .filter(Boolean);
   }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
-  const mapLayerClassName = 'zombies-character-sheet-layout__map';
+  const mapLayerClassName = useMemo(
+    () =>
+      classNames(
+        'zombies-character-sheet-layout__map',
+        shouldShowMapModal && 'zombies-character-sheet-layout__map--overlay-visible'
+      ),
+    [shouldShowMapModal]
+  );
 
   return (
     <div className="zombies-character-sheet-layout">


### PR DESCRIPTION
## Summary
- allow the background campaign map layer to stay interactive so figurine hover, drag, and panning behave like the modal view
- only raise the map layer above the sheet when the overlay is visible to keep the rest of the UI usable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690162acd550832e855386b97fa692ba