### PR TITLE
Improve footer layout on small screens

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3904,15 +3904,37 @@ h1 {
 }
 
 @media (max-width: 576px) {
+  .footer-toolbar {
+    gap: 6px;
+    padding: 10px 14px;
+  }
+
+  .footer-actions-wrapper {
+    gap: 4px;
+  }
+
+  .footer-actions-inline {
+    gap: 4px;
+  }
+
   .footer-btn {
-    width: 30px;
-    height: 30px;
+    width: 36px;
+    height: 36px;
     padding: 0;
     box-sizing: border-box;
     line-height: 1;
-    margin: 0 2px;
-    margin-top: 10px;
-    font-size: 0.9rem;
+    margin: 2px;
+    font-size: 0.95rem;
+  }
+
+  .footer-btn--attack {
+    width: 56px;
+    height: 56px;
+  }
+
+  .footer-btn--dice {
+    --footer-dice-size: clamp(88px, 36vw, 132px);
+    margin: 0;
   }
 
   .footer-actions-popover {


### PR DESCRIPTION
## Summary
- keep the footer dice quick action large on phones by overriding the generic button downsizing
- tighten mobile spacing between spell slots and footer buttons to bring the toolbar content together

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_6903ac21a53c832e815289095dbd72c8