### PR TITLE
Allow map drag beneath dice roller

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -217,6 +217,18 @@
   pointer-events: auto;
 }
 
+.zombies-character-sheet-layout--map-interaction-active {
+  .damage-roller__dice-wrapper,
+  .damage-roller__dice-area,
+  .damage-dice-canvas,
+  .damage-dice-canvas__box,
+  .damage-dice-canvas__box *,
+  #damage-dice-box,
+  #damage-dice-box * {
+    pointer-events: none !important;
+  }
+}
+
 .map-display__grid-overlay,
 .campaign-map-board__grid-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- prevent dice roller canvas and wrapper elements from capturing pointer events when the campaign map is active so the map can still be dragged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6906ad9e8f28832e853bdaf0d158c135