### PR TITLE
Align map board to map aspect ratio

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4745,7 +4745,7 @@ h1 {
     border-radius: 0.75rem;
     overflow: hidden;
     background: rgba(0, 0, 0, 0.35);
-    aspect-ratio: 1 / 1;
+    aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
   }
 
   &__image {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -538,19 +538,38 @@ const CampaignMapBoard = ({
     () => resolveGridDimensions(map),
     [map]
   );
+  const stageAspectRatio = useMemo(() => {
+    if (!Number.isFinite(gridColumns) || !Number.isFinite(gridRows)) {
+      return null;
+    }
+
+    const safeColumns = Math.max(1, Math.round(gridColumns));
+    const safeRows = Math.max(1, Math.round(gridRows));
+
+    if (safeColumns <= 0 || safeRows <= 0) {
+      return null;
+    }
+
+    return `${safeColumns} / ${safeRows}`;
+  }, [gridColumns, gridRows]);
   const metadataSquareSize = useMemo(() => resolveSquareSizeFromMetadata(map), [map]);
 
   useEffect(() => {
     mapPanOffsetRef.current = mapPanOffset;
   }, [mapPanOffset]);
 
-  const panStyle = useMemo(
-    () => ({
+  const panStyle = useMemo(() => {
+    const style = {
       '--campaign-map-pan-x': `${mapPanOffset.x}px`,
       '--campaign-map-pan-y': `${mapPanOffset.y}px`,
-    }),
-    [mapPanOffset.x, mapPanOffset.y]
-  );
+    };
+
+    if (stageAspectRatio) {
+      style['--campaign-map-stage-aspect-ratio'] = stageAspectRatio;
+    }
+
+    return style;
+  }, [mapPanOffset.x, mapPanOffset.y, stageAspectRatio]);
 
   useEffect(() => {
     mapPanStateRef.current = null;


### PR DESCRIPTION
## Summary
- compute a campaign map aspect ratio from grid dimensions and expose it via a CSS variable
- update the map board stage to apply the resolved aspect ratio so panning reaches the image edges

## Testing
- npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js --watchAll=false *(fails: pre-existing rotation test failure)*

------
https://chatgpt.com/codex/tasks/task_e_69075f4f7d18832e87bb584b3ec02210