### PR TITLE
Improve footer layout on small screens

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3904,15 +3904,47 @@ h1 {
 }
 
 @media (max-width: 576px) {
+  .footer-toolbar {
+    gap: 3px;
+    padding: 8px 12px 10px;
+  }
+
+  .footer-toolbar__slots {
+    margin-bottom: -6px;
+  }
+
+  .footer-toolbar__slots > .spell-slot-container {
+    gap: 0.35rem;
+    padding-top: 0;
+  }
+
+  .footer-actions-wrapper {
+    gap: 2px;
+  }
+
+  .footer-actions-inline {
+    gap: 8px;
+    align-items: center;
+  }
+
   .footer-btn {
-    width: 30px;
-    height: 30px;
+    width: 34px;
+    height: 34px;
     padding: 0;
     box-sizing: border-box;
     line-height: 1;
     margin: 0 2px;
-    margin-top: 10px;
-    font-size: 0.9rem;
+    font-size: 0.95rem;
+  }
+
+  .footer-btn--attack {
+    width: 52px;
+    height: 52px;
+  }
+
+  .footer-btn--dice {
+    --footer-dice-size: clamp(120px, 38vw, 168px);
+    margin-top: 8px;
   }
 
   .footer-actions-popover {


### PR DESCRIPTION
## Summary
- keep the footer dice quick action large on phones by overriding the generic button downsizing and lowering it toward the other actions
- tighten mobile spacing between spell slots and footer buttons to bring the toolbar content together

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_6903ac21a53c832e815289095dbd72c8