### PR TITLE
Adjust footer layout for spell slots and larger dice

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1741,14 +1741,12 @@ body.docked-modal--resizing {
 }
 
 .spell-slot-container {
-  position: fixed;
-  bottom: 60px;
-  left: 0;
-  right: 0;
-  display: flex;
+  display: inline-flex;
+  align-items: flex-end;
   justify-content: center;
   gap: 0.5rem;
-  z-index: 1030;
+  flex-wrap: wrap;
+  flex-shrink: 0;
 }
 
 .spell-slot {
@@ -1757,6 +1755,7 @@ body.docked-modal--resizing {
   height: 48px;
   color: #fff;
   padding: 2px;
+  flex-shrink: 0;
 }
 
 .spell-slot.focus-slot {
@@ -3695,7 +3694,7 @@ h1 {
   align-items: center;
   justify-content: center;
   margin: 0 4px;
-  margin-top: 10px;
+  flex-shrink: 0;
 }
 
 .footer-btn.btn-link {
@@ -3742,17 +3741,16 @@ h1 {
 
 .footer-btn--dice {
   position: relative;
-  width: 64px;
-  height: 64px;
-  margin-top: 2px;
+  width: 80px;
+  height: 80px;
   padding: 0;
   border: none;
   background: transparent !important;
   color: #ffffff !important;
-  font-size: 64px;
-  line-height: 64px;
+  font-size: 80px;
+  line-height: 80px;
   box-shadow: none;
-  --fa-font-size: 64px;
+  --fa-font-size: 80px;
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
 }
 
@@ -3798,16 +3796,52 @@ h1 {
 
 .footer-actions-wrapper {
   position: relative;
-  width: 100%;
   display: flex;
-  justify-content: center;
-  padding: 8px 0 4px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0;
+  gap: 8px;
 }
 
 .footer-actions-inline {
-  display: flex;
-  align-items: center;
+  display: inline-flex;
+  align-items: flex-end;
   justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.footer-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0));
+}
+
+.footer-nav {
+  width: 100%;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.footer-toolbar {
+  display: inline-flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 16px;
+  padding: 12px 18px;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 999px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  max-width: calc(100vw - 32px);
+  flex-wrap: wrap;
+  row-gap: 12px;
+}
+
+.footer-toolbar > .spell-slot-container {
+  justify-content: flex-start;
 }
 
 .footer-menu-toggle {
@@ -3816,9 +3850,9 @@ h1 {
 
 .footer-actions-popover {
   position: absolute;
-  bottom: 56px;
+  bottom: calc(100% + 12px);
   left: 50%;
-  transform: translate(-50%, 8px);
+  transform: translate(-50%, 12px);
   display: flex;
   flex-wrap: wrap;
   justify-content: center;

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -144,9 +144,13 @@ export default function SpellSlots({
   );
 
   return (
-    <div style={{ display: 'flex', flexShrink: 0 }}>
-      <div className="spell-slot-container">
-        <div className="spell-slot action-slot">
+    <div
+      className="spell-slot-container"
+      data-allow-pointer-events="true"
+      role="group"
+      aria-label="Spell slots and action tracking"
+    >
+      <div className="spell-slot action-slot">
           <div className="slot-level">A</div>
           <div className="slot-boxes">
             {Array.from({ length: actionCount }).map((_, i) => {
@@ -165,57 +169,56 @@ export default function SpellSlots({
             })}
           </div>
         </div>
-        <div className="spell-slot bonus-slot">
-          <div className="slot-level">B</div>
-          <div className="slot-boxes">
-            {Array.from({ length: bonusCount }).map((_, i) => {
-              const state = used.bonus?.[i];
-              const cls = state === 'used' ? 'slot-used' : 'slot-active';
-              return (
-                <div
-                  key={i}
-                  data-slot-index={i}
-                  className={`bonus-circle ${cls}`}
-                  onClick={() =>
-                    onToggleSlot && onToggleSlot('bonus', i, bonusCount)
-                  }
-                />
-              );
-            })}
+      <div className="spell-slot bonus-slot">
+        <div className="slot-level">B</div>
+        <div className="slot-boxes">
+          {Array.from({ length: bonusCount }).map((_, i) => {
+            const state = used.bonus?.[i];
+            const cls = state === 'used' ? 'slot-used' : 'slot-active';
+            return (
+              <div
+                key={i}
+                data-slot-index={i}
+                className={`bonus-circle ${cls}`}
+                onClick={() =>
+                  onToggleSlot && onToggleSlot('bonus', i, bonusCount)
+                }
+              />
+            );
+          })}
+        </div>
+      </div>
+      {hasMonkFocus && (
+        <div className="spell-slot focus-slot">
+          <div
+            className="focus-icon-wrapper"
+            role="button"
+            tabIndex={0}
+            onClick={handleFocusClick}
+            onContextMenu={handleFocusContext}
+            onDoubleClick={handleFocusDoubleClick}
+            onKeyDown={handleFocusKeyDown}
+            title={
+              "Monk's Focus: " +
+              `${focusRemaining}/${monkFocusPoints} remaining. ` +
+              'Click to spend, Shift+Click or right-click to restore, double-click to reset.'
+            }
+            aria-label={`Monk's Focus: ${focusRemaining} of ${monkFocusPoints} remaining`}
+          >
+            <div className="focus-count" aria-hidden="true">
+              {focusRemaining}
+            </div>
+            <FaHandSparkles
+              aria-hidden="true"
+              className={`focus-icon ${
+                focusRemaining > 0 ? 'focus-icon--glow' : ''
+              }`}
+            />
           </div>
         </div>
-        {hasMonkFocus && (
-          <div className="spell-slot focus-slot">
-            <div
-              className="focus-icon-wrapper"
-              role="button"
-              tabIndex={0}
-              onClick={handleFocusClick}
-              onContextMenu={handleFocusContext}
-              onDoubleClick={handleFocusDoubleClick}
-              onKeyDown={handleFocusKeyDown}
-              title={
-                "Monk's Focus: " +
-                `${focusRemaining}/${monkFocusPoints} remaining. ` +
-                'Click to spend, Shift+Click or right-click to restore, double-click to reset.'
-              }
-              aria-label={`Monk's Focus: ${focusRemaining} of ${monkFocusPoints} remaining`}
-            >
-              <div className="focus-count" aria-hidden="true">
-                {focusRemaining}
-              </div>
-              <FaHandSparkles
-                aria-hidden="true"
-                className={`focus-icon ${
-                  focusRemaining > 0 ? 'focus-icon--glow' : ''
-                }`}
-              />
-            </div>
-          </div>
-        )}
-        {regularLevels.length > 0 && renderGroup(slotData, 'regular')}
-        {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
-      </div>
+      )}
+      {regularLevels.length > 0 && renderGroup(slotData, 'regular')}
+      {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
     </div>
   );
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6046,106 +6046,104 @@ export default function ZombiesCharacterSheet() {
               />
             </div>
           </div>
-          {form && (
-            <div
-              className={overlaySurfaceClassName || undefined}
-              style={{ width: '100%' }}
-            >
-              <SpellSlots
-                form={form}
-                used={usedSlots}
-                onToggleSlot={handleCastSpell}
-                actionCount={actionCount}
-                longRestCount={longRestCount}
-                shortRestCount={shortRestCount}
-                onActionSurge={handleActionSurge}
-              />
-            </div>
-          )}
           <Navbar
             fixed="bottom"
             data-bs-theme="dark"
-            style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+            style={{ backgroundColor: 'transparent' }}
             className={overlaySurfaceClassName || undefined}
           >
-            <Container style={{ backgroundColor: 'transparent' }}>
+            <Container className="footer-container">
               <Nav
-                className="w-100 align-items-center"
-                style={{ backgroundColor: 'transparent' }}
+                className="footer-nav"
+                role="navigation"
+                aria-label="Character sheet footer actions"
               >
                 <div
-                  className="footer-actions-wrapper flex-grow-1"
-                  style={{ backgroundColor: 'transparent' }}
+                  className="footer-toolbar"
+                  data-allow-pointer-events="true"
                 >
-                  <div className="footer-actions-inline">
-                    {footerQuickActionButtons.map((action) => (
+                  {form && (
+                    <SpellSlots
+                      form={form}
+                      used={usedSlots}
+                      onToggleSlot={handleCastSpell}
+                      actionCount={actionCount}
+                      longRestCount={longRestCount}
+                      shortRestCount={shortRestCount}
+                      onActionSurge={handleActionSurge}
+                    />
+                  )}
+                  <div className="footer-actions-wrapper">
+                    <div className="footer-actions-inline">
+                      {footerQuickActionButtons.map((action) => (
+                        <Button
+                          key={action.key}
+                          variant={action.variant}
+                          className={action.className}
+                          style={action.style}
+                          type={action.type}
+                          onClick={() => {
+                            setShowFooterActions(false);
+                            action.onClick?.();
+                          }}
+                          aria-label={action.ariaLabel}
+                          title={action.title}
+                        >
+                          {action.content}
+                        </Button>
+                      ))}
                       <Button
-                        key={action.key}
-                        variant={action.variant}
-                        className={action.className}
-                        style={action.style}
-                        type={action.type}
-                        onClick={() => {
-                          setShowFooterActions(false);
-                          action.onClick?.();
-                        }}
-                        aria-label={action.ariaLabel}
-                        title={action.title}
+                        ref={footerToggleRef}
+                        onClick={() => setShowFooterActions((prev) => !prev)}
+                        aria-expanded={showFooterActions}
+                        aria-controls="footer-actions-panel"
+                        aria-label={
+                          showFooterActions
+                            ? 'Hide footer actions'
+                            : 'Show footer actions'
+                        }
+                        title={
+                          showFooterActions
+                            ? 'Hide footer actions'
+                            : 'Show footer actions'
+                        }
+                        className={`footer-btn footer-menu-toggle ${
+                          showFooterActions ? 'is-open' : ''
+                        }`}
+                        variant="secondary"
                       >
-                        {action.content}
+                        <i
+                          className={`fas ${showFooterActions ? 'fa-xmark' : 'fa-bars'}`}
+                          aria-hidden="true"
+                        ></i>
                       </Button>
-                    ))}
-                    <Button
-                      ref={footerToggleRef}
-                      onClick={() => setShowFooterActions((prev) => !prev)}
-                      aria-expanded={showFooterActions}
-                      aria-controls="footer-actions-panel"
-                      aria-label={
-                        showFooterActions
-                          ? 'Hide footer actions'
-                          : 'Show footer actions'
-                      }
-                      title={
-                        showFooterActions
-                          ? 'Hide footer actions'
-                          : 'Show footer actions'
-                      }
-                      className={`footer-btn footer-menu-toggle ${
+                    </div>
+                    <div
+                      ref={footerMenuRef}
+                      id="footer-actions-panel"
+                      className={`footer-actions-popover ${
                         showFooterActions ? 'is-open' : ''
                       }`}
-                      variant="secondary"
+                      aria-hidden={!showFooterActions}
                     >
-                      <i
-                        className={`fas ${showFooterActions ? 'fa-xmark' : 'fa-bars'}`}
-                        aria-hidden="true"
-                      ></i>
-                    </Button>
-                  </div>
-                  <div
-                    ref={footerMenuRef}
-                    id="footer-actions-panel"
-                    className={`footer-actions-popover ${
-                      showFooterActions ? 'is-open' : ''
-                    }`}
-                    aria-hidden={!showFooterActions}
-                  >
-                    {footerMenuButtons.map((action) => (
-                      <Button
-                        key={action.key}
-                        variant={action.variant}
-                        className={action.className}
-                        style={action.style}
-                        onClick={() => {
-                          setShowFooterActions(false);
-                          action.onClick?.();
-                        }}
-                        tabIndex={footerActionTabIndex}
-                        aria-label={action.ariaLabel}
-                        title={action.title}
-                      >
-                        {action.content}
-                      </Button>
-                    ))}
+                      {footerMenuButtons.map((action) => (
+                        <Button
+                          key={action.key}
+                          variant={action.variant}
+                          className={action.className}
+                          style={action.style}
+                          onClick={() => {
+                            setShowFooterActions(false);
+                            action.onClick?.();
+                          }}
+                          tabIndex={footerActionTabIndex}
+                          aria-label={action.ariaLabel}
+                          title={action.title}
+                        >
+                          {action.content}
+                        </Button>
+                      ))}
+                    </div>
                   </div>
                 </div>
               </Nav>


### PR DESCRIPTION
## Summary
- place the spell slot tracker inside the footer toolbar so it sits above the map overlay
- enlarge the dice quick action and restyle the footer so its background only wraps the content
- update spell slot markup and footer layout utilities to support the new toolbar arrangement

## Testing
- npm start *(fails: Module not found: Error: Can't resolve '@3d-dice/dice-box')*


------
https://chatgpt.com/codex/tasks/task_e_69039a022674832ea05ed81b71b39f82