### PR TITLE
Fix map background image resolution

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
+import resolveMapImageSource from '../utils/mapImages';
 import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
 import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
 
@@ -51,22 +52,6 @@ const formatHpValue = (value) => {
 
   const precision = Math.abs(clamped) >= 100 ? 0 : 1;
   return clamped.toFixed(precision);
-};
-
-const buildImageSource = ({ imageUrl, imageBase64, imageType }) => {
-  if (typeof imageUrl === 'string' && imageUrl.trim() !== '') {
-    return imageUrl.trim();
-  }
-
-  if (typeof imageBase64 === 'string' && imageBase64.trim() !== '') {
-    const mimeType =
-      typeof imageType === 'string' && imageType.trim() !== ''
-        ? imageType.trim()
-        : 'image/png';
-    return `data:${mimeType};base64,${imageBase64.trim()}`;
-  }
-
-  return null;
 };
 
 const normalizeText = (value) =>
@@ -489,7 +474,7 @@ const CampaignMapBoard = ({
     title ||
     normalizeText(safeMap.prompt) ||
     'Campaign map image';
-  const imageSrc = buildImageSource(safeMap);
+  const imageSrc = resolveMapImageSource(safeMap);
 
   const interactionDisabled = disabled || !imageSrc;
 

--- a/client/src/components/Zombies/attributes/MapDisplay.js
+++ b/client/src/components/Zombies/attributes/MapDisplay.js
@@ -1,21 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const buildImageSource = ({ imageUrl, imageBase64, imageType }) => {
-  if (typeof imageUrl === 'string' && imageUrl.trim() !== '') {
-    return imageUrl.trim();
-  }
-
-  if (typeof imageBase64 === 'string' && imageBase64.trim() !== '') {
-    const mimeType =
-      typeof imageType === 'string' && imageType.trim() !== ''
-        ? imageType.trim()
-        : 'image/png';
-    return `data:${mimeType};base64,${imageBase64.trim()}`;
-  }
-
-  return null;
-};
+import resolveMapImageSource from '../utils/mapImages';
 
 const normalizeText = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
@@ -28,7 +13,7 @@ const MapDisplay = ({ map }) => {
     title ||
     normalizeText(safeMap.prompt) ||
     'Campaign map image';
-  const imageSrc = buildImageSource(safeMap);
+  const imageSrc = resolveMapImageSource(safeMap);
 
   return (
     <div className="map-display">

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -4,6 +4,7 @@ import { Modal, Button, ListGroup, Badge, Spinner, Alert } from 'react-bootstrap
 import CampaignMapBoard from './CampaignMapBoard';
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from '../utils/mapGrouping';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
+import resolveMapImageSource from '../utils/mapImages';
 import DockControls from '../components/DockControls';
 
 const clamp01 = (value) => {
@@ -269,28 +270,6 @@ const normalizeMaps = (maps) =>
     ? maps.filter((map) => map && typeof map === 'object')
     : [];
 
-const buildMapImageSource = (map) => {
-  if (!map || typeof map !== 'object') {
-    return null;
-  }
-
-  const { imageUrl, imageBase64, imageType } = map;
-
-  if (typeof imageUrl === 'string' && imageUrl.trim() !== '') {
-    return imageUrl.trim();
-  }
-
-  if (typeof imageBase64 === 'string' && imageBase64.trim() !== '') {
-    const mimeType =
-      typeof imageType === 'string' && imageType.trim() !== ''
-        ? imageType.trim()
-        : 'image/png';
-    return `data:${mimeType};base64,${imageBase64.trim()}`;
-  }
-
-  return null;
-};
-
 const resolveMapTitle = (map, index) => {
   if (!map || typeof map !== 'object') {
     return `Map ${index + 1}`;
@@ -442,7 +421,7 @@ const MapModal = ({
   ]);
 
   const backgroundImageSrc = useMemo(
-    () => buildMapImageSource(previewMap),
+    () => resolveMapImageSource(previewMap),
     [previewMap]
   );
 

--- a/client/src/components/Zombies/utils/mapImages.js
+++ b/client/src/components/Zombies/utils/mapImages.js
@@ -1,0 +1,95 @@
+const trimString = (value) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+
+const buildDataUrl = (base64Value, mimeType) => {
+  const normalizedBase64 = trimString(base64Value);
+  if (normalizedBase64 === null) {
+    return null;
+  }
+
+  if (normalizedBase64.startsWith('data:')) {
+    return normalizedBase64;
+  }
+
+  const type = trimString(mimeType) || 'image/png';
+  return `data:${type};base64,${normalizedBase64}`;
+};
+
+const extractNestedImage = (image) => {
+  if (image === null || typeof image !== 'object') {
+    return null;
+  }
+
+  const nestedUrl =
+    trimString(image.url) ||
+    trimString(image.secureUrl) ||
+    trimString(image.href) ||
+    trimString(image.src);
+  if (nestedUrl) {
+    return nestedUrl;
+  }
+
+  const nestedDataUrl =
+    trimString(image.dataUrl) ||
+    trimString(image.dataURI) ||
+    trimString(image.dataUri);
+  if (nestedDataUrl) {
+    const type = trimString(image.type) || trimString(image.mimeType);
+    return buildDataUrl(nestedDataUrl, type);
+  }
+
+  const nestedBase64 =
+    trimString(image.base64) ||
+    trimString(image.base64Data) ||
+    trimString(image.base64String) ||
+    trimString(image.b64) ||
+    trimString(image.data);
+  if (nestedBase64) {
+    const type = trimString(image.type) || trimString(image.mimeType);
+    return buildDataUrl(nestedBase64, type);
+  }
+
+  return null;
+};
+
+export const resolveMapImageSource = (map) => {
+  if (map === null || typeof map !== 'object') {
+    return null;
+  }
+
+  const directUrl = trimString(map.imageUrl);
+  if (directUrl) {
+    return directUrl;
+  }
+
+  const directDataUrl =
+    trimString(map.imageDataUrl) ||
+    trimString(map.imageDataURI) ||
+    trimString(map.imageDataUri);
+  if (directDataUrl) {
+    return buildDataUrl(directDataUrl, map.imageType);
+  }
+
+  const directBase64 = trimString(map.imageBase64);
+  if (directBase64) {
+    return buildDataUrl(directBase64, map.imageType);
+  }
+
+  const nestedImage = extractNestedImage(map.image);
+  if (nestedImage) {
+    return nestedImage;
+  }
+
+  if (Array.isArray(map.images)) {
+    for (const entry of map.images) {
+      const resolved = extractNestedImage(entry);
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  return null;
+};
+
+export default resolveMapImageSource;

--- a/client/src/components/Zombies/utils/mapImages.test.js
+++ b/client/src/components/Zombies/utils/mapImages.test.js
@@ -1,0 +1,39 @@
+import resolveMapImageSource from './mapImages';
+
+describe('resolveMapImageSource', () => {
+  it('returns a trimmed imageUrl when available', () => {
+    expect(
+      resolveMapImageSource({ imageUrl: ' https://example.com/map.png ' })
+    ).toBe('https://example.com/map.png');
+  });
+
+  it('builds a data url from imageBase64', () => {
+    const result = resolveMapImageSource({ imageBase64: 'YmFzZTY0' });
+    expect(result).toBe('data:image/png;base64,YmFzZTY0');
+  });
+
+  it('uses the provided mime type for base64 images', () => {
+    const result = resolveMapImageSource({ imageBase64: 'YmFzZTY0', imageType: 'image/jpeg' });
+    expect(result).toBe('data:image/jpeg;base64,YmFzZTY0');
+  });
+
+  it('supports nested image objects with urls', () => {
+    const map = { image: { url: 'https://cdn.example.com/map.jpg' } };
+    expect(resolveMapImageSource(map)).toBe('https://cdn.example.com/map.jpg');
+  });
+
+  it('supports nested image objects with base64 data', () => {
+    const map = { image: { base64: 'QUJD', mimeType: 'image/gif' } };
+    expect(resolveMapImageSource(map)).toBe('data:image/gif;base64,QUJD');
+  });
+
+  it('falls back to the first resolvable entry in a nested images array', () => {
+    const map = { images: [{}, { data: 'Rk9P', mimeType: 'image/webp' }] };
+    expect(resolveMapImageSource(map)).toBe('data:image/webp;base64,Rk9P');
+  });
+
+  it('returns null when no source can be resolved', () => {
+    expect(resolveMapImageSource(null)).toBeNull();
+    expect(resolveMapImageSource({})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared resolver that can read campaign map images from URLs, base64 data, or nested image objects
- update the background map modal, campaign board, and map display to use the new resolver
- cover the resolver with unit tests for the supported input shapes

## Testing
- CI=true npm test --prefix client -- mapImages

------
https://chatgpt.com/codex/tasks/task_e_690286f381b8832eb13ab75b5c848017