### PR TITLE
Simplify dice footer button and hamburger toggle styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3283,6 +3283,9 @@ h1 {
   transition-duration: 400ms;
   transform: scale(1.1, 1.1) translate3d(0, 0, 0);
   cursor: pointer;
+  background: transparent;
+  box-shadow: none;
+  border: none;
 }
 
 .menuDM-open-button {
@@ -3292,6 +3295,9 @@ h1 {
   transition-duration: 400ms;
   transform: scale(1.1, 1.1) translate3d(0, 0, 0);
   cursor: pointer;
+  background: transparent;
+  box-shadow: none;
+  border: none;
 }
 
 .menu-open-button:hover {
@@ -3735,24 +3741,29 @@ h1 {
 }
 
 .footer-btn--dice {
-  width: 64px;
-  height: 64px;
-  margin-top: 0;
+  position: relative;
+  width: 48px;
+  height: 48px;
+  margin-top: 2px;
   padding: 0;
-  border-radius: 50%;
-  background: rgba(18, 38, 84, 0.78);
+  border: none;
+  background: transparent !important;
   color: #ffffff !important;
-  font-size: 1.8rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0.3);
+  font-size: 1.9rem;
+  line-height: 1;
+  box-shadow: none;
+  transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.footer-btn--dice::before {
+  display: none;
 }
 
 .footer-btn--dice:hover,
 .footer-btn--dice:focus-visible {
-  transform: scale(1.1);
-  background: rgba(44, 110, 255, 0.9);
-  box-shadow: 0 0 18px rgba(44, 110, 255, 0.6);
-  color: #ffffff !important;
+  transform: translateY(-1px) scale(1.05);
+  color: #f5f5f5 !important;
+  text-shadow: 0 0 12px rgba(136, 188, 255, 0.8);
 }
 
 .footer-btn--dice:focus-visible {
@@ -3760,12 +3771,8 @@ h1 {
 }
 
 .footer-btn--dice:active {
-  transform: scale(0.96);
-  box-shadow: 0 0 12px rgba(44, 110, 255, 0.45);
-}
-
-.footer-btn--dice i {
-  pointer-events: none;
+  transform: translateY(0) scale(0.95);
+  text-shadow: 0 0 6px rgba(136, 188, 255, 0.5);
 }
 
 .footer-actions-wrapper {


### PR DESCRIPTION
## Summary
- restyle the footer dice control to present as an icon-only button with subtle hover and active feedback
- remove the gray circular fill from both hamburger toggles so only the white bars remain visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902bae217b4832eaaecf0d3d969c14b