### PR TITLE
Reduce footer damage log button footprint

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4204,9 +4204,9 @@ h1 {
 .footer-character-slot__damage {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-start;
-  gap: 8px;
+  gap: 10px;
   padding: 10px 14px;
   border-radius: 10px;
   background: rgba(18, 32, 63, 0.82);
@@ -4233,18 +4233,29 @@ h1 {
 
 .footer-character-slot__damage-value {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 1.6rem;
   color: rgba(247, 249, 255, 0.95);
-  line-height: 1.05;
+  line-height: 1.1;
+  text-align: center;
 }
 
 .footer-character-slot__damage-log-button {
   display: inline-flex;
+  align-self: center;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  padding: 6px 12px;
-  margin-top: 4px;
+  width: auto;
+  min-width: 0;
+  padding: 2px 6px;
+  margin-top: 2px;
+  font-size: 0.65rem;
+}
+
+.footer-character-slot__damage .footer-pass-log-button {
+  font-size: 0.62rem;
+  padding: 2px 8px;
+  letter-spacing: 0.08em;
+  box-shadow: 0 3px 8px rgba(12, 20, 42, 0.35);
 }
 
 .footer-character-slot__damage--critical .footer-character-slot__damage-value {


### PR DESCRIPTION
## Summary
- center the footer damage card contents so the log button can align with the enlarged roll value
- tighten the damage log button padding and font sizing within the damage card to make it visibly smaller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69091bd98518832e964cc7de02b46dcd