### PR TITLE
Tighten footer action spacing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3721,7 +3721,7 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 0 3px;
+  margin: 0 1px;
   flex-shrink: 0;
 }
 
@@ -4386,7 +4386,7 @@ h1 {
   align-items: stretch;
   justify-content: flex-start;
   padding: 0;
-  gap: 10px;
+  gap: 6px;
   width: 100%;
   height: 100%;
 }
@@ -4395,7 +4395,7 @@ h1 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 4px;
   flex-wrap: nowrap;
   width: 100%;
   max-width: min(640px, 100%);
@@ -4413,7 +4413,7 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 8px;
+  gap: 4px;
 }
 
 @media (min-width: 992px) {
@@ -4451,24 +4451,24 @@ h1 {
   }
 
   .footer-actions-wrapper {
-    gap: 12px;
+    gap: 8px;
   }
 
   .footer-actions-inline {
     flex-wrap: nowrap;
-    gap: 12px;
+    gap: 6px;
     width: 100%;
     overflow: visible;
-    justify-content: space-between;
+    justify-content: center;
   }
 
   .footer-actions-menu {
-    gap: 12px;
+    gap: 6px;
     justify-content: flex-start;
   }
 
   .footer-pass-log-button {
-    padding: 5px 12px;
+    padding: 4px 10px;
     font-size: 0.76rem;
   }
 
@@ -4497,7 +4497,7 @@ h1 {
   font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.01em;
-  padding: 3px 10px;
+  padding: 2px 8px;
   border-radius: 999px;
   line-height: 1.1;
   white-space: nowrap;
@@ -4542,7 +4542,7 @@ h1 {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  gap: 18px;
+  gap: 12px;
   padding: 6px 12px calc(6px + env(safe-area-inset-bottom, 0));
   margin: 0 auto;
 }
@@ -4578,7 +4578,7 @@ h1 {
   }
 
   .footer-actions-inline {
-    gap: 6px;
+    gap: 3px;
     align-items: center;
   }
 
@@ -4588,7 +4588,7 @@ h1 {
     padding: 0;
     box-sizing: border-box;
     line-height: 1;
-    margin: 0 2px;
+    margin: 0 1px;
     font-size: 0.85rem;
   }
 


### PR DESCRIPTION
## Summary
- reduce the gap and margins between footer action buttons for a tighter row layout
- shrink pass/log button padding and footer container spacing so adjacent controls sit closer together

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69090abd34e8832e9dbd3d3f0b952be6