### PR TITLE
Fix footer dice icon alignment

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3754,34 +3754,17 @@ h1 {
   border: none;
   background: transparent !important;
   color: #ffffff !important;
-  font-size: calc(var(--footer-dice-size) * 0.95);
-  line-height: 1;
   box-shadow: none;
-  --fa-font-size: calc(var(--footer-dice-size) * 0.95);
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
 }
 
-.footer-btn--dice .fa-dice-d20 {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  font-size: calc(var(--footer-dice-size) * 0.96);
-  --fa-font-size: calc(var(--footer-dice-size) * 0.96);
-  line-height: 1;
-  text-align: center;
-}
-
-.footer-btn--dice .fa-dice-d20::before {
-  position: static;
+.footer-btn__dice-icon {
   display: block;
   width: 100%;
   height: 100%;
-  line-height: inherit;
-  font-size: inherit;
-  transform: none;
+  color: inherit;
+  fill: currentColor;
+  transition: inherit;
 }
 
 .footer-btn--dice::before {
@@ -3972,8 +3955,6 @@ h1 {
   .footer-btn--dice {
     --footer-dice-size: clamp(120px, 38vw, 168px);
     margin-top: 0;
-    font-size: calc(var(--footer-dice-size) * 0.95);
-    --fa-font-size: calc(var(--footer-dice-size) * 0.95);
   }
 
   .footer-actions-popover {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -41,6 +41,7 @@ import Features from "../attributes/Features";
 import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import { getMonkFocusPoints } from '../../../utils/monk';
+import { FaDiceD20 } from "react-icons/fa";
 import hasteIcon from "../../../images/spell-haste-icon.png";
 import largeFormIcon from "../../../images/large-form-icon.png";
 import dragonWingsIcon from "../../../images/dragon-wings-icon.png";
@@ -5439,7 +5440,9 @@ export default function ZombiesCharacterSheet() {
       type: 'button',
       ariaLabel: 'Open dice roller',
       title: 'Dice roller',
-      content: <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>,
+      content: (
+        <FaDiceD20 className="footer-btn__dice-icon" aria-hidden="true" focusable="false" />
+      ),
       onClick: () => {
         playerTurnActionsRef.current?.openDiceRoller?.();
       },


### PR DESCRIPTION
## Summary
- render the footer dice button with the SVG-based FaDiceD20 icon for consistent centering
- update the dice button styling to size and color the icon without font-based hacks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903ef383f64832eab664f45e6d17bf9