### PR TITLE
Refine footer damage controls and simplify character header

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4058,6 +4058,12 @@ h1 {
   min-width: 64px;
 }
 
+.footer-character-slot__damage-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .footer-character-slot__damage-label {
   font-size: 0.62rem;
   letter-spacing: 0.12em;
@@ -4079,6 +4085,61 @@ h1 {
 
 .footer-character-slot__damage--fumble .footer-character-slot__damage-value {
   color: #ff7b82;
+}
+
+.footer-character-slot__damage--recent {
+  animation: footer-damage-glow 1.6s ease-out;
+  box-shadow: 0 0 18px rgba(96, 163, 255, 0.75), inset 0 0 0 1px rgba(126, 174, 255, 0.6);
+}
+
+.footer-character-slot__damage--recent.footer-character-slot__damage--critical {
+  box-shadow: 0 0 20px rgba(255, 196, 102, 0.75), inset 0 0 0 1px rgba(255, 203, 132, 0.7);
+}
+
+.footer-character-slot__damage--recent.footer-character-slot__damage--fumble {
+  box-shadow: 0 0 20px rgba(255, 121, 121, 0.75), inset 0 0 0 1px rgba(255, 137, 137, 0.7);
+}
+
+.footer-character-slot__crit-button.btn {
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.58rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-color: rgba(180, 198, 246, 0.6);
+  color: rgba(233, 241, 255, 0.92);
+  background: rgba(18, 30, 54, 0.4);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.footer-character-slot__crit-button.btn:hover,
+.footer-character-slot__crit-button.btn:focus {
+  color: #101624;
+  background: rgba(164, 201, 255, 0.9);
+  border-color: rgba(164, 201, 255, 0.9);
+}
+
+.footer-character-slot__crit-button.is-active.btn {
+  color: #1c1404;
+  background: linear-gradient(135deg, rgba(255, 215, 140, 0.95), rgba(255, 186, 86, 0.9));
+  border-color: rgba(255, 198, 102, 0.85);
+  box-shadow: 0 0 14px rgba(255, 198, 102, 0.55);
+}
+
+@keyframes footer-damage-glow {
+  0% {
+    transform: scale(0.96);
+    opacity: 0.9;
+  }
+  45% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 .footer-character-slot__health-track {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1928,15 +1928,14 @@ const handleDamageClick = useCallback(() => {
   setIsFumble(false);
 }, []);
 
-const handleDamageKeyDown = useCallback(
-  (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      handleDamageClick();
-    }
-  },
-  [handleDamageClick]
-);
+const setCriticalState = useCallback((value) => {
+  const next = Boolean(value);
+  manualCriticalRef.current = next;
+  setIsCritical(next);
+  if (!next) {
+    setIsFumble(false);
+  }
+}, []);
 
 // Spells may come from different caster types (e.g., Wizard, Cleric). Before
 // rendering the spell table, group spells by caster type and sort each group by
@@ -2075,8 +2074,10 @@ useImperativeHandle(
     openAttackModal: handleShowAttack,
     openDiceRoller: handleShowDiceRoller,
     openDamageLog: () => setShowLog(true),
+    toggleCritical: handleDamageClick,
+    setCritical: setCriticalState,
   }),
-  [handleShowAttack, handleShowDiceRoller],
+  [handleShowAttack, handleShowDiceRoller, handleDamageClick, setCriticalState],
 );
 
 const [pulseClass, setPulseClass] = useState('');
@@ -2087,9 +2088,10 @@ useEffect(() => {
       value: damageValue,
       isCritical,
       isFumble,
+      timestamp: lastRollTimestamp || null,
     });
   }
-}, [onDamageSummaryChange, damageValue, isCritical, isFumble]);
+}, [onDamageSummaryChange, damageValue, isCritical, isFumble, lastRollTimestamp]);
 
 useEffect(() => {
   if (!lastRollTimestamp) {
@@ -2315,6 +2317,26 @@ const damageAmountStyle = {
           }`}
         >
           <div className="attack-roll-controls damage-roller__controls">
+            <span
+              id="damageValue"
+              className="visually-hidden"
+              aria-hidden="true"
+            >
+              {damageValue}
+            </span>
+            <button
+              type="button"
+              className="visually-hidden"
+              onClick={handleDamageClick}
+              aria-pressed={isCritical}
+              aria-label={
+                isCritical
+                  ? 'Critical damage roll enabled. Click to roll normally.'
+                  : 'Click to enable a critical damage roll on your next roll.'
+              }
+            >
+              Toggle critical damage roll
+            </button>
             <div
               className="damage-roller__dice-wrapper"
               style={{
@@ -2336,34 +2358,6 @@ const damageAmountStyle = {
                   instanceKey={characterId}
                   showOverlayDice={showOverlayDice}
                 />
-              </div>
-              <div className="damage-roller__overlay">
-                <div className="damage-roller__total">
-                  <span className="damage-roller__total-label">Total</span>
-                  <span
-                    id="damageValue"
-                    className={`damage-roller__total-value ${
-                      typeof damageValue === 'string' ? 'spell-cast-label' : ''
-                    }`}
-                    role="button"
-                    tabIndex={0}
-                    aria-pressed={isCritical}
-                    aria-label={
-                      isCritical
-                        ? 'Critical damage roll enabled. Click to roll normally.'
-                        : 'Click to enable a critical damage roll on your next roll.'
-                    }
-                    title={
-                      isCritical
-                        ? 'Critical roll ready. Click to roll normally.'
-                        : 'Click to make your next damage roll critical.'
-                    }
-                    onClick={handleDamageClick}
-                    onKeyDown={handleDamageKeyDown}
-                  >
-                    {damageValue}
-                  </span>
-                </div>
               </div>
             </div>
           </div>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -1261,7 +1261,7 @@ describe('PlayerTurnActions critical events', () => {
     expect(damage.classList.contains('pulse')).toBe(true);
   });
 
-  test('clicking damageAmount toggles critical class', () => {
+  test('critical toggle method toggles critical class', () => {
     const { actionsRef } = render(
       <PlayerTurnActions
         form={{ diceColor: '#000000', equipment: {}, spells: [] }}
@@ -1271,18 +1271,17 @@ describe('PlayerTurnActions critical events', () => {
     );
 
     const damage = document.getElementById('damageAmount');
-    const toggle = document.getElementById('damageValue');
 
     expect(damage.classList.contains('critical-active')).toBe(false);
 
     act(() => {
-      fireEvent.click(toggle);
+      actionsRef.current?.toggleCritical?.();
     });
 
     expect(damage.classList.contains('critical-active')).toBe(true);
 
     act(() => {
-      fireEvent.click(toggle);
+      actionsRef.current?.toggleCritical?.();
     });
 
     expect(damage.classList.contains('critical-active')).toBe(false);
@@ -1300,8 +1299,6 @@ describe('PlayerTurnActions critical events', () => {
     );
 
     const damage = document.getElementById('damageAmount');
-    const toggle = document.getElementById('damageValue');
-
     act(() => {
       window.dispatchEvent(
         new CustomEvent('damage-roll', { detail: { value: 7 } })
@@ -1309,7 +1306,7 @@ describe('PlayerTurnActions critical events', () => {
     });
 
     act(() => {
-      fireEvent.click(toggle);
+      actionsRef.current?.toggleCritical?.();
     });
 
     expect(damage.classList.contains('critical-active')).toBe(true);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -36,7 +36,6 @@ import {
   calculateCharacterArmorClass,
   calculateCharacterHitPoints,
 } from "../utils/characterMetrics";
-import HealthDefense from "../attributes/HealthDefense";
 import SpellSelector from "../attributes/SpellSelector";
 import StatusEffectBar from "../attributes/StatusEffectBar";
 import BackgroundModal from "../attributes/BackgroundModal";
@@ -1249,10 +1248,6 @@ export default function ZombiesCharacterSheet() {
   const adrenalineRushActive = useMemo(
     () => activeEffects.some((effect) => effect?.name === 'Adrenaline Rush'),
     [activeEffects]
-  );
-  const speedMultiplier = useMemo(
-    () => (adrenalineRushActive ? 2 : 1),
-    [adrenalineRushActive]
   );
   const temporarySize = form?.temporarySize;
   const temporarySpeedBonus = form?.temporarySpeedBonus;
@@ -3992,6 +3987,7 @@ export default function ZombiesCharacterSheet() {
     value: null,
     isCritical: false,
     isFumble: false,
+    timestamp: null,
   });
 
   const handleDamageSummaryChange = useCallback((summary) => {
@@ -4000,7 +3996,7 @@ export default function ZombiesCharacterSheet() {
         if (prev.value === null && !prev.isCritical && !prev.isFumble) {
           return prev;
         }
-        return { value: null, isCritical: false, isFumble: false };
+        return { value: null, isCritical: false, isFumble: false, timestamp: null };
       }
 
       const next = {
@@ -4011,12 +4007,17 @@ export default function ZombiesCharacterSheet() {
             : null,
         isCritical: Boolean(summary.isCritical),
         isFumble: Boolean(summary.isFumble),
+        timestamp:
+          typeof summary.timestamp === 'number' && Number.isFinite(summary.timestamp)
+            ? summary.timestamp
+            : null,
       };
 
       if (
         prev.value === next.value &&
         prev.isCritical === next.isCritical &&
-        prev.isFumble === next.isFumble
+        prev.isFumble === next.isFumble &&
+        prev.timestamp === next.timestamp
       ) {
         return prev;
       }
@@ -5533,6 +5534,9 @@ export default function ZombiesCharacterSheet() {
   const openDamageLog = useCallback(() => {
     playerTurnActionsRef.current?.openDamageLog?.();
   }, []);
+  const toggleCriticalFromFooter = useCallback(() => {
+    playerTurnActionsRef.current?.toggleCritical?.();
+  }, []);
   const passDisabled = !canPassTurn || isPassingTurn;
   const footerMenuButtons = [
     {
@@ -6055,39 +6059,6 @@ export default function ZombiesCharacterSheet() {
                 tokenLookup={tokenMetaById}
               />
             </div>
-            <h1
-              style={{
-                fontSize: "28px",
-                fontWeight: 600,
-                color: "#FFFFFF",
-                padding: "8px 0",
-                textAlign: "center",
-                letterSpacing: "1px",
-                textShadow: "1px 1px 2px rgba(0, 0, 0, 0.4)",
-                fontFamily: "'Merriweather', serif",
-                textTransform: "capitalize",
-                borderBottom: "2px solid #555", // Subtle underline for structure
-                display: "inline-block",
-              }}
-              className="mx-auto"
-            >
-              {form?.characterName || 'Loading Character'}
-            </h1>
-
-            <HealthDefense
-              form={form}
-              totalLevel={totalLevel}
-              dexMod={statMods.dex}
-              conMod={statMods.con}
-              wisMod={statMods.wis}
-              initiative={featBonuses.initiative}
-              speed={featBonuses.speed}
-              hpMaxBonus={featBonuses.hpMaxBonus}
-              hpMaxBonusPerLevel={featBonuses.hpMaxBonusPerLevel}
-              onTempHealthChange={handleHealthChange}
-              speedMultiplier={speedMultiplier}
-              {...(spellAbilityMod !== null && { spellAbilityMod })}
-            />
           </div>
           <div
             style={{
@@ -6267,6 +6238,7 @@ export default function ZombiesCharacterSheet() {
                       </div>
                     </div>
                   }
+                  onToggleCritical={toggleCriticalFromFooter}
                 />
               </Nav>
             </Container>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -109,12 +109,6 @@ jest.mock('../attributes/SpellSelector', () => (props) => {
   mockHandleClose.current = props.handleClose;
   return props.show ? <div data-testid="spell-selector" /> : null;
 });
-const mockHealthDefenseProps = { current: null };
-jest.mock('../attributes/HealthDefense', () => (props) => {
-  mockHealthDefenseProps.current = props;
-  return null;
-});
-
 const mockFeaturesModalProps = { current: null };
 jest.mock('../attributes/Features', () => (props) => {
   mockFeaturesModalProps.current = props;
@@ -204,7 +198,6 @@ beforeEach(() => {
   mockSkillsModalProps.current = null;
   mockDockedSkillsModalProps.current = null;
   mockCharacterInfoProps.current = null;
-  mockHealthDefenseProps.current = null;
   window.localStorage.clear();
   window.matchMedia = jest.fn().mockImplementation((query) => ({
     matches: false,
@@ -290,10 +283,6 @@ test('uses character-derived hit points for synced combat participants', async (
   expect(screen.getByText('4/10')).toBeInTheDocument();
   expect(screen.queryByText('5/40')).not.toBeInTheDocument();
 
-  await waitFor(() => {
-    expect(mockHealthDefenseProps.current).not.toBeNull();
-  });
-  expect(mockHealthDefenseProps.current.form.health).toBe(30);
 });
 
 test('spells button includes points-glow when spell points available', async () => {
@@ -423,10 +412,6 @@ test('activating Draconic Flight adds a persistent effect without duplicates', a
 
   expect(mockFeaturesModalProps.current?.characterId).toBe('1');
 
-  await waitFor(() => {
-    expect(mockHealthDefenseProps.current?.speedMultiplier).toBe(1);
-  });
-
   expect(typeof mockFeaturesModalProps.current.onDraconicFlight).toBe('function');
 
   await act(async () => {
@@ -533,9 +518,6 @@ test('adrenaline rush consumes a bonus action, persists once, grants temp HP, an
     );
   });
 
-  await waitFor(() => {
-    expect(mockHealthDefenseProps.current?.speedMultiplier).toBe(2);
-  });
 
   await waitFor(() => {
     const stored = window.localStorage.getItem('zombiesActiveEffects:1');
@@ -561,9 +543,6 @@ test('adrenaline rush consumes a bonus action, persists once, grants temp HP, an
     expect(mockFeaturesModalProps.current?.form?.tempHealth).toBe(0);
   });
 
-  await waitFor(() => {
-    expect(mockHealthDefenseProps.current?.speedMultiplier).toBe(1);
-  });
 
   window.localStorage.clear();
 });

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -28,11 +28,13 @@ const FooterCharacterSlot = ({
   actions,
   spellSlots,
   damageSummary,
+  onToggleCritical,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
   const [pendingHealth, setPendingHealth] = useState(null);
   const pendingCommitRef = useRef(null);
+  const [damageHighlightClass, setDamageHighlightClass] = useState('');
 
   const { resolvedCurrent, resolvedMax } = useMemo(() => {
     const numericCurrent = Number(currentHealth);
@@ -82,19 +84,26 @@ const FooterCharacterSlot = ({
 
   const normalizedDamageSummary = useMemo(() => {
     if (!damageSummary || typeof damageSummary !== 'object') {
-      return { value: null, isCritical: false, isFumble: false };
+      return { value: null, isCritical: false, isFumble: false, timestamp: null };
     }
 
-    const { value, isCritical, isFumble } = damageSummary;
+    const { value, isCritical, isFumble, timestamp } = damageSummary;
 
     return {
       value: value !== undefined ? value : null,
       isCritical: Boolean(isCritical),
       isFumble: Boolean(isFumble),
+      timestamp:
+        typeof timestamp === 'number' && Number.isFinite(timestamp) ? timestamp : null,
     };
   }, [damageSummary]);
 
-  const { value: damageSummaryValue, isCritical: damageIsCritical, isFumble: damageIsFumble } =
+  const {
+    value: damageSummaryValue,
+    isCritical: damageIsCritical,
+    isFumble: damageIsFumble,
+    timestamp: damageTimestamp,
+  } = normalizedDamageSummary;
     normalizedDamageSummary;
 
   const hasDamageValue =
@@ -108,11 +117,17 @@ const FooterCharacterSlot = ({
 
   const damageClassName = [
     'footer-character-slot__damage',
+    damageHighlightClass,
     damageIsCritical ? 'footer-character-slot__damage--critical' : '',
     damageIsFumble ? 'footer-character-slot__damage--fumble' : '',
   ]
     .filter(Boolean)
     .join(' ');
+  const handleCritButtonClick = useCallback(() => {
+    if (typeof onToggleCritical === 'function') {
+      onToggleCritical();
+    }
+  }, [onToggleCritical]);
   const canDecrease = !isUpdating && numericCurrent > 0;
   const canIncrease =
     !isUpdating &&
@@ -251,6 +266,27 @@ const FooterCharacterSlot = ({
     }
   }, [commitPendingUpdate, isUpdating]);
 
+  useEffect(() => {
+    if (!damageTimestamp) {
+      setDamageHighlightClass('');
+      return undefined;
+    }
+
+    setDamageHighlightClass('footer-character-slot__damage--recent');
+
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDamageHighlightClass('');
+    }, 1600);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [damageTimestamp]);
+
   return (
     <div className="footer-character-slot" data-allow-pointer-events="true">
       {spellSlots ? (
@@ -318,7 +354,33 @@ const FooterCharacterSlot = ({
                 </div>
               </div>
               <div className={damageClassName} role="status" aria-live="polite">
-                <span className="footer-character-slot__damage-label">Damage</span>
+                <div className="footer-character-slot__damage-header">
+                  <span className="footer-character-slot__damage-label">Damage</span>
+                  {typeof onToggleCritical === 'function' ? (
+                    <Button
+                      type="button"
+                      variant="outline-light"
+                      size="sm"
+                      className={`footer-character-slot__crit-button ${
+                        damageIsCritical ? 'is-active' : ''
+                      }`}
+                      onClick={handleCritButtonClick}
+                      aria-pressed={damageIsCritical}
+                      aria-label={
+                        damageIsCritical
+                          ? 'Critical damage roll enabled. Click to roll normally.'
+                          : 'Click to enable a critical damage roll on your next roll.'
+                      }
+                      title={
+                        damageIsCritical
+                          ? 'Critical damage roll enabled. Click to roll normally.'
+                          : 'Click to enable a critical damage roll on your next roll.'
+                      }
+                    >
+                      Crit
+                    </Button>
+                  ) : null}
+                </div>
                 <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
               </div>
             </div>
@@ -412,7 +474,9 @@ FooterCharacterSlot.propTypes = {
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     isCritical: PropTypes.bool,
     isFumble: PropTypes.bool,
+    timestamp: PropTypes.number,
   }),
+  onToggleCritical: PropTypes.func,
 };
 
 FooterCharacterSlot.defaultProps = {
@@ -426,6 +490,7 @@ FooterCharacterSlot.defaultProps = {
   actions: null,
   spellSlots: null,
   damageSummary: null,
+  onToggleCritical: undefined,
 };
 
 export default FooterCharacterSlot;


### PR DESCRIPTION
## Summary
- remove the character sheet header title and health panel now that the footer owns the display
- add a critical toggle button and roll highlight states to the footer damage summary while exposing a hidden toggle for existing flows
- update supporting state, styles, and tests to deliver footer damage timestamps and avoid stale health mocks

## Testing
- npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js src/components/Zombies/attributes/PlayerTurnActions.test.js *(fails: legacy expectations around damage controls and act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_69050453791c832ea5530576c3a40d3c