### PR TITLE
Use campaign map surface for enemy placement

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -322,6 +322,52 @@
   pointer-events: none;
 }
 
+.zombies-dm-page__map-placement-overlay {
+  position: absolute;
+  bottom: clamp(1.5rem, 6vh, 3rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  max-width: min(90vw, 420px);
+  width: calc(100% - 2rem);
+  background: rgba(0, 0, 0, 0.72);
+  color: #f8f9fa;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  pointer-events: auto;
+}
+
+.zombies-dm-page__map-placement-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.zombies-dm-page__map-placement-error {
+  width: 100%;
+  background: rgba(220, 53, 69, 0.2);
+  color: #ffc9c9;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+}
+
+.zombies-dm-page__map-placement-actions {
+  display: flex;
+  justify-content: center;
+}
+
 .zombies-dm-page__status-alert {
   position: absolute;
   top: calc(env(safe-area-inset-top, 0px) + 1.5rem);

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1383,6 +1383,8 @@ export default function ZombiesDM() {
       enemyId: null,
       enemyName: null,
     });
+    const [mapPlacementSaving, setMapPlacementSaving] = useState(false);
+    const [mapPlacementError, setMapPlacementError] = useState(null);
     const [showDiceRoller, setShowDiceRoller] = useState(false);
     const socketRef = useRef(null);
     const mapTokensRef = useRef(mapTokens);
@@ -3785,43 +3787,6 @@ export default function ZombiesDM() {
       );
     }, [activeMapId, campaignMap, displayedMap, generatedMap]);
 
-    const modalTokensByMapId = useMemo(() => {
-      const sanitizedMapTokens = sanitizeTokensByMapId(mapTokens);
-      const merged = { ...sanitizedMapTokens };
-
-      const campaignMapId =
-        typeof campaignMap?.mapId === 'string' && campaignMap.mapId.trim() !== ''
-          ? campaignMap.mapId.trim()
-          : null;
-
-      if (campaignMapId) {
-        const campaignTokens = sanitizeTokenDictionary(campaignMap?.tokens);
-        if (Object.keys(campaignTokens).length > 0) {
-          merged[campaignMapId] = {
-            ...(merged[campaignMapId] || {}),
-            ...campaignTokens,
-          };
-        }
-      }
-
-      const normalizedActiveMapId =
-        typeof activeMapId === 'string' && activeMapId.trim() !== ''
-          ? activeMapId.trim()
-          : null;
-
-      if (normalizedActiveMapId) {
-        const normalizedActiveTokens = sanitizeTokenDictionary(activeMapTokens);
-        if (Object.keys(normalizedActiveTokens).length > 0) {
-          merged[normalizedActiveMapId] = {
-            ...(merged[normalizedActiveMapId] || {}),
-            ...normalizedActiveTokens,
-          };
-        }
-      }
-
-      return merged;
-    }, [activeMapId, activeMapTokens, campaignMap, mapTokens]);
-
     const boardTokens = useMemo(() => {
       const activeCharacterId =
         typeof activeParticipant?.characterId === 'string' &&
@@ -3957,6 +3922,29 @@ export default function ZombiesDM() {
       tokenMetaById,
     ]);
 
+    const placementEnemyName = useMemo(() => {
+      if (typeof mapPlacementState.enemyName === 'string' && mapPlacementState.enemyName.trim() !== '') {
+        return mapPlacementState.enemyName.trim();
+      }
+      return null;
+    }, [mapPlacementState.enemyName]);
+
+    const mapPlacementInstruction = useMemo(() => {
+      if (!mapPlacementState.show) {
+        return '';
+      }
+
+      if (!shouldShowCampaignTokens) {
+        return 'Activate the campaign map to place this enemy.';
+      }
+
+      if (placementEnemyName) {
+        return `Click the map to place ${placementEnemyName}.`;
+      }
+
+      return 'Click the map to place the enemy.';
+    }, [mapPlacementState.show, placementEnemyName, shouldShowCampaignTokens]);
+
     const handleTokenPositionChange = useCallback(
       ({ characterId, x, y, rotation }) => {
         const normalizedDisplayedMapId =
@@ -4010,14 +3998,30 @@ export default function ZombiesDM() {
       setMapPlacementState({ show: false, enemyId: null, enemyName: null });
     }, []);
 
-    const handleMapModalTokenMove = useCallback(
-      async ({ mapId, characterId, x, y, rotation }) => {
-        const normalizedMapId =
-          typeof mapId === 'string' && mapId.trim() !== '' ? mapId.trim() : null;
+    useEffect(() => {
+      if (!mapPlacementState.show) {
+        setMapPlacementSaving(false);
+        setMapPlacementError(null);
+      }
+    }, [mapPlacementState.show]);
+
+    const commitEnemyMapPlacement = useCallback(
+      async ({ mapId, x, y, rotation }) => {
+        if (!mapPlacementState.show || !shouldShowCampaignTokens) {
+          return false;
+        }
+
         const normalizedCharacterId =
-          typeof characterId === 'string' && characterId.trim() !== ''
-            ? characterId.trim()
-            : mapPlacementState.enemyId;
+          typeof mapPlacementState.enemyId === 'string' && mapPlacementState.enemyId.trim() !== ''
+            ? mapPlacementState.enemyId.trim()
+            : null;
+        const candidateMapId =
+          typeof mapId === 'string' && mapId.trim() !== '' ? mapId.trim() : null;
+        const normalizedDisplayedMapId =
+          typeof displayedMap?.mapId === 'string' && displayedMap.mapId.trim() !== ''
+            ? displayedMap.mapId.trim()
+            : null;
+        const normalizedMapId = candidateMapId || normalizedDisplayedMapId;
         const clampedX = clamp01(x);
         const clampedY = clamp01(y);
         const normalizedRotation = normalizeRotation(rotation);
@@ -4036,7 +4040,44 @@ export default function ZombiesDM() {
 
         return true;
       },
-      [mapPlacementState.enemyId, persistTokenPosition]
+      [
+        displayedMap,
+        mapPlacementState.enemyId,
+        mapPlacementState.show,
+        persistTokenPosition,
+        shouldShowCampaignTokens,
+      ]
+    );
+
+    const handleMapBackgroundPlacement = useCallback(
+      async ({ x, y }) => {
+        if (!mapPlacementState.show || mapPlacementSaving) {
+          return false;
+        }
+
+        setMapPlacementSaving(true);
+        setMapPlacementError(null);
+
+        try {
+          const result = await commitEnemyMapPlacement({ x, y });
+          if (!result) {
+            setMapPlacementError('Unable to update figurine position.');
+            return false;
+          }
+
+          handleCloseMapPlacement();
+          return true;
+        } catch (error) {
+          const message =
+            (error && typeof error.message === 'string' && error.message.trim()) ||
+            'Failed to update figurine position.';
+          setMapPlacementError(message);
+          return false;
+        } finally {
+          setMapPlacementSaving(false);
+        }
+      },
+      [commitEnemyMapPlacement, handleCloseMapPlacement, mapPlacementSaving, mapPlacementState.show]
     );
 
 
@@ -5970,12 +6011,19 @@ const resolveIcon = (category, iconMap, fallback) => {
             className="zombies-dm-page__map-board"
             map={displayedMap}
             tokens={boardTokens}
-            disabled={!shouldShowCampaignTokens}
+            disabled={!shouldShowCampaignTokens || mapPlacementSaving}
             allowWheelZoom
             onTokenPositionChange={
-              shouldShowCampaignTokens ? handleTokenPositionChange : undefined
+              shouldShowCampaignTokens && !mapPlacementSaving
+                ? handleTokenPositionChange
+                : undefined
             }
             onTokenRemove={handleMapTokenRemove}
+            onBackgroundClick={
+              mapPlacementState.show && shouldShowCampaignTokens && !mapPlacementSaving
+                ? handleMapBackgroundPlacement
+                : undefined
+            }
           />
         ) : (
           <div className="zombies-dm-page__map-empty text-light">
@@ -5994,6 +6042,52 @@ const resolveIcon = (category, iconMap, fallback) => {
           >
             {status.message}
           </Alert>
+        )}
+
+        {mapPlacementState.show && (
+          <div
+            className="zombies-dm-page__map-placement-overlay"
+            data-testid="map-placement-overlay"
+          >
+            <div
+              className="zombies-dm-page__map-placement-message"
+              aria-live="polite"
+            >
+              {mapPlacementSaving ? (
+                <>
+                  <Spinner
+                    animation="border"
+                    role="status"
+                    size="sm"
+                    className="me-2"
+                  >
+                    <span className="visually-hidden">Saving figurine position…</span>
+                  </Spinner>
+                  <span>Saving figurine position…</span>
+                </>
+              ) : (
+                <span>{mapPlacementInstruction}</span>
+              )}
+            </div>
+            {mapPlacementError && (
+              <div
+                className="zombies-dm-page__map-placement-error"
+                role="alert"
+              >
+                {mapPlacementError}
+              </div>
+            )}
+            <div className="zombies-dm-page__map-placement-actions">
+              <Button
+                variant="outline-light"
+                size="sm"
+                onClick={handleCloseMapPlacement}
+                disabled={mapPlacementSaving}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
         )}
 
         {campaignTitle && (
@@ -8422,29 +8516,6 @@ const resolveIcon = (category, iconMap, fallback) => {
         actionInProgressId={mapActionLoadingId}
         activeCharacterId={activeParticipant?.characterId}
       />
-
-      <MapModal
-        show={mapPlacementState.show}
-        onHide={handleCloseMapPlacement}
-        title={
-          mapPlacementState.enemyName
-            ? `Place ${mapPlacementState.enemyName}`
-            : 'Place Enemy on Map'
-        }
-        maps={maps}
-        map={campaignMap}
-        activeMapId={activeMapId}
-        selectedMapId={selectedMapId}
-        onSelectMap={handleSelectMap}
-        tokensByMapId={modalTokensByMapId}
-        currentCharacterId={mapPlacementState.enemyId}
-        activeCharacterId={activeParticipant?.characterId}
-        characterLookup={tokenMetaById}
-        onTokenMove={handleMapModalTokenMove}
-        onTokenRemove={handleMapTokenRemove}
-        readOnly={false}
-      />
-
       <Modal
         className="dnd-modal"
         size="sm"

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1912,7 +1912,7 @@ describe('ZombiesDM AI generation', () => {
     ).toContain('Hero');
   });
 
-  test('opens map placement modal for enemies and persists placement moves', async () => {
+  test('allows the DM to place enemies directly on the campaign map surface', async () => {
     const enemies = [
       {
         enemyId: 'enemy-1',
@@ -1975,32 +1975,22 @@ describe('ZombiesDM AI generation', () => {
     await waitFor(() => expect(within(enemiesCard).getByText('Goblin')).toBeInTheDocument());
 
     const placeButton = within(enemiesCard).getByRole('button', { name: 'Place on Map' });
-
-    MapModal.mockClear();
-
+    CampaignMapBoard.mockClear();
     await userEvent.click(placeButton);
+    const overlay = await screen.findByTestId('map-placement-overlay');
+    expect(overlay).toHaveTextContent('Click the map to place Goblin.');
 
-    let placementProps;
-    await waitFor(() => {
-      const placementCalls = MapModal.mock.calls
-        .map(([props]) => props)
-        .filter((props) => props && props.readOnly === false && typeof props.onTokenMove === 'function');
-      expect(placementCalls.length).toBeGreaterThan(0);
-      placementProps = placementCalls[placementCalls.length - 1];
-      expect(placementProps.show).toBe(true);
-      expect(placementProps.currentCharacterId).toBe('enemy-1');
-    });
+    const boardCalls = CampaignMapBoard.mock.calls;
+    expect(boardCalls.length).toBeGreaterThan(0);
+    const placementBoardProps = boardCalls[boardCalls.length - 1][0];
+    expect(typeof placementBoardProps.onBackgroundClick).toBe('function');
+    expect(typeof placementBoardProps.onTokenRemove).toBe('function');
 
     apiFetch.mockClear();
 
-    await expect(
-      placementProps.onTokenMove({
-        mapId: 'map-123',
-        characterId: 'enemy-1',
-        x: 1.7,
-        y: -0.3,
-      })
-    ).resolves.toBe(true);
+    await act(async () => {
+      await placementBoardProps.onBackgroundClick({ x: 1.7, y: -0.3 });
+    });
 
     await waitFor(() => {
       expect(apiFetch).toHaveBeenCalledWith(
@@ -2013,10 +2003,16 @@ describe('ZombiesDM AI generation', () => {
       );
     });
 
+    await waitFor(() =>
+      expect(screen.queryByTestId('map-placement-overlay')).not.toBeInTheDocument()
+    );
+
     apiFetch.mockClear();
 
+    const latestBoardProps = CampaignMapBoard.mock.calls[CampaignMapBoard.mock.calls.length - 1][0];
+
     await expect(
-      placementProps.onTokenRemove({
+      latestBoardProps.onTokenRemove({
         mapId: 'map-123',
         characterId: 'enemy-1',
       })


### PR DESCRIPTION
## Summary
- replace the enemy placement modal with interactions on the full campaign map board
- surface placement instructions, status, and errors directly on the DM screen
- refresh the placement unit test to exercise the new board-based workflow and styling tweaks

## Testing
- CI=true npm test -- ZombiesDM.test *(fails with numerous pre-existing act() warnings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f58b1f14832e9718cb8371fc3644)