### PR TITLE
Fix mobile dice quick action alignment

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3973,7 +3973,9 @@ h1 {
 
   .footer-btn--dice {
     --footer-dice-size: clamp(120px, 38vw, 168px);
-    margin-top: 8px;
+    margin-top: 0;
+    font-size: calc(var(--footer-dice-size) * 0.95);
+    --fa-font-size: calc(var(--footer-dice-size) * 0.95);
   }
 
   .footer-actions-popover {


### PR DESCRIPTION
## Summary
- remove the mobile offset that pushed the dice quick action out of center
- restore the large icon sizing variables on mobile so the dice icon fills the button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903b33cb130832e824871c02027a67c