### PR TITLE
Adjust desktop footer layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4329,6 +4329,130 @@ h1 {
   flex-wrap: wrap;
 }
 
+@media (min-width: 992px) {
+  .footer-container {
+    padding: 8px 24px calc(8px + env(safe-area-inset-bottom, 0));
+    max-width: 1440px;
+  }
+
+  .footer-nav {
+    max-width: 1280px;
+  }
+
+  .footer-character-slot {
+    flex-direction: row;
+    align-items: center;
+    gap: 18px;
+    padding: 10px 20px;
+    width: min(100%, 1180px);
+  }
+
+  .footer-character-slot__main {
+    flex: 1 1 auto;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+  }
+
+  .footer-character-slot__details {
+    flex-direction: row;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+  }
+
+  .footer-character-slot__header {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+  }
+
+  .footer-character-slot__health {
+    flex: 1 1 320px;
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .footer-character-slot__health-top {
+    align-items: center;
+    gap: 12px;
+  }
+
+  .footer-character-slot__health-summary {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 6px;
+  }
+
+  .footer-character-slot__damage {
+    align-self: stretch;
+    justify-content: center;
+    min-width: 90px;
+  }
+
+  .footer-character-slot__health-track {
+    flex: 1 1 260px;
+    max-width: 420px;
+  }
+
+  .footer-character-slot__health-controls {
+    flex: 0 0 auto;
+    align-self: center;
+    margin-left: auto;
+  }
+
+  .footer-character-slot__error {
+    flex: 0 0 100%;
+  }
+
+  .footer-character-slot__actions {
+    margin-left: auto;
+    padding-left: 16px;
+    border-left: 1px solid rgba(80, 124, 196, 0.35);
+  }
+
+  .footer-actions-wrapper {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+  }
+
+  .footer-actions-inline {
+    flex-wrap: nowrap;
+    gap: 12px;
+  }
+
+  .footer-pass-log-button {
+    padding: 6px 14px;
+    font-size: 0.82rem;
+  }
+
+  .footer-btn {
+    width: 32px;
+    height: 32px;
+  }
+
+  .footer-btn--dice {
+    --footer-dice-size: 40px;
+  }
+
+  .footer-btn--attack {
+    width: 42px;
+    height: 42px;
+  }
+
+  .footer-character-slot__slots-wrapper {
+    order: 3;
+    margin-bottom: 0;
+    margin-left: auto;
+  }
+
+  .footer-character-slot__slots {
+    max-width: none;
+  }
+}
+
 .footer-pass-log-button {
   font-size: 0.75rem;
   font-weight: 600;
@@ -4376,6 +4500,7 @@ h1 {
   display: flex;
   justify-content: center;
   padding: 2px 8px calc(2px + env(safe-area-inset-bottom, 0));
+  margin: 0 auto;
 }
 
 .footer-nav {
@@ -4383,6 +4508,7 @@ h1 {
   padding: 0;
   display: flex;
   justify-content: center;
+  margin: 0 auto;
 }
 
 .footer-menu-toggle {


### PR DESCRIPTION
## Summary
- widen the desktop footer container to better match the in-game layout
- realign character slot, health, and action sections for a lower profile footer
- resize footer action buttons and spell slot groupings for the new horizontal flow

## Testing
- not run (style changes only)


------
https://chatgpt.com/codex/tasks/task_e_690605e5d424832e921e79ca4e4edc06