### PR TITLE
Increase dice footer icon size to 64px

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3742,14 +3742,14 @@ h1 {
 
 .footer-btn--dice {
   position: relative;
-  width: 48px;
-  height: 48px;
+  width: 64px;
+  height: 64px;
   margin-top: 2px;
   padding: 0;
   border: none;
   background: transparent !important;
   color: #ffffff !important;
-  font-size: 1.9rem;
+  font-size: 4rem;
   line-height: 1;
   box-shadow: none;
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;


### PR DESCRIPTION
## Summary
- enlarge the footer dice button dimensions to 64px square
- scale the dice icon font size to match the new dimensions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902bfb5c224832e81fd71064f3ef246