### PR TITLE
Normalize map token identifiers for figurine movement

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -159,6 +159,32 @@ const normalizeMapId = (value, visited = new Set()) => {
       }
     }
 
+    const prefixMatch = trimmed.match(
+      /^(?:characters?|character|pcs?|pc|npcs?|npc|tokens?|token|figurines?|figurine|miniatures?|miniature)[\s:._#\/\\]+(.+)$/i
+    );
+    if (prefixMatch) {
+      const remainder = prefixMatch[1].trim();
+      if (remainder) {
+        const normalizedRemainder = normalizeMapId(remainder, visited);
+        if (normalizedRemainder) {
+          return normalizedRemainder;
+        }
+      }
+    }
+
+    if (trimmed.includes('/') || trimmed.includes('\\')) {
+      const segments = trimmed.split(/[\/\\]+/).filter(Boolean);
+      if (segments.length > 1) {
+        const lastSegment = segments[segments.length - 1].trim();
+        if (lastSegment && lastSegment !== trimmed) {
+          const normalizedSegment = normalizeMapId(lastSegment, visited);
+          if (normalizedSegment) {
+            return normalizedSegment;
+          }
+        }
+      }
+    }
+
     return trimmed;
   }
 
@@ -935,11 +961,12 @@ const MapModal = ({
           typeof token.characterId === 'string' && token.characterId.trim() !== ''
             ? token.characterId.trim()
             : null;
+        const normalizedTokenIdentifier = normalizeMapId(tokenIdentifier);
 
         const matchesCurrentCharacter = Boolean(
           normalizedCurrentCharacterIdLower &&
-            tokenIdentifier &&
-            tokenIdentifier.toLowerCase() === normalizedCurrentCharacterIdLower
+            normalizedTokenIdentifier &&
+            normalizedTokenIdentifier.toLowerCase() === normalizedCurrentCharacterIdLower
         );
 
         const isMovable =

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -302,6 +302,39 @@ describe('MapModal figurine imagery', () => {
       isMovable: true,
     });
   });
+
+  it('treats prefixed character identifiers as movable for the current player', async () => {
+    render(
+      <MapModal
+        show
+        map={{ mapId: 'map-1', title: 'Dungeon', imageUrl: 'https://example.com/map.png' }}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            'characters/hero': {
+              characterId: 'characters/hero',
+              x: 0.4,
+              y: 0.6,
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        activeCharacterId="hero"
+        characterLookup={{
+          hero: { label: 'Hero' },
+        }}
+        onTokenMove={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.tokens).toHaveLength(1);
+    expect(boardProps.tokens[0]).toMatchObject({
+      characterId: 'characters/hero',
+      isMovable: true,
+    });
+  });
 });
 
 describe('MapModal background interaction resolution', () => {


### PR DESCRIPTION
## Summary
- strip common figurine prefixes when normalizing map identifiers so token ids align with player ids
- use the normalized identifier when determining whether a figurine is movable
- cover prefixed figurine ids with a dedicated MapModal regression test

## Testing
- npm test -- MapModal

------
https://chatgpt.com/codex/tasks/task_e_6902a1934b58832e8272ed1ca069ce8b