### PR TITLE
Align footer character HUD elements

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3811,7 +3811,7 @@ h1 {
   position: relative;
   display: flex;
   align-items: flex-end;
-  gap: 18px;
+  gap: 12px;
   padding: 0;
   margin: 0;
   min-height: 0;
@@ -3821,16 +3821,28 @@ h1 {
 .footer-character-slot__profile-card {
   position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  padding: 16px 18px 18px;
-  background: rgba(15, 22, 43, 0.88);
-  border-radius: 16px;
+  align-items: stretch;
+  justify-content: center;
+  width: clamp(190px, 32vw, 240px);
+  aspect-ratio: 1;
+  padding: 20px 18px 16px;
+  background: rgba(15, 22, 43, 0.9);
+  border-radius: 50%;
   border: 1px solid rgba(104, 144, 216, 0.35);
   box-shadow: 0 12px 22px rgba(6, 10, 20, 0.5);
   backdrop-filter: blur(4px);
   min-width: 0;
+}
+
+.footer-character-slot__hud {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 10px;
+  flex: 1 1 auto;
+  width: clamp(260px, 48vw, 380px);
+  max-width: 100%;
 }
 
 .footer-character-slot__footer-rail {
@@ -3838,28 +3850,24 @@ h1 {
   flex-direction: column;
   align-items: stretch;
   gap: 10px;
-  padding: 6px 14px;
-  border-radius: 999px;
+  padding: 10px 16px;
+  border-radius: 10px;
   border: 1px solid rgba(104, 144, 216, 0.35);
-  background: rgba(10, 16, 34, 0.9);
+  background: rgba(10, 16, 34, 0.92);
   box-shadow: 0 10px 20px rgba(6, 10, 20, 0.45);
   backdrop-filter: blur(4px);
   min-height: 0;
   width: 100%;
 }
 
-.footer-character-slot__footer-rail-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .footer-character-slot__footer-rail-body {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 14px;
+  flex-wrap: nowrap;
+  width: 100%;
+  min-width: 0;
 }
 
 .footer-character-slot__profile {
@@ -3867,8 +3875,9 @@ h1 {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  gap: 10px;
+  gap: 12px;
   width: 100%;
+  height: 100%;
   text-align: center;
 }
 
@@ -3970,17 +3979,25 @@ h1 {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-left: auto;
+}
+
+.footer-character-slot__slots-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin: 0;
 }
 
 .footer-character-slot__slots {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  padding: 2px 5px;
-  border-radius: 999px;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 14px;
   border: 1px solid rgba(80, 124, 196, 0.35);
-  background: rgba(8, 16, 36, 0.82);
+  background: rgba(8, 16, 36, 0.85);
   box-shadow: 0 10px 18px rgba(10, 18, 40, 0.45);
   margin: 0 auto;
   max-width: min(100%, 420px);
@@ -4258,6 +4275,8 @@ h1 {
   color: #ffb4a2;
   text-align: center;
   width: 100%;
+  margin-top: auto;
+  padding-bottom: 2px;
 }
 
 .footer-character-slot__health-readout .spinner-border {
@@ -4275,8 +4294,7 @@ h1 {
   }
 
   .footer-character-slot__profile-card {
-    width: 100%;
-    max-width: 320px;
+    width: clamp(200px, 80vw, 240px);
   }
 
   .footer-character-slot__footer-rail {
@@ -4329,8 +4347,8 @@ h1 {
   }
 
   .footer-character-slot__profile-card {
-    padding: 18px 24px 22px;
-    gap: 16px;
+    width: clamp(220px, 18vw, 280px);
+    padding: 26px 28px 18px;
   }
 
   .footer-character-slot__portrait {
@@ -4339,8 +4357,8 @@ h1 {
   }
 
   .footer-character-slot__footer-rail {
-    padding: 8px 20px;
-    gap: 18px;
+    padding: 14px 22px;
+    gap: 16px;
   }
 
   .footer-character-slot__footer-rail-body {

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -119,7 +119,7 @@ const FooterCharacterSlot = ({
   const hasDamageDisplay =
     hasDamageValue || typeof onToggleCritical === 'function';
   const hasFooterContent = hasActions || hasDamageDisplay;
-  const hasRail = hasSpellSlots || hasFooterContent;
+  const hasHudContent = hasSpellSlots || hasFooterContent;
 
   const damageClassName = [
     'footer-character-slot__damage',
@@ -410,52 +410,54 @@ const FooterCharacterSlot = ({
           </div>
         </div>
       </div>
-      {hasRail ? (
-        <div className="footer-character-slot__footer-rail" data-allow-pointer-events="true">
+      {hasHudContent ? (
+        <div className="footer-character-slot__hud" data-allow-pointer-events="true">
           {hasSpellSlots ? (
-            <div className="footer-character-slot__footer-rail-header">
+            <div className="footer-character-slot__slots-wrapper">
               <div className="footer-character-slot__slots">{spellSlots}</div>
             </div>
           ) : null}
           {hasFooterContent ? (
-            <div className="footer-character-slot__footer-rail-body">
-              {hasDamageDisplay ? (
-                <div className={damageClassName} role="status" aria-live="polite">
-                  <div className="footer-character-slot__damage-header">
-                    <span className="footer-character-slot__damage-label">Damage</span>
-                    {typeof onToggleCritical === 'function' ? (
-                      <Button
-                        type="button"
-                        variant="outline-light"
-                        size="sm"
-                        className={`footer-character-slot__crit-button ${
-                          damageIsCritical ? 'is-active' : ''
-                        }`}
-                        onClick={handleCritButtonClick}
-                        aria-pressed={damageIsCritical}
-                        aria-label={
-                          damageIsCritical
-                            ? 'Critical damage roll enabled. Click to roll normally.'
-                            : 'Click to enable a critical damage roll on your next roll.'
-                        }
-                        title={
-                          damageIsCritical
-                            ? 'Critical damage roll enabled. Click to roll normally.'
-                            : 'Click to enable a critical damage roll on your next roll.'
-                        }
-                      >
-                        Crit
-                      </Button>
-                    ) : null}
+            <div className="footer-character-slot__footer-rail" data-allow-pointer-events="true">
+              <div className="footer-character-slot__footer-rail-body">
+                {hasDamageDisplay ? (
+                  <div className={damageClassName} role="status" aria-live="polite">
+                    <div className="footer-character-slot__damage-header">
+                      <span className="footer-character-slot__damage-label">Damage</span>
+                      {typeof onToggleCritical === 'function' ? (
+                        <Button
+                          type="button"
+                          variant="outline-light"
+                          size="sm"
+                          className={`footer-character-slot__crit-button ${
+                            damageIsCritical ? 'is-active' : ''
+                          }`}
+                          onClick={handleCritButtonClick}
+                          aria-pressed={damageIsCritical}
+                          aria-label={
+                            damageIsCritical
+                              ? 'Critical damage roll enabled. Click to roll normally.'
+                              : 'Click to enable a critical damage roll on your next roll.'
+                          }
+                          title={
+                            damageIsCritical
+                              ? 'Critical damage roll enabled. Click to roll normally.'
+                              : 'Click to enable a critical damage roll on your next roll.'
+                          }
+                        >
+                          Crit
+                        </Button>
+                      ) : null}
+                    </div>
+                    <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
                   </div>
-                  <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
-                </div>
-              ) : null}
-              {hasActions ? (
-                <div className="footer-character-slot__actions" data-allow-pointer-events="true">
-                  {actions}
-                </div>
-              ) : null}
+                ) : null}
+                {hasActions ? (
+                  <div className="footer-character-slot__actions" data-allow-pointer-events="true">
+                    {actions}
+                  </div>
+                ) : null}
+              </div>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- wrap the spell slots and footer rail in a shared HUD column so the slots sit directly above the thin control bar
- keep the damage readout inline with the action buttons while tightening spacing so the profile badge hugs the bar
- adjust profile badge sizing and rail styling to prevent the portrait from appearing cropped

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69061d9403fc832e80482128ec9bf408