### PR TITLE
Refine footer dice button highlight

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3735,24 +3735,52 @@ h1 {
 }
 
 .footer-btn--dice {
-  width: 64px;
-  height: 64px;
+  --dice-button-size: 80px;
+  --dice-button-ring-offset: 6px;
+
+  position: relative;
+  z-index: 0;
+  width: var(--dice-button-size);
+  height: var(--dice-button-size);
   margin-top: 0;
   padding: 0;
-  border-radius: 50%;
-  background: rgba(18, 38, 84, 0.78);
+  border: none;
+  border-radius: 50% !important;
+  background: rgba(18, 38, 84, 0.82) !important;
   color: #ffffff !important;
-  font-size: 1.8rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0.3);
+  font-size: 2.4rem;
+  line-height: 1;
+  box-shadow: none;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.footer-btn--dice::before {
+  content: "";
+  position: absolute;
+  inset: calc(var(--dice-button-ring-offset) * -1);
+  border-radius: 50%;
+  border: 3px solid rgba(66, 128, 255, 0.55);
+  box-shadow: 0 0 22px rgba(44, 110, 255, 0.35);
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease;
+  pointer-events: none;
 }
 
 .footer-btn--dice:hover,
 .footer-btn--dice:focus-visible {
-  transform: scale(1.1);
-  background: rgba(44, 110, 255, 0.9);
-  box-shadow: 0 0 18px rgba(44, 110, 255, 0.6);
+  transform: scale(1.08);
+  background: rgba(18, 38, 84, 0.92) !important;
   color: #ffffff !important;
+}
+
+.footer-btn--dice:hover::before,
+.footer-btn--dice:focus-visible::before {
+  opacity: 1;
+  transform: scale(1);
+  border-color: rgba(102, 162, 255, 0.95);
+  box-shadow: 0 0 24px rgba(86, 144, 255, 0.65);
 }
 
 .footer-btn--dice:focus-visible {
@@ -3760,11 +3788,16 @@ h1 {
 }
 
 .footer-btn--dice:active {
-  transform: scale(0.96);
-  box-shadow: 0 0 12px rgba(44, 110, 255, 0.45);
+  transform: scale(0.95);
+}
+
+.footer-btn--dice:active::before {
+  box-shadow: 0 0 18px rgba(66, 128, 255, 0.55);
 }
 
 .footer-btn--dice i {
+  position: relative;
+  z-index: 1;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the footer dice button and enforce a circular shape regardless of Bootstrap defaults
- add a circular glow ring that animates on hover, focus, and active states so the highlight is no longer a square shadow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902bae217b4832eaaecf0d3d969c14b