### PR TITLE
Refine character footer layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3797,18 +3797,20 @@ h1 {
 
 .footer-character-slot {
   position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 16px;
-  padding: 10px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  padding: 14px 18px;
   background: rgba(15, 22, 43, 0.9);
   border-radius: 20px;
   border: 1px solid rgba(104, 144, 216, 0.45);
   box-shadow: 0 12px 26px rgba(6, 10, 20, 0.45);
   color: #f3f6ff;
-  margin: 0 4px;
+  margin: 0;
   min-height: 0;
   backdrop-filter: blur(4px);
+  width: min(100%, 720px);
 }
 
 .footer-character-slot::before {
@@ -3818,6 +3820,14 @@ h1 {
   border-radius: 16px;
   border: 1px solid rgba(47, 78, 143, 0.35);
   pointer-events: none;
+}
+
+.footer-character-slot__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
 .footer-character-slot__portrait {
@@ -3888,6 +3898,29 @@ h1 {
   flex-direction: column;
   gap: 8px;
   min-width: 0;
+  flex: 1 1 240px;
+}
+
+.footer-character-slot__actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.footer-character-slot__slots {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding: 6px 10px 4px;
+  border-radius: 14px;
+  border: 1px solid rgba(80, 124, 196, 0.35);
+  background: rgba(8, 16, 36, 0.55);
+  box-shadow: inset 0 0 14px rgba(10, 18, 40, 0.45);
+}
+
+.footer-character-slot__slots > .spell-slot-container {
+  justify-content: center;
 }
 
 .footer-character-slot__name {
@@ -4056,12 +4089,20 @@ h1 {
 
 @media (max-width: 600px) {
   .footer-character-slot {
-    flex-direction: row;
     width: 100%;
-    gap: 12px;
+  }
+
+  .footer-character-slot__main {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 20px;
   }
 
   .footer-character-slot__details {
+    width: 100%;
+  }
+
+  .footer-character-slot__actions {
     width: 100%;
   }
 
@@ -4102,31 +4143,6 @@ h1 {
   padding: 0;
   display: flex;
   justify-content: center;
-}
-
-.footer-toolbar {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 12px 18px;
-  background: rgba(0, 0, 0, 0.55);
-  border-radius: 999px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
-  max-width: calc(100vw - 32px);
-}
-
-.footer-toolbar__slots {
-  display: flex;
-  width: 100%;
-  justify-content: center;
-  margin-bottom: -2px;
-}
-
-.footer-toolbar__slots > .spell-slot-container {
-  justify-content: center;
-  gap: 0.4rem;
 }
 
 .footer-menu-toggle {
@@ -4190,20 +4206,6 @@ h1 {
 }
 
 @media (max-width: 576px) {
-  .footer-toolbar {
-    gap: 3px;
-    padding: 8px 12px 10px;
-  }
-
-  .footer-toolbar__slots {
-    margin-bottom: -6px;
-  }
-
-  .footer-toolbar__slots > .spell-slot-container {
-    gap: 0.35rem;
-    padding-top: 0;
-  }
-
   .footer-actions-wrapper {
     gap: 2px;
   }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6091,15 +6091,15 @@ export default function ZombiesCharacterSheet() {
           >
             <Container className="footer-container">
               <Nav className="footer-nav">
-                <div
-                  className="footer-toolbar"
-                  data-allow-pointer-events="true"
-                >
-                  {form && (
-                    <div
-                      className="footer-toolbar__slots"
-                      data-allow-pointer-events="true"
-                    >
+                <FooterCharacterSlot
+                  characterFigurine={characterFigurine}
+                  characterId={characterId}
+                  characterName={footerCharacterName}
+                  currentHealth={footerHealth.current}
+                  maxHealth={footerHealth.max}
+                  onHealthChange={handleHealthChange}
+                  spellSlots={
+                    form ? (
                       <SpellSlots
                         form={form}
                         used={usedSlots}
@@ -6109,101 +6109,92 @@ export default function ZombiesCharacterSheet() {
                         shortRestCount={shortRestCount}
                         onActionSurge={handleActionSurge}
                       />
-                    </div>
-                  )}
-                  <div className="footer-actions-wrapper">
-                    <div className="footer-actions-inline">
-                      <Button
-                        variant="link"
-                        className="footer-btn footer-btn--dice"
-                        type="button"
-                        onClick={() => handleFooterQuickAction(openDiceRoller)}
-                        aria-label="Open dice roller"
-                        title="Dice roller"
-                      >
-                        <FaDiceD20
-                          className="footer-btn__dice-icon"
-                          aria-hidden="true"
-                          focusable="false"
-                        />
-                      </Button>
-                      <FooterCharacterSlot
-                        characterFigurine={characterFigurine}
-                        characterId={characterId}
-                        characterName={footerCharacterName}
-                        currentHealth={footerHealth.current}
-                        maxHealth={footerHealth.max}
-                        onHealthChange={handleHealthChange}
-                      />
-                      <Button
-                        variant="link"
-                        className="footer-btn footer-btn--attack"
-                        type="button"
-                        onClick={() => handleFooterQuickAction(openAttackModal)}
-                        aria-label="Open attack actions"
-                        title="Attack options"
-                      >
-                        <img
-                          src={sword}
-                          alt=""
-                          aria-hidden="true"
-                          className="footer-btn__attack-image"
-                        />
-                      </Button>
-                      <Button
-                        ref={footerToggleRef}
-                        onClick={() => setShowFooterActions((prev) => !prev)}
-                        aria-expanded={showFooterActions}
-                        aria-controls="footer-actions-panel"
-                        aria-label={
-                          showFooterActions
-                            ? 'Hide footer actions'
-                            : 'Show footer actions'
-                        }
-                        title={
-                          showFooterActions
-                            ? 'Hide footer actions'
-                            : 'Show footer actions'
-                        }
-                        className={`footer-btn footer-menu-toggle ${
+                    ) : null
+                  }
+                  actions={
+                    <div className="footer-actions-wrapper">
+                      <div className="footer-actions-inline">
+                        <Button
+                          variant="link"
+                          className="footer-btn footer-btn--dice"
+                          type="button"
+                          onClick={() => handleFooterQuickAction(openDiceRoller)}
+                          aria-label="Open dice roller"
+                          title="Dice roller"
+                        >
+                          <FaDiceD20
+                            className="footer-btn__dice-icon"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                        </Button>
+                        <Button
+                          variant="link"
+                          className="footer-btn footer-btn--attack"
+                          type="button"
+                          onClick={() => handleFooterQuickAction(openAttackModal)}
+                          aria-label="Open attack actions"
+                          title="Attack options"
+                        >
+                          <img
+                            src={sword}
+                            alt=""
+                            aria-hidden="true"
+                            className="footer-btn__attack-image"
+                          />
+                        </Button>
+                        <Button
+                          ref={footerToggleRef}
+                          onClick={() => setShowFooterActions((prev) => !prev)}
+                          aria-expanded={showFooterActions}
+                          aria-controls="footer-actions-panel"
+                          aria-label={
+                            showFooterActions
+                              ? 'Hide footer actions'
+                              : 'Show footer actions'
+                          }
+                          title={
+                            showFooterActions
+                              ? 'Hide footer actions'
+                              : 'Show footer actions'
+                          }
+                          className={`footer-btn footer-menu-toggle ${
+                            showFooterActions ? 'is-open' : ''
+                          }`}
+                          variant="secondary"
+                        >
+                          <i
+                            className={`fas ${showFooterActions ? 'fa-xmark' : 'fa-bars'}`}
+                            aria-hidden="true"
+                          ></i>
+                        </Button>
+                      </div>
+                      <div
+                        ref={footerMenuRef}
+                        id="footer-actions-panel"
+                        className={`footer-actions-popover ${
                           showFooterActions ? 'is-open' : ''
                         }`}
-                        variant="secondary"
+                        aria-hidden={!showFooterActions}
                       >
-                        <i
-                          className={`fas ${showFooterActions ? 'fa-xmark' : 'fa-bars'}`}
-                          aria-hidden="true"
-                        ></i>
-                      </Button>
+                        {footerMenuButtons.map((action) => (
+                          <Button
+                            key={action.key}
+                            variant={action.variant}
+                            className={action.className}
+                            style={action.style}
+                            onClick={() => handleFooterQuickAction(action.onClick)}
+                            tabIndex={footerActionTabIndex}
+                            aria-label={action.ariaLabel}
+                            title={action.title}
+                          >
+                            {action.content}
+                          </Button>
+                        ))}
+                      </div>
                     </div>
-                    <div
-                      ref={footerMenuRef}
-                      id="footer-actions-panel"
-                      className={`footer-actions-popover ${
-                        showFooterActions ? 'is-open' : ''
-                      }`}
-                      aria-hidden={!showFooterActions}
-                    >
-                      {footerMenuButtons.map((action) => (
-                        <Button
-                          key={action.key}
-                          variant={action.variant}
-                          className={action.className}
-                          style={action.style}
-                          onClick={() => {
-                            setShowFooterActions(false);
-                            action.onClick?.();
-                          }}
-                          tabIndex={footerActionTabIndex}
-                          aria-label={action.ariaLabel}
-                          title={action.title}
-                        >
-                          {action.content}
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                </div>
+                  }
+                />
               </Nav>
             </Container>
           </Navbar>

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -24,6 +24,8 @@ const FooterCharacterSlot = ({
   currentHealth,
   maxHealth,
   onHealthChange,
+  actions,
+  spellSlots,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
@@ -194,103 +196,121 @@ const FooterCharacterSlot = ({
 
   return (
     <div className="footer-character-slot" data-allow-pointer-events="true">
-      <div className="footer-character-slot__portrait">
-        <div className="footer-character-slot__portrait-ring">
-          {figurineImageUrl ? (
-            <img
-              src={figurineImageUrl}
-              alt={
-                characterName
-                  ? `${characterName} figurine`
-                  : 'Selected character figurine'
-              }
-              className="footer-character-slot__figurine-image"
-            />
-          ) : (
-            <div className="footer-character-slot__figurine-placeholder" aria-hidden="true">
-              <i className="fas fa-chess-king" />
-            </div>
-          )}
-          <span className="footer-character-slot__portrait-gloss" />
+      {spellSlots ? (
+        <div
+          className="footer-character-slot__slots"
+          data-allow-pointer-events="true"
+        >
+          {spellSlots}
         </div>
-      </div>
-      <div className="footer-character-slot__details">
-        {characterName && (
-          <span className="footer-character-slot__name" title={characterName}>
-            {characterName}
-          </span>
-        )}
-        <div className="footer-character-slot__header">
-          <span className="footer-character-slot__health-label">Health</span>
-          <div className="footer-character-slot__health-readout" aria-live="polite">
-            {isUpdating ? (
-              <Spinner animation="border" role="status" size="sm">
-                <span className="visually-hidden">Updating health…</span>
-              </Spinner>
+      ) : null}
+      <div className="footer-character-slot__main">
+        <div className="footer-character-slot__portrait">
+          <div className="footer-character-slot__portrait-ring">
+            {figurineImageUrl ? (
+              <img
+                src={figurineImageUrl}
+                alt={
+                  characterName
+                    ? `${characterName} figurine`
+                    : 'Selected character figurine'
+                }
+                className="footer-character-slot__figurine-image"
+              />
             ) : (
-              <>
-                <span className="footer-character-slot__health-current">{displayCurrent}</span>
-                {displayMax !== '—' && (
-                  <span className="footer-character-slot__health-max">/ {displayMax}</span>
-                )}
-              </>
+              <div className="footer-character-slot__figurine-placeholder" aria-hidden="true">
+                <i className="fas fa-chess-king" />
+              </div>
             )}
+            <span className="footer-character-slot__portrait-gloss" />
           </div>
         </div>
-        <div className="footer-character-slot__health-track" role="presentation">
-          <div className="footer-character-slot__health-track-base">
-            <div
-              className="footer-character-slot__health-track-fill"
-              style={{ width: `${healthPercent}%` }}
+        <div className="footer-character-slot__details">
+          {characterName && (
+            <span className="footer-character-slot__name" title={characterName}>
+              {characterName}
+            </span>
+          )}
+          <div className="footer-character-slot__header">
+            <span className="footer-character-slot__health-label">Health</span>
+            <div className="footer-character-slot__health-readout" aria-live="polite">
+              {isUpdating ? (
+                <Spinner animation="border" role="status" size="sm">
+                  <span className="visually-hidden">Updating health…</span>
+                </Spinner>
+              ) : (
+                <>
+                  <span className="footer-character-slot__health-current">{displayCurrent}</span>
+                  {displayMax !== '—' && (
+                    <span className="footer-character-slot__health-max">/ {displayMax}</span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          <div className="footer-character-slot__health-track" role="presentation">
+            <div className="footer-character-slot__health-track-base">
+              <div
+                className="footer-character-slot__health-track-fill"
+                style={{ width: `${healthPercent}%` }}
+              />
+              <div className="footer-character-slot__health-track-border" />
+            </div>
+            <input
+              type="range"
+              min="0"
+              max={sliderMax}
+              value={numericCurrent}
+              onChange={handleSliderInput}
+              onMouseUp={handleSliderCommit}
+              onTouchEnd={handleSliderCommit}
+              onBlur={handleSliderCommit}
+              onKeyUp={(event) => {
+                if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+                  handleSliderCommit();
+                }
+              }}
+              className="footer-character-slot__health-slider"
+              aria-label="Adjust health"
+              aria-valuemin={0}
+              aria-valuemax={sliderMax}
+              aria-valuenow={numericCurrent}
             />
-            <div className="footer-character-slot__health-track-border" />
           </div>
-          <input
-            type="range"
-            min="0"
-            max={sliderMax}
-            value={numericCurrent}
-            onChange={handleSliderInput}
-            onMouseUp={handleSliderCommit}
-            onTouchEnd={handleSliderCommit}
-            onBlur={handleSliderCommit}
-            onKeyUp={(event) => {
-              if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
-                handleSliderCommit();
-              }
-            }}
-            className="footer-character-slot__health-slider"
-            aria-label="Adjust health"
-            aria-valuemin={0}
-            aria-valuemax={sliderMax}
-            aria-valuenow={numericCurrent}
-          />
+          <div className="footer-character-slot__health-controls" role="group" aria-label="Character health controls">
+            <Button
+              type="button"
+              variant="outline-light"
+              className="footer-character-slot__health-button footer-character-slot__health-button--decrease"
+              onClick={() => handleAdjustHealth(-1)}
+              disabled={!canDecrease}
+              aria-label="Decrease health"
+            >
+              <i className="fas fa-minus" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              variant="outline-light"
+              className="footer-character-slot__health-button footer-character-slot__health-button--increase"
+              onClick={() => handleAdjustHealth(1)}
+              disabled={!canIncrease}
+              aria-label="Increase health"
+            >
+              <i className="fas fa-plus" aria-hidden="true" />
+            </Button>
+          </div>
+          <div className="footer-character-slot__error" role="status" aria-live="polite">
+            {error}
+          </div>
         </div>
-        <div className="footer-character-slot__health-controls" role="group" aria-label="Character health controls">
-          <Button
-            type="button"
-            variant="outline-light"
-            className="footer-character-slot__health-button footer-character-slot__health-button--decrease"
-            onClick={() => handleAdjustHealth(-1)}
-            disabled={!canDecrease}
-            aria-label="Decrease health"
+        {actions ? (
+          <div
+            className="footer-character-slot__actions"
+            data-allow-pointer-events="true"
           >
-            <i className="fas fa-minus" aria-hidden="true" />
-          </Button>
-          <Button
-            type="button"
-            variant="outline-light"
-            className="footer-character-slot__health-button footer-character-slot__health-button--increase"
-            onClick={() => handleAdjustHealth(1)}
-            disabled={!canIncrease}
-            aria-label="Increase health"
-          >
-            <i className="fas fa-plus" aria-hidden="true" />
-          </Button>
-        </div>
-        <div className="footer-character-slot__error" role="status" aria-live="polite">
-          {error}
-        </div>
+            {actions}
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -306,6 +326,8 @@ FooterCharacterSlot.propTypes = {
   currentHealth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   maxHealth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   onHealthChange: PropTypes.func,
+  actions: PropTypes.node,
+  spellSlots: PropTypes.node,
 };
 
 FooterCharacterSlot.defaultProps = {
@@ -315,6 +337,8 @@ FooterCharacterSlot.defaultProps = {
   currentHealth: null,
   maxHealth: null,
   onHealthChange: undefined,
+  actions: null,
+  spellSlots: null,
 };
 
 export default FooterCharacterSlot;


### PR DESCRIPTION
## Summary
- embed the spell slots and footer action buttons directly inside the footer character card
- update the footer character slot component to accept action and spell slot content
- refresh footer styling to remove the gray bubble wrapper and align the controls inside the card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904b3955c6c832e9ecc1b288ccd5c2b