### PR TITLE
Refine zombies footer spacing and dice sizing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3741,16 +3741,17 @@ h1 {
 
 .footer-btn--dice {
   position: relative;
-  width: 80px;
-  height: 80px;
+  --footer-dice-size: clamp(112px, 24vw, 160px);
+  width: var(--footer-dice-size);
+  height: var(--footer-dice-size);
   padding: 0;
   border: none;
   background: transparent !important;
   color: #ffffff !important;
-  font-size: 80px;
-  line-height: 80px;
+  font-size: calc(var(--footer-dice-size) * 0.95);
+  line-height: var(--footer-dice-size);
   box-shadow: none;
-  --fa-font-size: 80px;
+  --fa-font-size: calc(var(--footer-dice-size) * 0.95);
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
 }
 
@@ -3764,6 +3765,10 @@ h1 {
   line-height: 1;
   max-width: 100%;
   max-height: 100%;
+}
+
+.footer-btn--dice .fa-dice-d20::before {
+  font-size: inherit;
 }
 
 .footer-btn--dice::before {
@@ -3794,6 +3799,7 @@ h1 {
   text-shadow: 0 0 6px rgba(136, 188, 255, 0.5);
 }
 
+
 .footer-actions-wrapper {
   position: relative;
   display: flex;
@@ -3801,14 +3807,14 @@ h1 {
   align-items: center;
   justify-content: flex-end;
   padding: 0;
-  gap: 8px;
+  gap: 6px;
 }
 
 .footer-actions-inline {
   display: inline-flex;
   align-items: flex-end;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
@@ -3816,7 +3822,7 @@ h1 {
   width: 100%;
   display: flex;
   justify-content: center;
-  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0));
+  padding: 10px 16px calc(10px + env(safe-area-inset-bottom, 0));
 }
 
 .footer-nav {
@@ -3828,20 +3834,27 @@ h1 {
 
 .footer-toolbar {
   display: inline-flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 10px;
   padding: 12px 18px;
   background: rgba(0, 0, 0, 0.55);
   border-radius: 999px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
   max-width: calc(100vw - 32px);
-  flex-wrap: wrap;
-  row-gap: 12px;
 }
 
-.footer-toolbar > .spell-slot-container {
-  justify-content: flex-start;
+.footer-toolbar__slots {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin-bottom: -2px;
+}
+
+.footer-toolbar__slots > .spell-slot-container {
+  justify-content: center;
+  gap: 0.4rem;
 }
 
 .footer-menu-toggle {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6063,15 +6063,20 @@ export default function ZombiesCharacterSheet() {
                   data-allow-pointer-events="true"
                 >
                   {form && (
-                    <SpellSlots
-                      form={form}
-                      used={usedSlots}
-                      onToggleSlot={handleCastSpell}
-                      actionCount={actionCount}
-                      longRestCount={longRestCount}
-                      shortRestCount={shortRestCount}
-                      onActionSurge={handleActionSurge}
-                    />
+                    <div
+                      className="footer-toolbar__slots"
+                      data-allow-pointer-events="true"
+                    >
+                      <SpellSlots
+                        form={form}
+                        used={usedSlots}
+                        onToggleSlot={handleCastSpell}
+                        actionCount={actionCount}
+                        longRestCount={longRestCount}
+                        shortRestCount={shortRestCount}
+                        onActionSurge={handleActionSurge}
+                      />
+                    </div>
                   )}
                   <div className="footer-actions-wrapper">
                     <div className="footer-actions-inline">


### PR DESCRIPTION
## Summary
- bring the footer toolbar spacing tighter so spell slots sit closer to the quick actions
- enlarge the dice roller button and icon so it reads prominently on all screen sizes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69039dcc0c64832eb18073e570ef69df