### PR TITLE
Remove undefined background panel setter

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -699,18 +699,6 @@ const MapModal = ({
     setPlacementPending(false);
   }, [previewMapId, currentCharacterId]);
 
-  useEffect(() => {
-    if (!isBackground) {
-      return;
-    }
-
-    if (show) {
-      setIsBackgroundPanelOpen(true);
-    } else {
-      setIsBackgroundPanelOpen(false);
-    }
-  }, [isBackground, show]);
-
   const isInteractive = useMemo(
     () => typeof onTokenMove === 'function' && previewMapIdCandidates.length > 0,
     [onTokenMove, previewMapIdCandidates]


### PR DESCRIPTION
## Summary
- remove the background-mode effect that called an undefined `setIsBackgroundPanelOpen`

## Testing
- CI=true npm test -- MapModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_6902620ac98c832eb1bb0f66c855e8a6