### PR TITLE
Redesign character footer quick actions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3795,6 +3795,150 @@ h1 {
   text-shadow: 0 0 6px rgba(136, 188, 255, 0.5);
 }
 
+.footer-character-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: rgba(9, 15, 34, 0.85);
+  border-radius: 24px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  color: #f1f5ff;
+  margin: 0 4px;
+  min-height: 72px;
+}
+
+.footer-character-slot__figurine {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 2px solid rgba(116, 163, 255, 0.7);
+  background: rgba(22, 32, 56, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 12px rgba(64, 108, 204, 0.35);
+}
+
+.footer-character-slot__figurine-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.footer-character-slot__figurine-placeholder {
+  font-size: 1.75rem;
+  color: rgba(173, 195, 255, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer-character-slot__health {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 136px;
+}
+
+.footer-character-slot__health-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(196, 208, 255, 0.75);
+}
+
+.footer-character-slot__health-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.footer-character-slot__health-button {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(136, 188, 255, 0.45);
+  background: rgba(24, 36, 68, 0.85);
+  color: #f2f5ff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.footer-character-slot__health-button i {
+  font-size: 0.95rem;
+}
+
+.footer-character-slot__health-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.footer-character-slot__health-button:not(:disabled):hover,
+.footer-character-slot__health-button:not(:disabled):focus-visible {
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: 0 0 14px rgba(136, 188, 255, 0.45);
+  border-color: rgba(136, 188, 255, 0.8);
+  outline: none;
+}
+
+.footer-character-slot__health-value {
+  min-width: 78px;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.footer-character-slot__health-max {
+  font-size: 0.95rem;
+  color: rgba(210, 220, 255, 0.9);
+}
+
+.footer-character-slot__error {
+  min-height: 0.8rem;
+  font-size: 0.7rem;
+  color: #ffb4a2;
+  text-align: center;
+}
+
+.footer-character-slot__health-value .spinner-border {
+  width: 1rem;
+  height: 1rem;
+  border-width: 0.15em;
+  color: #88bcff;
+}
+
+@media (max-width: 600px) {
+  .footer-character-slot {
+    flex-direction: column;
+    min-height: 0;
+    padding: 10px 12px;
+    gap: 10px;
+  }
+
+  .footer-character-slot__health {
+    min-width: 0;
+  }
+
+  .footer-character-slot__health-controls {
+    gap: 10px;
+  }
+}
+
 
 .footer-actions-wrapper {
   position: relative;
@@ -3808,9 +3952,9 @@ h1 {
 
 .footer-actions-inline {
   display: inline-flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -64,6 +64,7 @@ import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import TokenPickerModal from '../components/TokenPickerModal';
 import buildPlayerTokenFolderScope from '../utils/playerTokenFilters';
+import FooterCharacterSlot from './components/FooterCharacterSlot';
 
 const HEADER_PADDING = 16;
 const MIN_DOCKED_MODAL_WIDTH = 320;
@@ -3960,6 +3961,55 @@ export default function ZombiesCharacterSheet() {
 
   const characterFigurine = useMemo(() => resolveFigurineImageData(form), [form]);
 
+  const footerCharacterName = useMemo(() => {
+    if (!form || typeof form !== 'object') {
+      return null;
+    }
+
+    const candidateValues = [
+      form?.characterName,
+      form?.name,
+      form?.displayName,
+      form?.alias,
+    ];
+
+    for (const value of candidateValues) {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+    }
+
+    return null;
+  }, [form]);
+
+  const footerHealth = useMemo(() => {
+    if (!form || typeof form !== 'object') {
+      return { current: null, max: null };
+    }
+
+    const { currentHp, maxHp } = calculateCharacterHitPoints(form);
+
+    let resolvedMax = toFiniteNumberOrNull(maxHp);
+    if (resolvedMax === null) {
+      resolvedMax = toFiniteNumberOrNull(
+        form?.hpMax ?? form?.hitPoints ?? form?.health
+      );
+    }
+
+    let resolvedCurrent = toFiniteNumberOrNull(currentHp);
+    if (resolvedCurrent === null && resolvedMax !== null) {
+      resolvedCurrent = resolvedMax;
+    }
+
+    return {
+      current: resolvedCurrent,
+      max: resolvedMax,
+    };
+  }, [form]);
+
   const tokenPickerFilterScope = useMemo(() => {
     const raceValue =
       form?.race !== undefined && form?.race !== null && form?.race !== ''
@@ -5413,41 +5463,24 @@ export default function ZombiesCharacterSheet() {
   }, [isFormReady, showFooterActions]);
 
   const footerActionTabIndex = showFooterActions ? undefined : -1;
-  const footerQuickActionButtons = [
-    {
-      key: 'attack',
-      className: 'footer-btn footer-btn--attack',
-      variant: 'link',
-      type: 'button',
-      ariaLabel: 'Open attack actions',
-      title: 'Attack options',
-      content: (
-        <img
-          src={sword}
-          alt=""
-          aria-hidden="true"
-          className="footer-btn__attack-image"
-        />
-      ),
-      onClick: () => {
-        playerTurnActionsRef.current?.openAttackModal?.();
-      },
+
+  const handleFooterQuickAction = useCallback(
+    (action) => {
+      setShowFooterActions(false);
+      if (typeof action === 'function') {
+        action();
+      }
     },
-    {
-      key: 'dice',
-      className: 'footer-btn footer-btn--dice',
-      variant: 'link',
-      type: 'button',
-      ariaLabel: 'Open dice roller',
-      title: 'Dice roller',
-      content: (
-        <FaDiceD20 className="footer-btn__dice-icon" aria-hidden="true" focusable="false" />
-      ),
-      onClick: () => {
-        playerTurnActionsRef.current?.openDiceRoller?.();
-      },
-    },
-  ];
+    [setShowFooterActions]
+  );
+
+  const openAttackModal = useCallback(() => {
+    playerTurnActionsRef.current?.openAttackModal?.();
+  }, []);
+
+  const openDiceRoller = useCallback(() => {
+    playerTurnActionsRef.current?.openDiceRoller?.();
+  }, []);
   const footerMenuButtons = [
     {
       key: 'characterInfo',
@@ -6054,13 +6087,10 @@ export default function ZombiesCharacterSheet() {
             data-bs-theme="dark"
             style={{ backgroundColor: 'transparent' }}
             className={overlaySurfaceClassName || undefined}
+            aria-label="Character sheet footer actions"
           >
             <Container className="footer-container">
-              <Nav
-                className="footer-nav"
-                role="navigation"
-                aria-label="Character sheet footer actions"
-              >
+              <Nav className="footer-nav">
                 <div
                   className="footer-toolbar"
                   data-allow-pointer-events="true"
@@ -6083,23 +6113,43 @@ export default function ZombiesCharacterSheet() {
                   )}
                   <div className="footer-actions-wrapper">
                     <div className="footer-actions-inline">
-                      {footerQuickActionButtons.map((action) => (
-                        <Button
-                          key={action.key}
-                          variant={action.variant}
-                          className={action.className}
-                          style={action.style}
-                          type={action.type}
-                          onClick={() => {
-                            setShowFooterActions(false);
-                            action.onClick?.();
-                          }}
-                          aria-label={action.ariaLabel}
-                          title={action.title}
-                        >
-                          {action.content}
-                        </Button>
-                      ))}
+                      <Button
+                        variant="link"
+                        className="footer-btn footer-btn--dice"
+                        type="button"
+                        onClick={() => handleFooterQuickAction(openDiceRoller)}
+                        aria-label="Open dice roller"
+                        title="Dice roller"
+                      >
+                        <FaDiceD20
+                          className="footer-btn__dice-icon"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                      </Button>
+                      <FooterCharacterSlot
+                        characterFigurine={characterFigurine}
+                        characterId={characterId}
+                        characterName={footerCharacterName}
+                        currentHealth={footerHealth.current}
+                        maxHealth={footerHealth.max}
+                        onHealthChange={handleHealthChange}
+                      />
+                      <Button
+                        variant="link"
+                        className="footer-btn footer-btn--attack"
+                        type="button"
+                        onClick={() => handleFooterQuickAction(openAttackModal)}
+                        aria-label="Open attack actions"
+                        title="Attack options"
+                      >
+                        <img
+                          src={sword}
+                          alt=""
+                          aria-hidden="true"
+                          className="footer-btn__attack-image"
+                        />
+                      </Button>
                       <Button
                         ref={footerToggleRef}
                         onClick={() => setShowFooterActions((prev) => !prev)}

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -1,0 +1,189 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Spinner } from 'react-bootstrap';
+
+import apiFetch from '../../../../utils/apiFetch';
+
+const resolveFigurineImageUrl = (figurine) => {
+  if (!figurine || typeof figurine !== 'object') {
+    return null;
+  }
+
+  const { figurineImageUrl } = figurine;
+  if (typeof figurineImageUrl === 'string' && figurineImageUrl.trim() !== '') {
+    return figurineImageUrl.trim();
+  }
+
+  return null;
+};
+
+const FooterCharacterSlot = ({
+  characterFigurine,
+  characterId,
+  characterName,
+  currentHealth,
+  maxHealth,
+  onHealthChange,
+}) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState(null);
+
+  const { resolvedCurrent, resolvedMax } = useMemo(() => {
+    const numericCurrent = Number(currentHealth);
+    const numericMax = Number(maxHealth);
+
+    return {
+      resolvedCurrent: Number.isFinite(numericCurrent) ? numericCurrent : null,
+      resolvedMax: Number.isFinite(numericMax) ? numericMax : null,
+    };
+  }, [currentHealth, maxHealth]);
+
+  const figurineImageUrl = useMemo(
+    () => resolveFigurineImageUrl(characterFigurine),
+    [characterFigurine]
+  );
+
+  const baseCurrent = resolvedCurrent ?? 0;
+  const canDecrease = !isUpdating && baseCurrent > 0;
+  const canIncrease =
+    !isUpdating &&
+    (resolvedMax === null || resolvedCurrent === null || resolvedCurrent < resolvedMax);
+
+  const displayCurrent = resolvedCurrent ?? '—';
+  const displayMax = resolvedMax ?? '—';
+
+  const handleAdjustHealth = async (offset) => {
+    if (!Number.isFinite(Number(offset)) || Number(offset) === 0) {
+      return;
+    }
+    if (isUpdating || !characterId) {
+      return;
+    }
+
+    let nextHealth = baseCurrent + Number(offset);
+    if (resolvedMax !== null) {
+      nextHealth = Math.min(nextHealth, resolvedMax);
+    }
+    nextHealth = Math.max(nextHealth, 0);
+
+    if (!Number.isFinite(nextHealth) || nextHealth === baseCurrent) {
+      return;
+    }
+
+    setError(null);
+    setIsUpdating(true);
+    try {
+      const response = await apiFetch(`/characters/update-temphealth/${characterId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          tempHealth: nextHealth,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(response.statusText || 'Failed to update health.');
+      }
+
+      setError(null);
+      if (typeof onHealthChange === 'function') {
+        onHealthChange(nextHealth);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      setError('Failed to update health.');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <div className="footer-character-slot" data-allow-pointer-events="true">
+      <div className="footer-character-slot__figurine">
+        {figurineImageUrl ? (
+          <img
+            src={figurineImageUrl}
+            alt={
+              characterName
+                ? `${characterName} figurine`
+                : 'Selected character figurine'
+            }
+            className="footer-character-slot__figurine-image"
+          />
+        ) : (
+          <div className="footer-character-slot__figurine-placeholder" aria-hidden="true">
+            <i className="fas fa-chess-king" />
+          </div>
+        )}
+      </div>
+      <div className="footer-character-slot__health">
+        <span className="footer-character-slot__health-label">Health</span>
+        <div className="footer-character-slot__health-controls" role="group" aria-label="Character health controls">
+          <Button
+            type="button"
+            variant="outline-light"
+            className="footer-character-slot__health-button"
+            onClick={() => handleAdjustHealth(-1)}
+            disabled={!canDecrease}
+            aria-label="Decrease health"
+          >
+            <i className="fas fa-minus" aria-hidden="true" />
+          </Button>
+          <div className="footer-character-slot__health-value" aria-live="polite">
+            {isUpdating ? (
+              <Spinner animation="border" role="status" size="sm">
+                <span className="visually-hidden">Updating health…</span>
+              </Spinner>
+            ) : (
+              <>
+                <span className="footer-character-slot__health-current">{displayCurrent}</span>
+                {resolvedMax !== null && (
+                  <span className="footer-character-slot__health-max">/ {displayMax}</span>
+                )}
+              </>
+            )}
+          </div>
+          <Button
+            type="button"
+            variant="outline-light"
+            className="footer-character-slot__health-button"
+            onClick={() => handleAdjustHealth(1)}
+            disabled={!canIncrease}
+            aria-label="Increase health"
+          >
+            <i className="fas fa-plus" aria-hidden="true" />
+          </Button>
+        </div>
+        <div className="footer-character-slot__error" role="status" aria-live="polite">
+          {error}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+FooterCharacterSlot.propTypes = {
+  characterFigurine: PropTypes.shape({
+    figurineImageUrl: PropTypes.string,
+    figurineImagePublicId: PropTypes.string,
+  }),
+  characterId: PropTypes.string,
+  characterName: PropTypes.string,
+  currentHealth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
+  maxHealth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
+  onHealthChange: PropTypes.func,
+};
+
+FooterCharacterSlot.defaultProps = {
+  characterFigurine: null,
+  characterId: null,
+  characterName: null,
+  currentHealth: null,
+  maxHealth: null,
+  onHealthChange: undefined,
+};
+
+export default FooterCharacterSlot;


### PR DESCRIPTION
## Summary
- add a dedicated FooterCharacterSlot component that renders the character figurine and HP adjusters
- rearrange the footer quick actions so the dice roller sits left, health slot in the center, and attack/menu controls on the right
- refresh footer styling and spacing to suit the new layout

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js

------
https://chatgpt.com/codex/tasks/task_e_6903f3ce785c832e82d472033129034a