### PR TITLE
Resize footer dice icon to fill button

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3742,17 +3742,30 @@ h1 {
 
 .footer-btn--dice {
   position: relative;
-  width: 48px;
-  height: 48px;
+  width: 64px;
+  height: 64px;
   margin-top: 2px;
   padding: 0;
   border: none;
   background: transparent !important;
   color: #ffffff !important;
-  font-size: 1.9rem;
-  line-height: 1;
+  font-size: 64px;
+  line-height: 64px;
   box-shadow: none;
+  --fa-font-size: 64px;
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.footer-btn--dice .fa-dice-d20 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: inherit;
+  line-height: 1;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .footer-btn--dice::before {


### PR DESCRIPTION
## Summary
- enforce a fixed 64px font size and line height on the footer dice button so the icon inherits the full dimensions
- size the dice icon container to fill the 64px button regardless of whether Font Awesome renders via <i> or <svg>

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902bfb5c224832e81fd71064f3ef246