### PR TITLE
Improve campaign map zoom responsiveness

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -261,7 +261,6 @@
     var(--campaign-map-pan-x, 0),
     var(--campaign-map-pan-y, 0)
   );
-  transition: transform 0.08s ease-out;
   will-change: transform;
 }
 
@@ -4713,7 +4712,6 @@ h1 {
         var(--campaign-map-pan-y, 0)
       )
       scale(var(--campaign-map-zoom, 1));
-    transition: transform 0.08s ease-out;
     will-change: transform;
   }
 
@@ -4728,7 +4726,6 @@ h1 {
       var(--campaign-map-pan-y, 0)
     )
       scale(var(--campaign-map-zoom, 1));
-    transition: transform 0.08s ease-out;
     will-change: transform;
   }
 
@@ -4750,7 +4747,6 @@ h1 {
       var(--campaign-map-pan-y, 0)
     )
       scale(var(--campaign-map-zoom, 1));
-    transition: transform 0.08s ease-out;
     will-change: transform;
   }
 

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -4,7 +4,7 @@ import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import resolveMapImageSource from '../utils/mapImages';
-import clampMapZoom, { MAP_ZOOM_DEFAULT } from '../utils/mapZoom';
+import clampMapZoom, { MAP_ZOOM_DEFAULT, MAP_ZOOM_MIN, MAP_ZOOM_MAX } from '../utils/mapZoom';
 import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
 import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
 
@@ -798,12 +798,20 @@ const CampaignMapBoard = ({
   }, [allowWheelZoom]);
 
   const boardStyle = useMemo(() => {
+    const zoomValue = Number.isFinite(resolvedMapZoom) ? resolvedMapZoom : MAP_ZOOM_DEFAULT;
+    const normalizedZoom = Math.max(MAP_ZOOM_MIN, Math.min(MAP_ZOOM_MAX, zoomValue));
+    const gridLineWidth = Math.max(0.35, Math.min(0.75, 0.75 / normalizedZoom));
+
+    const baseStyle = {
+      '--campaign-map-grid-line-width': `${gridLineWidth}px`,
+    };
+
     if (!allowWheelZoom) {
-      return undefined;
+      return baseStyle;
     }
 
-    const zoomValue = resolvedMapZoom;
     return {
+      ...baseStyle,
       '--campaign-map-zoom': `${zoomValue}`,
       '--map-modal-background-scale': `${zoomValue}`,
     };


### PR DESCRIPTION
## Summary
- remove transform transitions on the campaign map board layers to make wheel zooming feel more immediate
- dynamically size the campaign map grid lines based on the resolved zoom level so they stay visually consistent when scaling

## Testing
- CI=true npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js *(fails: existing "marks the last dragged token and enables rotation controls" expectation)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910dd781e98832e8ec222669f4323b1)