### PR TITLE
Guard figurine scaling against missing map metadata

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1839,9 +1839,12 @@ const CampaignMapBoard = ({
                 const hasFigurineImage = Boolean(figurineImageUrl);
                 const figurineMetricKey = figurineImageUrl || characterId || `token-${tokenIndex}`;
                 const metrics = figurineMetricKey ? figurineImageMetrics[figurineMetricKey] : null;
-                const imageFootprint = hasFigurineImage
-                  ? resolveFigurineSquaresFromImageSize(metrics, metadataSquareSize)
-                  : null;
+                const hasMetadataSquareSize =
+                  Number.isFinite(metadataSquareSize) && metadataSquareSize > 0;
+                const imageFootprint =
+                  hasFigurineImage && hasMetadataSquareSize
+                    ? resolveFigurineSquaresFromImageSize(metrics, metadataSquareSize)
+                    : null;
                 const sizeKey = resolveFigurineSizeKey(size);
                 const hasExplicitSize = typeof size === 'string' && size.trim() !== '';
                 const baseFigurineScale =

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -516,7 +516,7 @@ describe('CampaignMapBoard pointer interactions', () => {
     }
   });
 
-  it('falls back to image dimensions when metadata is unavailable', async () => {
+  it('defaults to medium figurine scale when metadata is unavailable', async () => {
     const { container } = render(
       <CampaignMapBoard
         map={baseMap}
@@ -549,7 +549,7 @@ describe('CampaignMapBoard pointer interactions', () => {
       fireEvent.load(figurineImage);
 
       await waitFor(() => {
-        expect(tokenElement?.style.getPropertyValue('--figurine-size-scale')).toBe('2');
+        expect(tokenElement?.style.getPropertyValue('--figurine-size-scale')).toBe('1');
       });
     }
   });


### PR DESCRIPTION
## Summary
- avoid using figurine image dimensions to set scale when a map lacks pixels-per-square metadata
- update the CampaignMapBoard test expectation to reflect the medium-scale default without metadata

## Testing
- CI=1 npm test -- CampaignMapBoard *(fails: CampaignMapBoard pointer interactions › marks the last dragged token and enables rotation controls)*

------
https://chatgpt.com/codex/tasks/task_e_6908dfca7858832e84ed4863754416ee