### PR TITLE
Enable DM map wheel zoom support

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4676,6 +4676,7 @@ h1 {
 .campaign-map-board {
   --map-square-size: var(--campaign-map-square-size, clamp(48px, 10vw, 80px));
   --figurine-size-scale: 1;
+  --campaign-map-zoom: var(--map-modal-background-scale, 1);
 
   position: relative;
   background: rgba(18, 16, 14, 0.85);
@@ -4706,6 +4707,16 @@ h1 {
     aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
   }
 
+  &__grid-overlay {
+    transform: translate(
+        var(--campaign-map-pan-x, 0),
+        var(--campaign-map-pan-y, 0)
+      )
+      scale(var(--campaign-map-zoom, 1));
+    transition: transform 0.08s ease-out;
+    will-change: transform;
+  }
+
   &__image {
     display: block;
     width: 100%;
@@ -4715,7 +4726,8 @@ h1 {
     transform: translate(
       var(--campaign-map-pan-x, 0),
       var(--campaign-map-pan-y, 0)
-    );
+    )
+      scale(var(--campaign-map-zoom, 1));
     transition: transform 0.08s ease-out;
     will-change: transform;
   }
@@ -4736,7 +4748,8 @@ h1 {
     transform: translate(
       var(--campaign-map-pan-x, 0),
       var(--campaign-map-pan-y, 0)
-    );
+    )
+      scale(var(--campaign-map-zoom, 1));
     transition: transform 0.08s ease-out;
     will-change: transform;
   }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -4,6 +4,7 @@ import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import resolveMapImageSource from '../utils/mapImages';
+import clampMapZoom, { MAP_ZOOM_DEFAULT } from '../utils/mapZoom';
 import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
 import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
 
@@ -496,6 +497,7 @@ const CampaignMapBoard = ({
   disabled,
   className,
   children,
+  allowWheelZoom,
 }) => {
   const pointerEventsSupported = usePointerEventsSupported();
   const safeMap = map && typeof map === 'object' ? map : {};
@@ -527,6 +529,8 @@ const CampaignMapBoard = ({
   const tokenPositionsRef = useRef([]);
   const [layerNode, setLayerNode] = useState(null);
   const [figurineImageMetrics, setFigurineImageMetrics] = useState({});
+  const [mapZoom, setMapZoom] = useState(MAP_ZOOM_DEFAULT);
+  const resolvedMapZoom = useMemo(() => clampMapZoom(mapZoom), [mapZoom]);
   const rotationDragStateRef = useRef(null);
   const rotationMoveHandlerRef = useRef(null);
   const rotationUpHandlerRef = useRef(null);
@@ -652,7 +656,84 @@ const CampaignMapBoard = ({
       return { x: 0, y: 0 };
     });
     mapPanOffsetRef.current = { x: 0, y: 0 };
+    setMapZoom(MAP_ZOOM_DEFAULT);
   }, [imageSrc]);
+
+  useEffect(() => {
+    if (!allowWheelZoom) {
+      setMapZoom(MAP_ZOOM_DEFAULT);
+    }
+  }, [allowWheelZoom]);
+
+  const boardStyle = useMemo(() => {
+    if (!allowWheelZoom) {
+      return undefined;
+    }
+
+    const zoomValue = resolvedMapZoom;
+    return {
+      '--campaign-map-zoom': `${zoomValue}`,
+      '--map-modal-background-scale': `${zoomValue}`,
+    };
+  }, [allowWheelZoom, resolvedMapZoom]);
+
+  const handleWheel = useCallback(
+    (event) => {
+      if (!allowWheelZoom) {
+        return;
+      }
+
+      const wheelEvent = event?.nativeEvent ?? event;
+      if (!wheelEvent || typeof wheelEvent.deltaY !== 'number' || wheelEvent.deltaY === 0) {
+        return;
+      }
+
+      if (typeof event?.preventDefault === 'function') {
+        event.preventDefault();
+      }
+
+      if (typeof event?.stopPropagation === 'function') {
+        event.stopPropagation();
+      }
+
+      const { deltaY, ctrlKey, deltaMode } = wheelEvent;
+
+      const deltaPixels = (() => {
+        if (typeof deltaMode !== 'number') {
+          return deltaY;
+        }
+
+        if (deltaMode === 1) {
+          return deltaY * 16;
+        }
+
+        if (deltaMode === 2) {
+          return deltaY * 800;
+        }
+
+        return deltaY;
+      })();
+
+      if (!Number.isFinite(deltaPixels) || deltaPixels === 0) {
+        return;
+      }
+
+      const normalizedDelta = Math.max(-1, Math.min(1, deltaPixels / 120));
+      const zoomStrength = ctrlKey ? 0.12 : 0.2;
+      const zoomMultiplier = 1 - normalizedDelta * zoomStrength;
+
+      if (!Number.isFinite(zoomMultiplier) || zoomMultiplier <= 0) {
+        return;
+      }
+
+      setMapZoom((previousZoom) => {
+        const safePrevious = clampMapZoom(previousZoom);
+        const nextZoom = safePrevious * zoomMultiplier;
+        return clampMapZoom(nextZoom);
+      });
+    },
+    [allowWheelZoom]
+  );
 
   useEffect(() => {
     const boardElement = boardRef.current;
@@ -1772,6 +1853,8 @@ const CampaignMapBoard = ({
         className,
         interactionDisabled && 'campaign-map-board--disabled'
       )}
+      style={boardStyle}
+      onWheel={handleWheel}
     >
       {title && <h5 className="campaign-map-board__title">{title}</h5>}
       {imageSrc ? (
@@ -2410,6 +2493,7 @@ CampaignMapBoard.propTypes = {
   disabled: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
+  allowWheelZoom: PropTypes.bool,
 };
 
 CampaignMapBoard.defaultProps = {
@@ -2424,6 +2508,7 @@ CampaignMapBoard.defaultProps = {
   disabled: false,
   className: '',
   children: null,
+  allowWheelZoom: false,
 };
 
 export default CampaignMapBoard;

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -591,4 +591,45 @@ describe('CampaignMapBoard pointer interactions', () => {
       });
     }
   });
+
+  it('ignores wheel input when zooming is disabled', async () => {
+    const { container } = render(
+      <CampaignMapBoard map={baseMap} tokens={[baseToken]} allowWheelZoom={false} />
+    );
+
+    const boardElement = container.querySelector('.campaign-map-board');
+    expect(boardElement).not.toBeNull();
+    if (!boardElement) {
+      return;
+    }
+
+    expect(boardElement.style.getPropertyValue('--campaign-map-zoom')).toBe('');
+
+    fireEvent.wheel(boardElement, { deltaY: -240 });
+
+    await waitFor(() => {
+      expect(boardElement.style.getPropertyValue('--campaign-map-zoom')).toBe('');
+    });
+  });
+
+  it('applies zoom styling when wheel input is allowed', async () => {
+    const { container } = render(
+      <CampaignMapBoard map={baseMap} tokens={[baseToken]} allowWheelZoom />
+    );
+
+    const boardElement = container.querySelector('.campaign-map-board');
+    expect(boardElement).not.toBeNull();
+    if (!boardElement) {
+      return;
+    }
+
+    expect(boardElement.style.getPropertyValue('--campaign-map-zoom')).toBe('1');
+
+    fireEvent.wheel(boardElement, { deltaY: -240 });
+
+    await waitFor(() => {
+      const zoomValue = boardElement.style.getPropertyValue('--campaign-map-zoom');
+      expect(parseFloat(zoomValue)).toBeGreaterThan(1);
+    });
+  });
 });

--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1855,6 +1855,7 @@ const MapModal = ({
             map={previewMap}
             tokens={boardTokens}
             disabled={isBoardDisabled}
+            allowWheelZoom={!isBackground}
             onTokenPositionChange={
               canManipulateTokens ? handleTokenPositionChange : undefined
             }

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -211,6 +211,7 @@ describe('MapModal figurine imagery', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'hero',
@@ -260,6 +261,7 @@ describe('MapModal figurine imagery', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'hero',
@@ -296,6 +298,7 @@ describe('MapModal figurine imagery', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'CHAR-1',
@@ -329,6 +332,7 @@ describe('MapModal figurine imagery', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'characters/hero',
@@ -368,6 +372,7 @@ describe('MapModal figurine imagery', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'hero',
@@ -424,6 +429,7 @@ describe('MapModal background interaction resolution', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(false);
 
     expect(boardProps.onTokenPositionChange).toEqual(expect.any(Function));
     expect(boardProps.onBackgroundClick).toEqual(expect.any(Function));
@@ -478,6 +484,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(false);
     expect(boardProps.tokens).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ characterId: 'hero', label: 'Hero' }),
@@ -534,6 +541,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(false);
 
     await act(async () => {
       boardProps.onTokenPositionChange?.({ characterId: 'hero', x: 0.4, y: 0.6 });
@@ -584,6 +592,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(false);
     expect(typeof boardProps.onTokenPositionChange).toBe('function');
 
     await act(async () => {
@@ -632,6 +641,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(false);
     expect(boardProps.tokens).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ characterId: 'rogue', label: 'Rogue', isMovable: true }),
@@ -681,6 +691,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'ally',
@@ -709,6 +720,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'lone',
@@ -739,6 +751,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'rogue',
@@ -771,6 +784,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(true);
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({ characterId: 'pc-rogue', isMovable: true });
 
@@ -816,6 +830,7 @@ describe('MapModal background interactions', () => {
 
     await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
     const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.allowWheelZoom).toBe(false);
 
     expect(boardProps.map).toEqual(backgroundMap);
   });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6682,6 +6682,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                               map={displayedMap}
                               tokens={boardTokens}
                               disabled={!shouldShowCampaignTokens}
+                              allowWheelZoom
                               onTokenPositionChange={
                                 shouldShowCampaignTokens ? handleTokenPositionChange : undefined
                               }

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1658,6 +1658,7 @@ describe('ZombiesDM AI generation', () => {
       .find((props) => props && props.map && props.map.mapId === 'map-1');
 
     expect(initialBoardCall).toBeDefined();
+    expect(initialBoardCall.allowWheelZoom).toBe(true);
     expect(initialBoardCall.disabled).toBe(false);
     expect(initialBoardCall.tokens).toEqual(
       expect.arrayContaining([
@@ -1713,6 +1714,7 @@ describe('ZombiesDM AI generation', () => {
 
     const latestBoardProps = CampaignMapBoard.mock.calls[CampaignMapBoard.mock.calls.length - 1][0];
     expect(typeof latestBoardProps.onTokenRemove).toBe('function');
+    expect(latestBoardProps.allowWheelZoom).toBe(true);
 
     await act(async () => {
       const result = await latestBoardProps.onTokenRemove({
@@ -1735,6 +1737,7 @@ describe('ZombiesDM AI generation', () => {
         (token) => token.characterId === 'hero-1'
       );
       expect(hasHeroToken).toBe(false);
+      expect(updatedProps.allowWheelZoom).toBe(true);
     });
   });
 

--- a/client/src/components/Zombies/utils/mapZoom.js
+++ b/client/src/components/Zombies/utils/mapZoom.js
@@ -1,0 +1,21 @@
+export const MAP_ZOOM_DEFAULT = 1;
+export const MAP_ZOOM_MIN = 0.5;
+export const MAP_ZOOM_MAX = 6;
+
+export const clampMapZoom = (value) => {
+  if (!Number.isFinite(value)) {
+    return MAP_ZOOM_DEFAULT;
+  }
+
+  if (value < MAP_ZOOM_MIN) {
+    return MAP_ZOOM_MIN;
+  }
+
+  if (value > MAP_ZOOM_MAX) {
+    return MAP_ZOOM_MAX;
+  }
+
+  return value;
+};
+
+export default clampMapZoom;


### PR DESCRIPTION
## Summary
- add wheel-based zoom support to `CampaignMapBoard`, including new clamp helper and CSS transform updates
- enable `allowWheelZoom` for DM map views and management modals so the DM can zoom like players
- extend unit tests to cover the new zoom prop and behavior across the DM page, map modal, and board component

## Testing
- not run (node tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_690a15168184832e9e296cc7d9b11e73