### PR TITLE
Restore neutral map modal background

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -28,7 +28,7 @@
   z-index: 0;
   color: #fff;
   overflow: hidden;
-  background-color: transparent;
+  background-color: #0f1117;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -595,18 +595,12 @@ const MapModal = ({
     [previewMap]
   );
 
-  const backgroundStyle = useMemo(() => {
-    if (!backgroundImageSrc) {
-      return undefined;
-    }
-
-    return {
-      backgroundImage: `url("${backgroundImageSrc}")`,
-      backgroundSize: 'cover',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-    };
-  }, [backgroundImageSrc]);
+  const backgroundStyle = useMemo(
+    () => ({
+      backgroundColor: '#0f1117',
+    }),
+    []
+  );
 
   const previewMapIdCandidates = useMemo(() => {
     const fallbackIdentifiers = [];


### PR DESCRIPTION
## Summary
- replace the map modal background image styling with a consistent dark backdrop
- update the shared styles so the modal background uses the intended black-gray tone

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69050f847ac4832ea00529bc2f32aa27