### PR TITLE
Fix figurine rotation pivot

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4766,10 +4766,8 @@ h1 {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
     --figurine-rotation: 0deg;
-    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 1.35);
-    --figurine-rotation-origin-y-token: calc(
-      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.2
-    );
+    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.575);
+    --figurine-rotation-origin-y-token: var(--figurine-rotation-origin-y);
     position: absolute;
     transform: translate(-50%, -50%);
     pointer-events: auto;


### PR DESCRIPTION
## Summary
- adjust the figurine rotation origin so tokens spin around their center
- align the rotation handle overlay with the updated pivot point

## Testing
- not run (CSS change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fe05bbf8832e8778553695bea873)