### PR TITLE
Adjust footer damage controls layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -3927,12 +3927,12 @@ h1 {
 .footer-character-slot__hud {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: center;
   justify-content: flex-end;
   gap: 0;
-  flex: 1 1 560px;
-  width: clamp(320px, 62vw, 780px);
-  max-width: 100%;
+  flex: 0 1 auto;
+  width: 100%;
+  max-width: clamp(320px, 62vw, 780px);
 }
 
 .footer-character-slot__footer-rail {
@@ -3947,15 +3947,17 @@ h1 {
   box-shadow: 0 10px 20px rgba(6, 10, 20, 0.45);
   backdrop-filter: blur(4px);
   min-height: 0;
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
+  align-self: center;
 }
 
 .footer-character-slot__footer-rail-body {
   display: flex;
   align-items: stretch;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 12px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   width: 100%;
   min-width: 0;
 }
@@ -4083,9 +4085,9 @@ h1 {
   align-items: stretch;
   gap: 12px;
   margin-left: 0;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
-  width: 100%;
+  width: auto;
 }
 
 .footer-character-slot__actions > * {
@@ -4203,15 +4205,14 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: 6px;
+  justify-content: flex-start;
+  gap: 8px;
   padding: 10px 14px;
   border-radius: 10px;
   background: rgba(18, 32, 63, 0.82);
   box-shadow: inset 0 0 0 1px rgba(123, 149, 219, 0.32);
   min-width: 110px;
   max-width: 220px;
-  height: 100%;
 }
 
 .footer-character-slot__damage-header {
@@ -4235,6 +4236,15 @@ h1 {
   font-size: 1rem;
   color: rgba(247, 249, 255, 0.95);
   line-height: 1.05;
+}
+
+.footer-character-slot__damage-log-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 6px 12px;
+  margin-top: 4px;
 }
 
 .footer-character-slot__damage--critical .footer-character-slot__damage-value {
@@ -4387,7 +4397,7 @@ h1 {
   justify-content: flex-start;
   padding: 0;
   gap: 6px;
-  width: 100%;
+  width: auto;
   height: 100%;
 }
 
@@ -4397,7 +4407,7 @@ h1 {
   justify-content: flex-start;
   gap: 4px;
   flex-wrap: nowrap;
-  width: 100%;
+  width: auto;
   max-width: min(640px, 100%);
   margin: 0;
   overflow-x: auto;
@@ -4457,7 +4467,7 @@ h1 {
   .footer-actions-inline {
     flex-wrap: nowrap;
     gap: 6px;
-    width: 100%;
+    width: auto;
     overflow: visible;
     justify-content: flex-start;
     margin: 0;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6075,6 +6075,7 @@ export default function ZombiesCharacterSheet() {
                   armorClass={footerArmorClass}
                   onHealthChange={handleHealthChange}
                   damageSummary={footerDamageSummary}
+                  onOpenDamageLog={() => handleFooterQuickAction(openDamageLog)}
                   spellSlots={
                     form ? (
                       <SpellSlots
@@ -6117,16 +6118,6 @@ export default function ZombiesCharacterSheet() {
                           title="Pass turn"
                         >
                           Pass ➔
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline-light"
-                          className="footer-pass-log-button"
-                          onClick={() => handleFooterQuickAction(openDamageLog)}
-                          aria-label="Open damage log"
-                          title="Damage log"
-                        >
-                          ⚔️ Log
                         </Button>
                         <Button
                           variant="link"

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -29,6 +29,7 @@ const FooterCharacterSlot = ({
   spellSlots,
   damageSummary,
   onToggleCritical,
+  onOpenDamageLog,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
@@ -111,7 +112,9 @@ const FooterCharacterSlot = ({
   const hasSpellSlots = Boolean(spellSlots);
   const hasActions = Boolean(actions);
   const hasDamageDisplay =
-    hasDamageValue || typeof onToggleCritical === 'function';
+    hasDamageValue ||
+    typeof onToggleCritical === 'function' ||
+    typeof onOpenDamageLog === 'function';
   const hasFooterContent = hasActions || hasDamageDisplay;
   const hasHudContent = hasSpellSlots || hasFooterContent;
 
@@ -128,6 +131,11 @@ const FooterCharacterSlot = ({
       onToggleCritical();
     }
   }, [onToggleCritical]);
+  const handleDamageLogClick = useCallback(() => {
+    if (typeof onOpenDamageLog === 'function') {
+      onOpenDamageLog();
+    }
+  }, [onOpenDamageLog]);
   const canDecrease = !isUpdating && numericCurrent > 0;
   const canIncrease =
     !isUpdating &&
@@ -364,6 +372,18 @@ const FooterCharacterSlot = ({
                       ) : null}
                     </div>
                     <span className="footer-character-slot__damage-value">{displayDamageValue}</span>
+                    {typeof onOpenDamageLog === 'function' ? (
+                      <Button
+                        type="button"
+                        variant="outline-light"
+                        className="footer-character-slot__damage-log-button footer-pass-log-button"
+                        onClick={handleDamageLogClick}
+                        aria-label="Open damage log"
+                        title="Damage log"
+                      >
+                        ⚔️ Log
+                      </Button>
+                    ) : null}
                   </div>
                 ) : null}
                 {hasActions ? (
@@ -404,6 +424,7 @@ FooterCharacterSlot.propTypes = {
     timestamp: PropTypes.number,
   }),
   onToggleCritical: PropTypes.func,
+  onOpenDamageLog: PropTypes.func,
 };
 
 FooterCharacterSlot.defaultProps = {
@@ -418,6 +439,7 @@ FooterCharacterSlot.defaultProps = {
   spellSlots: null,
   damageSummary: null,
   onToggleCritical: undefined,
+  onOpenDamageLog: undefined,
 };
 
 export default FooterCharacterSlot;


### PR DESCRIPTION
## Summary
- move the footer damage log control into the damage panel and expose it through `FooterCharacterSlot`
- tighten footer layout styles to eliminate the empty right-side gap
- update damage display styling for the embedded log button

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_690915a327d8832eb935b0f9a6c6d69a