### PR TITLE
Restrict read-only movement to the active character token

### DIFF
--- a/client/src/components/Zombies/attributes/MapModal.js
+++ b/client/src/components/Zombies/attributes/MapModal.js
@@ -1001,10 +1001,6 @@ const MapModal = ({
   }, [characterLookup]);
 
   const currentCharacterIdCandidatesLower = useMemo(() => {
-    if (readOnly && controlledCharacterIdentifiersLower.size > 0) {
-      return new Set(controlledCharacterIdentifiersLower);
-    }
-
     const candidates = new Set();
 
     const addCandidate = (candidate) => {
@@ -1014,9 +1010,43 @@ const MapModal = ({
       }
     };
 
-    addCandidate(normalizedCurrentCharacterId);
+    const normalizedCurrentLower =
+      typeof normalizedCurrentCharacterId === 'string'
+        ? normalizedCurrentCharacterId.toLowerCase()
+        : null;
+    const normalizedActiveLower =
+      typeof normalizedActiveCharacterId === 'string'
+        ? normalizedActiveCharacterId.toLowerCase()
+        : null;
 
-    if (!normalizedCurrentCharacterId) {
+    const currentIsControlled = Boolean(
+      normalizedCurrentLower && controlledCharacterIdentifiersLower.has(normalizedCurrentLower)
+    );
+
+    const shouldIncludeCurrent = Boolean(
+      normalizedCurrentCharacterId &&
+        (!readOnly ||
+          controlledCharacterIdentifiersLower.size === 0 ||
+          currentIsControlled)
+    );
+
+    if (shouldIncludeCurrent) {
+      addCandidate(normalizedCurrentCharacterId);
+    }
+
+    const activeIsControlled = Boolean(
+      normalizedActiveLower && controlledCharacterIdentifiersLower.has(normalizedActiveLower)
+    );
+
+    const shouldIncludeActive = Boolean(
+      normalizedActiveCharacterId &&
+        (!normalizedCurrentCharacterId || !shouldIncludeCurrent) &&
+        (!readOnly ||
+          controlledCharacterIdentifiersLower.size === 0 ||
+          activeIsControlled)
+    );
+
+    if (shouldIncludeActive) {
       addCandidate(normalizedActiveCharacterId);
     }
 
@@ -1047,6 +1077,10 @@ const MapModal = ({
           });
         }
       });
+    }
+
+    if (candidates.size === 0 && readOnly && controlledCharacterIdentifiersLower.size > 0) {
+      return new Set(controlledCharacterIdentifiersLower);
     }
 
     return candidates;
@@ -1214,32 +1248,25 @@ const MapModal = ({
         return false;
       }
 
-      let hasControlledMatch = false;
-      if (readOnly && controlledCharacterIdentifiersLower.size > 0) {
-        for (const identifier of identifiers) {
-          if (controlledCharacterIdentifiersLower.has(identifier)) {
-            hasControlledMatch = true;
-            break;
-          }
-        }
-      }
-
-      if (
-        (!currentCharacterIdCandidatesLower || currentCharacterIdCandidatesLower.size === 0) &&
-        !hasControlledMatch
-      ) {
-        return false;
-      }
-
       if (currentCharacterIdCandidatesLower && currentCharacterIdCandidatesLower.size > 0) {
         for (const identifier of identifiers) {
           if (currentCharacterIdCandidatesLower.has(identifier)) {
             return true;
           }
         }
+
+        return false;
       }
 
-      return hasControlledMatch;
+      if (readOnly && controlledCharacterIdentifiersLower.size > 0) {
+        for (const identifier of identifiers) {
+          if (controlledCharacterIdentifiersLower.has(identifier)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
     },
     [
       controlledCharacterIdentifiersLower,
@@ -1258,38 +1285,39 @@ const MapModal = ({
 
       const normalizedLower = normalizedId.toLowerCase();
 
-      if (
-        readOnly &&
-        controlledCharacterIdentifiersLower.size > 0 &&
-        !controlledCharacterIdentifiersLower.has(normalizedLower)
-      ) {
-        return false;
-      }
-
-      if (!currentCharacterIdCandidatesLower || currentCharacterIdCandidatesLower.size === 0) {
-        if (!readOnly || controlledCharacterIdentifiersLower.size === 0) {
+      if (currentCharacterIdCandidatesLower && currentCharacterIdCandidatesLower.size > 0) {
+        if (currentCharacterIdCandidatesLower.has(normalizedLower)) {
           return true;
         }
 
-        return controlledCharacterIdentifiersLower.has(normalizedLower);
+        if (tokenIdentifierLookup.has(normalizedLower)) {
+          const identifiers = tokenIdentifierLookup.get(normalizedLower);
+          for (const identifier of identifiers) {
+            if (currentCharacterIdCandidatesLower.has(identifier)) {
+              return true;
+            }
+          }
+        }
+
+        return false;
       }
 
-      if (currentCharacterIdCandidatesLower.has(normalizedLower)) {
+      if (!readOnly) {
         return true;
       }
 
-      if (readOnly && controlledCharacterIdentifiersLower.has(normalizedLower)) {
+      if (controlledCharacterIdentifiersLower.size === 0) {
+        return false;
+      }
+
+      if (controlledCharacterIdentifiersLower.has(normalizedLower)) {
         return true;
       }
 
       if (tokenIdentifierLookup.has(normalizedLower)) {
         const identifiers = tokenIdentifierLookup.get(normalizedLower);
         for (const identifier of identifiers) {
-          if (currentCharacterIdCandidatesLower.has(identifier)) {
-            return true;
-          }
-
-          if (readOnly && controlledCharacterIdentifiersLower.has(identifier)) {
+          if (controlledCharacterIdentifiersLower.has(identifier)) {
             return true;
           }
         }
@@ -1361,26 +1389,7 @@ const MapModal = ({
           lookup.maxHp ?? token.maxHp ?? token.hpMax ?? token.health
         );
 
-        const hasCharacterContext = Boolean(
-          readOnly &&
-            currentCharacterIdCandidatesLower &&
-            currentCharacterIdCandidatesLower.size > 0
-        );
-
-        const matchesCurrentCharacter = hasCharacterContext
-          ? tokenMatchesCurrentCharacter(token)
-          : false;
-
-        const canCurrentlyManipulate = canManipulateTokens && !placementPending;
-
-        let isMovable =
-          canCurrentlyManipulate && (!hasCharacterContext || matchesCurrentCharacter);
-
-        if (token.isMovable === true) {
-          isMovable = canCurrentlyManipulate;
-        } else if (token.isMovable === false) {
-          isMovable = false;
-        }
+        const matchesCurrentCharacter = tokenMatchesCurrentCharacter(token);
 
         const lookupVariant =
           typeof lookup.variant === 'string' && lookup.variant.trim() !== ''
@@ -1420,6 +1429,32 @@ const MapModal = ({
           } else if (entityType === 'character' || entityType !== 'enemy') {
             variant = 'ally';
           }
+        }
+
+        const normalizedVariant =
+          typeof variant === 'string' && variant.trim() !== ''
+            ? variant.trim().toLowerCase()
+            : null;
+
+        const canCurrentlyManipulate = canManipulateTokens && !placementPending;
+        const isEnemyToken = normalizedVariant === 'enemy' || entityType === 'enemy';
+
+        let isMovable = canCurrentlyManipulate && (!readOnly || matchesCurrentCharacter);
+
+        if (readOnly && isEnemyToken) {
+          isMovable = false;
+        }
+
+        if (token.isMovable === true) {
+          if (!readOnly) {
+            isMovable = canCurrentlyManipulate;
+          } else if (!isEnemyToken && matchesCurrentCharacter) {
+            isMovable = canCurrentlyManipulate;
+          } else {
+            isMovable = false;
+          }
+        } else if (token.isMovable === false) {
+          isMovable = false;
         }
 
         const baseColor = lookup.color || token.color || null;

--- a/client/src/components/Zombies/attributes/MapModal.test.js
+++ b/client/src/components/Zombies/attributes/MapModal.test.js
@@ -795,7 +795,7 @@ describe('MapModal background interactions', () => {
     );
   });
 
-  it('keeps tokens movable when provided mobility flags override read-only restrictions', async () => {
+  it('ignores mobility overrides for read-only viewers without control', async () => {
     render(
       <MapModal
         show
@@ -825,11 +825,11 @@ describe('MapModal background interactions', () => {
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'ally',
-      isMovable: true,
+      isMovable: false,
     });
   });
 
-  it('allows interaction when no character identifiers are available', async () => {
+  it('disables movement when no character identifiers are available', async () => {
     render(
       <MapModal
         show
@@ -854,7 +854,7 @@ describe('MapModal background interactions', () => {
     expect(boardProps.tokens).toHaveLength(1);
     expect(boardProps.tokens[0]).toMatchObject({
       characterId: 'lone',
-      isMovable: true,
+      isMovable: false,
     });
   });
 
@@ -887,6 +887,119 @@ describe('MapModal background interactions', () => {
       characterId: 'rogue',
       isMovable: false,
     });
+  });
+
+  it('prevents read-only players from dragging enemy tokens', async () => {
+    render(
+      <MapModal
+        show
+        map={{ mapId: 'map-1', title: 'Dungeon', imageUrl: 'https://example.com/map.png' }}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            hero: {
+              characterId: 'hero',
+              x: 0.1,
+              y: 0.2,
+            },
+            'enemy-1': {
+              characterId: 'enemy-1',
+              x: 0.6,
+              y: 0.4,
+              entityType: 'enemy',
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        characterLookup={{
+          hero: { label: 'Hero', entityType: 'character' },
+          'enemy-1': { label: 'Goblin', entityType: 'enemy' },
+        }}
+        onTokenMove={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'hero', isMovable: true }),
+        expect.objectContaining({ characterId: 'enemy-1', isMovable: false }),
+      ])
+    );
+  });
+
+  it('prevents read-only players from dragging other controlled characters', async () => {
+    render(
+      <MapModal
+        show
+        map={{ mapId: 'map-1', title: 'Dungeon', imageUrl: 'https://example.com/map.png' }}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            hero: {
+              characterId: 'hero',
+              x: 0.1,
+              y: 0.2,
+            },
+            cleric: {
+              characterId: 'cleric',
+              x: 0.3,
+              y: 0.4,
+            },
+          },
+        }}
+        currentCharacterId="hero"
+        characterLookup={{
+          hero: { label: 'Hero', entityType: 'character' },
+          cleric: { label: 'Cleric', entityType: 'character' },
+        }}
+        onTokenMove={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'hero', isMovable: true }),
+        expect.objectContaining({ characterId: 'cleric', isMovable: false }),
+      ])
+    );
+  });
+
+  it('allows the DM map to drag enemy tokens', async () => {
+    render(
+      <MapModal
+        show
+        map={{ mapId: 'map-1', title: 'Dungeon', imageUrl: 'https://example.com/map.png' }}
+        activeMapId="map-1"
+        tokensByMapId={{
+          'map-1': {
+            'enemy-1': {
+              characterId: 'enemy-1',
+              x: 0.6,
+              y: 0.4,
+              entityType: 'enemy',
+            },
+          },
+        }}
+        currentCharacterId="enemy-1"
+        characterLookup={{
+          'enemy-1': { label: 'Goblin', entityType: 'enemy' },
+        }}
+        onTokenMove={jest.fn()}
+        readOnly={false}
+      />
+    );
+
+    await waitFor(() => expect(mockCapturedBoardProps.length).toBeGreaterThan(0));
+    const boardProps = mockCapturedBoardProps[mockCapturedBoardProps.length - 1];
+    expect(boardProps.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'enemy-1', isMovable: true }),
+      ])
+    );
   });
 
   it('allows token manipulation when alternate identifiers match the current character', async () => {


### PR DESCRIPTION
## Summary
- prevent read-only players from moving tokens they do not control, block enemy tokens outside the DM map, and restrict them to whichever character sheet is currently open
- keep enemy tokens draggable for the DM while respecting explicit immobility flags
- expand MapModal test coverage for the updated movement rules, including verifying other controlled characters remain immobile

## Testing
- CI=true npm test -- MapModal

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f7ff78cc832e92ac44277f85ec9a)