### PR TITLE
Adjust figurine rotation pivot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4766,9 +4766,9 @@ h1 {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
     --figurine-rotation: 0deg;
-    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.65);
+    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.8);
     --figurine-rotation-origin-y-token: calc(
-      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.45
+      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.3
     );
     position: absolute;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary
- center figurine rotation around the middle of the token image by updating the transform origin
- keep the rotation handle in the same relative location after shifting the pivot

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e5903f50832e8ad0ef0a7e9bf1f6)