### PR TITLE
Tame campaign map nameplate and health bar scaling at high zoom

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4901,6 +4901,12 @@ h1 {
       --campaign-map-board-health-color,
       #51cf66
     );
+    --figurine-health-zoom-adjustment: clamp(
+      0.35,
+      calc(1 / var(--map-modal-background-scale, 1)),
+      1
+    );
+    --figurine-health-scale: var(--figurine-health-zoom-adjustment);
     position: absolute;
     top: calc(50% - var(--figurine-base-size) * 0.68);
     left: 50%;
@@ -4910,8 +4916,8 @@ h1 {
     align-items: center;
     justify-content: flex-end;
     filter: drop-shadow(0 0.1rem 0.25rem rgba(0, 0, 0, 0.65));
-    transform-origin: 50% 50%;
-    transform: translate(-50%, -50%);
+    transform-origin: center bottom;
+    transform: translate(-50%, -50%) scale(var(--figurine-health-scale));
     pointer-events: none;
     z-index: 1;
   }
@@ -5201,10 +5207,18 @@ h1 {
   }
 
   &__figurine-label {
+    --figurine-label-zoom-adjustment: clamp(
+      0.25,
+      calc(1 / var(--map-modal-background-scale, 1)),
+      1
+    );
+    --figurine-label-scale: calc(0.82 * var(--figurine-label-zoom-adjustment));
+    --figurine-label-active-scale: calc(0.9 * var(--figurine-label-zoom-adjustment));
     position: absolute;
     bottom: calc(100% + clamp(0.15rem, calc(var(--figurine-base-size) * 0.16), 0.6rem));
     left: 50%;
-    transform: translate(-50%, calc(var(--figurine-base-size) * 0.04)) scale(0.82);
+    transform: translate(-50%, calc(var(--figurine-base-size) * 0.04))
+      scale(var(--figurine-label-scale));
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -5269,7 +5283,7 @@ h1 {
   &__token:hover .campaign-map-board__figurine-label,
   &__token:focus-visible .campaign-map-board__figurine-label {
     opacity: 1;
-    transform: translate(-50%, 0) scale(0.9);
+    transform: translate(-50%, 0) scale(var(--figurine-label-active-scale));
   }
 
   &__token:focus-visible .campaign-map-board__figurine {


### PR DESCRIPTION
## Summary
- dampen campaign map figurine label scaling when the background board is zoomed in heavily
- reuse the same adjustment when labels are hovered or focused so text remains readable without overwhelming the map
- apply matching zoom-aware scaling to figurine health bars so they stay proportionate at extreme magnification

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908d6e523c8832ebb0d284b072d40a6