### PR TITLE
Adjust character portrait size in footer slot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3847,15 +3847,15 @@ h1 {
   align-items: center;
   justify-content: flex-start;
   gap: 10px;
-  width: 140px;
+  width: 120px;
   flex-shrink: 0;
   text-align: center;
 }
 
 .footer-character-slot__portrait {
   position: relative;
-  width: 110px;
-  height: 110px;
+  width: 90px;
+  height: 90px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- reduce the footer character profile container width
- shrink the portrait dimensions so the character image appears smaller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69060e34fd34832e988d6b0405a9b021