### PR TITLE
Refine footer action layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4369,11 +4369,11 @@ h1 {
 .footer-actions-wrapper {
   position: relative;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 0;
-  gap: 6px;
+  gap: 10px;
 }
 
 .footer-actions-inline {
@@ -4382,6 +4382,13 @@ h1 {
   justify-content: center;
   gap: 6px;
   flex-wrap: wrap;
+}
+
+.footer-actions-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
 }
 
 @media (min-width: 992px) {
@@ -4419,14 +4426,15 @@ h1 {
   }
 
   .footer-actions-wrapper {
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
+    gap: 14px;
   }
 
   .footer-actions-inline {
     flex-wrap: nowrap;
+    gap: 10px;
+  }
+
+  .footer-actions-menu {
     gap: 10px;
   }
 
@@ -4517,58 +4525,6 @@ h1 {
   align-items: flex-end;
   justify-content: center;
   margin: 0 auto;
-}
-
-.footer-menu-toggle {
-  margin-top: 0;
-}
-
-.footer-menu-toggle.btn-secondary,
-.footer-menu-toggle.btn-secondary:hover,
-.footer-menu-toggle.btn-secondary:active {
-  background: transparent;
-  border: none;
-  color: #ffffff;
-  box-shadow: none;
-}
-
-.footer-menu-toggle.btn-secondary:focus,
-.footer-menu-toggle.btn-secondary:focus-visible {
-  background: transparent;
-  border: none;
-  color: #ffffff;
-  box-shadow: 0 0 0 3px rgba(136, 188, 255, 0.55);
-}
-
-.footer-actions-popover {
-  position: absolute;
-  bottom: calc(100% + 12px);
-  left: 50%;
-  transform: translate(-50%, 12px);
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 4px;
-  padding: 8px;
-  background: rgba(5, 10, 24, 0.92);
-  border-radius: 14px;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.5);
-  max-width: min(600px, calc(100vw - 24px));
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-  z-index: 10;
-}
-
-.footer-actions-popover.is-open {
-  opacity: 1;
-  pointer-events: auto;
-  transform: translate(-50%, 0);
-}
-
-.footer-actions-popover .footer-btn {
-  margin-top: 0;
-  margin: 3px;
 }
 
 .footer-btn__image {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2302,8 +2302,6 @@ export default function ZombiesCharacterSheet() {
   ]);
 
   const playerTurnActionsRef = useRef(null);
-  const footerMenuRef = useRef(null);
-  const footerToggleRef = useRef(null);
   const speakWithAnimalsPendingRef = useRef(false);
   const socketRef = useRef(null);
 
@@ -2313,9 +2311,6 @@ export default function ZombiesCharacterSheet() {
   const combatHeaderRef = useRef(null);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [navHeight, setNavHeight] = useState(0);
-  const [showFooterActions, setShowFooterActions] = useState(
-    () => process.env.NODE_ENV === 'test'
-  );
 
   useEffect(() => {
     if (!usageResetInitializedRef.current.long) {
@@ -5468,60 +5463,13 @@ export default function ZombiesCharacterSheet() {
   const shouldShowDiceLoadingOverlay =
     isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed;
 
-  useEffect(() => {
-    if (!showFooterActions) {
-      return undefined;
-    }
-
-    const handleKeyDown = (event) => {
-      if (event.key === 'Escape') {
-        setShowFooterActions(false);
-      }
-    };
-
-    const handlePointerEvent = (event) => {
-      const menu = footerMenuRef.current;
-      const toggle = footerToggleRef.current;
-      if (!menu || !toggle) {
-        return;
-      }
-
-      if (!menu.contains(event.target) && !toggle.contains(event.target)) {
-        setShowFooterActions(false);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('mousedown', handlePointerEvent);
-    document.addEventListener('touchstart', handlePointerEvent);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.removeEventListener('mousedown', handlePointerEvent);
-      document.removeEventListener('touchstart', handlePointerEvent);
-    };
-  }, [showFooterActions]);
-
-  useEffect(() => {
-    if (process.env.NODE_ENV === 'test') {
-      return;
-    }
-
-    if (!isFormReady && showFooterActions) {
-      setShowFooterActions(false);
-    }
-  }, [isFormReady, showFooterActions]);
-
-  const footerActionTabIndex = showFooterActions ? undefined : -1;
-
   const handleFooterQuickAction = useCallback(
     (action) => {
-      setShowFooterActions(false);
       if (typeof action === 'function') {
         action();
       }
     },
-    [setShowFooterActions]
+    []
   );
 
   const openAttackModal = useCallback(() => {
@@ -6209,40 +6157,8 @@ export default function ZombiesCharacterSheet() {
                             className="footer-btn__attack-image"
                           />
                         </Button>
-                        <Button
-                          ref={footerToggleRef}
-                          onClick={() => setShowFooterActions((prev) => !prev)}
-                          aria-expanded={showFooterActions}
-                          aria-controls="footer-actions-panel"
-                          aria-label={
-                            showFooterActions
-                              ? 'Hide footer actions'
-                              : 'Show footer actions'
-                          }
-                          title={
-                            showFooterActions
-                              ? 'Hide footer actions'
-                              : 'Show footer actions'
-                          }
-                          className={`footer-btn footer-menu-toggle ${
-                            showFooterActions ? 'is-open' : ''
-                          }`}
-                          variant="secondary"
-                        >
-                          <i
-                            className={`fas ${showFooterActions ? 'fa-xmark' : 'fa-bars'}`}
-                            aria-hidden="true"
-                          ></i>
-                        </Button>
                       </div>
-                      <div
-                        ref={footerMenuRef}
-                        id="footer-actions-panel"
-                        className={`footer-actions-popover ${
-                          showFooterActions ? 'is-open' : ''
-                        }`}
-                        aria-hidden={!showFooterActions}
-                      >
+                      <div className="footer-actions-menu">
                         {footerMenuButtons.map((action) => (
                           <Button
                             key={action.key}
@@ -6250,7 +6166,6 @@ export default function ZombiesCharacterSheet() {
                             className={action.className}
                             style={action.style}
                             onClick={() => handleFooterQuickAction(action.onClick)}
-                            tabIndex={footerActionTabIndex}
                             aria-label={action.ariaLabel}
                             title={action.title}
                           >


### PR DESCRIPTION
## Summary
- remove the footer hamburger toggle in favor of always-visible actions
- render footer menu actions as a second row beneath the primary footer buttons
- update footer styling to support the two-row layout

## Testing
- npm --prefix client start *(fails: missing optional dependencies / backend proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6908fe28af0c832eb5d3355e600c06e9