### PR TITLE
Add 120x120 map grid option and raise upload size limit

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -325,7 +325,7 @@ const toFiniteNumberOrNull = (value) => {
 
 const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
 const NEW_FOLDER_OPTION_VALUE = '__create_new_folder__';
-const MAP_GRID_DIMENSION_OPTIONS = [24, 64];
+const MAP_GRID_DIMENSION_OPTIONS = [24, 64, 120];
 const DEFAULT_MAP_GRID_DIMENSION = MAP_GRID_DIMENSION_OPTIONS[0];
 
 const normalizeCreatureSize = (value) => {

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -281,8 +281,8 @@ describe('ZombiesDM AI generation', () => {
       expect(modalQueries.queryByText('Alt text is required.')).not.toBeInTheDocument()
     );
 
-    await userEvent.selectOptions(gridSelect, '64');
-    expect(gridSelect).toHaveValue('64');
+    await userEvent.selectOptions(gridSelect, '120');
+    expect(gridSelect).toHaveValue('120');
 
     await userEvent.click(submitButton);
 
@@ -292,12 +292,12 @@ describe('ZombiesDM AI generation', () => {
 
     const [, firstRequestOptions] = getMapPostCalls()[0];
     const parsedRequestBody = JSON.parse(firstRequestOptions?.body || '{}');
-    expect(parsedRequestBody.map?.gridColumns).toBe(64);
-    expect(parsedRequestBody.map?.gridRows).toBe(64);
-    expect(parsedRequestBody.map?.gridDimensions).toBe('64x64');
-    expect(parsedRequestBody.map?.gridSize).toBe('64x64');
-    expect(parsedRequestBody.map?.grid?.columns).toBe(64);
-    expect(parsedRequestBody.map?.grid?.rows).toBe(64);
+    expect(parsedRequestBody.map?.gridColumns).toBe(120);
+    expect(parsedRequestBody.map?.gridRows).toBe(120);
+    expect(parsedRequestBody.map?.gridDimensions).toBe('120x120');
+    expect(parsedRequestBody.map?.gridSize).toBe('120x120');
+    expect(parsedRequestBody.map?.grid?.columns).toBe(120);
+    expect(parsedRequestBody.map?.grid?.rows).toBe(120);
   });
 
   test('map folder selection persists and manager groups maps by folder', async () => {

--- a/server/server.js
+++ b/server/server.js
@@ -38,8 +38,8 @@ app.use(cors({
   },
   credentials: true,
 }));
-app.use(express.json({ limit: '5mb' }));
-app.use(express.urlencoded({ extended: true, limit: '5mb' }));
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(cookieParser());
 const apiHost = process.env.API_ORIGIN || 'https://realmtracker.org';
 const connectSrc = ["'self'", apiHost];


### PR DESCRIPTION
## Summary
- add a 120x120 grid dimension option to the map editor
- update the map editor tests to validate the new 120-square selection
- raise the Express JSON/urlencoded payload limits to 10 MB to match Cloudinary's upload cap

## Testing
- CI=1 npm --prefix client test -- ZombiesDM.test.js *(fails: known ZombiesDM tests exceed Jest timeouts and emit act() warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6907771e2d64832eb163266b73abd932