### PR TITLE
Refine footer character slot layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3799,31 +3799,31 @@ h1 {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 18px;
-  padding: 14px 22px;
-  background: linear-gradient(135deg, rgba(9, 15, 34, 0.92), rgba(19, 28, 54, 0.85));
-  border-radius: 999px;
-  border: 1px solid rgba(116, 163, 255, 0.55);
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.45), inset 0 0 18px rgba(86, 140, 255, 0.25);
-  color: #f1f5ff;
-  margin: 0 6px;
-  min-height: 96px;
-  backdrop-filter: blur(6px);
+  gap: 16px;
+  padding: 10px 16px;
+  background: rgba(15, 22, 43, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(104, 144, 216, 0.45);
+  box-shadow: 0 12px 26px rgba(6, 10, 20, 0.45);
+  color: #f3f6ff;
+  margin: 0 4px;
+  min-height: 0;
+  backdrop-filter: blur(4px);
 }
 
 .footer-character-slot::before {
   content: '';
   position: absolute;
-  inset: 6px;
-  border-radius: 999px;
-  border: 1px solid rgba(43, 77, 156, 0.35);
+  inset: 4px;
+  border-radius: 16px;
+  border: 1px solid rgba(47, 78, 143, 0.35);
   pointer-events: none;
 }
 
 .footer-character-slot__portrait {
   position: relative;
-  width: 92px;
-  height: 92px;
+  width: 72px;
+  height: 72px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3835,9 +3835,9 @@ h1 {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  padding: 6px;
-  background: radial-gradient(circle at 30% 30%, rgba(124, 174, 255, 0.55), rgba(28, 44, 88, 0.95));
-  box-shadow: 0 10px 18px rgba(12, 18, 38, 0.65), inset 0 0 20px rgba(82, 126, 220, 0.45);
+  padding: 4px;
+  background: radial-gradient(circle at 35% 35%, rgba(120, 168, 255, 0.45), rgba(24, 36, 72, 0.9));
+  box-shadow: 0 8px 16px rgba(8, 12, 26, 0.6), inset 0 0 16px rgba(80, 124, 216, 0.4);
 }
 
 .footer-character-slot__portrait-ring::after {
@@ -3845,9 +3845,8 @@ h1 {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  border: 2px solid rgba(25, 38, 74, 0.85);
+  border: 1px solid rgba(22, 34, 66, 0.75);
   pointer-events: none;
-  mix-blend-mode: screen;
 }
 
 .footer-character-slot__figurine-image {
@@ -3855,8 +3854,8 @@ h1 {
   height: 100%;
   border-radius: 50%;
   object-fit: cover;
-  border: 3px solid rgba(18, 27, 54, 0.9);
-  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.45);
+  border: 2px solid rgba(16, 24, 48, 0.85);
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.35);
 }
 
 .footer-character-slot__figurine-placeholder {
@@ -3866,97 +3865,109 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, rgba(45, 68, 120, 0.85), rgba(18, 26, 52, 0.95));
-  color: rgba(173, 195, 255, 0.85);
-  font-size: 1.75rem;
+  background: linear-gradient(135deg, rgba(44, 66, 118, 0.8), rgba(18, 26, 52, 0.95));
+  color: rgba(175, 195, 245, 0.85);
+  font-size: 1.4rem;
 }
 
 .footer-character-slot__portrait-gloss {
   position: absolute;
-  top: 12%;
-  left: 18%;
-  width: 60%;
-  height: 32%;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.65), transparent);
+  top: 14%;
+  left: 20%;
+  width: 56%;
+  height: 28%;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.5), transparent);
   border-radius: 50%;
-  opacity: 0.45;
+  opacity: 0.35;
   pointer-events: none;
-  transform: rotate(-18deg);
+  transform: rotate(-15deg);
 }
 
-.footer-character-slot__health-readout {
-  position: absolute;
-  bottom: -18px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-  padding: 4px 10px;
-  background: linear-gradient(135deg, rgba(42, 56, 102, 0.95), rgba(26, 36, 68, 0.95));
-  border-radius: 999px;
-  border: 1px solid rgba(120, 170, 255, 0.45);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
-  font-weight: 700;
-  font-size: 0.95rem;
-  color: #f7f9ff;
-  text-shadow: 0 0 6px rgba(80, 130, 220, 0.6);
-  min-width: 64px;
-  justify-content: center;
-}
-
-.footer-character-slot__panel {
+.footer-character-slot__details {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.footer-character-slot__name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(216, 226, 255, 0.85);
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.footer-character-slot__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
-  min-width: clamp(220px, 28vw, 260px);
 }
 
 .footer-character-slot__health-label {
-  text-transform: uppercase;
   font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  color: rgba(193, 208, 255, 0.85);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(194, 208, 248, 0.8);
+}
+
+.footer-character-slot__health-readout {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(28, 40, 74, 0.8);
+  border: 1px solid rgba(112, 154, 230, 0.35);
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #f7f9ff;
 }
 
 .footer-character-slot__health-track {
   position: relative;
-  width: clamp(180px, 22vw, 240px);
-  height: 18px;
+  width: min(260px, 40vw);
+  height: 12px;
+  border-radius: 999px;
 }
 
 .footer-character-slot__health-track-base {
   position: absolute;
   inset: 0;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(18, 29, 54, 0.95), rgba(30, 44, 88, 0.85));
   overflow: hidden;
-  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55);
+  background: linear-gradient(135deg, rgba(30, 46, 92, 0.85), rgba(18, 28, 58, 0.95));
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.35);
 }
 
 .footer-character-slot__health-track-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #33d17a 0%, #5fffc5 55%, #88f4ff 100%);
-  box-shadow: 0 0 18px rgba(92, 255, 201, 0.45);
-  border-radius: inherit;
-  transition: width 0.25s ease-in-out;
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(98, 188, 255, 0.95), rgba(96, 255, 196, 0.9));
+  box-shadow: inset 0 0 8px rgba(255, 255, 255, 0.3);
+  transition: width 0.2s ease;
 }
 
 .footer-character-slot__health-track-border {
   position: absolute;
   inset: 0;
   border-radius: 999px;
-  border: 1px solid rgba(136, 188, 255, 0.35);
+  border: 1px solid rgba(132, 176, 248, 0.25);
   pointer-events: none;
 }
 
 .footer-character-slot__health-track::after {
   content: '';
   position: absolute;
-  inset: 2px 3px;
+  inset: 2px;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
   pointer-events: none;
 }
 
@@ -3972,103 +3983,93 @@ h1 {
 .footer-character-slot__health-controls {
   display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
 }
 
 .footer-character-slot__health-button {
-  width: 44px;
-  height: 44px;
+  width: 34px;
+  height: 34px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border-radius: 14px;
-  border: 1px solid rgba(120, 170, 255, 0.45);
-  background: linear-gradient(135deg, rgba(66, 106, 189, 0.85), rgba(32, 52, 98, 0.95));
+  border-radius: 10px;
+  border: 1px solid rgba(108, 154, 230, 0.45);
+  background: linear-gradient(135deg, rgba(60, 92, 160, 0.85), rgba(30, 46, 94, 0.95));
   color: #f5f7ff;
-  box-shadow: 0 10px 24px rgba(18, 24, 48, 0.5), inset 0 0 10px rgba(96, 150, 255, 0.3);
+  box-shadow: 0 8px 20px rgba(12, 16, 34, 0.5), inset 0 0 8px rgba(88, 138, 236, 0.28);
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
 .footer-character-slot__health-button--decrease {
-  background: linear-gradient(135deg, rgba(210, 68, 68, 0.9), rgba(122, 24, 24, 0.95));
-  border-color: rgba(255, 115, 115, 0.55);
-  box-shadow: 0 10px 24px rgba(64, 8, 8, 0.5), inset 0 0 10px rgba(255, 138, 138, 0.35);
+  background: linear-gradient(135deg, rgba(198, 70, 70, 0.9), rgba(118, 26, 26, 0.95));
+  border-color: rgba(242, 120, 120, 0.5);
+  box-shadow: 0 8px 20px rgba(58, 12, 12, 0.5), inset 0 0 8px rgba(255, 144, 144, 0.3);
 }
 
 .footer-character-slot__health-button--increase {
-  background: linear-gradient(135deg, rgba(56, 173, 108, 0.9), rgba(18, 95, 58, 0.95));
-  border-color: rgba(118, 255, 188, 0.45);
-  box-shadow: 0 10px 24px rgba(8, 58, 32, 0.5), inset 0 0 10px rgba(142, 255, 202, 0.35);
+  background: linear-gradient(135deg, rgba(54, 160, 104, 0.9), rgba(20, 92, 56, 0.95));
+  border-color: rgba(120, 240, 182, 0.45);
+  box-shadow: 0 8px 20px rgba(10, 58, 32, 0.45), inset 0 0 8px rgba(142, 255, 202, 0.28);
 }
 
 .footer-character-slot__health-button i {
-  font-size: 1.05rem;
+  font-size: 0.95rem;
 }
 
 .footer-character-slot__health-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
 }
 
 .footer-character-slot__health-button:not(:disabled):hover,
 .footer-character-slot__health-button:not(:disabled):focus-visible {
-  transform: translateY(-1px) scale(1.05);
-  box-shadow: 0 12px 28px rgba(39, 56, 106, 0.6), inset 0 0 12px rgba(142, 188, 255, 0.45);
+  transform: translateY(-1px) scale(1.04);
+  box-shadow: 0 10px 24px rgba(28, 42, 84, 0.55), inset 0 0 10px rgba(132, 180, 252, 0.4);
   filter: brightness(1.05);
 }
 
 .footer-character-slot__health-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(136, 188, 255, 0.35), 0 12px 28px rgba(39, 56, 106, 0.6);
+  box-shadow: 0 0 0 2px rgba(132, 180, 252, 0.35), 0 10px 24px rgba(28, 42, 84, 0.55);
 }
 
 .footer-character-slot__health-max {
-  font-size: 0.9rem;
-  color: rgba(210, 220, 255, 0.9);
+  font-size: 0.82rem;
+  color: rgba(210, 220, 255, 0.85);
 }
 
 .footer-character-slot__error {
-  min-height: 0.9rem;
-  font-size: 0.72rem;
+  min-height: 0.8rem;
+  font-size: 0.7rem;
   color: #ffb4a2;
   text-align: left;
 }
 
 .footer-character-slot__health-readout .spinner-border {
-  width: 1rem;
-  height: 1rem;
-  border-width: 0.15em;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-width: 0.12em;
   color: #88bcff;
 }
 
 @media (max-width: 600px) {
   .footer-character-slot {
-    flex-direction: column;
-    min-height: 0;
-    padding: 16px 18px 24px;
-    gap: 60px;
+    flex-direction: row;
+    width: 100%;
+    gap: 12px;
   }
 
-  .footer-character-slot__health-readout {
-    bottom: -26px;
-  }
-
-  .footer-character-slot__panel {
-    align-items: center;
-    min-width: 0;
+  .footer-character-slot__details {
     width: 100%;
   }
 
   .footer-character-slot__health-track {
     width: 100%;
   }
-
-  .footer-character-slot__health-controls {
-    gap: 12px;
-  }
 }
+
 
 
 .footer-actions-wrapper {

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -213,23 +213,30 @@ const FooterCharacterSlot = ({
           )}
           <span className="footer-character-slot__portrait-gloss" />
         </div>
-        <div className="footer-character-slot__health-readout" aria-live="polite">
-          {isUpdating ? (
-            <Spinner animation="border" role="status" size="sm">
-              <span className="visually-hidden">Updating health…</span>
-            </Spinner>
-          ) : (
-            <>
-              <span className="footer-character-slot__health-current">{displayCurrent}</span>
-              {displayMax !== '—' && (
-                <span className="footer-character-slot__health-max">/ {displayMax}</span>
-              )}
-            </>
-          )}
-        </div>
       </div>
-      <div className="footer-character-slot__panel">
-        <span className="footer-character-slot__health-label">Health</span>
+      <div className="footer-character-slot__details">
+        {characterName && (
+          <span className="footer-character-slot__name" title={characterName}>
+            {characterName}
+          </span>
+        )}
+        <div className="footer-character-slot__header">
+          <span className="footer-character-slot__health-label">Health</span>
+          <div className="footer-character-slot__health-readout" aria-live="polite">
+            {isUpdating ? (
+              <Spinner animation="border" role="status" size="sm">
+                <span className="visually-hidden">Updating health…</span>
+              </Spinner>
+            ) : (
+              <>
+                <span className="footer-character-slot__health-current">{displayCurrent}</span>
+                {displayMax !== '—' && (
+                  <span className="footer-character-slot__health-max">/ {displayMax}</span>
+                )}
+              </>
+            )}
+          </div>
+        </div>
         <div className="footer-character-slot__health-track" role="presentation">
           <div className="footer-character-slot__health-track-base">
             <div


### PR DESCRIPTION
## Summary
- move the health readout next to the portrait and expose the character name within the footer slot panel
- restyle the footer character slot to a more compact pill with smaller buttons and health track sizing

## Testing
- npm start *(fails: Module not found: Error: Can't resolve '@3d-dice/dice-box')*

------
https://chatgpt.com/codex/tasks/task_e_69040584f6d4832e846043fc5693d88d