### PR TITLE
Adjust footer profile area sizing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3847,15 +3847,15 @@ h1 {
   align-items: center;
   justify-content: flex-start;
   gap: 10px;
-  width: 140px;
+  width: 105px;
   flex-shrink: 0;
   text-align: center;
 }
 
 .footer-character-slot__portrait {
   position: relative;
-  width: 110px;
-  height: 110px;
+  width: 78px;
+  height: 78px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -4337,12 +4337,12 @@ h1 {
   }
 
   .footer-character-slot__profile {
-    width: 170px;
+    width: 130px;
   }
 
   .footer-character-slot__portrait {
-    width: 140px;
-    height: 140px;
+    width: 104px;
+    height: 104px;
   }
 
   .footer-character-slot__details {


### PR DESCRIPTION
## Summary
- restore the footer character card width so the overall panel keeps its footprint
- reduce the dedicated profile column width and portrait dimensions to shrink the image block

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69060e34fd34832e988d6b0405a9b021