### PR TITLE
Improve footer character slot layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3825,8 +3825,8 @@ h1 {
 .footer-character-slot__main {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  justify-content: flex-start;
+  gap: 16px;
   flex-wrap: wrap;
 }
 
@@ -3925,9 +3925,18 @@ h1 {
 .footer-character-slot__details {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   min-width: 0;
-  flex: 1 1 240px;
+  flex: 1 1 260px;
+}
+
+.footer-character-slot__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  row-gap: 6px;
+  width: 100%;
+  flex-wrap: wrap;
 }
 
 .footer-character-slot__actions {
@@ -3936,20 +3945,20 @@ h1 {
   justify-content: center;
   flex: 0 0 auto;
   gap: 8px;
+  margin-left: auto;
 }
 
 .footer-character-slot__slots {
-  position: absolute;
-  top: -10px;
-  right: 12px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
   border: 1px solid rgba(80, 124, 196, 0.3);
   background: rgba(8, 16, 36, 0.7);
   box-shadow: 0 6px 12px rgba(10, 18, 40, 0.4);
+  margin-left: auto;
+  flex: 0 0 auto;
 }
 
 .footer-character-slot__slots > .spell-slot-container {
@@ -3961,10 +3970,11 @@ h1 {
   font-weight: 600;
   letter-spacing: 0.01em;
   color: rgba(243, 246, 255, 0.92);
-  max-width: 220px;
+  max-width: 260px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1 1 auto;
 }
 
 .footer-character-slot__health {

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -218,14 +218,6 @@ const FooterCharacterSlot = ({
 
   return (
     <div className="footer-character-slot" data-allow-pointer-events="true">
-      {spellSlots ? (
-        <div
-          className="footer-character-slot__slots"
-          data-allow-pointer-events="true"
-        >
-          {spellSlots}
-        </div>
-      ) : null}
       <div className="footer-character-slot__main">
         <div className="footer-character-slot__portrait">
           <div className="footer-character-slot__portrait-ring">
@@ -256,10 +248,22 @@ const FooterCharacterSlot = ({
           </div>
         </div>
         <div className="footer-character-slot__details">
-          {characterName && (
-            <span className="footer-character-slot__name" title={characterName}>
-              {characterName}
-            </span>
+          {(characterName || spellSlots) && (
+            <div className="footer-character-slot__header">
+              {characterName && (
+                <span className="footer-character-slot__name" title={characterName}>
+                  {characterName}
+                </span>
+              )}
+              {spellSlots ? (
+                <div
+                  className="footer-character-slot__slots"
+                  data-allow-pointer-events="true"
+                >
+                  {spellSlots}
+                </div>
+              ) : null}
+            </div>
           )}
           <div className="footer-character-slot__health">
             <div className="footer-character-slot__health-top">


### PR DESCRIPTION
## Summary
- move spell slot controls into the footer character slot header so they no longer overlap the health readout
- adjust layout spacing so the portrait and health details stay grouped without large gaps
- update styles to let the character name flex alongside spell slots on small widths

## Testing
- npm test -- --watch=false --passWithNoTests


------
https://chatgpt.com/codex/tasks/task_e_6904c568c6a4832e9433b0f3e30c4bca