### PR TITLE
Expand character sheet dice roller display

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2270,9 +2270,9 @@ $rotateX: -$angle;
   align-items: center;
   justify-content: flex-start;
   gap: 18px;
-  width: min(90vw, var(--damage-roller-max-width, 520px));
-  max-width: min(90vw, var(--damage-roller-max-width, 520px));
-  min-height: max(240px, min(48vh, var(--damage-roller-min-height, 380px)));
+  width: min(92vw, var(--damage-roller-max-width, 720px));
+  max-width: min(92vw, var(--damage-roller-max-width, 720px));
+  min-height: max(280px, min(60vh, var(--damage-roller-min-height, 540px)));
   margin: 0 auto;
   padding: 32px 24px 48px;
   color: #ffffff;
@@ -2300,8 +2300,8 @@ $rotateX: -$angle;
 
 .damage-roller__dice-area {
   position: relative;
-  width: clamp(180px, 42vw, var(--damage-dice-area-size, 380px));
-  height: clamp(180px, 42vw, var(--damage-dice-area-size, 380px));
+  width: clamp(260px, 60vw, var(--damage-dice-area-size, 560px));
+  height: clamp(260px, 60vw, var(--damage-dice-area-size, 560px));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2312,7 +2312,7 @@ $rotateX: -$angle;
   perspective: 1400px;
   transform-style: preserve-3d;
   max-width: 100%;
-  max-height: var(--damage-dice-area-size, 380px);
+  max-height: var(--damage-dice-area-size, 560px);
 }
 
 .damage-roller__dice-wrapper {
@@ -2403,7 +2403,7 @@ $rotateX: -$angle;
 .zombies-character-sheet__dice-warning {
   margin: 12px auto 0;
   padding: 12px 18px;
-  max-width: 480px;
+  max-width: 640px;
   border-radius: 12px;
   background: rgba(0, 0, 0, 0.6);
   color: #ffd166;
@@ -2448,7 +2448,7 @@ $rotateX: -$angle;
 
 .damage-roller__controls {
   width: 100%;
-  max-width: min(70vw, var(--damage-roller-max-width, 360px));
+  max-width: min(72vw, var(--damage-roller-max-width, 560px));
   margin: 0 auto;
   gap: calc(var(--attack-die-size) * 0.2);
 }

--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -11,12 +11,12 @@ import {
 } from '../../../utils/diceColors';
 
 const DIE_SIZE_BY_SIDES = new Map([
-  [4, 44],
-  [6, 46],
-  [8, 48],
-  [10, 50],
-  [12, 54],
-  [20, 58],
+  [4, 72],
+  [6, 76],
+  [8, 80],
+  [10, 86],
+  [12, 94],
+  [20, 106],
 ]);
 
 const CATEGORY_CLASSNAMES = {
@@ -59,7 +59,7 @@ const getDieSize = (sides) => {
   if (DIE_SIZE_BY_SIDES.has(rounded)) {
     return DIE_SIZE_BY_SIDES.get(rounded);
   }
-  return clamp(52 + rounded * 0.9, 48, 92);
+  return clamp(88 + rounded * 1.2, 72, 160);
 };
 
 const getDieShapeClass = (sides) => {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -2136,8 +2136,8 @@ useEffect(() => {
 const damageWrapperRef = useRef(null);
 const damageAmountRef = useRef(null);
 const [damageLayout, setDamageLayout] = useState({
-  maxWidth: 360,
-  diceSize: 220,
+  maxWidth: 560,
+  diceSize: 340,
 });
 
 const updateDamageLayout = useCallback(() => {
@@ -2287,11 +2287,11 @@ useEffect(() => {
 
 const resolvedMaxWidth = Number.isFinite(damageLayout.maxWidth)
   ? damageLayout.maxWidth
-  : 360;
+  : 560;
 const resolvedDiceSize = Number.isFinite(damageLayout.diceSize)
   ? damageLayout.diceSize
-  : 220;
-const damageContainerMinHeight = Math.max(240, resolvedDiceSize + 160);
+  : 340;
+const damageContainerMinHeight = Math.max(280, resolvedDiceSize + 200);
 const damageAmountStyle = {
   '--damage-roller-max-width': `${resolvedMaxWidth}px`,
   '--damage-roller-min-height': `${damageContainerMinHeight}px`,


### PR DESCRIPTION
## Summary
- enlarge the damage roller container so the overlay fills more of the character sheet map area
- increase dice sizing so both 3d and fallback dice render noticeably larger during rolls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690523c5e6bc832eb04b3aa84d9ef892