### PR TITLE
Allow deeper zoom on character sheet map

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -35,7 +35,7 @@ const EMPTY_IDENTIFIER_SET = new Set();
 
 const BACKGROUND_ZOOM_DEFAULT = 1;
 const BACKGROUND_ZOOM_MIN = 0.5;
-const BACKGROUND_ZOOM_MAX = 2.5;
+const BACKGROUND_ZOOM_MAX = 4;
 
 const clampBackgroundZoom = (value) => {
   if (!Number.isFinite(value)) {


### PR DESCRIPTION
## Summary
- increase the maximum zoom level allowed for background maps in the character sheet map modal so players can zoom in further

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908c435115c832eaf96eb12739581ae