### PR TITLE
Align figurine rotation with token center

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -4766,10 +4766,8 @@ h1 {
     --figurine-base-size: calc(var(--map-square-size) * var(--figurine-size-scale, 1));
     --figurine-body-width: calc(var(--figurine-base-size) * 0.6);
     --figurine-rotation: 0deg;
-    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 1.35);
-    --figurine-rotation-origin-y-token: calc(
-      var(--figurine-rotation-origin-y) + var(--figurine-base-size) * 0.2
-    );
+    --figurine-rotation-origin-y: calc(var(--figurine-base-size) * 0.35);
+    --figurine-rotation-origin-y-token: calc(var(--figurine-base-size) * 0.8);
     position: absolute;
     transform: translate(-50%, -50%);
     pointer-events: auto;


### PR DESCRIPTION
## Summary
- reposition the figurine rotation origin to align with the token's board position
- update the rotation control overlay to match the new pivot point

## Testing
- not run (CSS change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fe05bbf8832e8778553695bea873)