### PR TITLE
Adjust footer character slot layout and styling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3812,8 +3812,8 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 4px;
-  padding: 6px 8px;
+  gap: 8px;
+  padding: 28px 12px 12px;
   background: rgba(15, 22, 43, 0.88);
   border-radius: 14px;
   border: 1px solid rgba(104, 144, 216, 0.35);
@@ -3835,28 +3835,36 @@ h1 {
 }
 
 .footer-character-slot__main {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: center;
+}
+
+.footer-character-slot__profile {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px;
-  flex-wrap: wrap;
+  gap: 10px;
+  width: 140px;
+  flex-shrink: 0;
+  text-align: center;
 }
 
 .footer-character-slot__portrait {
   position: relative;
-  width: 48px;
+  width: 110px;
+  height: 110px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  flex-shrink: 0;
 }
 
 .footer-character-slot__portrait-ring {
   position: relative;
-  width: 48px;
-  height: 48px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   padding: 2px;
   background: radial-gradient(circle at 35% 35%, rgba(120, 168, 255, 0.4), rgba(24, 36, 72, 0.85));
@@ -3895,10 +3903,10 @@ h1 {
 
 .footer-character-slot__portrait-gloss {
   position: absolute;
-  top: 16%;
-  left: 22%;
-  width: 50%;
-  height: 24%;
+  top: 20%;
+  left: 25%;
+  width: 48%;
+  height: 26%;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.45), transparent);
   border-radius: 50%;
   opacity: 0.3;
@@ -3907,18 +3915,22 @@ h1 {
 }
 
 .footer-character-slot__armor-class {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0;
-  font-size: 0.6rem;
-  letter-spacing: 0.04em;
-  color: rgba(216, 226, 255, 0.9);
-  background: rgba(18, 26, 52, 0.78);
-  border-radius: 6px;
-  padding: 1px 4px;
-  border: 1px solid rgba(112, 154, 230, 0.3);
-  box-shadow: 0 4px 10px rgba(8, 12, 24, 0.4);
+  justify-content: center;
+  min-width: 38px;
+  padding: 4px 6px;
+  border-radius: 10px;
+  background: rgba(10, 16, 34, 0.85);
+  border: 1px solid rgba(132, 176, 248, 0.55);
+  box-shadow: 0 6px 14px rgba(4, 6, 14, 0.6);
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  color: rgba(230, 236, 255, 0.95);
 }
 
 .footer-character-slot__armor-class-label {
@@ -3937,34 +3949,28 @@ h1 {
 .footer-character-slot__details {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 12px;
   min-width: 0;
-  flex: 1 1 200px;
-}
-
-.footer-character-slot__header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  row-gap: 4px;
-  width: 100%;
-  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .footer-character-slot__actions {
+  justify-self: end;
   display: flex;
   align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  gap: 4px;
-  margin-left: 6px;
+  gap: 6px;
+  align-self: center;
 }
 
 .footer-character-slot__slots-wrapper {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translate(-50%, -60%);
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 2px;
+  z-index: 3;
 }
 
 .footer-character-slot__slots {
@@ -4010,51 +4016,55 @@ h1 {
 }
 
 .footer-character-slot__name {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: 1.1rem;
+  font-weight: 700;
   letter-spacing: 0.01em;
-  color: rgba(243, 246, 255, 0.92);
-  max-width: 240px;
+  color: #f8faff;
+  max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 1 1 auto;
 }
 
-.footer-character-slot__health {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.footer-character-slot__health-top {
+.footer-character-slot__health-inline {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 6px;
+  width: 100%;
 }
 
-.footer-character-slot__health-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.footer-character-slot__health-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: rgba(194, 208, 248, 0.78);
-}
-
-.footer-character-slot__health-readout {
+.footer-character-slot__health-mini-button {
+  width: 24px;
+  height: 24px;
   display: inline-flex;
-  align-items: baseline;
-  gap: 3px;
-  font-weight: 600;
-  font-size: 0.78rem;
-  color: rgba(247, 249, 255, 0.92);
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: #f5f7ff;
+  padding: 0;
+  font-size: 0.65rem;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+}
+
+.footer-character-slot__health-mini-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.footer-character-slot__health-mini-button:not(:disabled):hover,
+.footer-character-slot__health-mini-button:not(:disabled):focus-visible {
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: none;
+  filter: brightness(1.2);
+}
+
+.footer-character-slot__health-mini-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(132, 176, 248, 0.4);
 }
 
 .footer-character-slot__damage {
@@ -4157,7 +4167,7 @@ h1 {
 .footer-character-slot__health-track {
   position: relative;
   width: 100%;
-  height: 6px;
+  height: 12px;
   border-radius: 999px;
   background: rgba(24, 40, 76, 0.88);
   overflow: hidden;
@@ -4206,76 +4216,53 @@ h1 {
   cursor: pointer;
 }
 
-.footer-character-slot__health-controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.footer-character-slot__health-track--compact {
+  max-width: 100%;
+  min-width: 0;
 }
 
-.footer-character-slot__health-button {
-  width: 26px;
-  height: 26px;
-  display: inline-flex;
+.footer-character-slot__health-readout {
+  position: absolute;
+  inset: 0;
+  display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  border-radius: 8px;
-  border: 1px solid rgba(108, 154, 230, 0.4);
-  background: linear-gradient(135deg, rgba(60, 92, 160, 0.82), rgba(30, 46, 94, 0.92));
-  color: #f5f7ff;
-  box-shadow: 0 6px 16px rgba(12, 16, 34, 0.45), inset 0 0 6px rgba(88, 138, 236, 0.25);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgba(240, 248, 255, 0.95);
+  text-shadow: 0 1px 3px rgba(6, 12, 24, 0.7);
+  pointer-events: none;
+  gap: 4px;
 }
 
-.footer-character-slot__health-button--decrease {
-  background: linear-gradient(135deg, rgba(198, 70, 70, 0.88), rgba(118, 26, 26, 0.92));
-  border-color: rgba(242, 120, 120, 0.45);
-  box-shadow: 0 6px 16px rgba(58, 12, 12, 0.45), inset 0 0 6px rgba(255, 144, 144, 0.28);
+.footer-character-slot__health-readout-values {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
 }
 
-.footer-character-slot__health-button--increase {
-  background: linear-gradient(135deg, rgba(54, 160, 104, 0.88), rgba(20, 92, 56, 0.92));
-  border-color: rgba(120, 240, 182, 0.4);
-  box-shadow: 0 6px 16px rgba(10, 58, 32, 0.4), inset 0 0 6px rgba(142, 255, 202, 0.25);
-}
-
-.footer-character-slot__health-button i {
-  font-size: 0.85rem;
-}
-
-.footer-character-slot__health-button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.28);
-}
-
-.footer-character-slot__health-button:not(:disabled):hover,
-.footer-character-slot__health-button:not(:disabled):focus-visible {
-  transform: translateY(-1px) scale(1.03);
-  box-shadow: 0 8px 20px rgba(28, 42, 84, 0.5), inset 0 0 8px rgba(132, 180, 252, 0.35);
-  filter: brightness(1.05);
-}
-
-.footer-character-slot__health-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(132, 180, 252, 0.3), 0 8px 20px rgba(28, 42, 84, 0.5);
+.footer-character-slot__health-current {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f0f6ff;
 }
 
 .footer-character-slot__health-max {
-  font-size: 0.72rem;
-  color: rgba(210, 220, 255, 0.82);
+  font-size: 0.75rem;
+  color: rgba(210, 220, 255, 0.9);
 }
 
 .footer-character-slot__error {
-  min-height: 0.7rem;
-  font-size: 0.68rem;
+  min-height: 0.8rem;
+  font-size: 0.7rem;
   color: #ffb4a2;
-  text-align: left;
+  text-align: center;
+  width: 100%;
 }
 
 .footer-character-slot__health-readout .spinner-border {
-  width: 0.8rem;
-  height: 0.8rem;
+  width: 0.7rem;
+  height: 0.7rem;
   border-width: 0.1em;
   color: #88bcff;
 }
@@ -4287,25 +4274,23 @@ h1 {
   }
 
   .footer-character-slot__main {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 10px;
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 12px;
+  }
+
+  .footer-character-slot__profile {
+    width: 100%;
   }
 
   .footer-character-slot__details {
     width: 100%;
+    align-items: center;
   }
 
   .footer-character-slot__actions {
     width: 100%;
-  }
-
-  .footer-character-slot__health-track {
-    width: 100%;
-  }
-
-  .footer-character-slot__health-controls {
-    justify-content: flex-end;
+    justify-content: center;
   }
 }
 
@@ -4340,74 +4325,42 @@ h1 {
   }
 
   .footer-character-slot {
-    flex-direction: row;
-    align-items: center;
+    width: min(100%, 560px);
+    padding: 20px 28px 22px;
     gap: 18px;
-    padding: 10px 20px;
-    width: min(100%, 1180px);
   }
 
   .footer-character-slot__main {
-    flex: 1 1 auto;
+    grid-template-columns: auto 1fr auto;
     align-items: center;
-    gap: 18px;
-    flex-wrap: wrap;
+    gap: 32px;
+  }
+
+  .footer-character-slot__profile {
+    width: 170px;
+  }
+
+  .footer-character-slot__portrait {
+    width: 140px;
+    height: 140px;
   }
 
   .footer-character-slot__details {
-    flex-direction: row;
-    align-items: center;
-    gap: 18px;
-    flex-wrap: wrap;
-  }
-
-  .footer-character-slot__header {
-    flex: 0 0 auto;
-    margin-bottom: 0;
-  }
-
-  .footer-character-slot__health {
-    flex: 1 1 320px;
-    flex-direction: row;
-    align-items: center;
-    gap: 16px;
-  }
-
-  .footer-character-slot__health-top {
-    align-items: center;
-    gap: 12px;
-  }
-
-  .footer-character-slot__health-summary {
-    flex-direction: row;
-    align-items: baseline;
-    gap: 6px;
+    align-items: flex-start;
+    gap: 20px;
   }
 
   .footer-character-slot__damage {
-    align-self: stretch;
-    justify-content: center;
-    min-width: 90px;
-  }
-
-  .footer-character-slot__health-track {
-    flex: 1 1 260px;
-    max-width: 420px;
-  }
-
-  .footer-character-slot__health-controls {
-    flex: 0 0 auto;
-    align-self: center;
-    margin-left: auto;
+    align-self: flex-start;
+    min-width: 120px;
   }
 
   .footer-character-slot__error {
-    flex: 0 0 100%;
+    max-width: 240px;
   }
 
   .footer-character-slot__actions {
-    margin-left: auto;
-    padding-left: 16px;
+    padding-left: 22px;
     border-left: 1px solid rgba(80, 124, 196, 0.35);
   }
 
@@ -4440,16 +4393,6 @@ h1 {
   .footer-btn--attack {
     width: 42px;
     height: 42px;
-  }
-
-  .footer-character-slot__slots-wrapper {
-    order: 3;
-    margin-bottom: 0;
-    margin-left: auto;
-  }
-
-  .footer-character-slot__slots {
-    max-width: none;
   }
 }
 

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -297,99 +297,47 @@ const FooterCharacterSlot = ({
         </div>
       ) : null}
       <div className="footer-character-slot__main">
-        <div className="footer-character-slot__portrait">
-          <div className="footer-character-slot__portrait-ring">
-            {figurineImageUrl ? (
-              <img
-                src={figurineImageUrl}
-                alt={
-                  characterName
-                    ? `${characterName} figurine`
-                    : 'Selected character figurine'
-                }
-                className="footer-character-slot__figurine-image"
-              />
-            ) : (
-              <div className="footer-character-slot__figurine-placeholder" aria-hidden="true">
-                <i className="fas fa-chess-king" />
-              </div>
-            )}
-            <span className="footer-character-slot__portrait-gloss" />
-          </div>
-          <div
-            className="footer-character-slot__armor-class"
-            aria-live="polite"
-            aria-label={armorClassAriaLabel}
-          >
-            <span className="footer-character-slot__armor-class-label">AC</span>
-            <span className="footer-character-slot__armor-class-value">{displayArmorClass}</span>
-          </div>
-        </div>
-        <div className="footer-character-slot__details">
+        <div className="footer-character-slot__profile">
           {characterName ? (
-            <div className="footer-character-slot__header">
-              <span className="footer-character-slot__name" title={characterName}>
-                {characterName}
-              </span>
-            </div>
+            <span className="footer-character-slot__name" title={characterName}>
+              {characterName}
+            </span>
           ) : null}
-          <div className="footer-character-slot__health">
-            <div className="footer-character-slot__health-top">
-              <div className="footer-character-slot__health-summary">
-                <span className="footer-character-slot__health-label">Health</span>
-                <div className="footer-character-slot__health-readout" aria-live="polite">
-                  {isUpdating ? (
-                    <Spinner animation="border" role="status" size="sm">
-                      <span className="visually-hidden">Updating health…</span>
-                    </Spinner>
-                  ) : (
-                    <>
-                      <span className="footer-character-slot__health-current">{displayCurrent}</span>
-                      {displayMax !== '—' && (
-                        <span className="footer-character-slot__health-max">/ {displayMax}</span>
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-              <div className={damageClassName} role="status" aria-live="polite">
-                <div className="footer-character-slot__damage-header">
-                  <span className="footer-character-slot__damage-label">Damage</span>
-                  {typeof onToggleCritical === 'function' ? (
-                    <Button
-                      type="button"
-                      variant="outline-light"
-                      size="sm"
-                      className={`footer-character-slot__crit-button ${
-                        damageIsCritical ? 'is-active' : ''
-                      }`}
-                      onClick={handleCritButtonClick}
-                      aria-pressed={damageIsCritical}
-                      aria-label={
-                        damageIsCritical
-                          ? 'Critical damage roll enabled. Click to roll normally.'
-                          : 'Click to enable a critical damage roll on your next roll.'
-                      }
-                      title={
-                        damageIsCritical
-                          ? 'Critical damage roll enabled. Click to roll normally.'
-                          : 'Click to enable a critical damage roll on your next roll.'
-                      }
-                    >
-                      Crit
-                    </Button>
-                  ) : null}
-                </div>
-                <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
-              </div>
-            </div>
-            <div className="footer-character-slot__health-track" role="presentation">
-              <div className="footer-character-slot__health-track-base">
-                <div
-                  className="footer-character-slot__health-track-fill"
-                  style={{ width: `${healthPercent}%` }}
-                />
-                <div className="footer-character-slot__health-track-border" />
+          <div
+            className="footer-character-slot__health-inline"
+            role="group"
+            aria-label="Character health controls"
+          >
+            <button
+              type="button"
+              className="footer-character-slot__health-mini-button footer-character-slot__health-mini-button--decrease"
+              onClick={() => handleAdjustHealth(-1)}
+              disabled={!canDecrease}
+              aria-label="Decrease health"
+            >
+              <i className="fas fa-minus" aria-hidden="true" />
+            </button>
+            <div className="footer-character-slot__health-track footer-character-slot__health-track--compact" role="presentation">
+              <div className="footer-character-slot__health-track-base" />
+              <div
+                className="footer-character-slot__health-track-fill"
+                style={{ width: `${healthPercent}%` }}
+              />
+              <div className="footer-character-slot__health-track-border" />
+              <div className="footer-character-slot__health-readout" aria-live="polite">
+                <span className="visually-hidden">Health</span>
+                {isUpdating ? (
+                  <Spinner animation="border" role="status" size="sm">
+                    <span className="visually-hidden">Updating health…</span>
+                  </Spinner>
+                ) : (
+                  <span className="footer-character-slot__health-readout-values">
+                    <span className="footer-character-slot__health-current">{displayCurrent}</span>
+                    {displayMax !== '—' && (
+                      <span className="footer-character-slot__health-max">/ {displayMax}</span>
+                    )}
+                  </span>
+                )}
               </div>
               <input
                 type="range"
@@ -401,7 +349,12 @@ const FooterCharacterSlot = ({
                 onTouchEnd={handleSliderCommit}
                 onBlur={handleSliderCommit}
                 onKeyUp={(event) => {
-                  if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+                  if (
+                    event.key === 'ArrowLeft' ||
+                    event.key === 'ArrowRight' ||
+                    event.key === 'Home' ||
+                    event.key === 'End'
+                  ) {
                     handleSliderCommit();
                   }
                 }}
@@ -412,31 +365,78 @@ const FooterCharacterSlot = ({
                 aria-valuenow={numericCurrent}
               />
             </div>
-          </div>
-          <div className="footer-character-slot__health-controls" role="group" aria-label="Character health controls">
-            <Button
+            <button
               type="button"
-              variant="outline-light"
-              className="footer-character-slot__health-button footer-character-slot__health-button--decrease"
-              onClick={() => handleAdjustHealth(-1)}
-              disabled={!canDecrease}
-              aria-label="Decrease health"
-            >
-              <i className="fas fa-minus" aria-hidden="true" />
-            </Button>
-            <Button
-              type="button"
-              variant="outline-light"
-              className="footer-character-slot__health-button footer-character-slot__health-button--increase"
+              className="footer-character-slot__health-mini-button footer-character-slot__health-mini-button--increase"
               onClick={() => handleAdjustHealth(1)}
               disabled={!canIncrease}
               aria-label="Increase health"
             >
               <i className="fas fa-plus" aria-hidden="true" />
-            </Button>
+            </button>
+          </div>
+          <div className="footer-character-slot__portrait">
+            <div className="footer-character-slot__portrait-ring">
+              {figurineImageUrl ? (
+                <img
+                  src={figurineImageUrl}
+                  alt={
+                    characterName
+                      ? `${characterName} figurine`
+                      : 'Selected character figurine'
+                  }
+                  className="footer-character-slot__figurine-image"
+                />
+              ) : (
+                <div className="footer-character-slot__figurine-placeholder" aria-hidden="true">
+                  <i className="fas fa-chess-king" />
+                </div>
+              )}
+              <span className="footer-character-slot__portrait-gloss" />
+            </div>
+            <div
+              className="footer-character-slot__armor-class"
+              aria-live="polite"
+              aria-label={armorClassAriaLabel}
+            >
+              <span className="footer-character-slot__armor-class-label">AC</span>
+              <span className="footer-character-slot__armor-class-value">{displayArmorClass}</span>
+            </div>
           </div>
           <div className="footer-character-slot__error" role="status" aria-live="polite">
             {error}
+          </div>
+        </div>
+        <div className="footer-character-slot__details">
+          <div className={damageClassName} role="status" aria-live="polite">
+            <div className="footer-character-slot__damage-header">
+              <span className="footer-character-slot__damage-label">Damage</span>
+              {typeof onToggleCritical === 'function' ? (
+                <Button
+                  type="button"
+                  variant="outline-light"
+                  size="sm"
+                  className={`footer-character-slot__crit-button ${
+                    damageIsCritical ? 'is-active' : ''
+                  }`}
+                  onClick={handleCritButtonClick}
+                  aria-pressed={damageIsCritical}
+                  aria-label={
+                    damageIsCritical
+                      ? 'Critical damage roll enabled. Click to roll normally.'
+                      : 'Click to enable a critical damage roll on your next roll.'
+                  }
+                  title={
+                    damageIsCritical
+                      ? 'Critical damage roll enabled. Click to roll normally.'
+                      : 'Click to enable a critical damage roll on your next roll.'
+                  }
+                >
+                  Crit
+                </Button>
+              ) : null}
+            </div>
+            <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
           </div>
         </div>
         {actions ? (


### PR DESCRIPTION
## Summary
- enlarge the footer character portrait and overlay the armor class badge
- move the health bar and controls above the portrait with centered readouts
- center the spell slots above the card and refresh responsive styling

## Testing
- npm start *(fails: Module not found: Can't resolve '@3d-dice/dice-box')*

------
https://chatgpt.com/codex/tasks/task_e_690609773748832ea49a05ce87f7c81f