### PR TITLE
Add pointer event fallbacks for background map interactions

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
+import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
+import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -479,6 +481,7 @@ const CampaignMapBoard = ({
   className,
   children,
 }) => {
+  const pointerEventsSupported = usePointerEventsSupported();
   const safeMap = map && typeof map === 'object' ? map : {};
   const title = normalizeText(safeMap.title);
   const altText =
@@ -790,7 +793,10 @@ const CampaignMapBoard = ({
         onTokenDragStart({ token, characterId });
       }
 
-      if (event.currentTarget.setPointerCapture) {
+      if (
+        event.pointerId !== undefined &&
+        event.currentTarget.setPointerCapture
+      ) {
         try {
           event.currentTarget.setPointerCapture(event.pointerId);
         } catch (error) {
@@ -1018,7 +1024,10 @@ const CampaignMapBoard = ({
         return;
       }
 
-      if (event.currentTarget.releasePointerCapture) {
+      if (
+        event.pointerId !== undefined &&
+        event.currentTarget.releasePointerCapture
+      ) {
         try {
           event.currentTarget.releasePointerCapture(event.pointerId);
         } catch (error) {
@@ -1072,7 +1081,10 @@ const CampaignMapBoard = ({
         return;
       }
 
-      if (event.currentTarget.releasePointerCapture) {
+      if (
+        event.pointerId !== undefined &&
+        event.currentTarget.releasePointerCapture
+      ) {
         try {
           event.currentTarget.releasePointerCapture(event.pointerId);
         } catch (error) {
@@ -1129,7 +1141,17 @@ const CampaignMapBoard = ({
     if (rotationMoveHandlerRef.current) {
       targets.forEach((target) => {
         if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointermove', rotationMoveHandlerRef.current);
+          if (pointerEventsSupported) {
+            target.removeEventListener('pointermove', rotationMoveHandlerRef.current);
+          } else {
+            const handlers = rotationMoveHandlerRef.current;
+            if (handlers?.mouse) {
+              target.removeEventListener('mousemove', handlers.mouse);
+            }
+            if (handlers?.touch) {
+              target.removeEventListener('touchmove', handlers.touch);
+            }
+          }
         }
       });
       rotationMoveHandlerRef.current = null;
@@ -1138,7 +1160,17 @@ const CampaignMapBoard = ({
     if (rotationUpHandlerRef.current) {
       targets.forEach((target) => {
         if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointerup', rotationUpHandlerRef.current);
+          if (pointerEventsSupported) {
+            target.removeEventListener('pointerup', rotationUpHandlerRef.current);
+          } else {
+            const handlers = rotationUpHandlerRef.current;
+            if (handlers?.mouse) {
+              target.removeEventListener('mouseup', handlers.mouse);
+            }
+            if (handlers?.touch) {
+              target.removeEventListener('touchend', handlers.touch);
+            }
+          }
         }
       });
       rotationUpHandlerRef.current = null;
@@ -1147,7 +1179,18 @@ const CampaignMapBoard = ({
     if (rotationCancelHandlerRef.current) {
       targets.forEach((target) => {
         if (target && typeof target.removeEventListener === 'function') {
-          target.removeEventListener('pointercancel', rotationCancelHandlerRef.current);
+          if (pointerEventsSupported) {
+            target.removeEventListener('pointercancel', rotationCancelHandlerRef.current);
+          } else {
+            const handlers = rotationCancelHandlerRef.current;
+            if (handlers?.mouse) {
+              target.removeEventListener('mouseleave', handlers.mouse);
+              target.removeEventListener('mouseout', handlers.mouse);
+            }
+            if (handlers?.touch) {
+              target.removeEventListener('touchcancel', handlers.touch);
+            }
+          }
         }
       });
       rotationCancelHandlerRef.current = null;
@@ -1155,7 +1198,7 @@ const CampaignMapBoard = ({
 
     rotationDragStateRef.current = null;
     setDraggingRotationTokenId(null);
-  }, [setDraggingRotationTokenId]);
+  }, [pointerEventsSupported, setDraggingRotationTokenId]);
 
   useEffect(() => () => stopRotationDrag(), [stopRotationDrag]);
 
@@ -1479,9 +1522,24 @@ const CampaignMapBoard = ({
         stopRotationDrag();
       };
 
-      rotationMoveHandlerRef.current = handleMove;
-      rotationUpHandlerRef.current = handleRelease;
-      rotationCancelHandlerRef.current = handleCancel;
+      if (pointerEventsSupported) {
+        rotationMoveHandlerRef.current = handleMove;
+        rotationUpHandlerRef.current = handleRelease;
+        rotationCancelHandlerRef.current = handleCancel;
+      } else {
+        rotationMoveHandlerRef.current = {
+          mouse: (ev) => handleMove(enhanceMouseEvent(ev)),
+          touch: (ev) => handleMove(enhanceTouchEvent(ev)),
+        };
+        rotationUpHandlerRef.current = {
+          mouse: (ev) => handleRelease(enhanceMouseEvent(ev)),
+          touch: (ev) => handleRelease(enhanceTouchEvent(ev)),
+        };
+        rotationCancelHandlerRef.current = {
+          mouse: (ev) => handleCancel(enhanceMouseEvent(ev)),
+          touch: (ev) => handleCancel(enhanceTouchEvent(ev)),
+        };
+      }
 
       const targets = [];
       if (typeof window !== 'undefined') {
@@ -1493,9 +1551,51 @@ const CampaignMapBoard = ({
 
       targets.forEach((target) => {
         if (target && typeof target.addEventListener === 'function') {
-          target.addEventListener('pointermove', handleMove, { passive: false });
-          target.addEventListener('pointerup', handleRelease, { passive: false });
-          target.addEventListener('pointercancel', handleCancel, { passive: false });
+          if (pointerEventsSupported) {
+            target.addEventListener('pointermove', handleMove, { passive: false });
+            target.addEventListener('pointerup', handleRelease, { passive: false });
+            target.addEventListener('pointercancel', handleCancel, { passive: false });
+          } else {
+            const moveHandlers = rotationMoveHandlerRef.current;
+            const upHandlers = rotationUpHandlerRef.current;
+            const cancelHandlers = rotationCancelHandlerRef.current;
+
+            if (moveHandlers?.mouse) {
+              target.addEventListener('mousemove', moveHandlers.mouse, {
+                passive: false,
+              });
+            }
+            if (moveHandlers?.touch) {
+              target.addEventListener('touchmove', moveHandlers.touch, {
+                passive: false,
+              });
+            }
+
+            if (upHandlers?.mouse) {
+              target.addEventListener('mouseup', upHandlers.mouse, {
+                passive: false,
+              });
+            }
+            if (upHandlers?.touch) {
+              target.addEventListener('touchend', upHandlers.touch, {
+                passive: false,
+              });
+            }
+
+            if (cancelHandlers?.mouse) {
+              target.addEventListener('mouseleave', cancelHandlers.mouse, {
+                passive: false,
+              });
+              target.addEventListener('mouseout', cancelHandlers.mouse, {
+                passive: false,
+              });
+            }
+            if (cancelHandlers?.touch) {
+              target.addEventListener('touchcancel', cancelHandlers.touch, {
+                passive: false,
+              });
+            }
+          }
         }
       });
 
@@ -1507,6 +1607,7 @@ const CampaignMapBoard = ({
     [
       applyTokenRotation,
       interactionDisabled,
+      pointerEventsSupported,
       previewTokenRotation,
       setDraggingRotationTokenId,
       setHoveredTokenId,
@@ -1597,6 +1698,54 @@ const CampaignMapBoard = ({
               onPointerMove={handleLayerPointerMove}
               onPointerUp={handleLayerPointerUp}
               onPointerCancel={handleLayerPointerCancel}
+              onMouseDown={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerDown(enhanceMouseEvent(event));
+              }}
+              onMouseMove={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerMove(enhanceMouseEvent(event));
+              }}
+              onMouseUp={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerUp(enhanceMouseEvent(event));
+              }}
+              onMouseLeave={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerCancel(enhanceMouseEvent(event));
+              }}
+              onTouchStart={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerDown(enhanceTouchEvent(event));
+              }}
+              onTouchMove={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerMove(enhanceTouchEvent(event));
+              }}
+              onTouchEnd={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerUp(enhanceTouchEvent(event));
+              }}
+              onTouchCancel={(event) => {
+                if (pointerEventsSupported) {
+                  return;
+                }
+                handleLayerPointerCancel(enhanceTouchEvent(event));
+              }}
             >
               {tokenPositions.map((token, tokenIndex) => {
                 const {
@@ -1747,6 +1896,102 @@ const CampaignMapBoard = ({
                       }
                       setHoveredTokenId((prev) => (prev === characterId ? null : prev));
                     }}
+                    onMouseDown={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      const adapted = enhanceMouseEvent(event);
+                      if (characterId) {
+                        setActiveLabelTokenId(characterId);
+                      }
+                      handlePointerDown(adapted, token);
+                    }}
+                    onMouseMove={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      handlePointerMove(enhanceMouseEvent(event));
+                    }}
+                    onMouseUp={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      const adapted = enhanceMouseEvent(event);
+                      setActiveLabelTokenId((prev) =>
+                        prev === characterId ? null : prev
+                      );
+                      handlePointerUp(adapted);
+                    }}
+                    onMouseLeave={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      if (
+                        draggingRotationTokenId === characterId ||
+                        (event?.relatedTarget &&
+                          event.currentTarget &&
+                          event.currentTarget.contains(event.relatedTarget))
+                      ) {
+                        return;
+                      }
+                      setHoveredTokenId((prev) => (prev === characterId ? null : prev));
+                      handlePointerCancel(enhanceMouseEvent(event));
+                    }}
+                    onMouseOver={() => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      if (!interactionDisabled && characterId) {
+                        setHoveredTokenId(characterId);
+                      }
+                    }}
+                    onMouseEnter={() => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      if (!interactionDisabled && characterId) {
+                        setHoveredTokenId(characterId);
+                      }
+                    }}
+                    onTouchStart={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      const adapted = enhanceTouchEvent(event);
+                      if (characterId) {
+                        setActiveLabelTokenId(characterId);
+                        setHoveredTokenId(characterId);
+                      }
+                      handlePointerDown(adapted, token);
+                    }}
+                    onTouchMove={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      handlePointerMove(enhanceTouchEvent(event));
+                    }}
+                    onTouchEnd={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      const adapted = enhanceTouchEvent(event);
+                      setActiveLabelTokenId((prev) =>
+                        prev === characterId ? null : prev
+                      );
+                      setHoveredTokenId((prev) => (prev === characterId ? null : prev));
+                      handlePointerUp(adapted);
+                    }}
+                    onTouchCancel={(event) => {
+                      if (pointerEventsSupported) {
+                        return;
+                      }
+                      const adapted = enhanceTouchEvent(event);
+                      setActiveLabelTokenId((prev) =>
+                        prev === characterId ? null : prev
+                      );
+                      setHoveredTokenId((prev) => (prev === characterId ? null : prev));
+                      handlePointerCancel(adapted);
+                    }}
                     onContextMenu={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
@@ -1870,6 +2115,36 @@ const CampaignMapBoard = ({
                             event.stopPropagation();
                           }
                         }}
+                        onMouseDown={(event) => {
+                          if (!pointerEventsSupported) {
+                            event.stopPropagation();
+                          }
+                        }}
+                        onMouseMove={(event) => {
+                          if (!pointerEventsSupported && !isRotationDragging) {
+                            event.stopPropagation();
+                          }
+                        }}
+                        onMouseUp={(event) => {
+                          if (!pointerEventsSupported && !isRotationDragging) {
+                            event.stopPropagation();
+                          }
+                        }}
+                        onTouchStart={(event) => {
+                          if (!pointerEventsSupported) {
+                            event.stopPropagation();
+                          }
+                        }}
+                        onTouchMove={(event) => {
+                          if (!pointerEventsSupported && !isRotationDragging) {
+                            event.stopPropagation();
+                          }
+                        }}
+                        onTouchEnd={(event) => {
+                          if (!pointerEventsSupported && !isRotationDragging) {
+                            event.stopPropagation();
+                          }
+                        }}
                       >
                         <div className="campaign-map-board__rotation-handle-track">
                           <button
@@ -1883,10 +2158,66 @@ const CampaignMapBoard = ({
                             onPointerDown={(event) =>
                               handleRotationHandlePointerDown(event, characterId, rotationValue)
                             }
+                            onPointerUp={(event) => {
+                              event.stopPropagation();
+                              lockRotation(characterId);
+                            }}
+                            onPointerCancel={(event) => {
+                              event.stopPropagation();
+                              stopRotationDrag();
+                            }}
                             onFocus={() => setLastDraggedTokenId(characterId)}
                             onBlur={() =>
                               setLastDraggedTokenId((prev) => (prev === characterId ? null : prev))
                             }
+                            onMouseDown={(event) => {
+                              if (pointerEventsSupported) {
+                                return;
+                              }
+                              handleRotationHandlePointerDown(
+                                enhanceMouseEvent(event),
+                                characterId,
+                                rotationValue
+                              );
+                            }}
+                            onMouseUp={(event) => {
+                              if (pointerEventsSupported) {
+                                return;
+                              }
+                              event.stopPropagation();
+                              lockRotation(characterId);
+                            }}
+                            onMouseLeave={(event) => {
+                              if (pointerEventsSupported) {
+                                return;
+                              }
+                              event.stopPropagation();
+                              stopRotationDrag();
+                            }}
+                            onTouchStart={(event) => {
+                              if (pointerEventsSupported) {
+                                return;
+                              }
+                              handleRotationHandlePointerDown(
+                                enhanceTouchEvent(event),
+                                characterId,
+                                rotationValue
+                              );
+                            }}
+                            onTouchEnd={(event) => {
+                              if (pointerEventsSupported) {
+                                return;
+                              }
+                              event.stopPropagation();
+                              lockRotation(characterId);
+                            }}
+                            onTouchCancel={(event) => {
+                              if (pointerEventsSupported) {
+                                return;
+                              }
+                              event.stopPropagation();
+                              stopRotationDrag();
+                            }}
                           >
                             <svg
                               aria-hidden="true"

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -6,6 +6,8 @@ import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from '../utils/mapGrouping';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import DockControls from '../components/DockControls';
 import classNames from '../../../utils/classNames';
+import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
+import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -183,6 +185,7 @@ const MapModal = ({
   const backgroundBoardContainerRef = useRef(null);
   const backgroundBoardRef = useRef(null);
   const backgroundDragStateRef = useRef(null);
+  const pointerEventsSupported = usePointerEventsSupported();
   const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
   const normalizedActiveId = useMemo(() => normalizeMapId(activeMapId), [activeMapId]);
   const normalizedActionId = useMemo(
@@ -885,10 +888,12 @@ const MapModal = ({
       event.stopPropagation();
       event.preventDefault();
 
-      try {
-        container.setPointerCapture?.(event.pointerId);
-      } catch (error) {
-        // Ignore pointer capture failures in environments that do not support it.
+      if (pointerEventsSupported && event.pointerId !== undefined) {
+        try {
+          container.setPointerCapture?.(event.pointerId);
+        } catch (error) {
+          // Ignore pointer capture failures in environments that do not support it.
+        }
       }
 
       backgroundDragStateRef.current = {
@@ -903,7 +908,7 @@ const MapModal = ({
         shouldHandlePlacement: isPrimaryPointer,
       };
     },
-    [backgroundPan.x, backgroundPan.y, isBackground]
+    [backgroundPan.x, backgroundPan.y, isBackground, pointerEventsSupported]
   );
 
   const finalizeBackgroundDrag = useCallback(() => {
@@ -1074,14 +1079,46 @@ const MapModal = ({
     isBackgroundDragging && 'map-modal-background__board-inner--dragging'
   );
 
-  const backgroundPointerHandlers = isBackground
-    ? {
-        onPointerDownCapture: handleBackgroundPointerDownCapture,
-        onPointerMoveCapture: handleBackgroundPointerMove,
-        onPointerUpCapture: handleBackgroundPointerEnd,
-        onPointerCancelCapture: handleBackgroundPointerCancel,
-      }
-    : {};
+  const backgroundPointerHandlers = useMemo(() => {
+    if (!isBackground) {
+      return {};
+    }
+
+    const handlers = {
+      onPointerDownCapture: handleBackgroundPointerDownCapture,
+      onPointerMoveCapture: handleBackgroundPointerMove,
+      onPointerUpCapture: handleBackgroundPointerEnd,
+      onPointerCancelCapture: handleBackgroundPointerCancel,
+    };
+
+    if (!pointerEventsSupported) {
+      handlers.onMouseDownCapture = (event) =>
+        handleBackgroundPointerDownCapture(enhanceMouseEvent(event));
+      handlers.onMouseMoveCapture = (event) =>
+        handleBackgroundPointerMove(enhanceMouseEvent(event));
+      handlers.onMouseUpCapture = (event) =>
+        handleBackgroundPointerEnd(enhanceMouseEvent(event));
+      handlers.onMouseLeaveCapture = (event) =>
+        handleBackgroundPointerCancel(enhanceMouseEvent(event));
+      handlers.onTouchStartCapture = (event) =>
+        handleBackgroundPointerDownCapture(enhanceTouchEvent(event));
+      handlers.onTouchMoveCapture = (event) =>
+        handleBackgroundPointerMove(enhanceTouchEvent(event));
+      handlers.onTouchEndCapture = (event) =>
+        handleBackgroundPointerEnd(enhanceTouchEvent(event));
+      handlers.onTouchCancelCapture = (event) =>
+        handleBackgroundPointerCancel(enhanceTouchEvent(event));
+    }
+
+    return handlers;
+  }, [
+    handleBackgroundPointerCancel,
+    handleBackgroundPointerDownCapture,
+    handleBackgroundPointerEnd,
+    handleBackgroundPointerMove,
+    isBackground,
+    pointerEventsSupported,
+  ]);
 
   const handleTokenRemove = useCallback(
     ({ characterId, token }) => {

--- a/client/src/hooks/usePointerEventsSupported.js
+++ b/client/src/hooks/usePointerEventsSupported.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const detectPointerEventsSupport = () => {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  return 'PointerEvent' in window;
+};
+
+export default function usePointerEventsSupported() {
+  const [isSupported, setIsSupported] = useState(detectPointerEventsSupport);
+
+  useEffect(() => {
+    setIsSupported(detectPointerEventsSupport());
+  }, []);
+
+  return isSupported;
+}

--- a/client/src/utils/pointerEvents.js
+++ b/client/src/utils/pointerEvents.js
@@ -1,0 +1,66 @@
+const assignEventValue = (event, key, value) => {
+  if (!event || value === undefined) {
+    return;
+  }
+
+  try {
+    event[key] = value; // eslint-disable-line no-param-reassign
+  } catch (error) {
+    try {
+      Object.defineProperty(event, key, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value,
+      });
+    } catch (defineError) {
+      // Ignore assignment failures.
+    }
+  }
+};
+
+export const enhanceMouseEvent = (event) => {
+  if (!event) {
+    return event;
+  }
+
+  assignEventValue(event, 'pointerType', 'mouse');
+  if (event.pointerId === undefined || event.pointerId === null) {
+    assignEventValue(event, 'pointerId', -1);
+  }
+
+  if (typeof event.button !== 'number') {
+    assignEventValue(event, 'button', 0);
+  }
+
+  return event;
+};
+
+export const enhanceTouchEvent = (event) => {
+  if (!event) {
+    return event;
+  }
+
+  const primaryTouch =
+    (event.changedTouches && event.changedTouches[0]) ||
+    (event.touches && event.touches[0]) ||
+    null;
+
+  if (primaryTouch) {
+    assignEventValue(event, 'clientX', primaryTouch.clientX);
+    assignEventValue(event, 'clientY', primaryTouch.clientY);
+    assignEventValue(event, 'pageX', primaryTouch.pageX);
+    assignEventValue(event, 'pageY', primaryTouch.pageY);
+    assignEventValue(event, 'pointerId', primaryTouch.identifier ?? 0);
+  } else if (event.pointerId === undefined || event.pointerId === null) {
+    assignEventValue(event, 'pointerId', 0);
+  }
+
+  assignEventValue(event, 'pointerType', 'touch');
+
+  if (typeof event.button !== 'number') {
+    assignEventValue(event, 'button', 0);
+  }
+
+  return event;
+};


### PR DESCRIPTION
## Summary
- add a shared hook and helpers to detect pointer-event support and normalize mouse/touch events
- wire CampaignMapBoard to use the adapters so map panning, token drag, and rotation work without PointerEvent APIs
- extend MapModal background handlers with the same fallbacks to keep the background map interactive across browsers

## Testing
- npm --prefix client test -- --watchAll=false *(fails: existing ZombiesCharacterSheet tests emit act warnings and time out)*

------
https://chatgpt.com/codex/tasks/task_e_690175d16858832eb98faead75be0046