### PR TITLE
Align damage rail with footer actions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3810,35 +3810,65 @@ h1 {
 .footer-character-slot {
   position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 6px;
-  padding: 22px 10px 10px;
-  background: rgba(15, 22, 43, 0.88);
-  border-radius: 14px;
-  border: 1px solid rgba(104, 144, 216, 0.35);
-  box-shadow: 0 8px 18px rgba(6, 10, 20, 0.4);
-  color: #f3f6ff;
+  align-items: flex-end;
+  gap: 18px;
+  padding: 0;
   margin: 0;
   min-height: 0;
-  backdrop-filter: blur(4px);
-  width: min(100%, 320px);
+  color: #f3f6ff;
 }
 
-.footer-character-slot::before {
-  content: '';
-  position: absolute;
-  inset: 3px;
-  border-radius: 12px;
-  border: 1px solid rgba(47, 78, 143, 0.25);
-  pointer-events: none;
-}
-
-.footer-character-slot__main {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 12px;
+.footer-character-slot__profile-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 12px;
+  padding: 16px 18px 18px;
+  background: rgba(15, 22, 43, 0.88);
+  border-radius: 16px;
+  border: 1px solid rgba(104, 144, 216, 0.35);
+  box-shadow: 0 12px 22px rgba(6, 10, 20, 0.5);
+  backdrop-filter: blur(4px);
+  min-width: 0;
+}
+
+.footer-character-slot__rail-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.footer-character-slot__slots-rail {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(104, 144, 216, 0.35);
+  background: rgba(10, 16, 34, 0.9);
+  box-shadow: 0 10px 20px rgba(6, 10, 20, 0.45);
+  backdrop-filter: blur(4px);
+  min-height: 0;
+  width: 100%;
+}
+
+.footer-character-slot__footer-rail {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(104, 144, 216, 0.35);
+  background: rgba(10, 16, 34, 0.9);
+  box-shadow: 0 10px 20px rgba(6, 10, 20, 0.45);
+  backdrop-filter: blur(4px);
+  min-height: 0;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .footer-character-slot__profile {
@@ -3846,9 +3876,8 @@ h1 {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px;
-  width: 96px;
-  flex-shrink: 0;
+  gap: 10px;
+  width: 100%;
   text-align: center;
 }
 
@@ -3946,31 +3975,10 @@ h1 {
   color: #f7f9ff;
 }
 
-.footer-character-slot__details {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-width: 0;
-  justify-content: center;
-}
-
 .footer-character-slot__actions {
-  justify-self: end;
   display: flex;
   align-items: center;
-  gap: 6px;
-  align-self: center;
-}
-
-.footer-character-slot__slots-wrapper {
-  position: absolute;
-  top: 6px;
-  left: 50%;
-  transform: translate(-50%, -60%);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 3;
+  gap: 8px;
 }
 
 .footer-character-slot__slots {
@@ -4070,7 +4078,7 @@ h1 {
 .footer-character-slot__damage {
   display: inline-flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   justify-content: center;
   gap: 2px;
   padding: 3px 6px;
@@ -4078,6 +4086,7 @@ h1 {
   background: rgba(18, 32, 63, 0.82);
   box-shadow: inset 0 0 0 1px rgba(123, 149, 219, 0.32);
   min-width: 56px;
+  margin-right: auto;
 }
 
 .footer-character-slot__damage-header {
@@ -4269,27 +4278,23 @@ h1 {
 
 @media (max-width: 600px) {
   .footer-character-slot {
-    width: 100%;
-    padding: 6px;
-  }
-
-  .footer-character-slot__main {
-    grid-template-columns: 1fr;
-    justify-items: center;
+    flex-direction: column;
+    align-items: center;
     gap: 12px;
   }
 
-  .footer-character-slot__profile {
+  .footer-character-slot__profile-card {
     width: 100%;
+    max-width: 320px;
   }
 
-  .footer-character-slot__details {
+  .footer-character-slot__footer-rail {
     width: 100%;
-    align-items: center;
+    justify-content: center;
   }
 
   .footer-character-slot__actions {
-    width: 100%;
+    flex-wrap: wrap;
     justify-content: center;
   }
 }
@@ -4299,11 +4304,11 @@ h1 {
 .footer-actions-wrapper {
   position: relative;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   padding: 0;
-  gap: 3px;
+  gap: 6px;
 }
 
 .footer-actions-inline {
@@ -4325,19 +4330,12 @@ h1 {
   }
 
   .footer-character-slot {
-    width: min(100%, 420px);
-    padding: 16px 22px 18px;
-    gap: 14px;
-  }
-
-  .footer-character-slot__main {
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
     gap: 24px;
   }
 
-  .footer-character-slot__profile {
-    width: 120px;
+  .footer-character-slot__profile-card {
+    padding: 18px 24px 22px;
+    gap: 16px;
   }
 
   .footer-character-slot__portrait {
@@ -4345,23 +4343,13 @@ h1 {
     height: 92px;
   }
 
-  .footer-character-slot__details {
-    align-items: flex-start;
+  .footer-character-slot__footer-rail {
+    padding: 8px 20px;
     gap: 16px;
   }
 
-  .footer-character-slot__damage {
-    align-self: flex-start;
-    min-width: 108px;
-  }
-
-  .footer-character-slot__error {
-    max-width: 220px;
-  }
-
   .footer-character-slot__actions {
-    padding-left: 18px;
-    border-left: 1px solid rgba(80, 124, 196, 0.35);
+    gap: 12px;
   }
 
   .footer-actions-wrapper {
@@ -4439,19 +4427,22 @@ h1 {
 }
 
 .footer-container {
-  width: 100%;
+  width: auto;
   max-width: none;
   display: flex;
+  align-items: flex-end;
   justify-content: center;
-  padding: 4px 12px calc(4px + env(safe-area-inset-bottom, 0));
+  gap: 18px;
+  padding: 6px 12px calc(6px + env(safe-area-inset-bottom, 0));
   margin: 0 auto;
 }
 
 .footer-nav {
-  width: 100%;
+  width: auto;
   max-width: none;
   padding: 0;
   display: flex;
+  align-items: flex-end;
   justify-content: center;
   margin: 0 auto;
 }
@@ -5219,3 +5210,9 @@ h1 {
     }
   }
 }
+.footer-navbar.navbar {
+  padding: 0;
+  --bs-navbar-padding-y: 0;
+  min-height: 0;
+}
+

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6108,7 +6108,9 @@ export default function ZombiesCharacterSheet() {
             fixed="bottom"
             data-bs-theme="dark"
             style={{ backgroundColor: 'transparent' }}
-            className={overlaySurfaceClassName || undefined}
+            className={[overlaySurfaceClassName, 'footer-navbar']
+              .filter(Boolean)
+              .join(' ')}
             aria-label="Character sheet footer actions"
           >
             <Container className="footer-container">

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -114,6 +114,9 @@ const FooterCharacterSlot = ({
     ? `${damageSummaryValue}`
     : '—';
 
+  const hasSpellSlots = Boolean(spellSlots);
+  const hasActions = Boolean(actions);
+
   const damageClassName = [
     'footer-character-slot__damage',
     damageHighlightClass,
@@ -288,15 +291,7 @@ const FooterCharacterSlot = ({
 
   return (
     <div className="footer-character-slot" data-allow-pointer-events="true">
-      {spellSlots ? (
-        <div
-          className="footer-character-slot__slots-wrapper"
-          data-allow-pointer-events="true"
-        >
-          <div className="footer-character-slot__slots">{spellSlots}</div>
-        </div>
-      ) : null}
-      <div className="footer-character-slot__main">
+      <div className="footer-character-slot__profile-card">
         <div className="footer-character-slot__profile">
           {characterName ? (
             <span className="footer-character-slot__name" title={characterName}>
@@ -317,7 +312,10 @@ const FooterCharacterSlot = ({
             >
               <i className="fas fa-minus" aria-hidden="true" />
             </button>
-            <div className="footer-character-slot__health-track footer-character-slot__health-track--compact" role="presentation">
+            <div
+              className="footer-character-slot__health-track footer-character-slot__health-track--compact"
+              role="presentation"
+            >
               <div className="footer-character-slot__health-track-base" />
               <div
                 className="footer-character-slot__health-track-fill"
@@ -407,7 +405,14 @@ const FooterCharacterSlot = ({
             {error}
           </div>
         </div>
-        <div className="footer-character-slot__details">
+      </div>
+      <div className="footer-character-slot__rail-stack" data-allow-pointer-events="true">
+        {hasSpellSlots ? (
+          <div className="footer-character-slot__slots-rail" data-allow-pointer-events="true">
+            <div className="footer-character-slot__slots">{spellSlots}</div>
+          </div>
+        ) : null}
+        <div className="footer-character-slot__footer-rail" data-allow-pointer-events="true">
           <div className={damageClassName} role="status" aria-live="polite">
             <div className="footer-character-slot__damage-header">
               <span className="footer-character-slot__damage-label">Damage</span>
@@ -438,15 +443,12 @@ const FooterCharacterSlot = ({
             </div>
             <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
           </div>
+          {hasActions ? (
+            <div className="footer-character-slot__actions" data-allow-pointer-events="true">
+              {actions}
+            </div>
+          ) : null}
         </div>
-        {actions ? (
-          <div
-            className="footer-character-slot__actions"
-            data-allow-pointer-events="true"
-          >
-            {actions}
-          </div>
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- stack spell slots in a dedicated top rail so they float above the footer controls
- relocate the damage summary into the footer action rail alongside the other controls
- tweak footer rail styling to stretch across the action column and left-align the damage block

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690614fc070c832e8d8104bc8b76b7b0