### PR TITLE
feat: redesign character map as full-screen overlay

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -59,6 +59,119 @@
   padding-block: 0.75rem;
 }
 
+.map-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, rgba(22, 25, 32, 0.95), rgba(7, 9, 12, 0.95));
+  color: #f8f9fa;
+}
+
+.map-modal-overlay__header,
+.map-modal-overlay__footer {
+  padding: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.map-modal-overlay__header-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.map-modal-overlay__header-bar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(8, 9, 14, 0.75);
+  border-radius: 0.75rem;
+  padding: clamp(0.5rem, 1.5vw, 1rem) clamp(0.75rem, 2vw, 1.25rem);
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.35);
+}
+
+.map-modal-overlay__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.map-modal-overlay__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(248, 249, 250, 0.7);
+}
+
+.map-modal-overlay__title {
+  font-size: clamp(1.25rem, 2.4vw, 1.75rem);
+  margin: 0;
+  font-weight: 600;
+}
+
+.map-modal-overlay__tracker {
+  background: rgba(8, 9, 14, 0.65);
+  border-radius: 0.75rem;
+  padding: clamp(0.5rem, 1.5vw, 1rem);
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.35);
+}
+
+.map-modal-overlay__tracker .combat-turn-header {
+  margin-bottom: 0;
+}
+
+.map-modal-overlay__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: clamp(0.75rem, 2.5vw, 2rem);
+}
+
+.map-modal-overlay__content {
+  flex: 1 1 auto;
+  max-width: min(1200px, 95vw);
+  border-radius: 1rem;
+  background: rgba(10, 12, 18, 0.8);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.45);
+  padding: clamp(1rem, 2.5vw, 2rem);
+  overflow: auto;
+}
+
+.map-modal-overlay__footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.map-modal-overlay__footer-bar {
+  background: rgba(8, 9, 14, 0.75);
+  border-radius: 9999px;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.35);
+}
+
+.map-modal-overlay__footer .navbar {
+  width: min(640px, 90vw);
+  border-radius: 9999px;
+  background: rgba(8, 9, 14, 0.85) !important;
+  backdrop-filter: blur(8px);
+  padding-block: 0.25rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.4);
+}
+
+.map-modal-overlay__footer .navbar .footer-btn {
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .zombies-dm-container {
   padding-left: 1rem;
   padding-right: 1rem;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -152,6 +152,9 @@ const MapModal = ({
   dockedSide = null,
   onDockClose,
   onDockChange,
+  displayMode = 'modal',
+  overlayHeader,
+  overlayFooter,
 }) => {
   const normalizedMaps = useMemo(() => normalizeMaps(maps), [maps]);
   const normalizedActiveId = useMemo(() => normalizeMapId(activeMapId), [activeMapId]);
@@ -922,6 +925,100 @@ const MapModal = ({
     onHide?.();
   }, [isDocked, onDockClose, onHide]);
 
+  const mainContent = hasManagementFeatures ? (
+    <div className="d-flex flex-column flex-lg-row gap-4">
+      <div className="flex-grow-1" data-testid="map-modal-sidebar">
+        <h5 className="h6 mb-3">Saved Maps</h5>
+        {renderMapList()}
+      </div>
+      <div className="flex-grow-1" data-testid="map-modal-preview">
+        {previewMap ? renderPreviewContent() : (
+          <p className="text-muted mb-0">No map selected.</p>
+        )}
+      </div>
+    </div>
+  ) : (
+    <div data-testid="map-modal-preview">
+      {previewMap ? renderPreviewContent() : (
+        <p className="text-muted mb-0">No map image available.</p>
+      )}
+    </div>
+  );
+
+  useEffect(() => {
+    if (displayMode !== 'overlay' || !show) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onHide?.();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [displayMode, show, onHide]);
+
+  if (displayMode === 'overlay') {
+    if (!show) {
+      return null;
+    }
+
+    const resolvedHeader =
+      typeof overlayHeader !== 'undefined'
+        ? overlayHeader
+        : (
+            <div className="map-modal-overlay__header-bar">
+              <div className="map-modal-overlay__title-group">
+                <div className="map-modal-overlay__eyebrow">Campaign Map</div>
+                <h2 className="map-modal-overlay__title">{title}</h2>
+              </div>
+              <Button
+                variant="outline-light"
+                size="sm"
+                onClick={onHide}
+                data-testid="map-modal-overlay-close"
+              >
+                Close
+              </Button>
+            </div>
+          );
+
+    const resolvedFooter =
+      typeof overlayFooter !== 'undefined'
+        ? overlayFooter
+        : (
+            <div className="map-modal-overlay__footer-bar">
+              <Button variant="secondary" onClick={onHide}>
+                Close
+              </Button>
+            </div>
+          );
+
+    return (
+      <div
+        className="map-modal-overlay"
+        data-testid="map-modal-wrapper"
+        role="dialog"
+        aria-modal="true"
+        aria-label={typeof title === 'string' ? title : 'Campaign Map'}
+      >
+        {resolvedHeader !== null && (
+          <div className="map-modal-overlay__header">{resolvedHeader}</div>
+        )}
+        <div className="map-modal-overlay__body">
+          <div className="map-modal-overlay__content">{mainContent}</div>
+        </div>
+        {resolvedFooter !== null && (
+          <div className="map-modal-overlay__footer">{resolvedFooter}</div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <Modal
       className={modalClassName}
@@ -943,27 +1040,7 @@ const MapModal = ({
         />
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        {hasManagementFeatures ? (
-          <div className="d-flex flex-column flex-lg-row gap-4">
-            <div className="flex-grow-1" data-testid="map-modal-sidebar">
-              <h5 className="h6 mb-3">Saved Maps</h5>
-              {renderMapList()}
-            </div>
-            <div className="flex-grow-1" data-testid="map-modal-preview">
-              {previewMap ? renderPreviewContent() : (
-                <p className="text-muted mb-0">No map selected.</p>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div data-testid="map-modal-preview">
-            {previewMap ? renderPreviewContent() : (
-              <p className="text-muted mb-0">No map image available.</p>
-            )}
-          </div>
-        )}
-      </Modal.Body>
+      <Modal.Body>{mainContent}</Modal.Body>
       <Modal.Footer>
         <Button className="action-btn close-btn" onClick={handleModalHide} data-testid="map-modal-close">
           Close
@@ -1009,6 +1086,9 @@ MapModal.propTypes = {
   dockedSide: PropTypes.oneOf(['left', 'right']),
   onDockClose: PropTypes.func,
   onDockChange: PropTypes.func,
+  displayMode: PropTypes.oneOf(['modal', 'overlay']),
+  overlayHeader: PropTypes.node,
+  overlayFooter: PropTypes.node,
 };
 
 MapModal.defaultProps = {
@@ -1036,6 +1116,9 @@ MapModal.defaultProps = {
   dockedSide: null,
   onDockClose: null,
   onDockChange: null,
+  displayMode: 'modal',
+  overlayHeader: undefined,
+  overlayFooter: undefined,
 };
 
 export default MapModal;

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MapModal from './MapModal';
 
@@ -227,5 +227,47 @@ describe('MapModal figurine imagery', () => {
       'data-figurine-public-id',
       'figurines/heroes/lookup-hero'
     );
+  });
+});
+
+describe('MapModal overlay mode', () => {
+  it('renders the overlay layout with default controls', async () => {
+    const onHide = jest.fn();
+    render(
+      <MapModal
+        show
+        displayMode="overlay"
+        onHide={onHide}
+        title="Overlay Map"
+        map={{
+          mapId: 'overlay-map',
+          title: 'Overlay Map',
+          imageUrl: 'https://example.com/overlay.png',
+        }}
+      />
+    );
+
+    const overlay = await screen.findByTestId('map-modal-wrapper');
+    expect(overlay).toHaveClass('map-modal-overlay');
+
+    const closeButton = screen.getByTestId('map-modal-overlay-close');
+    await act(async () => {
+      await userEvent.click(closeButton);
+    });
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it('supports custom overlay header and footer content', () => {
+    render(
+      <MapModal
+        show
+        displayMode="overlay"
+        overlayHeader={<div data-testid="custom-overlay-header">Header</div>}
+        overlayFooter={null}
+      />
+    );
+
+    expect(screen.getByTestId('custom-overlay-header')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5560,6 +5560,189 @@ export default function ZombiesCharacterSheet() {
       .filter(Boolean);
   }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
+  const renderFooterNavigation = (mode = 'default') => {
+    const isOverlay = mode === 'overlay';
+    const navbarProps = {
+      bg: 'dark',
+      variant: 'dark',
+      'data-bs-theme': 'dark',
+      style: isOverlay
+        ? { backgroundColor: 'transparent' }
+        : { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
+      className: 'footer-navbar',
+    };
+
+    if (!isOverlay) {
+      navbarProps.fixed = 'bottom';
+    }
+
+    return (
+      <Navbar {...navbarProps} key={`footer-${mode}`}>
+        <Container style={{ backgroundColor: 'transparent' }}>
+          <Nav className="w-100 align-items-center" style={{ backgroundColor: 'transparent' }}>
+            <div
+              className="d-flex justify-content-center flex-wrap flex-grow-1"
+              style={{ backgroundColor: 'transparent' }}
+            >
+              <Button
+                onClick={handleShowCharacterInfo}
+                style={{ color: 'black' }}
+                className="footer-btn"
+                variant="secondary"
+              >
+                <i className="fas fa-image-portrait" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={handleShowStats}
+                style={{
+                  color: 'black',
+                  backgroundColor: statPointsLeft > 0 ? 'gold' : '#6C757D',
+                }}
+                className="footer-btn"
+                variant="secondary"
+              >
+                <i className="fas fa-scroll" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={handleShowSkill}
+                style={{
+                  color: 'black',
+                  backgroundColor: skillsGold,
+                }}
+                className={`footer-btn ${
+                  skillPointsLeft > 0 || expertisePointsLeft > 0 ? 'points-glow' : ''
+                }`}
+                variant="secondary"
+              >
+                <i className="fas fa-book-open" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={handleShowFeats}
+                style={{
+                  color: 'black',
+                  backgroundColor: featsGold,
+                }}
+                className={`footer-btn ${featPointsLeft > 0 ? 'points-glow' : ''}`}
+                variant="secondary"
+              >
+                <i className="fas fa-hand-fist" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={handleShowFeatures}
+                style={{
+                  color: 'black',
+                  backgroundColor: '#6C757D',
+                }}
+                className="footer-btn"
+                variant="secondary"
+              >
+                <i className="fas fa-star" aria-hidden="true"></i>
+              </Button>
+              {hasSpellcasting && (
+                <Button
+                  onClick={handleShowSpells}
+                  style={{
+                    color: 'black',
+                    backgroundColor: spellsGold,
+                  }}
+                  className={`footer-btn ${spellPointsLeft > 0 ? 'points-glow' : ''}`}
+                  variant="secondary"
+                >
+                  <i className="fas fa-hat-wizard" aria-hidden="true"></i>
+                </Button>
+              )}
+              <Button
+                onClick={handleShowEquipment}
+                style={{
+                  color: 'black',
+                  backgroundColor: '#6C757D',
+                }}
+                className="footer-btn"
+                variant="secondary"
+              >
+                <i className="fas fa-toolbox" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={() => handleShowInventory()}
+                style={{
+                  color: 'black',
+                  backgroundColor: '#6C757D',
+                }}
+                className="footer-btn"
+                variant="secondary"
+              >
+                <i className="fas fa-box-open" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={() => handleShowShop()}
+                style={{
+                  color: 'black',
+                  backgroundColor: '#6C757D',
+                }}
+                className="footer-btn"
+                variant="secondary"
+              >
+                <i className="fas fa-store" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={shouldShowMapModal ? handleCloseMapModal : handleShowMapModal}
+                style={{
+                  color: 'black',
+                  backgroundColor: '#6C757D',
+                }}
+                className="footer-btn"
+                variant="secondary"
+                aria-label={shouldShowMapModal ? 'Hide campaign map' : 'Show campaign map'}
+                aria-pressed={shouldShowMapModal}
+              >
+                <i className="fas fa-map" aria-hidden="true"></i>
+              </Button>
+              <Button
+                onClick={handleShowHelpModal}
+                style={{ color: 'white' }}
+                className="footer-btn"
+                variant="primary"
+              >
+                <i className="fas fa-info" aria-hidden="true"></i>
+              </Button>
+            </div>
+          </Nav>
+        </Container>
+      </Navbar>
+    );
+  };
+
+  const campaignMapTitle =
+    typeof campaignMap?.title === 'string' && campaignMap.title.trim() !== ''
+      ? campaignMap.title.trim()
+      : 'Campaign Map';
+
+  const mapOverlayHeader = (
+    <div className="map-modal-overlay__header-content">
+      <div className="map-modal-overlay__header-bar">
+        <div className="map-modal-overlay__title-group">
+          <div className="map-modal-overlay__eyebrow">Campaign Map</div>
+          <h2 className="map-modal-overlay__title">{campaignMapTitle}</h2>
+        </div>
+        <Button
+          variant="outline-light"
+          size="sm"
+          onClick={handleCloseMapModal}
+          data-testid="character-map-overlay-close"
+        >
+          <i className="fas fa-times me-2" aria-hidden="true"></i>
+          Close Map
+        </Button>
+      </div>
+      <div className="map-modal-overlay__tracker">
+        <CombatTurnHeader
+          participants={participantsWithDetails}
+          tokenLookup={tokenMetaById}
+        />
+      </div>
+    </div>
+  );
+
   return (
     <div
       ref={rootContainerRef}
@@ -5698,150 +5881,7 @@ export default function ZombiesCharacterSheet() {
               onActionSurge={handleActionSurge}
             />
           )}
-          <Navbar
-            fixed="bottom"
-            data-bs-theme="dark"
-            style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
-          >
-            <Container style={{ backgroundColor: 'transparent' }}>
-              <Nav
-                className="w-100 align-items-center"
-                style={{ backgroundColor: 'transparent' }}
-              >
-                <div
-                  className="d-flex justify-content-center flex-wrap flex-grow-1"
-                  style={{ backgroundColor: 'transparent' }}
-                >
-                  <Button
-                    onClick={handleShowCharacterInfo}
-                    style={{ color: "black" }}
-                    className="footer-btn"
-                    variant="secondary"
-                  >
-                    <i className="fas fa-image-portrait" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={handleShowStats}
-                    style={{
-                      color: "black",
-                      backgroundColor: statPointsLeft > 0 ? "gold" : "#6C757D",
-                    }}
-                    className="footer-btn"
-                    variant="secondary"
-                  >
-                    <i className="fas fa-scroll" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={handleShowSkill}
-                    style={{
-                      color: "black",
-                      backgroundColor: skillsGold,
-                    }}
-                    className={`footer-btn ${
-                      skillPointsLeft > 0 || expertisePointsLeft > 0
-                        ? 'points-glow'
-                        : ''
-                    }`}
-                    variant="secondary"
-                  >
-                    <i className="fas fa-book-open" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={handleShowFeats}
-                    style={{
-                      color: "black",
-                      backgroundColor: featsGold,
-                    }}
-                    className={`footer-btn ${
-                      featPointsLeft > 0 ? 'points-glow' : ''
-                    }`}
-                    variant="secondary"
-                  >
-                    <i className="fas fa-hand-fist" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={handleShowFeatures}
-                    style={{
-                      color: "black",
-                      backgroundColor: "#6C757D",
-                    }}
-                    className="footer-btn"
-                    variant="secondary"
-                  >
-                    <i className="fas fa-star" aria-hidden="true"></i>
-                  </Button>
-                  {hasSpellcasting && (
-                    <Button
-                      onClick={handleShowSpells}
-                      style={{
-                        color: 'black',
-                        backgroundColor: spellsGold,
-                      }}
-                      className={`footer-btn ${
-                        spellPointsLeft > 0 ? 'points-glow' : ''
-                      }`}
-                      variant="secondary"
-                    >
-                      <i className="fas fa-hat-wizard" aria-hidden="true"></i>
-                    </Button>
-                  )}
-                  <Button
-                    onClick={handleShowEquipment}
-                    style={{
-                      color: 'black',
-                      backgroundColor: '#6C757D',
-                    }}
-                    className="footer-btn"
-                    variant="secondary"
-                  >
-                    <i className="fas fa-toolbox" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={() => handleShowInventory()}
-                    style={{
-                      color: "black",
-                      backgroundColor: "#6C757D",
-                    }}
-                    className="footer-btn"
-                    variant="secondary"
-                  >
-                    <i className="fas fa-box-open" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={() => handleShowShop()}
-                    style={{
-                      color: "black",
-                      backgroundColor: "#6C757D",
-                    }}
-                    className="footer-btn"
-                    variant="secondary"
-                  >
-                    <i className="fas fa-store" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={handleShowMapModal}
-                    style={{
-                      color: "black",
-                      backgroundColor: "#6C757D",
-                    }}
-                    className="footer-btn"
-                    variant="secondary"
-                    aria-label="Show campaign map"
-                  >
-                    <i className="fas fa-map" aria-hidden="true"></i>
-                  </Button>
-                  <Button
-                    onClick={handleShowHelpModal}
-                    style={{ color: "white" }}
-                    className="footer-btn"
-                    variant="primary"
-                  >
-                    <i className="fas fa-info" aria-hidden="true"></i>
-                  </Button>
-                </div>
-              </Nav>
-            </Container>
-          </Navbar>
+          {!shouldShowMapModal && renderFooterNavigation('default')}
         </>
       ) : (
         <div
@@ -6017,8 +6057,9 @@ export default function ZombiesCharacterSheet() {
       characterLookup={tokenMetaById}
       onTokenMove={handleTokenMove}
       onTokenRemove={handleTokenRemove}
-      dockedSide={getDockedSide('map')}
-      onDockChange={(side) => handleDockChange('map', side)}
+      displayMode="overlay"
+      overlayHeader={mapOverlayHeader}
+      overlayFooter={renderFooterNavigation('overlay')}
     />
     {dockedModalElements}
   </div>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -673,31 +673,10 @@ test('modal docking controls update docking state', async () => {
     expect(mockSkillsModalProps.current.dockedSide).toBeNull();
   });
 
-  expect(typeof mockMapModalProps.current?.onDockChange).toBe('function');
-
-  act(() => {
-    mockMapModalProps.current?.onDockChange?.('right');
-  });
-
-  await waitFor(() => {
-    expect(mockMapModalProps.current).not.toBeNull();
-    if (mockMapModalProps.current && typeof mockMapModalProps.current.isDocked !== 'undefined') {
-      expect(mockMapModalProps.current.isDocked).toBe(true);
-      expect(mockMapModalProps.current.dockedSide).toBe('right');
-    }
-    expect(mockMapModalProps.current?.show).toBe(true);
-  });
-
-  act(() => {
-    mockMapModalProps.current?.onDockClose?.();
-  });
-
-  await waitFor(() => {
-    expect(mockMapModalProps.current).not.toBeNull();
-    if (mockMapModalProps.current && typeof mockMapModalProps.current.isDocked !== 'undefined') {
-      expect(mockMapModalProps.current.isDocked).toBe(false);
-    }
-  });
+  expect(mockMapModalProps.current).not.toBeNull();
+  expect(mockMapModalProps.current.displayMode).toBe('overlay');
+  expect(mockMapModalProps.current.overlayHeader).toBeTruthy();
+  expect(mockMapModalProps.current.overlayFooter).toBeTruthy();
 });
 
 test('docked inventory modal retains item change handler', async () => {


### PR DESCRIPTION
## Summary
- add an overlay display mode to the map modal and customize the character sheet to show the campaign map full screen with combat tracker and footer controls
- introduce styling for the full-screen overlay presentation
- update unit tests to cover the overlay mode and revised character sheet behaviour

## Testing
- npm test -- MapModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_69028f86d7ac832e91a621cbd7257820