### PR TITLE
Add clear dice control to character footer

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3785,6 +3785,76 @@ h1 {
   transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
 }
 
+.footer-btn--clear-dice {
+  position: relative;
+  width: clamp(40px, 8vw, 58px);
+  height: clamp(40px, 8vw, 58px);
+  padding: 0;
+  border: none;
+  background: transparent !important;
+  color: #f1f5ff !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+  transition: transform 0.2s ease, color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.footer-btn__clear-dice-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 74%;
+  height: 74%;
+  color: inherit;
+}
+
+.footer-btn__clear-dice-icon::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  box-sizing: border-box;
+  background: radial-gradient(circle, rgba(12, 20, 42, 0.65) 0%, transparent 68%);
+}
+
+.footer-btn__clear-dice-icon::after {
+  content: '';
+  position: absolute;
+  width: max(2px, 0.18em);
+  height: 120%;
+  background-color: currentColor;
+  transform: rotate(45deg);
+  border-radius: 999px;
+  box-shadow: 0 0 6px rgba(12, 20, 42, 0.45);
+}
+
+.footer-btn__clear-dice-icon-die {
+  position: relative;
+  font-size: clamp(0.95rem, 0.8vw + 0.55rem, 1.25rem);
+  color: currentColor;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.45));
+}
+
+.footer-btn--clear-dice:hover,
+.footer-btn--clear-dice:focus-visible {
+  transform: translateY(-1px) scale(1.05);
+  color: #ffffff !important;
+  text-shadow: 0 0 10px rgba(240, 244, 255, 0.6);
+}
+
+.footer-btn--clear-dice:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(180, 208, 255, 0.4);
+  border-radius: 999px;
+}
+
+.footer-btn--clear-dice:active {
+  transform: translateY(0);
+}
+
 .footer-btn__dice-icon {
   display: block;
   width: 1.1em;
@@ -4427,6 +4497,11 @@ h1 {
     height: 28px;
   }
 
+  .footer-btn--clear-dice {
+    width: clamp(38px, 6vw, 54px);
+    height: clamp(38px, 6vw, 54px);
+  }
+
   .footer-btn--dice {
     --footer-dice-size: clamp(68px, 5.5vw, 92px);
   }
@@ -4579,6 +4654,11 @@ h1 {
     line-height: 1;
     margin: 0 2px;
     font-size: 0.85rem;
+  }
+
+  .footer-btn--clear-dice {
+    width: clamp(32px, 18vw, 46px);
+    height: clamp(32px, 18vw, 46px);
   }
 
   .footer-btn--attack {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -18,7 +18,11 @@ import weaponTypeMasteries from '../../../data/weaponTypeMasteries';
 import { rollSkillWithDiceBox } from './Skills';
 import DamageDiceCanvas from './DamageDiceCanvas';
 import DiceRollerModal from '../common/DiceRollerModal';
-import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
+import {
+  clearDiceBoxResults,
+  rollDiceWithBox,
+  setDiceBoxThemeColor,
+} from '../../../utils/diceBoxManager';
 import {
   collectRollValues,
   normalizeRollValue,
@@ -1984,6 +1988,11 @@ const triggerDiceAnimation = useCallback((diceDetails = []) => {
   setActiveDice(nextDice);
 }, []);
 
+const clearDamageDice = useCallback(() => {
+  setActiveDice([]);
+  clearDiceBoxResults();
+}, []);
+
 const preparedDice = useMemo(
   () =>
     activeDice.map((die) => {
@@ -2076,8 +2085,9 @@ useImperativeHandle(
     openDamageLog: () => setShowLog(true),
     toggleCritical: handleDamageClick,
     setCritical: setCriticalState,
+    clearDamageDice,
   }),
-  [handleShowAttack, handleShowDiceRoller, handleDamageClick, setCriticalState],
+  [handleShowAttack, handleShowDiceRoller, handleDamageClick, setCriticalState, clearDamageDice],
 );
 
 const [pulseClass, setPulseClass] = useState('');

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5534,6 +5534,9 @@ export default function ZombiesCharacterSheet() {
   const openDamageLog = useCallback(() => {
     playerTurnActionsRef.current?.openDamageLog?.();
   }, []);
+  const clearDamageDice = useCallback(() => {
+    playerTurnActionsRef.current?.clearDamageDice?.();
+  }, [playerTurnActionsRef]);
   const toggleCriticalFromFooter = useCallback(() => {
     playerTurnActionsRef.current?.toggleCritical?.();
   }, []);
@@ -6139,12 +6142,28 @@ export default function ZombiesCharacterSheet() {
                   }
                   actions={
                     <div className="footer-actions-wrapper">
-                      <div className="footer-actions-inline">
-                        <Button
-                          type="button"
-                          variant="outline-light"
-                          className="footer-pass-log-button"
-                          disabled={passDisabled}
+                    <div className="footer-actions-inline">
+                      <Button
+                        variant="link"
+                        className="footer-btn footer-btn--clear-dice"
+                        type="button"
+                        onClick={() => handleFooterQuickAction(clearDamageDice)}
+                        aria-label="Clear rolled dice"
+                        title="Clear dice"
+                      >
+                        <span className="footer-btn__clear-dice-icon" aria-hidden="true">
+                          <FaDiceD20
+                            className="footer-btn__clear-dice-icon-die"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                        </span>
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline-light"
+                        className="footer-pass-log-button"
+                        disabled={passDisabled}
                           onClick={() => handleFooterQuickAction(handlePassTurn)}
                           aria-label="Pass turn"
                           title="Pass turn"

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -951,6 +951,18 @@ export const warmupDiceBox = () => {
   });
 };
 
+export const clearDiceBoxResults = () => {
+  if (diceBoxInstance && typeof diceBoxInstance.clear === 'function') {
+    try {
+      diceBoxInstance.clear();
+    } catch (error) {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Failed to clear dice box results', error);
+      }
+    }
+  }
+};
+
 export const rollDiceWithBox = (requests) => {
   if (!Array.isArray(requests) || requests.length === 0) {
     return Promise.resolve({
@@ -1074,6 +1086,7 @@ export default {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady,
   hasDiceBoxFailed,
+  clearDiceBoxResults,
   rollDiceWithBox,
   setDiceBoxThemeColor,
   setDiceBoxTheme,


### PR DESCRIPTION
## Summary
- add a helper to clear active dice from the dice box and expose it through PlayerTurnActions
- surface a new clear dice button in the Zombies character footer and wire it to the new helper
- style the clear dice control to show a strikethrough dice icon across breakpoints

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js *(fails: existing ZombiesCharacterSheet expectations about docked map modal visibility)*

------
https://chatgpt.com/codex/tasks/task_e_6906af0eb7d4832ea4f73333548e9ea6