### PR TITLE
Restrict enemy token movement to the DM map

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1361,26 +1361,7 @@ const MapModal = ({
           lookup.maxHp ?? token.maxHp ?? token.hpMax ?? token.health
         );
 
-        const hasCharacterContext = Boolean(
-          readOnly &&
-            currentCharacterIdCandidatesLower &&
-            currentCharacterIdCandidatesLower.size > 0
-        );
-
-        const matchesCurrentCharacter = hasCharacterContext
-          ? tokenMatchesCurrentCharacter(token)
-          : false;
-
-        const canCurrentlyManipulate = canManipulateTokens && !placementPending;
-
-        let isMovable =
-          canCurrentlyManipulate && (!hasCharacterContext || matchesCurrentCharacter);
-
-        if (token.isMovable === true) {
-          isMovable = canCurrentlyManipulate;
-        } else if (token.isMovable === false) {
-          isMovable = false;
-        }
+        const matchesCurrentCharacter = tokenMatchesCurrentCharacter(token);
 
         const lookupVariant =
           typeof lookup.variant === 'string' && lookup.variant.trim() !== ''
@@ -1420,6 +1401,32 @@ const MapModal = ({
           } else if (entityType === 'character' || entityType !== 'enemy') {
             variant = 'ally';
           }
+        }
+
+        const normalizedVariant =
+          typeof variant === 'string' && variant.trim() !== ''
+            ? variant.trim().toLowerCase()
+            : null;
+
+        const canCurrentlyManipulate = canManipulateTokens && !placementPending;
+        const isEnemyToken = normalizedVariant === 'enemy' || entityType === 'enemy';
+
+        let isMovable = canCurrentlyManipulate && (!readOnly || matchesCurrentCharacter);
+
+        if (readOnly && isEnemyToken) {
+          isMovable = false;
+        }
+
+        if (token.isMovable === true) {
+          if (!readOnly) {
+            isMovable = canCurrentlyManipulate;
+          } else if (!isEnemyToken && matchesCurrentCharacter) {
+            isMovable = canCurrentlyManipulate;
+          } else {
+            isMovable = false;
+          }
+        } else if (token.isMovable === false) {
+          isMovable = false;
         }
 
         const baseColor = lookup.color || token.color || null;

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -795,7 +795,7 @@ describe('MapModal background interactions', () => {
     );
   });
 
-  it('keeps tokens movable when provided mobility flags override read-only restrictions', async () => {
+  it('ignores mobility overrides for read-only viewers without control', async () => {
     render(
       <MapModal
         show
@@ -825,11 +825,11 @@ describe('MapModal background interactions', () => {
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'ally',
-      isMovable: true,
+      isMovable: false,
     });
   });
 
-  it('allows interaction when no character identifiers are available', async () => {
+  it('disables movement when no character identifiers are available', async () => {
     render(
       <MapModal
         show
@@ -854,7 +854,7 @@ describe('MapModal background interactions', () => {
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'lone',
-      isMovable: true,
+      isMovable: false,
     });
   });
 
@@ -887,6 +887,80 @@ describe('MapModal background interactions', () => {
       characterId: 'rogue',
       isMovable: false,
     });
+  });
+
+  it('prevents read-only players from dragging enemy tokens', async () => {
+    render(
+      <MapModal
+        show
+        map={{ mapId: 'map-1', title: 'Dungeon', imageUrl: 'https://example.com/map.png' }}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            hero: {
+              characterId: 'hero',
+              x: 0.1,
+              y: 0.2,
+            },
+            'enemy-1': {
+              characterId: 'enemy-1',
+              x: 0.6,
+              y: 0.4,
+              entityType: 'enemy',
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        characterLookup={{
+          hero: { label: 'Hero', entityType: 'character' },
+          'enemy-1': { label: 'Goblin', entityType: 'enemy' },
+        }}
+        onTokenMove={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'hero', isMovable: true }),
+        expect.objectContaining({ characterId: 'enemy-1', isMovable: false }),
+      ])
+    );
+  });
+
+  it('allows the DM map to drag enemy tokens', async () => {
+    render(
+      <MapModal
+        show
+        map={{ mapId: 'map-1', title: 'Dungeon', imageUrl: 'https://example.com/map.png' }}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            'enemy-1': {
+              characterId: 'enemy-1',
+              x: 0.6,
+              y: 0.4,
+              entityType: 'enemy',
+            },
+          },
+        }}
+        currentCharacterId="enemy-1"
+        characterLookup={{
+          'enemy-1': { label: 'Goblin', entityType: 'enemy' },
+        }}
+        onTokenMove={jest.fn()}
+        readOnly={false}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'enemy-1', isMovable: true }),
+      ])
+    );
   });
 
   it('allows token manipulation when alternate identifiers match the current character', async () => {


### PR DESCRIPTION
## Summary
- prevent read-only players from moving tokens they do not control and block enemy tokens outside the DM map
- keep enemy tokens draggable for the DM while respecting explicit immobility flags
- expand MapModal test coverage for the updated movement rules

## Testing
- CI=true npm test -- MapModal

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f7ff78cc832e92ac44277f85ec9a)