### PR TITLE
Tame campaign map nameplate scaling at high zoom

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -5201,10 +5201,18 @@ h1 {
   }
 
   &__figurine-label {
+    --figurine-label-zoom-adjustment: clamp(
+      0.25,
+      calc(1 / var(--map-modal-background-scale, 1)),
+      1
+    );
+    --figurine-label-scale: calc(0.82 * var(--figurine-label-zoom-adjustment));
+    --figurine-label-active-scale: calc(0.9 * var(--figurine-label-zoom-adjustment));
     position: absolute;
     bottom: calc(100% + clamp(0.15rem, calc(var(--figurine-base-size) * 0.16), 0.6rem));
     left: 50%;
-    transform: translate(-50%, calc(var(--figurine-base-size) * 0.04)) scale(0.82);
+    transform: translate(-50%, calc(var(--figurine-base-size) * 0.04))
+      scale(var(--figurine-label-scale));
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -5269,7 +5277,7 @@ h1 {
   &__token:hover .campaign-map-board__figurine-label,
   &__token:focus-visible .campaign-map-board__figurine-label {
     opacity: 1;
-    transform: translate(-50%, 0) scale(0.9);
+    transform: translate(-50%, 0) scale(var(--figurine-label-active-scale));
   }
 
   &__token:focus-visible .campaign-map-board__figurine {


### PR DESCRIPTION
## Summary
- dampen campaign map figurine label scaling when the background board is zoomed in heavily
- reuse the same adjustment when labels are hovered or focused so text remains readable without overwhelming the map

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908d6e523c8832ebb0d284b072d40a6