### PR TITLE
Separate background map view from modal display

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5555,6 +5555,19 @@ export default function ZombiesCharacterSheet() {
     <div className="zombies-character-sheet-layout">
       <div className={mapLayerClassName}>
         <MapModal
+          show={false}
+          map={campaignMap}
+          maps={campaignMaps}
+          activeMapId={campaignActiveMapId}
+          tokensByMapId={modalTokensByMapId}
+          currentCharacterId={resolvedCharacterId}
+          activeCharacterId={activeTurnParticipantId}
+          characterLookup={tokenMetaById}
+          onTokenMove={shouldShowMapModal ? undefined : handleTokenMove}
+          onTokenRemove={shouldShowMapModal ? undefined : handleTokenRemove}
+          displayMode="background"
+        />
+        <MapModal
           show={shouldShowMapModal}
           onHide={handleCloseMapModal}
           map={campaignMap}
@@ -5568,7 +5581,6 @@ export default function ZombiesCharacterSheet() {
           onTokenRemove={handleTokenRemove}
           dockedSide={getDockedSide('map')}
           onDockChange={(side) => handleDockChange('map', side)}
-          displayMode="background"
         />
       </div>
       <div


### PR DESCRIPTION
## Summary
- render a dedicated MapModal instance to drive the campaign background without opening the modal overlay
- keep the modal-based MapModal for map management interactions on the character sheet

## Testing
- npm test -- MapModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_69016810ebb4832e999daeac67b40694