### PR TITLE
Improve mobile dice quick action icon layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3768,22 +3768,20 @@ h1 {
   justify-content: center;
   width: 100%;
   height: 100%;
-  font-size: inherit;
+  font-size: calc(var(--footer-dice-size) * 0.96);
+  --fa-font-size: calc(var(--footer-dice-size) * 0.96);
   line-height: 1;
-  max-width: 100%;
-  max-height: 100%;
+  text-align: center;
 }
 
 .footer-btn--dice .fa-dice-d20::before {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  position: static;
   display: block;
-  width: 1em;
-  height: 1em;
-  line-height: 1;
+  width: 100%;
+  height: 100%;
+  line-height: inherit;
   font-size: inherit;
+  transform: none;
 }
 
 .footer-btn--dice::before {
@@ -3973,7 +3971,9 @@ h1 {
 
   .footer-btn--dice {
     --footer-dice-size: clamp(120px, 38vw, 168px);
-    margin-top: 8px;
+    margin-top: 0;
+    font-size: calc(var(--footer-dice-size) * 0.95);
+    --fa-font-size: calc(var(--footer-dice-size) * 0.95);
   }
 
   .footer-actions-popover {


### PR DESCRIPTION
## Summary
- update the dice quick action styles so the Font Awesome icon fills the quick action button and stays centered
- tie the icon sizing variables directly to the quick action dimensions for consistent appearance on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903b33cb130832e824871c02027a67c