### PR TITLE
Reduce map jiggle during panning

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4787,6 +4787,14 @@ h1 {
     cursor: grabbing;
   }
 
+  &__stage--panning {
+    .campaign-map-board__image,
+    .campaign-map-board__grid-overlay,
+    .campaign-map-board__tokens-layer {
+      transition: none;
+    }
+  }
+
   &__token {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1728,7 +1728,13 @@ const CampaignMapBoard = ({
     >
       {title && <h5 className="campaign-map-board__title">{title}</h5>}
       {imageSrc ? (
-        <div className="campaign-map-board__stage" style={panStyle}>
+        <div
+          className={classNames(
+            'campaign-map-board__stage',
+            isMapPanning && 'campaign-map-board__stage--panning'
+          )}
+          style={panStyle}
+        >
           <div className="campaign-map-board__image-wrapper">
             <img
               src={imageSrc}


### PR DESCRIPTION
## Summary
- add a panning state class to the campaign map stage while the user drags
- disable transform transitions on the map image, grid, and tokens when panning to stop visible jitter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69076b2088a0832e89cc3ab616387ee2