### PR TITLE
Fix ActiveEnemyQuickList hook usage

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -211,11 +211,12 @@ export function ActiveEnemyQuickList({
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
 }) {
+  const [isCollapsed, setIsCollapsed] = React.useState(false);
+
   if (!Array.isArray(summaries) || summaries.length === 0) {
     return null;
   }
 
-  const [isCollapsed, setIsCollapsed] = React.useState(false);
   const collapseButtonLabel = isCollapsed
     ? 'Expand active enemy display'
     : 'Collapse active enemy display';


### PR DESCRIPTION
## Summary
- move the ActiveEnemyQuickList collapse state hook so it always runs
- avoid conditional hook invocation when the summaries list is empty

## Testing
- npm run lint *(fails: script not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151f7362f4832e90046d9c64d46f1c)