### PR TITLE
Expand overlay map layout to fill the viewport

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -141,6 +141,72 @@
   overflow: auto;
 }
 
+.map-modal-overlay--full {
+  .map-modal-overlay__header,
+  .map-modal-overlay__footer {
+    padding: clamp(0.5rem, 1.5vw, 1rem);
+  }
+
+  .map-modal-overlay__body {
+    align-items: stretch;
+    justify-content: center;
+    padding: clamp(0.5rem, 1.5vw, 1.25rem);
+  }
+
+  .map-modal-overlay__content {
+    max-width: none;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.75rem, 1.5vw, 1.5rem);
+    padding: clamp(0.75rem, 2vw, 1.5rem);
+    border-radius: clamp(0.75rem, 2vw, 1.5rem);
+    background: rgba(6, 8, 12, 0.7);
+    backdrop-filter: blur(12px);
+    box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.45);
+    overflow: auto;
+  }
+
+  .map-modal__board-wrapper {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+  }
+
+  .map-modal__board-wrapper > .campaign-map-board {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .map-modal__board-wrapper > .campaign-map-board .campaign-map-board__title {
+    margin-bottom: clamp(0.5rem, 1.5vw, 1rem);
+  }
+
+  .map-modal__board-wrapper > .campaign-map-board .campaign-map-board__stage {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+  }
+
+  .map-modal__board-wrapper > .campaign-map-board .campaign-map-board__image-wrapper {
+    flex: 1 1 auto;
+    min-height: 0;
+    aspect-ratio: auto;
+    height: auto;
+  }
+
+  .map-modal__board-wrapper > .campaign-map-board .campaign-map-board__image {
+    height: 100%;
+  }
+
+  .map-modal-overlay__content > :not(.map-modal__board-wrapper) {
+    flex: 0 0 auto;
+  }
+}
+
 .map-modal-overlay__footer {
   display: flex;
   justify-content: center;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, ListGroup, Badge, Spinner, Alert, CloseButton } from 'react-bootstrap';
+import classNames from '../../../utils/classNames';
 import MapDisplay from './MapDisplay';
 import CampaignMapBoard from './CampaignMapBoard';
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from '../utils/mapGrouping';
@@ -1014,9 +1015,14 @@ const MapModal = ({
       );
     }
 
+    const overlayClassName = classNames(
+      'map-modal-overlay',
+      displayMode === 'overlay' && !hasManagementFeatures && 'map-modal-overlay--full'
+    );
+
     return (
       <div
-        className="map-modal-overlay"
+        className={overlayClassName}
         data-testid="map-modal-wrapper"
         role="dialog"
         aria-modal="true"


### PR DESCRIPTION
## Summary
- add a modifier class that lets the map overlay stretch across the entire viewport
- ensure the overlay campaign map board and wrappers flex to consume the available space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69029cabe964832e83dd6e21b6a7a8a8