### PR TITLE
Center figurine rotation pivot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4766,9 +4766,9 @@ h1 {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
     --figurine-rotation: 0deg;
-    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.65);
+    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.5);
     --figurine-rotation-origin-y-token: calc(
-      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.45
+      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.6
     );
     position: absolute;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary
- center the figurine rotation origin so minis spin around their image midpoint
- keep the rotation handle positioned consistently with the new pivot

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e5903f50832e8ad0ef0a7e9bf1f6)