### PR TITLE
Dock footer portrait to bottom-right HUD edge

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3809,11 +3809,13 @@ h1 {
 
 
 .footer-character-slot {
-  --footer-character-portrait-size: clamp(150px, 18vw, 220px);
+  --footer-character-portrait-size: clamp(72px, 11vw, 132px);
   position: relative;
   display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
   align-items: flex-end;
-  gap: 0.25rem;
+  gap: 0;
   padding: 0;
   margin: 0;
   min-height: 0;
@@ -3825,8 +3827,9 @@ h1 {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  width: calc(var(--footer-character-portrait-size) + 32px);
-  padding: 0 12px 2px;
+  width: calc(var(--footer-character-portrait-size) + 12px);
+  padding: 0 2px 0 0;
+  margin-bottom: -6px;
   background: none;
   border-radius: 16px;
   border: none;
@@ -3841,8 +3844,8 @@ h1 {
   align-items: stretch;
   justify-content: flex-end;
   gap: 0;
-  flex: 1 1 420px;
-  width: clamp(280px, 56vw, 540px);
+  flex: 1 1 380px;
+  width: clamp(260px, 52vw, 520px);
   max-width: 100%;
 }
 
@@ -3896,7 +3899,7 @@ h1 {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  padding: clamp(10px, 1.6vw, 14px);
+  padding: clamp(8px, 1.1vw, 12px);
   background: radial-gradient(circle at 35% 35%, rgba(120, 168, 255, 0.4), rgba(24, 36, 72, 0.85));
   box-shadow: 0 6px 12px rgba(8, 12, 26, 0.55), inset 0 0 12px rgba(80, 124, 216, 0.35);
 }
@@ -3946,10 +3949,10 @@ h1 {
 
 .footer-character-slot__portrait-health {
   position: absolute;
-  bottom: clamp(16px, 2.1vw, 22px);
+  bottom: clamp(6px, 1vw, 12px);
   left: 50%;
   transform: translateX(-50%);
-  width: 88%;
+  width: 86%;
   display: flex;
   justify-content: center;
   z-index: 2;
@@ -3957,21 +3960,22 @@ h1 {
 
 .footer-character-slot__armor-class {
   position: absolute;
-  bottom: clamp(14px, 1.9vw, 20px);
-  right: clamp(14px, 1.9vw, 20px);
+  top: clamp(8px, 1vw, 14px);
+  right: clamp(4px, 0.9vw, 12px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-width: 40px;
-  padding: 4px 7px;
-  border-radius: 10px;
+  min-width: 32px;
+  padding: 2px 5px;
+  border-radius: 8px;
   background: rgba(10, 16, 34, 0.85);
   border: 1px solid rgba(132, 176, 248, 0.55);
   box-shadow: 0 6px 14px rgba(4, 6, 14, 0.6);
-  font-size: 0.68rem;
-  letter-spacing: 0.05em;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
   color: rgba(230, 236, 255, 0.95);
+  z-index: 3;
 }
 
 .footer-character-slot__armor-class-label {
@@ -3982,7 +3986,7 @@ h1 {
 
 .footer-character-slot__armor-class-value {
   font-weight: 700;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   line-height: 1;
   color: #f7f9ff;
 }
@@ -4308,11 +4312,13 @@ h1 {
     flex-direction: column;
     align-items: center;
     gap: 10px;
-    --footer-character-portrait-size: clamp(160px, 48vw, 220px);
+    --footer-character-portrait-size: clamp(88px, 44vw, 132px);
   }
 
   .footer-character-slot__profile-card {
-    width: calc(var(--footer-character-portrait-size) + 28px);
+    width: calc(var(--footer-character-portrait-size) + 10px);
+    padding: 0;
+    margin-bottom: 0;
   }
 
   .footer-character-slot__footer-rail {
@@ -4361,13 +4367,14 @@ h1 {
   }
 
   .footer-character-slot {
-    gap: 0.5rem;
-    --footer-character-portrait-size: clamp(190px, calc(12vw + 140px), 240px);
+    gap: 0;
+    --footer-character-portrait-size: clamp(100px, calc(4.6vw + 68px), 156px);
   }
 
   .footer-character-slot__profile-card {
-    width: calc(var(--footer-character-portrait-size) + 36px);
-    padding: 0 14px 4px;
+    width: calc(var(--footer-character-portrait-size) + 14px);
+    padding: 0 2px 0 0;
+    margin-bottom: -8px;
   }
 
   .footer-character-slot__footer-rail {


### PR DESCRIPTION
## Summary
- shrink the footer portrait sizing across breakpoints and tighten the portrait ring padding so the figure reads smaller
- reverse the footer slot layout, remove gaps, and drop the profile card to rest on the HUD’s lower edge
- reposition the AC badge and health bar spacing so they fit the compact portrait without overlap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906291d812c832e8ddcfc45dac47a68