### PR TITLE
Adjust character sheet map overlay styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -162,8 +162,13 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(13, 27, 42, 0.3);
   pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(13, 27, 42, 0.08) 0%,
+    rgba(13, 27, 42, 0.16) 45%,
+    rgba(13, 27, 42, 0.08) 100%
+  );
 }
 
 .zombies-character-sheet-layout__map {


### PR DESCRIPTION
## Summary
- soften the character sheet overlay tint so the campaign map is no longer excessively dimmed

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_69051ab236c4832e999311d6efebdc31