### PR TITLE
Reposition spell slots and enlarge dice button

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3741,16 +3741,17 @@ h1 {
 
 .footer-btn--dice {
   position: relative;
-  width: 80px;
-  height: 80px;
+  --footer-dice-size: clamp(88px, 18vw, 112px);
+  width: var(--footer-dice-size);
+  height: var(--footer-dice-size);
   padding: 0;
   border: none;
   background: transparent !important;
   color: #ffffff !important;
-  font-size: 80px;
-  line-height: 80px;
+  font-size: calc(var(--footer-dice-size) * 0.9);
+  line-height: var(--footer-dice-size);
   box-shadow: none;
-  --fa-font-size: 80px;
+  --fa-font-size: calc(var(--footer-dice-size) * 0.9);
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
 }
 
@@ -3764,6 +3765,10 @@ h1 {
   line-height: 1;
   max-width: 100%;
   max-height: 100%;
+}
+
+.footer-btn--dice .fa-dice-d20::before {
+  font-size: inherit;
 }
 
 .footer-btn--dice::before {
@@ -3828,20 +3833,25 @@ h1 {
 
 .footer-toolbar {
   display: inline-flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: stretch;
   justify-content: center;
   gap: 16px;
-  padding: 12px 18px;
+  padding: 16px 20px;
   background: rgba(0, 0, 0, 0.55);
   border-radius: 999px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
   max-width: calc(100vw - 32px);
-  flex-wrap: wrap;
-  row-gap: 12px;
 }
 
-.footer-toolbar > .spell-slot-container {
-  justify-content: flex-start;
+.footer-toolbar__slots {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}
+
+.footer-toolbar__slots > .spell-slot-container {
+  justify-content: center;
 }
 
 .footer-menu-toggle {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6063,15 +6063,20 @@ export default function ZombiesCharacterSheet() {
                   data-allow-pointer-events="true"
                 >
                   {form && (
-                    <SpellSlots
-                      form={form}
-                      used={usedSlots}
-                      onToggleSlot={handleCastSpell}
-                      actionCount={actionCount}
-                      longRestCount={longRestCount}
-                      shortRestCount={shortRestCount}
-                      onActionSurge={handleActionSurge}
-                    />
+                    <div
+                      className="footer-toolbar__slots"
+                      data-allow-pointer-events="true"
+                    >
+                      <SpellSlots
+                        form={form}
+                        used={usedSlots}
+                        onToggleSlot={handleCastSpell}
+                        actionCount={actionCount}
+                        longRestCount={longRestCount}
+                        shortRestCount={shortRestCount}
+                        onActionSurge={handleActionSurge}
+                      />
+                    </div>
                   )}
                   <div className="footer-actions-wrapper">
                     <div className="footer-actions-inline">


### PR DESCRIPTION
## Summary
- stack the spell slot tracker above the footer controls for clearer separation
- enlarge the dice roller button with responsive sizing and ensure the icon scales with it

## Testing
- npm run start -- --host 0.0.0.0 --port 3000 *(fails: Module not found: Error: Can't resolve '@3d-dice/dice-box')*

------
https://chatgpt.com/codex/tasks/task_e_69039dcc0c64832eb18073e570ef69df