### PR TITLE
Allow map clicks through docked overlay surfaces

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -183,9 +183,33 @@
 }
 
 .zombies-character-sheet-layout__overlay-surface {
-  pointer-events: auto;
   position: relative;
   z-index: 2;
+}
+
+.zombies-character-sheet-layout--map-interaction-active
+  // Allow the map to receive clicks when docked by default, while
+  // re-enabling interaction on specific focusable controls.
+  .zombies-character-sheet-layout__overlay-surface {
+  pointer-events: none;
+}
+
+.zombies-character-sheet-layout--map-interaction-active
+  .zombies-character-sheet-layout__overlay-surface
+  :is(
+    button,
+    [role='button'],
+    a,
+    input,
+    select,
+    textarea,
+    label,
+    summary,
+    details,
+    [tabindex]:not([tabindex='-1']),
+    [data-allow-pointer-events='true']
+  ) {
+  pointer-events: auto;
 }
 
 .map-display__grid-overlay,


### PR DESCRIPTION
## Summary
- let the docked character overlay release pointer events so the campaign map can be clicked
- re-enable pointer events for focusable controls to keep the health and action widgets usable

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_6902acdb0df8832e865fc1f32f3be67b