### PR TITLE
Broaden campaign map health bar scale

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4901,17 +4901,29 @@ h1 {
       --campaign-map-board-health-color,
       #51cf66
     );
+    --campaign-map-board-health-zoom-adjustment: clamp(
+      0.85,
+      calc(1 / var(--map-modal-background-scale, 1)),
+      1.1
+    );
+    --campaign-map-board-health-scale: calc(
+      0.92 * var(--campaign-map-board-health-zoom-adjustment)
+    );
     position: absolute;
-    top: calc(50% - var(--figurine-base-size) * 0.68);
+    top: calc(50% - var(--figurine-base-size) * 0.7);
     left: 50%;
-    width: calc(var(--figurine-base-size) * 0.95);
+    width: clamp(
+      1.65rem,
+      calc(var(--figurine-base-size) * 1.08),
+      6rem
+    );
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-end;
-    filter: drop-shadow(0 0.1rem 0.25rem rgba(0, 0, 0, 0.65));
+    filter: drop-shadow(0 0.18rem 0.35rem rgba(0, 0, 0, 0.65));
     transform-origin: 50% 50%;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%) scale(var(--campaign-map-board-health-scale));
     pointer-events: none;
     z-index: 1;
   }
@@ -4927,12 +4939,15 @@ h1 {
   &__health-track {
     position: relative;
     width: 100%;
-    height: clamp(4px, calc(var(--figurine-base-size) * 0.22), 8px);
+    height: clamp(6px, calc(var(--figurine-base-size) * 0.28), 14px);
     background: rgba(0, 0, 0, 0.6);
     border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    border: clamp(1px, calc(var(--figurine-base-size) * 0.02), 2px) solid
+      rgba(255, 255, 255, 0.18);
     overflow: hidden;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.75);
+    box-shadow:
+      inset 0 1px 2px rgba(0, 0, 0, 0.75),
+      0 0.1rem 0.25rem rgba(0, 0, 0, 0.35);
   }
 
   &__health-fill {
@@ -5201,10 +5216,18 @@ h1 {
   }
 
   &__figurine-label {
+    --figurine-label-zoom-adjustment: clamp(
+      0.25,
+      calc(1 / var(--map-modal-background-scale, 1)),
+      1
+    );
+    --figurine-label-scale: calc(0.82 * var(--figurine-label-zoom-adjustment));
+    --figurine-label-active-scale: calc(0.9 * var(--figurine-label-zoom-adjustment));
     position: absolute;
     bottom: calc(100% + clamp(0.15rem, calc(var(--figurine-base-size) * 0.16), 0.6rem));
     left: 50%;
-    transform: translate(-50%, calc(var(--figurine-base-size) * 0.04)) scale(0.82);
+    transform: translate(-50%, calc(var(--figurine-base-size) * 0.04))
+      scale(var(--figurine-label-scale));
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -5269,7 +5292,7 @@ h1 {
   &__token:hover .campaign-map-board__figurine-label,
   &__token:focus-visible .campaign-map-board__figurine-label {
     opacity: 1;
-    transform: translate(-50%, 0) scale(0.9);
+    transform: translate(-50%, 0) scale(var(--figurine-label-active-scale));
   }
 
   &__token:focus-visible .campaign-map-board__figurine {


### PR DESCRIPTION
## Summary
- widen the health bar container and give it a gentle zoom-aware scale so it remains legible across map magnifications
- increase the health track thickness, border, and shadow so the bar reads clearly above each figurine

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908d6e523c8832ebb0d284b072d40a6