### PR TITLE
Condense footer character slot layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3800,25 +3800,25 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 12px;
-  padding: 14px 18px;
-  background: rgba(15, 22, 43, 0.9);
-  border-radius: 20px;
-  border: 1px solid rgba(104, 144, 216, 0.45);
-  box-shadow: 0 12px 26px rgba(6, 10, 20, 0.45);
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(15, 22, 43, 0.88);
+  border-radius: 14px;
+  border: 1px solid rgba(104, 144, 216, 0.35);
+  box-shadow: 0 8px 18px rgba(6, 10, 20, 0.4);
   color: #f3f6ff;
   margin: 0;
   min-height: 0;
   backdrop-filter: blur(4px);
-  width: min(100%, 720px);
+  width: min(100%, 520px);
 }
 
 .footer-character-slot::before {
   content: '';
   position: absolute;
-  inset: 4px;
-  border-radius: 16px;
-  border: 1px solid rgba(47, 78, 143, 0.35);
+  inset: 3px;
+  border-radius: 12px;
+  border: 1px solid rgba(47, 78, 143, 0.25);
   pointer-events: none;
 }
 
@@ -3826,29 +3826,29 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
 .footer-character-slot__portrait {
   position: relative;
-  width: 72px;
+  width: 58px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
   flex-shrink: 0;
 }
 
 .footer-character-slot__portrait-ring {
   position: relative;
-  width: 72px;
-  height: 72px;
+  width: 58px;
+  height: 58px;
   border-radius: 50%;
-  padding: 4px;
-  background: radial-gradient(circle at 35% 35%, rgba(120, 168, 255, 0.45), rgba(24, 36, 72, 0.9));
-  box-shadow: 0 8px 16px rgba(8, 12, 26, 0.6), inset 0 0 16px rgba(80, 124, 216, 0.4);
+  padding: 3px;
+  background: radial-gradient(circle at 35% 35%, rgba(120, 168, 255, 0.4), rgba(24, 36, 72, 0.85));
+  box-shadow: 0 6px 12px rgba(8, 12, 26, 0.55), inset 0 0 12px rgba(80, 124, 216, 0.35);
 }
 
 .footer-character-slot__portrait-ring::after {
@@ -3856,7 +3856,7 @@ h1 {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  border: 1px solid rgba(22, 34, 66, 0.75);
+  border: 1px solid rgba(22, 34, 66, 0.6);
   pointer-events: none;
 }
 
@@ -3876,20 +3876,20 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, rgba(44, 66, 118, 0.8), rgba(18, 26, 52, 0.95));
-  color: rgba(175, 195, 245, 0.85);
-  font-size: 1.4rem;
+  background: linear-gradient(135deg, rgba(44, 66, 118, 0.75), rgba(18, 26, 52, 0.9));
+  color: rgba(175, 195, 245, 0.82);
+  font-size: 1.1rem;
 }
 
 .footer-character-slot__portrait-gloss {
   position: absolute;
-  top: 14%;
-  left: 20%;
-  width: 56%;
-  height: 28%;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.5), transparent);
+  top: 16%;
+  left: 22%;
+  width: 50%;
+  height: 24%;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.45), transparent);
   border-radius: 50%;
-  opacity: 0.35;
+  opacity: 0.3;
   pointer-events: none;
   transform: rotate(-15deg);
 }
@@ -3898,26 +3898,26 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  font-size: 0.75rem;
+  gap: 1px;
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   color: rgba(216, 226, 255, 0.9);
-  background: rgba(18, 26, 52, 0.8);
-  border-radius: 10px;
-  padding: 4px 8px;
-  border: 1px solid rgba(112, 154, 230, 0.35);
-  box-shadow: 0 4px 10px rgba(8, 12, 24, 0.45);
+  background: rgba(18, 26, 52, 0.78);
+  border-radius: 8px;
+  padding: 3px 6px;
+  border: 1px solid rgba(112, 154, 230, 0.3);
+  box-shadow: 0 4px 10px rgba(8, 12, 24, 0.4);
 }
 
 .footer-character-slot__armor-class-label {
-  font-size: 0.68rem;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  opacity: 0.85;
+  opacity: 0.8;
 }
 
 .footer-character-slot__armor-class-value {
   font-weight: 700;
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   line-height: 1;
   color: #f7f9ff;
 }
@@ -3935,17 +3935,21 @@ h1 {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  gap: 8px;
 }
 
 .footer-character-slot__slots {
-  position: relative;
+  position: absolute;
+  top: -10px;
+  right: 12px;
   display: flex;
-  justify-content: center;
-  padding: 6px 10px 4px;
-  border-radius: 14px;
-  border: 1px solid rgba(80, 124, 196, 0.35);
-  background: rgba(8, 16, 36, 0.55);
-  box-shadow: inset 0 0 14px rgba(10, 18, 40, 0.45);
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(80, 124, 196, 0.3);
+  background: rgba(8, 16, 36, 0.7);
+  box-shadow: 0 6px 12px rgba(10, 18, 40, 0.4);
 }
 
 .footer-character-slot__slots > .spell-slot-container {
@@ -3953,74 +3957,77 @@ h1 {
 }
 
 .footer-character-slot__name {
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
-  color: rgba(216, 226, 255, 0.85);
+  letter-spacing: 0.01em;
+  color: rgba(243, 246, 255, 0.92);
   max-width: 220px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.footer-character-slot__header {
+.footer-character-slot__health {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.footer-character-slot__health-top {
+  display: flex;
+  align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: 6px;
 }
 
 .footer-character-slot__health-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.06em;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   font-weight: 600;
-  color: rgba(194, 208, 248, 0.8);
+  color: rgba(194, 208, 248, 0.78);
 }
 
 .footer-character-slot__health-readout {
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: rgba(28, 40, 74, 0.8);
-  border: 1px solid rgba(112, 154, 230, 0.35);
   font-weight: 600;
-  font-size: 0.9rem;
-  color: #f7f9ff;
+  font-size: 0.78rem;
+  color: rgba(247, 249, 255, 0.92);
 }
 
 .footer-character-slot__health-track {
   position: relative;
-  width: min(260px, 40vw);
+  width: 100%;
   height: 12px;
   border-radius: 999px;
+  background: rgba(24, 40, 76, 0.88);
+  overflow: hidden;
+  box-shadow: inset 0 1px 4px rgba(10, 16, 32, 0.7);
 }
 
 .footer-character-slot__health-track-base {
   position: absolute;
   inset: 0;
   border-radius: 999px;
-  overflow: hidden;
-  background: linear-gradient(135deg, rgba(30, 46, 92, 0.85), rgba(18, 28, 58, 0.95));
-  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(135deg, rgba(30, 46, 92, 0.82), rgba(18, 28, 58, 0.92));
 }
 
 .footer-character-slot__health-track-fill {
   position: absolute;
   inset: 0;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(98, 188, 255, 0.95), rgba(96, 255, 196, 0.9));
-  box-shadow: inset 0 0 8px rgba(255, 255, 255, 0.3);
-  transition: width 0.2s ease;
+  background: linear-gradient(90deg, rgba(94, 220, 198, 0.9), rgba(74, 158, 236, 0.9));
+  box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.3);
+  transition: width 0.25s ease;
 }
 
 .footer-character-slot__health-track-border {
   position: absolute;
   inset: 0;
   border-radius: 999px;
-  border: 1px solid rgba(132, 176, 248, 0.25);
+  border: 1px solid rgba(132, 176, 248, 0.2);
   pointer-events: none;
 }
 
@@ -4029,7 +4036,7 @@ h1 {
   position: absolute;
   inset: 2px;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
   pointer-events: none;
 }
 
@@ -4045,86 +4052,87 @@ h1 {
 .footer-character-slot__health-controls {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .footer-character-slot__health-button {
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border-radius: 10px;
-  border: 1px solid rgba(108, 154, 230, 0.45);
-  background: linear-gradient(135deg, rgba(60, 92, 160, 0.85), rgba(30, 46, 94, 0.95));
+  border-radius: 8px;
+  border: 1px solid rgba(108, 154, 230, 0.4);
+  background: linear-gradient(135deg, rgba(60, 92, 160, 0.82), rgba(30, 46, 94, 0.92));
   color: #f5f7ff;
-  box-shadow: 0 8px 20px rgba(12, 16, 34, 0.5), inset 0 0 8px rgba(88, 138, 236, 0.28);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  box-shadow: 0 6px 16px rgba(12, 16, 34, 0.45), inset 0 0 6px rgba(88, 138, 236, 0.25);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
 }
 
 .footer-character-slot__health-button--decrease {
-  background: linear-gradient(135deg, rgba(198, 70, 70, 0.9), rgba(118, 26, 26, 0.95));
-  border-color: rgba(242, 120, 120, 0.5);
-  box-shadow: 0 8px 20px rgba(58, 12, 12, 0.5), inset 0 0 8px rgba(255, 144, 144, 0.3);
+  background: linear-gradient(135deg, rgba(198, 70, 70, 0.88), rgba(118, 26, 26, 0.92));
+  border-color: rgba(242, 120, 120, 0.45);
+  box-shadow: 0 6px 16px rgba(58, 12, 12, 0.45), inset 0 0 6px rgba(255, 144, 144, 0.28);
 }
 
 .footer-character-slot__health-button--increase {
-  background: linear-gradient(135deg, rgba(54, 160, 104, 0.9), rgba(20, 92, 56, 0.95));
-  border-color: rgba(120, 240, 182, 0.45);
-  box-shadow: 0 8px 20px rgba(10, 58, 32, 0.45), inset 0 0 8px rgba(142, 255, 202, 0.28);
+  background: linear-gradient(135deg, rgba(54, 160, 104, 0.88), rgba(20, 92, 56, 0.92));
+  border-color: rgba(120, 240, 182, 0.4);
+  box-shadow: 0 6px 16px rgba(10, 58, 32, 0.4), inset 0 0 6px rgba(142, 255, 202, 0.25);
 }
 
 .footer-character-slot__health-button i {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
 }
 
 .footer-character-slot__health-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
-  box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.28);
 }
 
 .footer-character-slot__health-button:not(:disabled):hover,
 .footer-character-slot__health-button:not(:disabled):focus-visible {
-  transform: translateY(-1px) scale(1.04);
-  box-shadow: 0 10px 24px rgba(28, 42, 84, 0.55), inset 0 0 10px rgba(132, 180, 252, 0.4);
+  transform: translateY(-1px) scale(1.03);
+  box-shadow: 0 8px 20px rgba(28, 42, 84, 0.5), inset 0 0 8px rgba(132, 180, 252, 0.35);
   filter: brightness(1.05);
 }
 
 .footer-character-slot__health-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(132, 180, 252, 0.35), 0 10px 24px rgba(28, 42, 84, 0.55);
+  box-shadow: 0 0 0 2px rgba(132, 180, 252, 0.3), 0 8px 20px rgba(28, 42, 84, 0.5);
 }
 
 .footer-character-slot__health-max {
-  font-size: 0.82rem;
-  color: rgba(210, 220, 255, 0.85);
+  font-size: 0.72rem;
+  color: rgba(210, 220, 255, 0.82);
 }
 
 .footer-character-slot__error {
-  min-height: 0.8rem;
-  font-size: 0.7rem;
+  min-height: 0.7rem;
+  font-size: 0.68rem;
   color: #ffb4a2;
   text-align: left;
 }
 
 .footer-character-slot__health-readout .spinner-border {
-  width: 0.9rem;
-  height: 0.9rem;
-  border-width: 0.12em;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-width: 0.1em;
   color: #88bcff;
 }
 
 @media (max-width: 600px) {
   .footer-character-slot {
     width: 100%;
+    padding: 10px;
   }
 
   .footer-character-slot__main {
     flex-direction: column;
     align-items: stretch;
-    gap: 20px;
+    gap: 14px;
   }
 
   .footer-character-slot__details {
@@ -4137,6 +4145,10 @@ h1 {
 
   .footer-character-slot__health-track {
     width: 100%;
+  }
+
+  .footer-character-slot__health-controls {
+    justify-content: flex-end;
   }
 }
 

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -261,51 +261,53 @@ const FooterCharacterSlot = ({
               {characterName}
             </span>
           )}
-          <div className="footer-character-slot__header">
-            <span className="footer-character-slot__health-label">Health</span>
-            <div className="footer-character-slot__health-readout" aria-live="polite">
-              {isUpdating ? (
-                <Spinner animation="border" role="status" size="sm">
-                  <span className="visually-hidden">Updating health…</span>
-                </Spinner>
-              ) : (
-                <>
-                  <span className="footer-character-slot__health-current">{displayCurrent}</span>
-                  {displayMax !== '—' && (
-                    <span className="footer-character-slot__health-max">/ {displayMax}</span>
-                  )}
-                </>
-              )}
+          <div className="footer-character-slot__health">
+            <div className="footer-character-slot__health-top">
+              <span className="footer-character-slot__health-label">Health</span>
+              <div className="footer-character-slot__health-readout" aria-live="polite">
+                {isUpdating ? (
+                  <Spinner animation="border" role="status" size="sm">
+                    <span className="visually-hidden">Updating health…</span>
+                  </Spinner>
+                ) : (
+                  <>
+                    <span className="footer-character-slot__health-current">{displayCurrent}</span>
+                    {displayMax !== '—' && (
+                      <span className="footer-character-slot__health-max">/ {displayMax}</span>
+                    )}
+                  </>
+                )}
+              </div>
             </div>
-          </div>
-          <div className="footer-character-slot__health-track" role="presentation">
-            <div className="footer-character-slot__health-track-base">
-              <div
-                className="footer-character-slot__health-track-fill"
-                style={{ width: `${healthPercent}%` }}
+            <div className="footer-character-slot__health-track" role="presentation">
+              <div className="footer-character-slot__health-track-base">
+                <div
+                  className="footer-character-slot__health-track-fill"
+                  style={{ width: `${healthPercent}%` }}
+                />
+                <div className="footer-character-slot__health-track-border" />
+              </div>
+              <input
+                type="range"
+                min="0"
+                max={sliderMax}
+                value={numericCurrent}
+                onChange={handleSliderInput}
+                onMouseUp={handleSliderCommit}
+                onTouchEnd={handleSliderCommit}
+                onBlur={handleSliderCommit}
+                onKeyUp={(event) => {
+                  if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+                    handleSliderCommit();
+                  }
+                }}
+                className="footer-character-slot__health-slider"
+                aria-label="Adjust health"
+                aria-valuemin={0}
+                aria-valuemax={sliderMax}
+                aria-valuenow={numericCurrent}
               />
-              <div className="footer-character-slot__health-track-border" />
             </div>
-            <input
-              type="range"
-              min="0"
-              max={sliderMax}
-              value={numericCurrent}
-              onChange={handleSliderInput}
-              onMouseUp={handleSliderCommit}
-              onTouchEnd={handleSliderCommit}
-              onBlur={handleSliderCommit}
-              onKeyUp={(event) => {
-                if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
-                  handleSliderCommit();
-                }
-              }}
-              className="footer-character-slot__health-slider"
-              aria-label="Adjust health"
-              aria-valuemin={0}
-              aria-valuemax={sliderMax}
-              aria-valuenow={numericCurrent}
-            />
           </div>
           <div className="footer-character-slot__health-controls" role="group" aria-label="Character health controls">
             <Button


### PR DESCRIPTION
## Summary
- shrink the footer character slot card footprint with tighter spacing and reduced visuals
- move the health readout above the bar and adjust related styling for a more compact layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904c23abfc4832e97a35b835e725f5f