### PR TITLE
Extract active map enemy quick list

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -709,6 +709,84 @@
   );
 }
 
+.zombies-dm-active-enemies {
+  background-color: rgba(10, 10, 10, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 1rem;
+  padding: 1rem;
+  margin-top: 1rem;
+  color: #fff;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
+}
+
+.zombies-dm-active-enemies__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.zombies-dm-active-enemies__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.zombies-dm-active-enemies__count {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.zombies-dm-active-enemies__list {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.75rem;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.enemy-quick-card {
+  background-color: rgba(20, 20, 20, 0.85);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.enemy-quick-card__header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.enemy-quick-card__badge {
+  font-size: 0.75rem;
+}
+
+.enemy-quick-card__meta-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.enemy-quick-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.enemy-card__health-controls--compact {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.enemy-card__health-input--compact {
+  flex: 1 1 120px;
+  min-width: 90px;
+}
+
 @media (min-width: 768px) {
   .zombies-dm-container {
     padding-left: 1.5rem;

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -1,0 +1,267 @@
+import React from 'react';
+import { Card, Button, Badge } from 'react-bootstrap';
+import { FiList } from 'react-icons/fi';
+import { sanitizeIdentifierForTestId } from '../utils/sanitizeIdentifierForTestId';
+
+export function ActiveEnemyQuickCard({
+  enemy,
+  challengeText,
+  sizeDisplay,
+  armorClassDisplay,
+  maxHpValue,
+  resolvedCurrentHp,
+  healthSummary,
+  inCombat,
+  onToggleParticipant,
+  onOpenMapPlacement,
+  onViewDetails,
+  enemyHealthAdjustments,
+  enemyHealthSaving,
+  onEnemyAdjustmentInputChange,
+  onApplyEnemyHealthAdjustment,
+  onResetEnemyHealth,
+}) {
+  if (!enemy) {
+    return null;
+  }
+
+  const normalizedEnemyId =
+    typeof enemy.enemyId === 'string' && enemy.enemyId.trim() !== ''
+      ? enemy.enemyId.trim()
+      : null;
+  const adjustmentValue = normalizedEnemyId
+    ? enemyHealthAdjustments?.[normalizedEnemyId] ?? ''
+    : '';
+  const isSavingHealth = normalizedEnemyId
+    ? Boolean(enemyHealthSaving?.[normalizedEnemyId])
+    : false;
+
+  let healthPercent = null;
+  if (
+    maxHpValue !== null &&
+    maxHpValue > 0 &&
+    resolvedCurrentHp !== null &&
+    Number.isFinite(resolvedCurrentHp)
+  ) {
+    healthPercent = Math.max(
+      0,
+      Math.min(100, Math.round((resolvedCurrentHp / maxHpValue) * 100))
+    );
+  }
+
+  const healthText = healthSummary;
+  const identifier = sanitizeIdentifierForTestId(normalizedEnemyId, 'active-enemy');
+  const label = enemy.name || enemy.displayType || normalizedEnemyId || 'enemy';
+
+  return (
+    <Card
+      className="resource-card enemy-card enemy-quick-card text-start"
+      data-testid="active-map-enemy-card"
+      data-enemy-id={normalizedEnemyId || undefined}
+      id={identifier ? `active-enemy-${identifier}` : undefined}
+    >
+      <Card.Body className="d-flex flex-column gap-2">
+        <div className="enemy-quick-card__header">
+          <div className="flex-grow-1">
+            <Card.Title className="h6 mb-1">{enemy.name || 'Unnamed Enemy'}</Card.Title>
+            <Card.Subtitle className="text-muted small">
+              {[enemy.displayType, challengeText].filter(Boolean).join(' • ') || '—'}
+            </Card.Subtitle>
+          </div>
+          <Badge bg="secondary" className="enemy-quick-card__badge">
+            AC {armorClassDisplay}
+          </Badge>
+        </div>
+        <div className="enemy-quick-card__meta-line">
+          <span className="enemy-card__summary-label">Size:</span>
+          <span aria-hidden="true">{sizeDisplay}</span>
+        </div>
+        <div className="enemy-card__health">
+          <div
+            className="enemy-card__health-bar"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={maxHpValue ?? undefined}
+            aria-valuenow={resolvedCurrentHp ?? undefined}
+          >
+            <div
+              className="enemy-card__health-bar-fill"
+              style={{
+                width: `${
+                  healthPercent !== null
+                    ? healthPercent
+                    : resolvedCurrentHp !== null
+                      ? 100
+                      : 0
+                }%`,
+              }}
+            />
+          </div>
+          <div className="enemy-card__health-text">{healthText}</div>
+        </div>
+        <div
+          className="enemy-card__health-controls enemy-card__health-controls--compact"
+          role="group"
+          aria-label={`Quick health controls for ${label}`}
+        >
+          <Button
+            variant="outline-danger"
+            size="sm"
+            className="enemy-card__health-button"
+            onClick={() =>
+              normalizedEnemyId && onApplyEnemyHealthAdjustment(normalizedEnemyId, -1)
+            }
+            disabled={isSavingHealth || !normalizedEnemyId}
+            aria-label={`Damage ${label}`}
+          >
+            −
+          </Button>
+          <FormControlButtonInput
+            value={adjustmentValue}
+            disabled={isSavingHealth || !normalizedEnemyId}
+            onChange={(event) =>
+              normalizedEnemyId &&
+              onEnemyAdjustmentInputChange(normalizedEnemyId, event.target.value)
+            }
+          />
+          <Button
+            variant="outline-success"
+            size="sm"
+            className="enemy-card__health-button"
+            onClick={() =>
+              normalizedEnemyId && onApplyEnemyHealthAdjustment(normalizedEnemyId, 1)
+            }
+            disabled={isSavingHealth || !normalizedEnemyId}
+            aria-label={`Heal ${label}`}
+          >
+            +
+          </Button>
+          <Button
+            variant="outline-light"
+            size="sm"
+            className="enemy-card__health-button enemy-card__health-button--reset"
+            onClick={() => normalizedEnemyId && onResetEnemyHealth(normalizedEnemyId)}
+            disabled={isSavingHealth || maxHpValue === null || !normalizedEnemyId}
+          >
+            Reset
+          </Button>
+        </div>
+        <div className="enemy-quick-card__actions">
+          <Button
+            variant={inCombat ? 'success' : 'outline-primary'}
+            size="sm"
+            onClick={() => normalizedEnemyId && onToggleParticipant(normalizedEnemyId)}
+            disabled={!normalizedEnemyId}
+          >
+            {inCombat ? 'Remove from Combat' : 'Add to Combat'}
+          </Button>
+          <Button
+            variant="outline-light"
+            size="sm"
+            onClick={() =>
+              normalizedEnemyId &&
+              onOpenMapPlacement(
+                normalizedEnemyId,
+                enemy.name || enemy.displayType || normalizedEnemyId
+              )
+            }
+            disabled={!normalizedEnemyId}
+          >
+            Reposition
+          </Button>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => onViewDetails && normalizedEnemyId && onViewDetails(normalizedEnemyId)}
+            disabled={!onViewDetails}
+          >
+            Details
+          </Button>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+}
+
+function FormControlButtonInput({ value, disabled, onChange }) {
+  return (
+    <input
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9-]*"
+      className="form-control form-control-sm enemy-card__health-adjustment"
+      value={value}
+      disabled={disabled}
+      onChange={onChange}
+      aria-label="Health adjustment"
+    />
+  );
+}
+
+export function ActiveEnemyQuickList({
+  summaries,
+  activeMapTitle,
+  onManageEnemies,
+  onToggleParticipant,
+  onOpenMapPlacement,
+  onViewDetails,
+  enemyHealthAdjustments,
+  enemyHealthSaving,
+  onEnemyAdjustmentInputChange,
+  onApplyEnemyHealthAdjustment,
+  onResetEnemyHealth,
+}) {
+  if (!Array.isArray(summaries) || summaries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="zombies-dm-active-enemies" data-testid="active-map-enemies" aria-live="polite">
+      <div className="zombies-dm-active-enemies__header">
+        <div>
+          <div className="zombies-dm-active-enemies__label">Active Map Enemies</div>
+          <div className="zombies-dm-active-enemies__count">
+            {summaries.length === 1
+              ? '1 enemy deployed'
+              : `${summaries.length} enemies deployed`}
+            {activeMapTitle ? ` • ${activeMapTitle}` : ''}
+          </div>
+        </div>
+        <Button
+          variant="outline-light"
+          size="sm"
+          onClick={onManageEnemies}
+          className="d-inline-flex align-items-center gap-2"
+        >
+          <FiList aria-hidden="true" />
+          <span>Manage Enemies</span>
+        </Button>
+      </div>
+      <div className="zombies-dm-active-enemies__list">
+        {summaries.map((summary) => (
+          <ActiveEnemyQuickCard
+            key={summary.enemy.enemyId || summary.enemy._id}
+            enemy={summary.enemy}
+            challengeText={summary.challengeText}
+            sizeDisplay={summary.sizeDisplay}
+            armorClassDisplay={summary.armorClassDisplay}
+            maxHpValue={summary.maxHpValue}
+            resolvedCurrentHp={summary.resolvedCurrentHp}
+            healthSummary={summary.healthSummary}
+            inCombat={summary.inCombat}
+            onToggleParticipant={onToggleParticipant}
+            onOpenMapPlacement={onOpenMapPlacement}
+            onViewDetails={onViewDetails}
+            enemyHealthAdjustments={enemyHealthAdjustments}
+            enemyHealthSaving={enemyHealthSaving}
+            onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
+            onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
+            onResetEnemyHealth={onResetEnemyHealth}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ActiveEnemyQuickList;

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ActiveEnemyQuickList } from './ActiveEnemyQuickList';
+
+describe('ActiveEnemyQuickList', () => {
+  const baseSummary = {
+    enemy: { enemyId: 'enemy-1', name: 'Goblin', displayType: 'humanoid' },
+    challengeText: 'CR 1/4',
+    sizeDisplay: 'Small',
+    armorClassDisplay: '13',
+    maxHpValue: 12,
+    resolvedCurrentHp: 9,
+    healthSummary: '9 / 12',
+    inCombat: false,
+  };
+
+  const renderList = (overrides = {}) => {
+    const props = {
+      summaries: [baseSummary],
+      activeMapTitle: 'Dungeon Entrance',
+      onManageEnemies: jest.fn(),
+      onToggleParticipant: jest.fn(),
+      onOpenMapPlacement: jest.fn(),
+      onViewDetails: jest.fn(),
+      enemyHealthAdjustments: { 'enemy-1': '' },
+      enemyHealthSaving: {},
+      onEnemyAdjustmentInputChange: jest.fn(),
+      onApplyEnemyHealthAdjustment: jest.fn(),
+      onResetEnemyHealth: jest.fn(),
+      ...overrides,
+    };
+
+    render(<ActiveEnemyQuickList {...props} />);
+    return props;
+  };
+
+  it('renders a condensed list with header context and manage button', async () => {
+    const props = renderList();
+
+    expect(screen.getByText('Active Map Enemies')).toBeInTheDocument();
+    expect(screen.getByText('1 enemy deployed • Dungeon Entrance')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Manage Enemies/i }));
+
+    expect(props.onManageEnemies).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes health controls for the condensed cards', async () => {
+    const props = renderList();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Damage Goblin' }));
+    expect(props.onApplyEnemyHealthAdjustment).toHaveBeenCalledWith('enemy-1', -1);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Heal Goblin' }));
+    expect(props.onApplyEnemyHealthAdjustment).toHaveBeenCalledWith('enemy-1', 1);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reset' }));
+    expect(props.onResetEnemyHealth).toHaveBeenCalledWith('enemy-1');
+
+    const input = screen.getByLabelText('Health adjustment');
+    await userEvent.clear(input);
+    await userEvent.type(input, '5');
+    expect(props.onEnemyAdjustmentInputChange).toHaveBeenLastCalledWith('enemy-1', '5');
+  });
+
+  it('passes interaction callbacks for combat, placement, and details', async () => {
+    const props = renderList();
+
+    await userEvent.click(screen.getByRole('button', { name: /Add to Combat/i }));
+    expect(props.onToggleParticipant).toHaveBeenCalledWith('enemy-1');
+
+    await userEvent.click(screen.getByRole('button', { name: /Reposition/i }));
+    expect(props.onOpenMapPlacement).toHaveBeenCalledWith('enemy-1', 'Goblin');
+
+    await userEvent.click(screen.getByRole('button', { name: /Details/i }));
+    expect(props.onViewDetails).toHaveBeenCalledWith('enemy-1');
+  });
+
+  it('renders nothing when summaries are empty', () => {
+    renderList({ summaries: [] });
+    expect(screen.queryByTestId('active-map-enemies')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js
@@ -1,0 +1,84 @@
+import { createActiveMapEnemySummaries } from './ZombiesDM';
+
+describe('createActiveMapEnemySummaries', () => {
+  const baseOptions = {
+    tokenMetaById: {},
+    participantLookup: new Map(),
+    formatArmorClass: () => '—',
+    formatChallengeRatingValue: (value) => value,
+  };
+
+  it('returns an empty array when no enemy tokens exist on the active map', () => {
+    const results = createActiveMapEnemySummaries({
+      ...baseOptions,
+      activeMapTokens: {
+        'enemy-1': { characterId: 'enemy-1' },
+      },
+      enemies: [
+        { enemyId: 'enemy-1', name: 'Goblin', hitPoints: 7, armorClass: [{ value: 13 }] },
+      ],
+      tokenMetaById: {
+        'enemy-1': { entityType: 'character' },
+      },
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it('summarizes enemy data for tokens on the active map', () => {
+    const participantLookup = new Map([["enemy-1", { characterId: 'enemy-1' }]]);
+
+    const results = createActiveMapEnemySummaries({
+      ...baseOptions,
+      activeMapTokens: {
+        'enemy-1': { characterId: 'enemy-1' },
+      },
+      tokenMetaById: {
+        'enemy-1': { entityType: 'enemy' },
+      },
+      enemies: [
+        {
+          enemyId: 'enemy-1',
+          name: 'Goblin',
+          size: 'Small',
+          hitPoints: 12,
+          armorClass: [{ value: 13 }],
+          challengeRating: 0.25,
+        },
+      ],
+      participantLookup,
+      formatArmorClass: () => '13',
+      formatChallengeRatingValue: (value) => (value === 0.25 ? '1/4' : value),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      challengeText: 'CR 1/4',
+      sizeDisplay: 'Small',
+      armorClassDisplay: '13',
+      healthSummary: '12 / 12',
+      inCombat: true,
+    });
+  });
+
+  it('sorts summaries alphabetically by enemy name', () => {
+    const results = createActiveMapEnemySummaries({
+      ...baseOptions,
+      activeMapTokens: {
+        'enemy-a': { characterId: 'enemy-a' },
+        'enemy-b': { characterId: 'enemy-b' },
+      },
+      tokenMetaById: {
+        'enemy-a': { entityType: 'enemy' },
+        'enemy-b': { entityType: 'enemy' },
+      },
+      enemies: [
+        { enemyId: 'enemy-b', name: 'Zombie', hitPoints: 10 },
+        { enemyId: 'enemy-a', name: 'Acolyte', hitPoints: 10 },
+      ],
+    });
+
+    const names = results.map((entry) => entry.enemy.name);
+    expect(names).toEqual(['Acolyte', 'Zombie']);
+  });
+});

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -66,7 +66,9 @@ import { FiChevronDown, FiChevronRight, FiList, FiPlus } from "react-icons/fi";
 import { groupMapsByFolder, UNGROUPED_FOLDER_KEY } from "../utils/mapGrouping";
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import TokenPickerModal from '../components/TokenPickerModal';
+import ActiveEnemyQuickList from '../components/ActiveEnemyQuickList';
 import { buildEnemyTokenFilterScopeValues } from '../utils/enemyTokenFilters';
+import { sanitizeIdentifierForTestId } from '../utils/sanitizeIdentifierForTestId';
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -871,6 +873,129 @@ const normalizeCombatState = (state) => {
   return { participants: sortedParticipants, activeTurn };
 };
 
+export const createActiveMapEnemySummaries = ({
+  activeMapTokens,
+  enemies,
+  tokenMetaById = {},
+  participantLookup,
+  formatArmorClass,
+  formatChallengeRatingValue,
+}) => {
+  if (
+    !Array.isArray(enemies) ||
+    enemies.length === 0 ||
+    !activeMapTokens ||
+    typeof activeMapTokens !== 'object'
+  ) {
+    return [];
+  }
+
+  const activeEnemyIds = new Set();
+  Object.entries(activeMapTokens).forEach(([key, token]) => {
+    const candidateId =
+      (typeof key === 'string' && key.trim()) ||
+      (typeof token?.characterId === 'string' && token.characterId.trim()) ||
+      null;
+    if (!candidateId) {
+      return;
+    }
+
+    const meta = tokenMetaById?.[candidateId];
+    if (meta?.entityType === 'enemy') {
+      activeEnemyIds.add(candidateId);
+    }
+  });
+
+  if (activeEnemyIds.size === 0) {
+    return [];
+  }
+
+  const summaries = enemies
+    .filter((enemy) => {
+      if (!enemy || typeof enemy.enemyId !== 'string') {
+        return false;
+      }
+      const trimmedId = enemy.enemyId.trim();
+      if (!trimmedId) {
+        return false;
+      }
+      return activeEnemyIds.has(trimmedId);
+    })
+    .map((enemy) => {
+      const resolvedChallengeValue =
+        typeof formatChallengeRatingValue === 'function'
+          ? formatChallengeRatingValue(enemy.challengeRating)
+          : enemy.challengeRating;
+      const challengeText =
+        enemy.challengeRating !== null && enemy.challengeRating !== undefined
+          ? `CR ${resolvedChallengeValue}`
+          : null;
+      const sizeDisplay = enemy.size || enemy.displayType || '—';
+      const armorClassDisplay =
+        typeof formatArmorClass === 'function'
+          ? formatArmorClass(enemy.armorClass)
+          : '—';
+      const maxHpValue = toFiniteNumberOrNull(enemy.maxHp ?? enemy.hitPoints);
+      const currentHpCandidate =
+        enemy.currentHp !== undefined
+          ? toFiniteNumberOrNull(enemy.currentHp)
+          : null;
+      const resolvedCurrentHp =
+        currentHpCandidate !== null
+          ? currentHpCandidate
+          : maxHpValue !== null
+            ? maxHpValue
+            : null;
+      const healthSummary =
+        maxHpValue !== null
+          ? `${resolvedCurrentHp !== null ? resolvedCurrentHp : '—'} / ${maxHpValue}`
+          : resolvedCurrentHp !== null
+            ? `${resolvedCurrentHp}`
+            : '—';
+
+      let inCombat = false;
+      if (enemy.enemyId) {
+        if (participantLookup && typeof participantLookup.get === 'function') {
+          inCombat = Boolean(participantLookup.get(enemy.enemyId));
+        } else if (
+          participantLookup &&
+          typeof participantLookup === 'object' &&
+          enemy.enemyId in participantLookup
+        ) {
+          inCombat = Boolean(participantLookup[enemy.enemyId]);
+        }
+      }
+
+      return {
+        enemy,
+        challengeText,
+        sizeDisplay,
+        armorClassDisplay,
+        maxHpValue,
+        resolvedCurrentHp,
+        healthSummary,
+        inCombat,
+      };
+    });
+
+  summaries.sort((a, b) => {
+    const nameA = (a.enemy?.name || '').toLowerCase();
+    const nameB = (b.enemy?.name || '').toLowerCase();
+    if (nameA && nameB) {
+      return nameA.localeCompare(nameB);
+    }
+    if (nameA) {
+      return -1;
+    }
+    if (nameB) {
+      return 1;
+    }
+    return 0;
+  });
+
+  return summaries;
+};
+
 const applyDerivedInitiativesToParticipants = (participants, initiativeMap) => {
   if (!Array.isArray(participants) || !initiativeMap || initiativeMap.size === 0) {
     return participants;
@@ -1048,13 +1173,6 @@ const getNormalizedIdentifiers = (entity) => {
     identifiers.push(entity.characterId.trim());
   }
   return Array.from(new Set(identifiers));
-};
-
-const sanitizeIdentifierForTestId = (value, fallback) => {
-  if (typeof value === 'string' && value.trim() !== '') {
-    return value.trim().replace(/[^0-9A-Za-z_-]/g, '-');
-  }
-  return fallback;
 };
 
 export const matchesCharacterIdentifier = (record, normalizedCharacterId) => {
@@ -3759,6 +3877,21 @@ export default function ZombiesDM() {
 
     const displayedMap = generatedMap || previewMap || campaignMap;
 
+    const activeMapTitle = useMemo(() => {
+      if (campaignMap) {
+        return getMapDisplayTitle(campaignMap, DEFAULT_MAP_TITLE);
+      }
+      if (
+        displayedMap &&
+        typeof displayedMap.mapId === 'string' &&
+        typeof activeMapId === 'string' &&
+        displayedMap.mapId.trim() === activeMapId.trim()
+      ) {
+        return getMapDisplayTitle(displayedMap, DEFAULT_MAP_TITLE);
+      }
+      return null;
+    }, [activeMapId, campaignMap, displayedMap]);
+
     const shouldShowCampaignTokens = useMemo(() => {
       const normalizedDisplayedMapId =
         typeof displayedMap?.mapId === 'string' && displayedMap.mapId.trim() !== ''
@@ -3921,6 +4054,26 @@ export default function ZombiesDM() {
       mapTokens,
       tokenMetaById,
     ]);
+
+    const activeMapEnemySummaries = useMemo(
+      () =>
+        createActiveMapEnemySummaries({
+          activeMapTokens,
+          enemies,
+          tokenMetaById,
+          participantLookup,
+          formatArmorClass,
+          formatChallengeRatingValue,
+        }),
+      [
+        activeMapTokens,
+        enemies,
+        formatArmorClass,
+        formatChallengeRatingValue,
+        participantLookup,
+        tokenMetaById,
+      ]
+    );
 
     const placementEnemyName = useMemo(() => {
       if (typeof mapPlacementState.enemyName === 'string' && mapPlacementState.enemyName.trim() !== '') {
@@ -4086,6 +4239,10 @@ export default function ZombiesDM() {
 
       setActiveResourceTab((current) => (current === key ? null : key));
     }, []);
+
+    const handleShowEnemiesTab = useCallback(() => {
+      setActiveResourceTab('enemies');
+    }, [setActiveResourceTab]);
 
     const handleOpenMapPlacement = useCallback(
       (enemyId, enemyName) => {
@@ -6103,6 +6260,20 @@ const resolveIcon = (category, iconMap, fallback) => {
             </span>
           </div>
         )}
+
+        <ActiveEnemyQuickList
+          summaries={activeMapEnemySummaries}
+          activeMapTitle={activeMapTitle}
+          onManageEnemies={handleShowEnemiesTab}
+          onToggleParticipant={handleToggleParticipant}
+          onOpenMapPlacement={handleOpenMapPlacement}
+          onViewDetails={handleShowEnemiesTab}
+          enemyHealthAdjustments={enemyHealthAdjustments}
+          enemyHealthSaving={enemyHealthSaving}
+          onEnemyAdjustmentInputChange={handleEnemyAdjustmentInputChange}
+          onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
+          onResetEnemyHealth={handleResetEnemyHealth}
+        />
       </div>
 
       <div

--- a/client/src/components/Zombies/utils/sanitizeIdentifierForTestId.js
+++ b/client/src/components/Zombies/utils/sanitizeIdentifierForTestId.js
@@ -1,0 +1,17 @@
+export const sanitizeIdentifierForTestId = (value, fallback = '') => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-');
+  }
+  if (typeof fallback === 'string' && fallback.trim() !== '') {
+    return fallback
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-');
+  }
+  return '';
+};
+
+export default sanitizeIdentifierForTestId;


### PR DESCRIPTION
## Summary
- extract the active enemy quick card markup into a dedicated `ActiveEnemyQuickList` component and reuse it inside `ZombiesDM`
- add a `createActiveMapEnemySummaries` helper plus a shared `sanitizeIdentifierForTestId` utility so the quick list can be unit tested
- replace the brittle DM integration test with focused tests that cover the quick list interactions and the active map summary logic

## Testing
- CI=true npm test -- --runTestsByPath client/src/components/Zombies/components/ActiveEnemyQuickList.test.js client/src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915116c037c832e8e2008f0cf44184f)