### PR TITLE
Use background map as sole board source

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -78,7 +78,28 @@ const sanitizeTokenDictionary = (tokens) => {
   }, {});
 };
 
-const MAP_IDENTIFIER_KEYS = ['mapId', '_id', 'id', 'uuid', 'guid', 'slug', 'identifier'];
+const MAP_IDENTIFIER_KEYS = [
+  'mapId',
+  'map_id',
+  'mapID',
+  'MapId',
+  'MapID',
+  'MAPID',
+  'MAP_ID',
+  '_id',
+  'id',
+  'Id',
+  'ID',
+  'uuid',
+  'UUID',
+  'guid',
+  'GUID',
+  'slug',
+  'Slug',
+  'identifier',
+  'Identifier',
+  'IDENTIFIER',
+];
 const MAP_IDENTIFIER_FALLBACK_KEYS = [
   '$oid',
   '$id',
@@ -90,6 +111,33 @@ const MAP_IDENTIFIER_FALLBACK_KEYS = [
   'string',
   'idStr',
 ];
+const NORMALIZED_IDENTIFIER_KEY_VALUES = new Set([
+  'mapid',
+  'id',
+  'uuid',
+  'guid',
+  'slug',
+  'identifier',
+]);
+const NORMALIZED_FALLBACK_IDENTIFIER_KEY_VALUES = new Set([
+  'oid',
+  'id',
+  'uuid',
+  'guid',
+  'hex',
+  'hexstring',
+  'value',
+  'string',
+  'idstr',
+]);
+
+const normalizeIdentifierKey = (key) => {
+  if (typeof key !== 'string') {
+    return '';
+  }
+
+  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+};
 
 const normalizeMapId = (value, visited = new Set()) => {
   if (value === null || value === undefined) {
@@ -152,10 +200,25 @@ const normalizeMapId = (value, visited = new Set()) => {
       }
     }
 
-    const keysToInspect = [...MAP_IDENTIFIER_KEYS, ...MAP_IDENTIFIER_FALLBACK_KEYS];
+    const keysToInspect = Array.from(
+      new Set([...MAP_IDENTIFIER_KEYS, ...MAP_IDENTIFIER_FALLBACK_KEYS])
+    );
     for (const key of keysToInspect) {
       if (Object.prototype.hasOwnProperty.call(value, key)) {
         const normalized = normalizeMapId(value[key], visited);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+
+    for (const [candidateKey, candidateValue] of Object.entries(value)) {
+      const normalizedKey = normalizeIdentifierKey(candidateKey);
+      if (
+        NORMALIZED_IDENTIFIER_KEY_VALUES.has(normalizedKey) ||
+        NORMALIZED_FALLBACK_IDENTIFIER_KEY_VALUES.has(normalizedKey)
+      ) {
+        const normalized = normalizeMapId(candidateValue, visited);
         if (normalized) {
           return normalized;
         }
@@ -297,7 +360,10 @@ const MapModal = ({
 }) => {
   const isBackground = displayMode === 'background';
   const backgroundBoardContainerRef = useRef(null);
-  const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
+  const normalizedMaps = useMemo(
+    () => (isBackground ? [] : normalizeMaps(maps)),
+    [isBackground, maps]
+  );
   const normalizedTokensByMapId = useMemo(() => {
     if (!tokensByMapId || typeof tokensByMapId !== 'object') {
       return {};
@@ -346,6 +412,10 @@ const MapModal = ({
   }, [normalizedMaps, normalizedSelectedId, normalizedActiveId]);
 
   const previewMap = useMemo(() => {
+    if (isBackground) {
+      return map || null;
+    }
+
     if (normalizedMaps.length > 0) {
       const selectedFromList = findMapById(normalizedMaps, resolvedSelectedId);
       if (selectedFromList) {
@@ -363,7 +433,13 @@ const MapModal = ({
     }
 
     return map || null;
-  }, [normalizedMaps, resolvedSelectedId, normalizedActiveId, map]);
+  }, [
+    isBackground,
+    map,
+    normalizedMaps,
+    resolvedSelectedId,
+    normalizedActiveId,
+  ]);
 
   const backgroundImageSrc = useMemo(
     () => buildMapImageSource(previewMap),
@@ -427,6 +503,38 @@ const MapModal = ({
     normalizedActiveId,
     normalizedSelectedId,
     previewMapId,
+    tokenMapIdCandidates,
+  ]);
+
+  const resolvedPlacementMapId = useMemo(() => {
+    if (placementMapId) {
+      return placementMapId;
+    }
+
+    const directMapIdentifier = normalizeMapId(previewMap?.mapId);
+    if (directMapIdentifier) {
+      return directMapIdentifier;
+    }
+
+    const fallbackPreviewId = normalizeMapId(previewMap?.id ?? previewMap?._id);
+    if (fallbackPreviewId) {
+      return fallbackPreviewId;
+    }
+
+    if (normalizedSelectedId) {
+      return normalizedSelectedId;
+    }
+
+    if (normalizedActiveId) {
+      return normalizedActiveId;
+    }
+
+    return tokenMapIdCandidates[0] || null;
+  }, [
+    placementMapId,
+    previewMap,
+    normalizedSelectedId,
+    normalizedActiveId,
     tokenMapIdCandidates,
   ]);
 
@@ -800,11 +908,16 @@ const MapModal = ({
   useEffect(() => {
     setPlacementError(null);
     setPlacementPending(false);
-  }, [placementMapId, currentCharacterId]);
+  }, [resolvedPlacementMapId, currentCharacterId]);
 
-  const isInteractive = useMemo(
-    () => typeof onTokenMove === 'function' && Boolean(placementMapId),
-    [onTokenMove, placementMapId]
+  const hasInteractiveBoard = useMemo(() => Boolean(previewMap), [previewMap]);
+  const canManipulateTokens = useMemo(
+    () => hasInteractiveBoard && typeof onTokenMove === 'function',
+    [hasInteractiveBoard, onTokenMove]
+  );
+  const canHandleTokenRemoval = useMemo(
+    () => hasInteractiveBoard && typeof onTokenRemove === 'function',
+    [hasInteractiveBoard, onTokenRemove]
   );
 
   const backgroundClassName = useMemo(() => {
@@ -814,12 +927,12 @@ const MapModal = ({
       classes.push('map-modal-background--has-image');
     }
 
-    if (isInteractive) {
+    if (hasInteractiveBoard) {
       classes.push('map-modal-background--interactive');
     }
 
     return classes.join(' ');
-  }, [backgroundImageSrc, isInteractive]);
+  }, [backgroundImageSrc, hasInteractiveBoard]);
 
   const boardTokens = useMemo(() => {
     const tokensList = Object.values(tokensDictionary);
@@ -851,7 +964,7 @@ const MapModal = ({
         );
 
         const isMovable =
-          isInteractive &&
+          canManipulateTokens &&
           !placementPending &&
           (!readOnly || matchesCurrentCharacter);
 
@@ -930,7 +1043,7 @@ const MapModal = ({
         return labelA.localeCompare(labelB);
       });
   }, [
-    isInteractive,
+    canManipulateTokens,
     normalizedCharacterLookup,
     normalizedCurrentCharacterId,
     normalizedActiveCharacterId,
@@ -961,12 +1074,12 @@ const MapModal = ({
 
   const handleCommitMove = useCallback(
     async ({ characterId, x, y, rotation }) => {
-      if (!isInteractive || placementPending) {
+      if (!canManipulateTokens || placementPending) {
         return;
       }
 
       const normalizedCharacterId = normalizeMapId(characterId);
-      if (!normalizedCharacterId || !placementMapId) {
+      if (!normalizedCharacterId) {
         return;
       }
 
@@ -979,14 +1092,22 @@ const MapModal = ({
 
       try {
         const payload = {
-          mapId: placementMapId,
           characterId: normalizedCharacterId,
           x,
           y,
         };
 
+        const payloadMapId = resolvedPlacementMapId;
+        if (payloadMapId) {
+          payload.mapId = payloadMapId;
+        }
+
         if (Number.isFinite(rotation)) {
           payload.rotation = rotation;
+        }
+
+        if (typeof onTokenMove !== 'function') {
+          return;
         }
 
         const result = await onTokenMove(payload);
@@ -1005,28 +1126,28 @@ const MapModal = ({
     },
     [
       normalizedCurrentCharacterId,
-      isInteractive,
+      canManipulateTokens,
       onTokenMove,
       placementPending,
-      placementMapId,
       readOnly,
+      resolvedPlacementMapId,
     ]
   );
 
   const handleTokenPositionChange = useCallback(
     ({ characterId, x, y, rotation }) => {
-      if (!isInteractive) {
+      if (!canManipulateTokens) {
         return;
       }
 
       handleCommitMove({ characterId, x, y, rotation });
     },
-    [handleCommitMove, isInteractive]
+    [handleCommitMove, canManipulateTokens]
   );
 
   const handleBackgroundPlacement = useCallback(
     ({ x, y }) => {
-      if (!isInteractive || placementPending) {
+      if (!canManipulateTokens || placementPending) {
         return;
       }
 
@@ -1036,7 +1157,13 @@ const MapModal = ({
 
       handleCommitMove({ characterId: normalizedCurrentCharacterId, x, y });
     },
-    [currentToken, handleCommitMove, isInteractive, normalizedCurrentCharacterId, placementPending]
+    [
+      currentToken,
+      handleCommitMove,
+      canManipulateTokens,
+      normalizedCurrentCharacterId,
+      placementPending,
+    ]
   );
 
   const backgroundBoardStyleValue = useMemo(() => {
@@ -1056,11 +1183,11 @@ const MapModal = ({
 
   const handleTokenRemove = useCallback(
     ({ characterId, token }) => {
-      if (!isInteractive || placementPending) {
+      if (!canHandleTokenRemoval || placementPending) {
         return false;
       }
 
-      if (typeof onTokenRemove !== 'function' || !placementMapId) {
+      if (typeof onTokenRemove !== 'function') {
         return false;
       }
 
@@ -1074,9 +1201,12 @@ const MapModal = ({
       }
 
       const payload = {
-        mapId: placementMapId,
         characterId: normalizedCharacterId,
       };
+
+      if (resolvedPlacementMapId) {
+        payload.mapId = resolvedPlacementMapId;
+      }
 
       if (token) {
         payload.token = token;
@@ -1084,13 +1214,17 @@ const MapModal = ({
         payload.token = tokensDictionary[normalizedCharacterId];
       }
 
+      if (typeof onTokenRemove !== 'function') {
+        return false;
+      }
+
       return onTokenRemove(payload);
     },
     [
-      isInteractive,
+      canHandleTokenRemoval,
       placementPending,
       onTokenRemove,
-      placementMapId,
+      resolvedPlacementMapId,
       readOnly,
       normalizedCurrentCharacterId,
       tokensDictionary,
@@ -1100,12 +1234,12 @@ const MapModal = ({
   const canClickToPlace = useMemo(
     () =>
       Boolean(
-        isInteractive &&
+        canManipulateTokens &&
           !placementPending &&
           normalizedCurrentCharacterId &&
           !currentToken
       ),
-    [currentToken, isInteractive, normalizedCurrentCharacterId, placementPending]
+    [currentToken, canManipulateTokens, normalizedCurrentCharacterId, placementPending]
   );
 
   const handleSelectMap = useCallback(
@@ -1337,12 +1471,16 @@ const MapModal = ({
             tokens={boardTokens}
             disabled={isBoardDisabled}
             onTokenPositionChange={
-              isInteractive ? handleTokenPositionChange : undefined
+              canManipulateTokens ? handleTokenPositionChange : undefined
             }
-            onBackgroundClick={isInteractive ? handleBackgroundPlacement : undefined}
-            onTokenRemove={isInteractive ? handleTokenRemove : undefined}
+            onBackgroundClick={
+              canManipulateTokens ? handleBackgroundPlacement : undefined
+            }
+            onTokenRemove={
+              canHandleTokenRemoval ? handleTokenRemove : undefined
+            }
           />
-          {isInteractive && placementPending && (
+          {canManipulateTokens && placementPending && (
             <div
               className="map-modal__saving-indicator d-flex align-items-center gap-2 text-muted small"
               data-testid="map-modal-placement-pending"
@@ -1354,12 +1492,12 @@ const MapModal = ({
             </div>
           )}
         </div>
-        {isInteractive && canClickToPlace && (
+        {canManipulateTokens && canClickToPlace && (
           <div className="text-info small mt-3" data-testid="map-modal-placement-hint">
             Click the map to place your figurine.
           </div>
         )}
-        {isInteractive && placementError && (
+        {canManipulateTokens && placementError && (
           <Alert variant="danger" className="mt-3" data-testid="map-modal-placement-error">
             {placementError}
           </Alert>

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -430,6 +430,106 @@ describe('MapModal background interactions', () => {
     );
   });
 
+  it('keeps the background board interactive when the preview map lacks an identifier', async () => {
+    const handleTokenMove = jest.fn().mockResolvedValue(true);
+
+    render(
+      <MapModal
+        show
+        displayMode="background"
+        map={{
+          title: 'Mystery Cavern',
+          imageUrl: 'https://example.com/mystery-cavern.png',
+        }}
+        tokensByMapId={{
+          'token-map': {
+            hero: {
+              characterId: 'hero',
+              x: 0.2,
+              y: 0.3,
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        characterLookup={{ hero: { label: 'Hero' } }}
+        onTokenMove={handleTokenMove}
+        onTokenRemove={jest.fn()}
+      />
+    );
+
+    const wrapper = await screen.findByTestId('map-modal-wrapper');
+    expect(wrapper.className).toContain('map-modal-background--interactive');
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+
+    await act(async () => {
+      boardProps.onTokenPositionChange?.({ characterId: 'hero', x: 0.4, y: 0.6 });
+    });
+
+    await waitFor(() =>
+      expect(handleTokenMove).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mapId: 'token-map',
+          characterId: 'hero',
+          x: 0.4,
+          y: 0.6,
+        })
+      )
+    );
+  });
+
+  it('treats snake_case map identifiers as interactive background boards', async () => {
+    const handleTokenMove = jest.fn().mockResolvedValue(true);
+
+    render(
+      <MapModal
+        show
+        displayMode="background"
+        map={{
+          map_id: 'legacy-map-123',
+          metadata: { map_identifier: { value: { $id: 'legacy-map-123' } } },
+          imageUrl: 'https://example.com/legacy-map.png',
+        }}
+        tokensByMapId={{
+          'legacy-map-123': {
+            hero: {
+              characterId: 'hero',
+              x: 0.5,
+              y: 0.5,
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        characterLookup={{ hero: { label: 'Hero' } }}
+        onTokenMove={handleTokenMove}
+        onTokenRemove={jest.fn()}
+      />
+    );
+
+    const wrapper = await screen.findByTestId('map-modal-wrapper');
+    expect(wrapper.className).toContain('map-modal-background--interactive');
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(typeof boardProps.onTokenPositionChange).toBe('function');
+
+    await act(async () => {
+      boardProps.onTokenPositionChange?.({ characterId: 'hero', x: 0.6, y: 0.7 });
+    });
+
+    await waitFor(() =>
+      expect(handleTokenMove).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mapId: 'legacy-map-123',
+          characterId: 'hero',
+          x: 0.6,
+          y: 0.7,
+        })
+      )
+    );
+  });
+
   it('allows interactivity when map identifiers only exist in the token payload', async () => {
     const handleTokenMove = jest.fn().mockResolvedValue(true);
 
@@ -481,6 +581,36 @@ describe('MapModal background interactions', () => {
         })
       )
     );
+  });
+
+  it('prioritizes the provided background map even when saved maps exist', async () => {
+    const backgroundMap = {
+      _id: 'primary-map',
+      title: 'Primary Map',
+      imageUrl: 'https://example.com/primary-map.png',
+    };
+
+    render(
+      <MapModal
+        show
+        displayMode="background"
+        map={backgroundMap}
+        maps={[
+          {
+            mapId: 'saved-map',
+            title: 'Saved Map',
+            imageUrl: 'https://example.com/saved-map.png',
+          },
+        ]}
+        onTokenMove={jest.fn()}
+        onTokenRemove={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+
+    expect(boardProps.map).toEqual(backgroundMap);
   });
 
   it('renders the background board without overlay controls', async () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -3193,18 +3193,6 @@ export default function ZombiesCharacterSheet() {
     ]
   );
 
-  const hasInteractiveCampaignMap = useMemo(() => {
-    if (campaignMap) {
-      return true;
-    }
-
-    if (Array.isArray(campaignMaps) && campaignMaps.length > 0) {
-      return true;
-    }
-
-    return false;
-  }, [campaignMap, campaignMaps]);
-
   const resolvedCampaignMap = useMemo(() => {
     if (campaignMap) {
       return campaignMap;
@@ -3237,6 +3225,18 @@ export default function ZombiesCharacterSheet() {
 
     return campaignMaps[0] || null;
   }, [campaignActiveMapId, campaignMap, campaignMaps]);
+
+  const hasInteractiveCampaignMap = useMemo(() => {
+    if (resolvedCampaignMap) {
+      return true;
+    }
+
+    if (Array.isArray(campaignMaps) && campaignMaps.length > 0) {
+      return true;
+    }
+
+    return false;
+  }, [campaignMaps, resolvedCampaignMap]);
 
   const handleShowSkill = useCallback(() => setShowSkill(true), []);
   const handleCloseSkill = useCallback(() => {


### PR DESCRIPTION
## Summary
- ensure the background MapModal bypasses saved map lists so the provided campaign board stays active
- add regression coverage confirming the background board receives the supplied map even when saved maps exist

## Testing
- npm test -- MapModal --watch=false

------
https://chatgpt.com/codex/tasks/task_e_6902734dd3fc832e892621dc34688907