### PR TITLE
Simplify footer health controls

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4288,74 +4288,16 @@ h1 {
   }
 }
 
-.footer-character-slot__health-track {
-  position: relative;
-  width: 100%;
-  height: 18px;
-  border-radius: 999px;
-  background: rgba(24, 40, 76, 0.92);
-  overflow: hidden;
-  box-shadow: inset 0 1px 4px rgba(10, 16, 32, 0.7);
-}
-
-.footer-character-slot__health-track-base {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(30, 46, 92, 0.82), rgba(18, 28, 58, 0.92));
-}
-
-.footer-character-slot__health-track-fill {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(94, 220, 198, 0.9), rgba(74, 158, 236, 0.9));
-  box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.3);
-  transition: width 0.25s ease;
-}
-
-.footer-character-slot__health-track-border {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  border: 1px solid rgba(132, 176, 248, 0.2);
-  pointer-events: none;
-}
-
-.footer-character-slot__health-track::after {
-  content: '';
-  position: absolute;
-  inset: 1px;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-  pointer-events: none;
-}
-
-.footer-character-slot__health-slider {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
-}
-
-.footer-character-slot__health-track--compact {
-  max-width: 100%;
-  min-width: 0;
-}
-
 .footer-character-slot__health-readout {
-  position: absolute;
-  inset: 0;
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: center;
-  font-size: 0.82rem;
+  min-width: 80px;
+  padding: 4px 0;
+  font-size: 0.88rem;
   font-weight: 600;
   color: rgba(240, 248, 255, 0.95);
-  text-shadow: 0 1px 3px rgba(6, 12, 24, 0.7);
-  pointer-events: none;
+  text-shadow: 0 1px 3px rgba(6, 12, 24, 0.6);
   gap: 6px;
 }
 

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Spinner } from 'react-bootstrap';
 
@@ -33,7 +33,6 @@ const FooterCharacterSlot = ({
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
   const [pendingHealth, setPendingHealth] = useState(null);
-  const pendingCommitRef = useRef(null);
   const [damageHighlightClass, setDamageHighlightClass] = useState('');
 
   const { resolvedCurrent, resolvedMax } = useMemo(() => {
@@ -53,11 +52,6 @@ const FooterCharacterSlot = ({
 
   const effectiveCurrent = pendingHealth ?? resolvedCurrent;
   const numericCurrent = Number.isFinite(effectiveCurrent) ? effectiveCurrent : 0;
-  const sliderMax =
-    resolvedMax !== null && Number.isFinite(resolvedMax) && resolvedMax > 0
-      ? resolvedMax
-      : Math.max(numericCurrent + 20, 20);
-  const healthPercent = sliderMax > 0 ? Math.min((numericCurrent / sliderMax) * 100, 100) : 0;
   const displayCurrent = Number.isFinite(effectiveCurrent) ? Math.round(effectiveCurrent) : '—';
   const displayMax = Number.isFinite(resolvedMax) ? Math.round(resolvedMax) : '—';
   const displayArmorClass = useMemo(() => {
@@ -195,22 +189,12 @@ const FooterCharacterSlot = ({
         console.error(err);
         setError('Failed to update health.');
         setPendingHealth(null);
-        pendingCommitRef.current = null;
       } finally {
         setIsUpdating(false);
       }
     },
     [characterId, clampHealthValue, onHealthChange, resolvedCurrent]
   );
-
-  const commitPendingUpdate = useCallback(() => {
-    if (pendingCommitRef.current === null) {
-      return;
-    }
-    const valueToCommit = pendingCommitRef.current;
-    pendingCommitRef.current = null;
-    updateHealth(valueToCommit);
-  }, [updateHealth]);
 
   const handleAdjustHealth = (offset) => {
     if (!Number.isFinite(Number(offset)) || Number(offset) === 0) {
@@ -230,31 +214,6 @@ const FooterCharacterSlot = ({
     updateHealth(next);
   };
 
-  const handleSliderInput = useCallback(
-    (event) => {
-      const rawValue = Number(event.target.value);
-      if (Number.isNaN(rawValue)) {
-        return;
-      }
-
-      const next = clampHealthValue(rawValue);
-      if (next === null) {
-        return;
-      }
-
-      setPendingHealth(next);
-      pendingCommitRef.current = next;
-    },
-    [clampHealthValue]
-  );
-
-  const handleSliderCommit = useCallback(() => {
-    if (isUpdating) {
-      return;
-    }
-    commitPendingUpdate();
-  }, [commitPendingUpdate, isUpdating]);
-
   useEffect(() => {
     if (
       pendingHealth !== null &&
@@ -265,12 +224,6 @@ const FooterCharacterSlot = ({
       setPendingHealth(null);
     }
   }, [pendingHealth, resolvedCurrent]);
-
-  useEffect(() => {
-    if (!isUpdating) {
-      commitPendingUpdate();
-    }
-  }, [commitPendingUpdate, isUpdating]);
 
   useEffect(() => {
     if (!damageTimestamp) {
@@ -331,56 +284,20 @@ const FooterCharacterSlot = ({
                 >
                   <i className="fas fa-minus" aria-hidden="true" />
                 </button>
-                <div
-                  className="footer-character-slot__health-track footer-character-slot__health-track--compact"
-                  role="presentation"
-                >
-                  <div className="footer-character-slot__health-track-base" />
-                  <div
-                    className="footer-character-slot__health-track-fill"
-                    style={{ width: `${healthPercent}%` }}
-                  />
-                  <div className="footer-character-slot__health-track-border" />
-                  <div className="footer-character-slot__health-readout" aria-live="polite">
-                    <span className="visually-hidden">Health</span>
-                    {isUpdating ? (
-                      <Spinner animation="border" role="status" size="sm">
-                        <span className="visually-hidden">Updating health…</span>
-                      </Spinner>
-                    ) : (
-                      <span className="footer-character-slot__health-readout-values">
-                        <span className="footer-character-slot__health-current">{displayCurrent}</span>
-                        {displayMax !== '—' && (
-                          <span className="footer-character-slot__health-max">/ {displayMax}</span>
-                        )}
-                      </span>
-                    )}
-                  </div>
-                  <input
-                    type="range"
-                    min="0"
-                    max={sliderMax}
-                    value={numericCurrent}
-                    onChange={handleSliderInput}
-                    onMouseUp={handleSliderCommit}
-                    onTouchEnd={handleSliderCommit}
-                    onBlur={handleSliderCommit}
-                    onKeyUp={(event) => {
-                      if (
-                        event.key === 'ArrowLeft' ||
-                        event.key === 'ArrowRight' ||
-                        event.key === 'Home' ||
-                        event.key === 'End'
-                      ) {
-                        handleSliderCommit();
-                      }
-                    }}
-                    className="footer-character-slot__health-slider"
-                    aria-label="Adjust health"
-                    aria-valuemin={0}
-                    aria-valuemax={sliderMax}
-                    aria-valuenow={numericCurrent}
-                  />
+                <div className="footer-character-slot__health-readout" aria-live="polite">
+                  <span className="visually-hidden">Health</span>
+                  {isUpdating ? (
+                    <Spinner animation="border" role="status" size="sm">
+                      <span className="visually-hidden">Updating health…</span>
+                    </Spinner>
+                  ) : (
+                    <span className="footer-character-slot__health-readout-values">
+                      <span className="footer-character-slot__health-current">{displayCurrent}</span>
+                      {displayMax !== '—' && (
+                        <span className="footer-character-slot__health-max">/ {displayMax}</span>
+                      )}
+                    </span>
+                  )}
                 </div>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- replace the footer portrait health slider with a compact numeric health readout and +/- controls
- remove the slider-specific state management and styling that made multi-digit values unreadable

## Testing
- CI=true npm test -- FooterCharacterSlot *(fails: no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_6908fbeffe34832e874ae713964a9d18