### PR TITLE
Improve campaign map access from character sheet

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -51,6 +51,91 @@
   z-index: 1;
 }
 
+.zombies-character-sheet__map-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1040;
+  background: linear-gradient(180deg, rgba(4, 4, 4, 0.92) 0%, rgba(4, 4, 4, 0.98) 100%);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.zombies-character-sheet__map-overlay-header {
+  width: min(100%, 960px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: #f8f9fa;
+}
+
+.zombies-character-sheet__map-overlay-title {
+  margin: 0;
+  font-family: 'Raleway', sans-serif;
+  font-weight: 600;
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  letter-spacing: 0.02em;
+}
+
+.zombies-character-sheet__map-overlay-close {
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #f8f9fa;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.zombies-character-sheet__map-overlay-close:hover,
+.zombies-character-sheet__map-overlay-close:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.zombies-character-sheet__map-overlay-board {
+  width: min(100%, 960px);
+  height: min(80vh, 960px);
+  display: flex;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.6);
+  background: rgba(18, 18, 18, 0.9);
+}
+
+.zombies-character-sheet__map-overlay-board .campaign-map-board {
+  flex: 1 1 auto;
+}
+
+.zombies-character-sheet__map-overlay-launcher {
+  margin: 0.5rem 0 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.zombies-character-sheet__map-overlay-hint {
+  color: rgba(248, 249, 250, 0.7);
+  text-align: center;
+}
+
+.zombies-character-sheet__map-backdrop--interactive {
+  cursor: pointer;
+}
+
+.zombies-character-sheet__map-backdrop--interactive:focus-visible {
+  outline: 2px solid rgba(248, 249, 250, 0.65);
+  outline-offset: -4px;
+}
+
 .map-modal__saving-indicator {
   position: absolute;
   inset: auto 0 0 0;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6,6 +6,7 @@ import { useParams } from "react-router-dom";
 import { Nav, Navbar, Container, Button } from 'react-bootstrap';
 import '../../../App.scss';
 import loginbg from "../../../images/loginbg.png";
+import classNames from "../../../utils/classNames";
 import CharacterInfo from "../attributes/CharacterInfo";
 import Stats from "../attributes/Stats";
 import Skills from "../attributes/Skills";
@@ -82,6 +83,7 @@ const DOCKABLE_MODAL_DEFINITIONS = {
   help: { label: 'Help', component: Help },
 };
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
+const MAP_OVERLAY_DISMISSAL_STORAGE_KEY = 'zombiesCharacterSheet.mapOverlayDismissed';
 
 const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
 
@@ -5314,6 +5316,85 @@ export default function ZombiesCharacterSheet() {
   const diceBoxFailed = diceBoxStatus.failed;
   const shouldShowDiceLoadingOverlay =
     isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed;
+  const [isMapOverlayOpen, setIsMapOverlayOpen] = useState(false);
+  const [shouldAutoOpenMapOverlay, setShouldAutoOpenMapOverlay] = useState(false);
+  const hasAutoOpenedMapOverlayRef = useRef(false);
+  const mapOverlayCloseButtonRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      setShouldAutoOpenMapOverlay(false);
+      return;
+    }
+
+    try {
+      const storedValue = window.sessionStorage.getItem(
+        MAP_OVERLAY_DISMISSAL_STORAGE_KEY
+      );
+      setShouldAutoOpenMapOverlay(storedValue !== 'true');
+    } catch (error) {
+      setShouldAutoOpenMapOverlay(true);
+    }
+  }, []);
+
+  const openMapOverlay = useCallback(() => {
+    hasAutoOpenedMapOverlayRef.current = true;
+    setIsMapOverlayOpen(true);
+    if (typeof window !== 'undefined') {
+      try {
+        window.sessionStorage.removeItem(MAP_OVERLAY_DISMISSAL_STORAGE_KEY);
+      } catch (error) {
+        // Ignore storage errors (e.g., in private browsing)
+      }
+    }
+  }, []);
+
+  const closeMapOverlay = useCallback(() => {
+    setIsMapOverlayOpen(false);
+    hasAutoOpenedMapOverlayRef.current = true;
+    if (typeof window !== 'undefined') {
+      try {
+        window.sessionStorage.setItem(MAP_OVERLAY_DISMISSAL_STORAGE_KEY, 'true');
+      } catch (error) {
+        // Ignore storage errors (e.g., in private browsing)
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isMapOverlayOpen) {
+      return;
+    }
+
+    const target = mapOverlayCloseButtonRef.current;
+    if (target && typeof target.focus === 'function') {
+      try {
+        target.focus({ preventScroll: true });
+      } catch (error) {
+        target.focus();
+      }
+    }
+  }, [isMapOverlayOpen]);
+
+  useEffect(() => {
+    if (!isMapOverlayOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event?.key === 'Escape') {
+        event.preventDefault();
+        closeMapOverlay();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeMapOverlay, isMapOverlayOpen]);
+
   const mapBackgroundImage = useMemo(
     () => buildMapBackgroundImageSource(campaignMap),
     [campaignMap]
@@ -5362,6 +5443,57 @@ export default function ZombiesCharacterSheet() {
       imageUrl: loginbg,
     };
   }, [campaignMap, mapBackgroundImage]);
+
+  useEffect(() => {
+    if (
+      !mapBoardMap ||
+      isMapOverlayOpen ||
+      hasAutoOpenedMapOverlayRef.current ||
+      !shouldAutoOpenMapOverlay
+    ) {
+      return;
+    }
+
+    hasAutoOpenedMapOverlayRef.current = true;
+    setIsMapOverlayOpen(true);
+  }, [isMapOverlayOpen, mapBoardMap, shouldAutoOpenMapOverlay]);
+
+  useEffect(() => {
+    if (isMapOverlayOpen && !mapBoardMap) {
+      setIsMapOverlayOpen(false);
+    }
+  }, [isMapOverlayOpen, mapBoardMap]);
+
+  const handleMapBackdropPointerDown = useCallback(
+    (event) => {
+      if (isMapOverlayOpen || !mapBoardMap) {
+        return;
+      }
+
+      if (event && typeof event.button === 'number' && event.button !== 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      openMapOverlay();
+    },
+    [isMapOverlayOpen, mapBoardMap, openMapOverlay]
+  );
+
+  const handleMapBackdropKeyDown = useCallback(
+    (event) => {
+      if (isMapOverlayOpen || !mapBoardMap) {
+        return;
+      }
+
+      if (event?.key === 'Enter' || event?.key === ' ' || event?.key === 'Spacebar') {
+        event.preventDefault();
+        openMapOverlay();
+      }
+    },
+    [isMapOverlayOpen, mapBoardMap, openMapOverlay]
+  );
 
   const activeCampaignMapId = useMemo(() => {
     if (typeof campaignMap?.mapId !== 'string') {
@@ -5922,7 +6054,19 @@ export default function ZombiesCharacterSheet() {
       }}
     >
       <div
-        className="zombies-character-sheet__map-backdrop"
+        className={classNames(
+          'zombies-character-sheet__map-backdrop',
+          mapBoardMap && !isMapOverlayOpen && 'zombies-character-sheet__map-backdrop--interactive'
+        )}
+        role={mapBoardMap ? 'button' : undefined}
+        tabIndex={mapBoardMap && !isMapOverlayOpen ? 0 : -1}
+        aria-label={
+          mapBoardMap && !isMapOverlayOpen
+            ? 'Open interactive campaign map controls'
+            : undefined
+        }
+        onPointerDownCapture={handleMapBackdropPointerDown}
+        onKeyDown={handleMapBackdropKeyDown}
         style={{
           position: 'absolute',
           inset: 0,
@@ -5946,7 +6090,7 @@ export default function ZombiesCharacterSheet() {
               map={mapBoardMap}
               tokens={mapBoardTokens}
               className="campaign-map-board--background"
-              disabled={mapInteractionPending}
+              disabled={mapInteractionPending || isMapOverlayOpen}
               onTokenPositionChange={handleMapBoardTokenPositionChange}
               onBackgroundClick={handleMapBoardBackgroundClick}
               onTokenRemove={handleMapBoardTokenRemove}
@@ -5975,6 +6119,31 @@ export default function ZombiesCharacterSheet() {
           }}
         />
       </div>
+      {isMapOverlayOpen && mapBoardMap && (
+        <div className="zombies-character-sheet__map-overlay" role="dialog" aria-modal="true">
+          <div className="zombies-character-sheet__map-overlay-header">
+            <h2 className="zombies-character-sheet__map-overlay-title">Campaign Map</h2>
+            <button
+              type="button"
+              className="zombies-character-sheet__map-overlay-close"
+              ref={mapOverlayCloseButtonRef}
+              onClick={closeMapOverlay}
+            >
+              Close
+            </button>
+          </div>
+          <div className="zombies-character-sheet__map-overlay-board">
+            <CampaignMapBoard
+              map={mapBoardMap}
+              tokens={mapBoardTokens}
+              disabled={mapInteractionPending}
+              onTokenPositionChange={handleMapBoardTokenPositionChange}
+              onBackgroundClick={handleMapBoardBackgroundClick}
+              onTokenRemove={handleMapBoardTokenRemove}
+            />
+          </div>
+        </div>
+      )}
       <div
         ref={contentColumnRef}
         className="zombies-character-sheet__content"
@@ -6016,6 +6185,21 @@ export default function ZombiesCharacterSheet() {
                   tokenLookup={tokenMetaById}
                 />
               </div>
+              {mapBoardMap && (
+                <div className="zombies-character-sheet__map-overlay-launcher">
+                  <button
+                    type="button"
+                    className="btn btn-outline-light btn-sm"
+                    onClick={openMapOverlay}
+                    disabled={isMapOverlayOpen}
+                  >
+                    Open Interactive Map
+                  </button>
+                  <div className="zombies-character-sheet__map-overlay-hint text-muted small">
+                    Click or tap the map background to enter the interactive view.
+                  </div>
+                </div>
+              )}
               <h1
                 style={{
                   fontSize: "28px",


### PR DESCRIPTION
## Summary
- persist an overlay dismissal preference and automatically surface the interactive map when a campaign board loads
- make the background map container clickable/keyboard accessible to open the overlay and focus the close control on launch
- refresh launcher styling with helper text and interactive cursor affordances for the background map

## Testing
- npm test -- ZombiesCharacterSheet.test.js --watch=false *(fails: known ZombiesCharacterSheet tests require act-wrapped updates and time out while looking for legacy figurine controls)*

------
https://chatgpt.com/codex/tasks/task_e_69016c746a04832ebe7da466366d81c4