### PR TITLE
Adjust footer dice button styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3735,23 +3735,26 @@ h1 {
 }
 
 .footer-btn--dice {
-  width: 64px;
-  height: 64px;
+  width: 72px;
+  height: 72px;
   margin-top: 0;
   padding: 0;
   border-radius: 50%;
   background: rgba(18, 38, 84, 0.78);
   color: #ffffff !important;
-  font-size: 1.8rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0.3);
+  font-size: 2.1rem;
+  border: 3px solid rgba(44, 110, 255, 0.45);
+  box-shadow: 0 0 0 0 rgba(44, 110, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease;
 }
 
 .footer-btn--dice:hover,
 .footer-btn--dice:focus-visible {
   transform: scale(1.1);
-  background: rgba(44, 110, 255, 0.9);
-  box-shadow: 0 0 18px rgba(44, 110, 255, 0.6);
+  background: rgba(18, 38, 84, 0.9);
+  border-color: rgba(86, 144, 255, 0.9);
+  box-shadow: 0 0 0 6px rgba(44, 110, 255, 0.25), 0 0 18px rgba(44, 110, 255, 0.55);
   color: #ffffff !important;
 }
 
@@ -3761,7 +3764,7 @@ h1 {
 
 .footer-btn--dice:active {
   transform: scale(0.96);
-  box-shadow: 0 0 12px rgba(44, 110, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(44, 110, 255, 0.35), 0 0 12px rgba(44, 110, 255, 0.45);
 }
 
 .footer-btn--dice i {


### PR DESCRIPTION
## Summary
- enlarge the footer dice button and switch to a circular glow treatment for hover and focus states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902bae217b4832eaaecf0d3d969c14b