### PR TITLE
Improve footer layout on small screens

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3904,15 +3904,49 @@ h1 {
 }
 
 @media (max-width: 576px) {
+  .footer-toolbar {
+    gap: 2px;
+    padding: 6px 10px 8px;
+  }
+
+  .footer-toolbar__slots {
+    margin-bottom: -10px;
+  }
+
+  .footer-toolbar__slots > .spell-slot-container {
+    gap: 0.25rem;
+    padding-top: 0;
+  }
+
+  .footer-actions-wrapper {
+    gap: 4px;
+  }
+
+  .footer-actions-inline {
+    gap: 8px;
+    align-items: flex-end;
+  }
+
   .footer-btn {
-    width: 30px;
-    height: 30px;
+    width: 34px;
+    height: 34px;
     padding: 0;
     box-sizing: border-box;
     line-height: 1;
     margin: 0 2px;
-    margin-top: 10px;
-    font-size: 0.9rem;
+    font-size: 1rem;
+  }
+
+  .footer-btn--attack {
+    width: 56px;
+    height: 56px;
+  }
+
+  .footer-btn--dice {
+    --footer-dice-size: clamp(120px, 42vw, 176px);
+    width: var(--footer-dice-size);
+    height: var(--footer-dice-size);
+    margin-top: 0;
   }
 
   .footer-actions-popover {


### PR DESCRIPTION
## Summary
- tighten spacing around the mobile footer toolbar so spell slots sit closer to the quick actions
- keep the dice quick action oversized on phones by explicitly resetting its width and height within the small-screen breakpoint

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_6903ac21a53c832e815289095dbd72c8