### PR TITLE
Adjust figurine rotation pivot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4766,9 +4766,9 @@ h1 {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
     --figurine-rotation: 0deg;
-    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.8);
+    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 1.35);
     --figurine-rotation-origin-y-token: calc(
-      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.3
+      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.2
     );
     position: absolute;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary
- move the figurine rotation origin closer to the base to prevent the stretched rotation arc
- update the rotation handle positioning to align with the new pivot point

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f6409180832e8b52c4c49f3e4b0f)