### PR TITLE
Fix background map identifier detection

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -78,7 +78,28 @@ const sanitizeTokenDictionary = (tokens) => {
   }, {});
 };
 
-const MAP_IDENTIFIER_KEYS = ['mapId', '_id', 'id', 'uuid', 'guid', 'slug', 'identifier'];
+const MAP_IDENTIFIER_KEYS = [
+  'mapId',
+  'map_id',
+  'mapID',
+  'MapId',
+  'MapID',
+  'MAPID',
+  'MAP_ID',
+  '_id',
+  'id',
+  'Id',
+  'ID',
+  'uuid',
+  'UUID',
+  'guid',
+  'GUID',
+  'slug',
+  'Slug',
+  'identifier',
+  'Identifier',
+  'IDENTIFIER',
+];
 const MAP_IDENTIFIER_FALLBACK_KEYS = [
   '$oid',
   '$id',
@@ -90,6 +111,33 @@ const MAP_IDENTIFIER_FALLBACK_KEYS = [
   'string',
   'idStr',
 ];
+const NORMALIZED_IDENTIFIER_KEY_VALUES = new Set([
+  'mapid',
+  'id',
+  'uuid',
+  'guid',
+  'slug',
+  'identifier',
+]);
+const NORMALIZED_FALLBACK_IDENTIFIER_KEY_VALUES = new Set([
+  'oid',
+  'id',
+  'uuid',
+  'guid',
+  'hex',
+  'hexstring',
+  'value',
+  'string',
+  'idstr',
+]);
+
+const normalizeIdentifierKey = (key) => {
+  if (typeof key !== 'string') {
+    return '';
+  }
+
+  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+};
 
 const normalizeMapId = (value, visited = new Set()) => {
   if (value === null || value === undefined) {
@@ -152,10 +200,25 @@ const normalizeMapId = (value, visited = new Set()) => {
       }
     }
 
-    const keysToInspect = [...MAP_IDENTIFIER_KEYS, ...MAP_IDENTIFIER_FALLBACK_KEYS];
+    const keysToInspect = Array.from(
+      new Set([...MAP_IDENTIFIER_KEYS, ...MAP_IDENTIFIER_FALLBACK_KEYS])
+    );
     for (const key of keysToInspect) {
       if (Object.prototype.hasOwnProperty.call(value, key)) {
         const normalized = normalizeMapId(value[key], visited);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+
+    for (const [candidateKey, candidateValue] of Object.entries(value)) {
+      const normalizedKey = normalizeIdentifierKey(candidateKey);
+      if (
+        NORMALIZED_IDENTIFIER_KEY_VALUES.has(normalizedKey) ||
+        NORMALIZED_FALLBACK_IDENTIFIER_KEY_VALUES.has(normalizedKey)
+      ) {
+        const normalized = normalizeMapId(candidateValue, visited);
         if (normalized) {
           return normalized;
         }

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -430,6 +430,57 @@ describe('MapModal background interactions', () => {
     );
   });
 
+  it('treats snake_case map identifiers as interactive background boards', async () => {
+    const handleTokenMove = jest.fn().mockResolvedValue(true);
+
+    render(
+      <MapModal
+        show
+        displayMode="background"
+        map={{
+          map_id: 'legacy-map-123',
+          metadata: { map_identifier: { value: { $id: 'legacy-map-123' } } },
+          imageUrl: 'https://example.com/legacy-map.png',
+        }}
+        tokensByMapId={{
+          'legacy-map-123': {
+            hero: {
+              characterId: 'hero',
+              x: 0.5,
+              y: 0.5,
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        characterLookup={{ hero: { label: 'Hero' } }}
+        onTokenMove={handleTokenMove}
+        onTokenRemove={jest.fn()}
+      />
+    );
+
+    const wrapper = await screen.findByTestId('map-modal-wrapper');
+    expect(wrapper.className).toContain('map-modal-background--interactive');
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(typeof boardProps.onTokenPositionChange).toBe('function');
+
+    await act(async () => {
+      boardProps.onTokenPositionChange?.({ characterId: 'hero', x: 0.6, y: 0.7 });
+    });
+
+    await waitFor(() =>
+      expect(handleTokenMove).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mapId: 'legacy-map-123',
+          characterId: 'hero',
+          x: 0.6,
+          y: 0.7,
+        })
+      )
+    );
+  });
+
   it('allows interactivity when map identifiers only exist in the token payload', async () => {
     const handleTokenMove = jest.fn().mockResolvedValue(true);
 


### PR DESCRIPTION
## Summary
- broaden map identifier normalization to handle snake_case and other variations so the background campaign map can resolve IDs and enable interactivity
- add tests covering legacy identifier shapes to ensure the background board becomes interactive for those data sets

## Testing
- npm test -- MapModal --watch=false

------
https://chatgpt.com/codex/tasks/task_e_6902734dd3fc832e892621dc34688907