### PR TITLE
Supersize character sheet damage dice

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -2270,9 +2270,9 @@ $rotateX: -$angle;
   align-items: center;
   justify-content: flex-start;
   gap: 18px;
-  width: min(90vw, var(--damage-roller-max-width, 520px));
-  max-width: min(90vw, var(--damage-roller-max-width, 520px));
-  min-height: max(240px, min(48vh, var(--damage-roller-min-height, 380px)));
+  width: min(96vw, var(--damage-roller-max-width, 1280px));
+  max-width: min(96vw, var(--damage-roller-max-width, 1280px));
+  min-height: max(420px, min(96vh, var(--damage-roller-min-height, 1040px)));
   margin: 0 auto;
   padding: 32px 24px 48px;
   color: #ffffff;
@@ -2300,8 +2300,8 @@ $rotateX: -$angle;
 
 .damage-roller__dice-area {
   position: relative;
-  width: clamp(180px, 42vw, var(--damage-dice-area-size, 380px));
-  height: clamp(180px, 42vw, var(--damage-dice-area-size, 380px));
+  width: clamp(360px, 88vw, var(--damage-dice-area-size, 960px));
+  height: clamp(360px, 88vw, var(--damage-dice-area-size, 960px));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2312,7 +2312,7 @@ $rotateX: -$angle;
   perspective: 1400px;
   transform-style: preserve-3d;
   max-width: 100%;
-  max-height: var(--damage-dice-area-size, 380px);
+  max-height: var(--damage-dice-area-size, 960px);
 }
 
 .damage-roller__dice-wrapper {
@@ -2403,7 +2403,7 @@ $rotateX: -$angle;
 .zombies-character-sheet__dice-warning {
   margin: 12px auto 0;
   padding: 12px 18px;
-  max-width: 480px;
+  max-width: 640px;
   border-radius: 12px;
   background: rgba(0, 0, 0, 0.6);
   color: #ffd166;
@@ -2448,7 +2448,7 @@ $rotateX: -$angle;
 
 .damage-roller__controls {
   width: 100%;
-  max-width: min(70vw, var(--damage-roller-max-width, 360px));
+  max-width: min(92vw, var(--damage-roller-max-width, 1120px));
   margin: 0 auto;
   gap: calc(var(--attack-die-size) * 0.2);
 }
@@ -2543,7 +2543,12 @@ $rotateX: -$angle;
   --rot-y-end: 0deg;
   --rot-z-end: 0deg;
   --die-surface-color: var(--dice-face-color, #1f46cc);
-  filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.45));
+  filter: drop-shadow(
+    0
+    calc(var(--die-size, 36px) * 0.18)
+    calc(var(--die-size, 36px) * 0.28)
+    rgba(0, 0, 0, 0.45)
+  );
   animation: damage-die-flight var(--drop-duration) cubic-bezier(0.25, 0.72, 0.13, 0.99)
     forwards;
   animation-delay: var(--drop-delay);
@@ -2621,13 +2626,14 @@ $rotateX: -$angle;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 16px;
-  min-height: 16px;
-  padding: 2px 4px;
-  font-size: 0.95rem;
+  min-width: calc(var(--die-size, 36px) * 0.26);
+  min-height: calc(var(--die-size, 36px) * 0.26);
+  padding: calc(var(--die-size, 36px) * 0.05) calc(var(--die-size, 36px) * 0.12);
+  font-size: clamp(1.2rem, calc(var(--die-size, 36px) * 0.22), 3.6rem);
   font-weight: 700;
   color: #fff;
-  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.65);
+  text-shadow: 0 calc(var(--die-size, 36px) * 0.06) calc(var(--die-size, 36px) * 0.12)
+    rgba(0, 0, 0, 0.65);
   transform: translateZ(1.2px);
 }
 
@@ -2680,11 +2686,12 @@ $rotateX: -$angle;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.05rem;
+  font-size: clamp(1.4rem, calc(var(--die-size, 36px) * 0.26), 4.6rem);
   line-height: 1;
   font-weight: 700;
   color: #fff;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.65);
+  text-shadow: 0 calc(var(--die-size, 36px) * 0.08) calc(var(--die-size, 36px) * 0.16)
+    rgba(0, 0, 0, 0.65);
   pointer-events: none;
   backface-visibility: hidden;
   transform: translateZ(6px);

--- a/client/src/components/Zombies/attributes/DamageDiceCanvas.js
+++ b/client/src/components/Zombies/attributes/DamageDiceCanvas.js
@@ -11,12 +11,12 @@ import {
 } from '../../../utils/diceColors';
 
 const DIE_SIZE_BY_SIDES = new Map([
-  [4, 44],
-  [6, 46],
-  [8, 48],
-  [10, 50],
-  [12, 54],
-  [20, 58],
+  [4, 248],
+  [6, 276],
+  [8, 304],
+  [10, 336],
+  [12, 368],
+  [20, 408],
 ]);
 
 const CATEGORY_CLASSNAMES = {
@@ -54,12 +54,19 @@ const createSeededRandom = (seedValue) => {
   };
 };
 
-const getDieSize = (sides) => {
+const getDieSize = (sides, areaSize) => {
   const rounded = Math.round(sides);
   if (DIE_SIZE_BY_SIDES.has(rounded)) {
     return DIE_SIZE_BY_SIDES.get(rounded);
   }
-  return clamp(52 + rounded * 0.9, 48, 92);
+  const fallbackSize = clamp(280 + rounded * 4.4, 200, 520);
+  if (!Number.isFinite(areaSize) || areaSize <= 0) {
+    return fallbackSize;
+  }
+  const upperBound = Math.max(220, areaSize * 0.96);
+  const lowerBound = Math.max(200, areaSize * 0.68);
+  const sized = Math.max(fallbackSize, lowerBound);
+  return Math.min(sized, upperBound);
 };
 
 const getDieShapeClass = (sides) => {
@@ -104,25 +111,35 @@ const usePrefersReducedMotion = () => {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 };
 
-const createDieStyle = (die, index, reduceMotion) => {
+const createDieStyle = (die, index, reduceMotion, areaSize, densityScale = 1) => {
   const seed = `${die.id ?? index}-${die.value}-${die.sides}`;
   const random = createSeededRandom(seed);
+  const normalizedScale = clamp(densityScale, 0.42, 1.05);
+  const dieSize = Math.max(140, getDieSize(die.sides, areaSize) * normalizedScale);
 
   const baseDelay = reduceMotion
     ? index * 0.02
     : index * 0.12 + random() * 0.08;
   const duration = reduceMotion ? 0.1 : 0.82 + random() * 0.5;
 
-  const startX = reduceMotion ? 0 : (random() - 0.5) * 260;
-  const startY = reduceMotion ? 0 : -130 - random() * 90;
-  const startZ = reduceMotion ? 0 : (random() - 0.5) * 200;
+  const areaLimit = Number.isFinite(areaSize) && areaSize > 0 ? areaSize : null;
+  const horizontalLimit = areaLimit
+    ? Math.max(dieSize * 0.9, areaLimit * 0.88)
+    : dieSize * 2.4;
+  const launchRadius = Math.min(dieSize * 2.2, horizontalLimit);
+  const dropRadius = Math.min(dieSize * 1.6, horizontalLimit * 0.92);
+  const launchHeight = dieSize * (1.05 + random() * 0.75);
 
-  const midX = reduceMotion ? 0 : (random() - 0.5) * 170;
-  const midY = reduceMotion ? 0 : -70 - random() * 70;
-  const midZ = reduceMotion ? 0 : (random() - 0.5) * 170;
+  const startX = reduceMotion ? 0 : (random() - 0.5) * launchRadius;
+  const startY = reduceMotion ? 0 : -launchHeight;
+  const startZ = reduceMotion ? 0 : (random() - 0.5) * dropRadius;
 
-  const endY = reduceMotion ? 0 : 34 + random() * 34;
-  const bounce = reduceMotion ? 0 : 6 + random() * 10;
+  const midX = reduceMotion ? 0 : (random() - 0.5) * (launchRadius * 0.65);
+  const midY = reduceMotion ? 0 : -dieSize * (0.72 + random() * 0.4);
+  const midZ = reduceMotion ? 0 : (random() - 0.5) * (dropRadius * 0.7);
+
+  const endY = reduceMotion ? 0 : dieSize * (0.28 + random() * 0.22);
+  const bounce = reduceMotion ? 0 : dieSize * (0.06 + random() * 0.08);
 
   const rotStartX = reduceMotion ? 0 : random() * 360;
   const rotStartY = reduceMotion ? 0 : random() * 360;
@@ -138,7 +155,7 @@ const createDieStyle = (die, index, reduceMotion) => {
 
   return {
     left: '50%',
-    '--die-size': formatCssNumber(getDieSize(die.sides), 'px', 0),
+    '--die-size': formatCssNumber(dieSize, 'px', 0),
     '--drop-delay': formatSeconds(baseDelay),
     '--drop-duration': formatSeconds(duration),
     '--flight-start-x': formatCssNumber(startX, 'px'),
@@ -166,6 +183,7 @@ const DamageDiceCanvas = ({
   diceColor,
   instanceKey = null,
   showOverlayDice = false,
+  diceAreaSize = null,
 }) => {
   const resolvedColor = useMemo(
     () => normalizeDiceColor(diceColor) || DEFAULT_DICE_COLOR,
@@ -198,6 +216,9 @@ const DamageDiceCanvas = ({
       return [];
     }
 
+    const diceCount = dice.length;
+    const densityScale = diceCount > 1 ? clamp(0.96 / Math.sqrt(diceCount), 0.48, 1) : 1;
+
     return dice
       .filter((die) => die && Number.isFinite(Number(die.sides)))
       .map((die, index) => {
@@ -205,7 +226,13 @@ const DamageDiceCanvas = ({
         const value = toNumericValue(die.value);
         const color = die.typeColor || resolvedColor;
         const style = {
-          ...createDieStyle({ ...die, sides }, index, reduceMotion),
+          ...createDieStyle(
+            { ...die, sides },
+            index,
+            reduceMotion,
+            diceAreaSize,
+            densityScale,
+          ),
           ...createDiceCategoryStyles(color, die.category),
         };
         const classes = [
@@ -241,7 +268,7 @@ const DamageDiceCanvas = ({
           </div>
         );
       });
-  }, [dice, reduceMotion, resolvedColor, showOverlayDice]);
+  }, [dice, diceAreaSize, reduceMotion, resolvedColor, showOverlayDice]);
 
   return (
     <div className="damage-dice-canvas" aria-hidden="true">

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -2136,8 +2136,8 @@ useEffect(() => {
 const damageWrapperRef = useRef(null);
 const damageAmountRef = useRef(null);
 const [damageLayout, setDamageLayout] = useState({
-  maxWidth: 360,
-  diceSize: 220,
+  maxWidth: 1200,
+  diceSize: 640,
 });
 
 const updateDamageLayout = useCallback(() => {
@@ -2153,25 +2153,10 @@ const updateDamageLayout = useCallback(() => {
   }
 
   const wrapperWidth = wrapperEl.clientWidth || window.innerWidth;
+  const viewportWidth = window.innerWidth || document.documentElement?.clientWidth || wrapperWidth;
   const spellSlotsEl = document.querySelector('.spell-slot-container');
-  const footerButtonsContainer = document.querySelector('.footer-btn')?.parentElement;
 
-  const widthCandidates = [wrapperWidth];
-
-  if (spellSlotsEl) {
-    const { width } = spellSlotsEl.getBoundingClientRect();
-    if (Number.isFinite(width) && width > 0) {
-      widthCandidates.push(width);
-    }
-  }
-
-  if (footerButtonsContainer) {
-    const { width } = footerButtonsContainer.getBoundingClientRect();
-    if (Number.isFinite(width) && width > 0) {
-      widthCandidates.push(width);
-    }
-  }
-
+  const widthCandidates = [wrapperWidth, Math.max(0, viewportWidth - 64)];
   const positiveWidths = widthCandidates.filter((value) => Number.isFinite(value) && value > 0);
   const maxAllowedWidth = positiveWidths.length > 0 ? Math.min(...positiveWidths) : wrapperWidth;
 
@@ -2200,8 +2185,8 @@ const updateDamageLayout = useCallback(() => {
 
   const bottomBoundary = boundaries.length > 0 ? Math.min(...boundaries) : viewportHeight;
   const verticalGap = bottomBoundary ? bottomBoundary - damageRect.top - 16 : maxAllowedWidth;
-  const maxAllowedHeight = Math.max(140, verticalGap);
-  const diceSize = Math.max(140, Math.min(maxAllowedWidth, maxAllowedHeight));
+  const maxAllowedHeight = Math.max(260, verticalGap);
+  const diceSize = Math.max(360, Math.min(maxAllowedWidth * 0.96, maxAllowedHeight * 0.96));
 
   setDamageLayout((prev) => {
     const next = {
@@ -2287,11 +2272,11 @@ useEffect(() => {
 
 const resolvedMaxWidth = Number.isFinite(damageLayout.maxWidth)
   ? damageLayout.maxWidth
-  : 360;
+  : 1200;
 const resolvedDiceSize = Number.isFinite(damageLayout.diceSize)
   ? damageLayout.diceSize
-  : 220;
-const damageContainerMinHeight = Math.max(240, resolvedDiceSize + 160);
+  : 640;
+const damageContainerMinHeight = Math.max(420, resolvedDiceSize + 320);
 const damageAmountStyle = {
   '--damage-roller-max-width': `${resolvedMaxWidth}px`,
   '--damage-roller-min-height': `${damageContainerMinHeight}px`,
@@ -2357,6 +2342,7 @@ const damageAmountStyle = {
                   diceColor={diceFaceColor}
                   instanceKey={characterId}
                   showOverlayDice={showOverlayDice}
+                  diceAreaSize={resolvedDiceSize}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- expand the damage roller overlay so it can consume nearly the entire sheet viewport and provide a much larger dice canvas
- overhaul dice size and animation scaling so fallback dice stay massive while adapting to the number of dice and available space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690523c5e6bc832eb04b3aa84d9ef892