### PR TITLE
Add interactive map overlay to character sheet

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -51,6 +51,74 @@
   z-index: 1;
 }
 
+.zombies-character-sheet__map-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1040;
+  background: linear-gradient(180deg, rgba(4, 4, 4, 0.92) 0%, rgba(4, 4, 4, 0.98) 100%);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.zombies-character-sheet__map-overlay-header {
+  width: min(100%, 960px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: #f8f9fa;
+}
+
+.zombies-character-sheet__map-overlay-title {
+  margin: 0;
+  font-family: 'Raleway', sans-serif;
+  font-weight: 600;
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  letter-spacing: 0.02em;
+}
+
+.zombies-character-sheet__map-overlay-close {
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #f8f9fa;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.zombies-character-sheet__map-overlay-close:hover,
+.zombies-character-sheet__map-overlay-close:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.zombies-character-sheet__map-overlay-board {
+  width: min(100%, 960px);
+  height: min(80vh, 960px);
+  display: flex;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.6);
+  background: rgba(18, 18, 18, 0.9);
+}
+
+.zombies-character-sheet__map-overlay-board .campaign-map-board {
+  flex: 1 1 auto;
+}
+
+.zombies-character-sheet__map-overlay-launcher {
+  margin: 0.5rem 0 1rem;
+  display: flex;
+  justify-content: center;
+}
+
 .map-modal__saving-indicator {
   position: absolute;
   inset: auto 0 0 0;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5314,6 +5314,33 @@ export default function ZombiesCharacterSheet() {
   const diceBoxFailed = diceBoxStatus.failed;
   const shouldShowDiceLoadingOverlay =
     isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed;
+  const [isMapOverlayOpen, setIsMapOverlayOpen] = useState(false);
+  const openMapOverlay = useCallback(() => {
+    setIsMapOverlayOpen(true);
+  }, []);
+  const closeMapOverlay = useCallback(() => {
+    setIsMapOverlayOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isMapOverlayOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event?.key === 'Escape') {
+        event.preventDefault();
+        closeMapOverlay();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeMapOverlay, isMapOverlayOpen]);
+
   const mapBackgroundImage = useMemo(
     () => buildMapBackgroundImageSource(campaignMap),
     [campaignMap]
@@ -5362,6 +5389,12 @@ export default function ZombiesCharacterSheet() {
       imageUrl: loginbg,
     };
   }, [campaignMap, mapBackgroundImage]);
+
+  useEffect(() => {
+    if (isMapOverlayOpen && !mapBoardMap) {
+      setIsMapOverlayOpen(false);
+    }
+  }, [isMapOverlayOpen, mapBoardMap]);
 
   const activeCampaignMapId = useMemo(() => {
     if (typeof campaignMap?.mapId !== 'string') {
@@ -5946,7 +5979,7 @@ export default function ZombiesCharacterSheet() {
               map={mapBoardMap}
               tokens={mapBoardTokens}
               className="campaign-map-board--background"
-              disabled={mapInteractionPending}
+              disabled={mapInteractionPending || isMapOverlayOpen}
               onTokenPositionChange={handleMapBoardTokenPositionChange}
               onBackgroundClick={handleMapBoardBackgroundClick}
               onTokenRemove={handleMapBoardTokenRemove}
@@ -5975,6 +6008,30 @@ export default function ZombiesCharacterSheet() {
           }}
         />
       </div>
+      {isMapOverlayOpen && mapBoardMap && (
+        <div className="zombies-character-sheet__map-overlay" role="dialog" aria-modal="true">
+          <div className="zombies-character-sheet__map-overlay-header">
+            <h2 className="zombies-character-sheet__map-overlay-title">Campaign Map</h2>
+            <button
+              type="button"
+              className="zombies-character-sheet__map-overlay-close"
+              onClick={closeMapOverlay}
+            >
+              Close
+            </button>
+          </div>
+          <div className="zombies-character-sheet__map-overlay-board">
+            <CampaignMapBoard
+              map={mapBoardMap}
+              tokens={mapBoardTokens}
+              disabled={mapInteractionPending}
+              onTokenPositionChange={handleMapBoardTokenPositionChange}
+              onBackgroundClick={handleMapBoardBackgroundClick}
+              onTokenRemove={handleMapBoardTokenRemove}
+            />
+          </div>
+        </div>
+      )}
       <div
         ref={contentColumnRef}
         className="zombies-character-sheet__content"
@@ -6016,6 +6073,18 @@ export default function ZombiesCharacterSheet() {
                   tokenLookup={tokenMetaById}
                 />
               </div>
+              {mapBoardMap && (
+                <div className="zombies-character-sheet__map-overlay-launcher">
+                  <button
+                    type="button"
+                    className="btn btn-outline-light btn-sm"
+                    onClick={openMapOverlay}
+                    disabled={isMapOverlayOpen}
+                  >
+                    Open Interactive Map
+                  </button>
+                </div>
+              )}
               <h1
                 style={{
                   fontSize: "28px",


### PR DESCRIPTION
## Summary
- add state and handlers so the character sheet can open a dedicated interactive campaign map overlay
- disable background map interactions while the overlay is active and expose a launcher control in the header
- style the fullscreen overlay container, header, close button, and embedded board for consistent presentation

## Testing
- npm test -- ZombiesCharacterSheet.test.js --watch=false *(fails: existing act warnings and figurine button lookup in ZombiesCharacterSheet.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_69016c746a04832ebe7da466366d81c4