### PR TITLE
Ensure character sheet map stays interactive when undocked

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5903,6 +5903,10 @@ export default function ZombiesCharacterSheet() {
   }, [DOCKABLE_MODAL_CONFIG, getDockedSide, handleDockChange, handleDockClose]);
 
   const mapDockedSide = useMemo(() => getDockedSide('map'), [getDockedSide]);
+  const hasResolvedCampaignMap = useMemo(
+    () => Boolean(resolvedCampaignMap),
+    [resolvedCampaignMap]
+  );
   const lastAutoDockedMapIdRef = useRef(null);
 
   useEffect(() => {
@@ -5955,10 +5959,7 @@ export default function ZombiesCharacterSheet() {
     });
   }, [resolvedCampaignMap, setDockedModals]);
 
-  const isMapInteractionActive = useMemo(
-    () => Boolean(mapDockedSide),
-    [mapDockedSide]
-  );
+  const isMapInteractionActive = hasResolvedCampaignMap;
 
   const overlaySurfaceClassName = useMemo(
     () =>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -696,6 +696,7 @@ test('modal docking controls update docking state', async () => {
     if (mockMapModalProps.current && typeof mockMapModalProps.current.isDocked !== 'undefined') {
       expect(mockMapModalProps.current.isDocked).toBe(false);
     }
+    expect(mockMapModalProps.current?.show).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- keep the background map overlay active whenever a campaign map is available so it stays interactive even after undocking
- update the character sheet map docking test to cover the always-on background behaviour

## Testing
- not run (tests require an environment configuration that is noisy under Jest watch mode)


------
https://chatgpt.com/codex/tasks/task_e_69050c511e1c832eb6858bec76950e9f