### PR TITLE
Display armor class in footer

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3833,17 +3833,18 @@ h1 {
 .footer-character-slot__portrait {
   position: relative;
   width: 72px;
-  height: 72px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 8px;
   flex-shrink: 0;
 }
 
 .footer-character-slot__portrait-ring {
   position: relative;
-  width: 100%;
-  height: 100%;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
   padding: 4px;
   background: radial-gradient(circle at 35% 35%, rgba(120, 168, 255, 0.45), rgba(24, 36, 72, 0.9));
@@ -3891,6 +3892,34 @@ h1 {
   opacity: 0.35;
   pointer-events: none;
   transform: rotate(-15deg);
+}
+
+.footer-character-slot__armor-class {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: rgba(216, 226, 255, 0.9);
+  background: rgba(18, 26, 52, 0.8);
+  border-radius: 10px;
+  padding: 4px 8px;
+  border: 1px solid rgba(112, 154, 230, 0.35);
+  box-shadow: 0 4px 10px rgba(8, 12, 24, 0.45);
+}
+
+.footer-character-slot__armor-class-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.footer-character-slot__armor-class-value {
+  font-weight: 700;
+  font-size: 0.95rem;
+  line-height: 1;
+  color: #f7f9ff;
 }
 
 .footer-character-slot__details {

--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -4,7 +4,10 @@ import { Button } from 'react-bootstrap'; // Adjust as per your actual UI librar
 import { useParams } from "react-router-dom";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { normalizeEquipmentMap } from './equipmentNormalization';
-import { calculateCharacterHitPoints } from '../utils/characterMetrics';
+import {
+  calculateCharacterArmorClass,
+  calculateCharacterHitPoints,
+} from '../utils/characterMetrics';
 
 export default function HealthDefense({
   form,
@@ -12,7 +15,6 @@ export default function HealthDefense({
   dexMod,
   wisMod = 0,
   totalLevel,
-  ac = 0,
   hpMaxBonus = 0,
   hpMaxBonusPerLevel = 0,
   initiative = 0,
@@ -46,34 +48,6 @@ export default function HealthDefense({
     }
     return Array.isArray(form.armor) ? form.armor.filter(Boolean) : [];
   }, [hasEquipment, normalizedEquipment, form.armor]);
-
-  const armorAcBonus = armorItems.map((item) => {
-    if (Array.isArray(item)) {
-      const value = Number(item[1] ?? 0);
-      return value > 10 ? value - 10 : value;
-    }
-    return Number(item.acBonus ?? item.armorBonus ?? item.ac ?? 0);
-  });
-  const armorMaxDexBonus = armorItems.map((item) =>
-    Array.isArray(item)
-      ? Number(item[2] ?? 0)
-      : Number(item.maxDex ?? item.maxDexterity ?? 0)
-  );
-  let totalArmorAcBonus =
-    armorAcBonus.reduce((partialSum, a) => Number(partialSum) + Number(a), 0) +
-    Number(ac);
-  let filteredMaxDexArray = armorMaxDexBonus.filter((e) => e !== 0);
-  let armorMaxDexMin = Math.min(...filteredMaxDexArray);
-
-     let armorMaxDex;
-     if (Number(armorMaxDexMin) < Number(dexMod) && Number(armorMaxDexMin > 0)) {
-        armorMaxDex = armorMaxDexMin;
-     } else {
-      armorMaxDex = dexMod;
-     }
-
-  const numericWisMod = Number(wisMod);
-  const safeWisMod = Number.isFinite(numericWisMod) ? numericWisMod : 0;
 
   const isShieldItem = (item) => {
     if (!item) return false;
@@ -109,22 +83,6 @@ export default function HealthDefense({
     [armorItems]
   );
 
-  const hasUnarmoredDefenseFeature = useMemo(() => {
-    const searchValue = 'unarmored defense';
-    const checkValue = (value) => {
-      if (!value) return false;
-      if (Array.isArray(value)) {
-        return value.some((entry) => checkValue(entry));
-      }
-      if (typeof value === 'object') {
-        return Object.values(value).some((entry) => checkValue(entry));
-      }
-      return typeof value === 'string' && value.toLowerCase().includes(searchValue);
-    };
-
-    return checkValue(form?.features);
-  }, [form?.features]);
-
   const monkLevel = useMemo(() => {
     if (!Array.isArray(form?.occupation)) {
       return 0;
@@ -157,27 +115,14 @@ export default function HealthDefense({
     }, 0);
   }, [form?.occupation]);
 
-  const hasMonkLevels = monkLevel > 0;
-
-  const shouldApplyUnarmoredDefenseWisBonus = useMemo(() => {
-    if (hasArmorEquipped || hasShieldEquipped) {
-      return false;
-    }
-    if (!Number.isFinite(numericWisMod)) {
-      return false;
-    }
-    return hasUnarmoredDefenseFeature || hasMonkLevels;
-  }, [
-    hasArmorEquipped,
-    hasShieldEquipped,
-    hasMonkLevels,
-    hasUnarmoredDefenseFeature,
-    numericWisMod,
-  ]);
-
-  const wisdomBonusToAc = shouldApplyUnarmoredDefenseWisBonus ? safeWisMod : 0;
-
-  const totalArmorClass = Number(totalArmorAcBonus) + 10 + Number(armorMaxDex) + wisdomBonusToAc;
+  const totalArmorClass = useMemo(
+    () =>
+      calculateCharacterArmorClass(form, {
+        dexMod,
+        wisMod,
+      }),
+    [form, dexMod, wisMod]
+  );
     
   const derivedTotalLevel = useMemo(() => {
     if (Number.isFinite(totalLevel)) {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -32,7 +32,10 @@ import {
   collectFeatAbilityBonuses,
   collectFeatNumericBonuses,
 } from "../utils/derivedStats";
-import { calculateCharacterHitPoints } from "../utils/characterMetrics";
+import {
+  calculateCharacterArmorClass,
+  calculateCharacterHitPoints,
+} from "../utils/characterMetrics";
 import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import StatusEffectBar from "../attributes/StatusEffectBar";
@@ -5311,6 +5314,15 @@ export default function ZombiesCharacterSheet() {
     cha: Math.floor((computedStats.cha - 10) / 2),
   };
 
+  const footerArmorClass = useMemo(
+    () =>
+      calculateCharacterArmorClass(form, {
+        dexMod: statMods.dex,
+        wisMod: statMods.wis,
+      }),
+    [form, statMods.dex, statMods.wis]
+  );
+
   const SPELLCASTING_ABILITIES = {
     cleric: 'wis',
     druid: 'wis',
@@ -6029,7 +6041,6 @@ export default function ZombiesCharacterSheet() {
               wisMod={statMods.wis}
               initiative={featBonuses.initiative}
               speed={featBonuses.speed}
-              ac={featBonuses.ac}
               hpMaxBonus={featBonuses.hpMaxBonus}
               hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
               onTempHealthChange={handleHealthChange}
@@ -6097,6 +6108,7 @@ export default function ZombiesCharacterSheet() {
                   characterName={footerCharacterName}
                   currentHealth={footerHealth.current}
                   maxHealth={footerHealth.max}
+                  armorClass={footerArmorClass}
                   onHealthChange={handleHealthChange}
                   spellSlots={
                     form ? (

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -23,6 +23,7 @@ const FooterCharacterSlot = ({
   characterName,
   currentHealth,
   maxHealth,
+  armorClass,
   onHealthChange,
   actions,
   spellSlots,
@@ -56,6 +57,27 @@ const FooterCharacterSlot = ({
   const healthPercent = sliderMax > 0 ? Math.min((numericCurrent / sliderMax) * 100, 100) : 0;
   const displayCurrent = Number.isFinite(effectiveCurrent) ? Math.round(effectiveCurrent) : '—';
   const displayMax = Number.isFinite(resolvedMax) ? Math.round(resolvedMax) : '—';
+  const displayArmorClass = useMemo(() => {
+    if (armorClass === null || armorClass === undefined) {
+      return '—';
+    }
+
+    if (typeof armorClass === 'string') {
+      const trimmed = armorClass.trim();
+      return trimmed ? trimmed : '—';
+    }
+
+    const numeric = Number(armorClass);
+    if (Number.isFinite(numeric)) {
+      return Math.round(numeric);
+    }
+
+    return '—';
+  }, [armorClass]);
+  const armorClassAriaLabel = useMemo(
+    () => (displayArmorClass === '—' ? 'Armor Class unavailable' : `Armor Class ${displayArmorClass}`),
+    [displayArmorClass]
+  );
   const canDecrease = !isUpdating && numericCurrent > 0;
   const canIncrease =
     !isUpdating &&
@@ -224,6 +246,14 @@ const FooterCharacterSlot = ({
             )}
             <span className="footer-character-slot__portrait-gloss" />
           </div>
+          <div
+            className="footer-character-slot__armor-class"
+            aria-live="polite"
+            aria-label={armorClassAriaLabel}
+          >
+            <span className="footer-character-slot__armor-class-label">AC</span>
+            <span className="footer-character-slot__armor-class-value">{displayArmorClass}</span>
+          </div>
         </div>
         <div className="footer-character-slot__details">
           {characterName && (
@@ -325,6 +355,11 @@ FooterCharacterSlot.propTypes = {
   characterName: PropTypes.string,
   currentHealth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   maxHealth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
+  armorClass: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.oneOf([null]),
+  ]),
   onHealthChange: PropTypes.func,
   actions: PropTypes.node,
   spellSlots: PropTypes.node,
@@ -336,6 +371,7 @@ FooterCharacterSlot.defaultProps = {
   characterName: null,
   currentHealth: null,
   maxHealth: null,
+  armorClass: null,
   onHealthChange: undefined,
   actions: null,
   spellSlots: null,

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -159,6 +159,203 @@ const resolveHpBonusFromSource = (character) => {
   };
 };
 
+const resolveArmorItems = (character) => {
+  const normalizedEquipment = normalizeEquipmentMap(character?.equipment);
+  const equipmentEntries = Object.values(normalizedEquipment || {}).filter(Boolean);
+
+  if (equipmentEntries.length) {
+    return equipmentEntries.filter((item) => {
+      if (!item || typeof item !== 'object' || isExplicitlyUnowned(item)) {
+        return false;
+      }
+
+      if (Array.isArray(item)) {
+        return true;
+      }
+
+      const source = String(item.__source ?? item.source ?? '').toLowerCase();
+      if (source === 'armor') {
+        return true;
+      }
+
+      return (
+        item.acBonus != null ||
+        item.armorBonus != null ||
+        item.ac != null ||
+        item.maxDex != null ||
+        item.maxDexterity != null ||
+        item.checkPenalty != null ||
+        item.stealth != null
+      );
+    });
+  }
+
+  const armorCollection = Array.isArray(character?.armor) ? character.armor : [];
+  return armorCollection.filter(Boolean);
+};
+
+const isShieldItem = (item) => {
+  if (!item) {
+    return false;
+  }
+
+  if (Array.isArray(item)) {
+    const [name] = item;
+    return typeof name === 'string' && name.toLowerCase().includes('shield');
+  }
+
+  const category = String(item.category ?? item.type ?? '').toLowerCase();
+  if (category.includes('shield')) {
+    return true;
+  }
+
+  const name = String(
+    item.name ?? item.title ?? item.displayName ?? item.label ?? ''
+  ).toLowerCase();
+  return name.includes('shield');
+};
+
+const resolveMonkLevel = (character) => {
+  if (!Array.isArray(character?.occupation)) {
+    return 0;
+  }
+
+  return character.occupation.reduce((total, occupationEntry) => {
+    if (!occupationEntry || typeof occupationEntry !== 'object') {
+      return total;
+    }
+
+    const name = String(
+      occupationEntry.Name ??
+        occupationEntry.Occupation ??
+        occupationEntry.name ??
+        occupationEntry.occupation ??
+        ''
+    ).toLowerCase();
+
+    if (name !== 'monk') {
+      return total;
+    }
+
+    const levelValue = Number(
+      occupationEntry.Level ??
+        occupationEntry.level ??
+        occupationEntry.Levels ??
+        occupationEntry.levels ??
+        0
+    );
+
+    if (!Number.isFinite(levelValue) || levelValue <= 0) {
+      return total;
+    }
+
+    return total + levelValue;
+  }, 0);
+};
+
+const hasUnarmoredDefense = (character) => {
+  const searchValue = 'unarmored defense';
+  const checkValue = (value) => {
+    if (!value) return false;
+    if (Array.isArray(value)) {
+      return value.some((entry) => checkValue(entry));
+    }
+    if (typeof value === 'object') {
+      return Object.values(value).some((entry) => checkValue(entry));
+    }
+    return typeof value === 'string' && value.toLowerCase().includes(searchValue);
+  };
+
+  return checkValue(character?.features);
+};
+
+export const calculateCharacterArmorClass = (character, overrides = {}) => {
+  if (!character || typeof character !== 'object') {
+    return null;
+  }
+
+  const armorItems = resolveArmorItems(character);
+
+  const armorAcBonus = armorItems.reduce((total, item) => {
+    if (Array.isArray(item)) {
+      const value = Number(item[1] ?? 0);
+      if (!Number.isFinite(value)) {
+        return total;
+      }
+      return total + (value > 10 ? value - 10 : value);
+    }
+
+    const value = Number(item?.acBonus ?? item?.armorBonus ?? item?.ac ?? 0);
+    return Number.isFinite(value) ? total + value : total;
+  }, 0);
+
+  const featAcBonus =
+    overrides.featAcBonus !== undefined
+      ? toFiniteNumberOrZero(overrides.featAcBonus)
+      : toFiniteNumberOrZero(collectFeatNumericBonuses(character?.feat).ac);
+
+  const additionalAcBonus = toFiniteNumberOrZero(overrides.additionalAcBonus);
+
+  const armorMaxDexCaps = armorItems
+    .map((item) => {
+      if (Array.isArray(item)) {
+        const value = Number(item[2] ?? 0);
+        return Number.isFinite(value) ? value : 0;
+      }
+
+      const value = Number(item?.maxDex ?? item?.maxDexterity ?? 0);
+      return Number.isFinite(value) ? value : 0;
+    })
+    .filter((value) => Number.isFinite(value));
+
+  const abilities = calculateEffectiveAbilityScores(character);
+
+  const baseDexMod = Number.isFinite(overrides.dexMod)
+    ? overrides.dexMod
+    : Math.floor((abilities.dex - 10) / 2);
+
+  let dexContribution = baseDexMod;
+  const positiveCaps = armorMaxDexCaps.filter((value) => value !== 0 && value > 0);
+  if (positiveCaps.length > 0) {
+    const minCap = Math.min(...positiveCaps);
+    if (Number.isFinite(minCap) && minCap < dexContribution) {
+      dexContribution = minCap;
+    }
+  }
+
+  const baseWisMod = Number.isFinite(overrides.wisMod)
+    ? overrides.wisMod
+    : Math.floor((abilities.wis - 10) / 2);
+
+  const hasShieldEquipped = armorItems.some((item) => isShieldItem(item));
+  const hasArmorEquipped = armorItems.some((item) => {
+    if (!item) {
+      return false;
+    }
+    if (Array.isArray(item)) {
+      return true;
+    }
+    if (typeof item !== 'object') {
+      return false;
+    }
+    if (isShieldItem(item)) {
+      return false;
+    }
+    const source = String(item.__source ?? item.source ?? '').toLowerCase();
+    return source === 'armor';
+  });
+
+  const monkLevel = resolveMonkLevel(character);
+  const wisdomBonus =
+    !hasArmorEquipped && !hasShieldEquipped && (hasUnarmoredDefense(character) || monkLevel > 0)
+      ? baseWisMod
+      : 0;
+
+  const armorClass = 10 + armorAcBonus + featAcBonus + additionalAcBonus + dexContribution + wisdomBonus;
+  const normalized = Number(armorClass);
+  return Number.isFinite(normalized) ? normalized : null;
+};
+
 export const calculateCharacterHitPoints = (character, overrides = {}) => {
   if (!character || typeof character !== 'object') {
     return { currentHp: null, maxHp: null };


### PR DESCRIPTION
## Summary
- compute the active character's armor class in the sheet reducer and surface it to the footer slot
- render the armor class beneath the portrait with new styling for the footer card
- centralize armor class calculations in a reusable utility and update HealthDefense to use it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904b8da9c7c832e8aee5b781924a5c7