### PR TITLE
Add combat control buttons to active enemy quick list

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -202,6 +202,10 @@ export function ActiveEnemyQuickList({
   summaries,
   activeMapTitle,
   onManageEnemies,
+  onResetInitiative,
+  onRollInitiative,
+  onAdvanceTurn,
+  combatControlsDisabled = false,
   onToggleParticipant,
   onOpenMapPlacement,
   onViewDetails,
@@ -240,6 +244,50 @@ export function ActiveEnemyQuickList({
           </div>
         </div>
         <div className="zombies-dm-active-enemies__actions">
+          {(onResetInitiative || onRollInitiative || onAdvanceTurn) && (
+            <div className="d-inline-flex align-items-center gap-2 me-2">
+              {onResetInitiative && (
+                <Button
+                  variant="outline-light"
+                  size="sm"
+                  onClick={onResetInitiative}
+                  disabled={combatControlsDisabled}
+                >
+                  Clear Initiative
+                </Button>
+              )}
+              {onRollInitiative && (
+                <Button
+                  variant="outline-light"
+                  size="sm"
+                  onClick={onRollInitiative}
+                  disabled={combatControlsDisabled}
+                >
+                  Roll Initiative
+                </Button>
+              )}
+              {onAdvanceTurn && (
+                <>
+                  <Button
+                    variant="outline-light"
+                    size="sm"
+                    onClick={() => onAdvanceTurn(-1)}
+                    disabled={combatControlsDisabled}
+                  >
+                    Previous Turn
+                  </Button>
+                  <Button
+                    variant="outline-light"
+                    size="sm"
+                    onClick={() => onAdvanceTurn(1)}
+                    disabled={combatControlsDisabled}
+                  >
+                    Next Turn
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
           <Button
             variant="outline-light"
             size="sm"

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -20,6 +20,10 @@ describe('ActiveEnemyQuickList', () => {
       summaries: [baseSummary],
       activeMapTitle: 'Dungeon Entrance',
       onManageEnemies: jest.fn(),
+      onResetInitiative: jest.fn(),
+      onRollInitiative: jest.fn(),
+      onAdvanceTurn: jest.fn(),
+      combatControlsDisabled: false,
       onToggleParticipant: jest.fn(),
       onOpenMapPlacement: jest.fn(),
       onViewDetails: jest.fn(),
@@ -67,6 +71,22 @@ describe('ActiveEnemyQuickList', () => {
     });
 
     expect(list).toBeVisible();
+  });
+
+  it('exposes combat control buttons when callbacks are provided', async () => {
+    const props = renderList();
+
+    await userEvent.click(screen.getByRole('button', { name: /Clear Initiative/i }));
+    expect(props.onResetInitiative).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', { name: /Roll Initiative/i }));
+    expect(props.onRollInitiative).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', { name: /Previous Turn/i }));
+    expect(props.onAdvanceTurn).toHaveBeenCalledWith(-1);
+
+    await userEvent.click(screen.getByRole('button', { name: /Next Turn/i }));
+    expect(props.onAdvanceTurn).toHaveBeenCalledWith(1);
   });
 
   it('exposes health controls for the condensed cards', async () => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6388,6 +6388,10 @@ const resolveIcon = (category, iconMap, fallback) => {
           summaries={activeMapEnemySummaries}
           activeMapTitle={activeMapTitle}
           onManageEnemies={handleShowEnemiesTab}
+          onResetInitiative={handleResetInitiative}
+          onRollInitiative={handleRollInitiative}
+          onAdvanceTurn={handleAdvanceTurn}
+          combatControlsDisabled={combatParticipantCount === 0}
           onToggleParticipant={handleToggleParticipant}
           onOpenMapPlacement={handleOpenMapPlacement}
           onViewDetails={handleShowEnemiesTab}


### PR DESCRIPTION
## Summary
- add combat control buttons to the active enemy quick list header when handlers are provided
- wire the DM page combat actions through to the active enemy list and disable them when no participants are available
- extend component tests to cover the new controls

## Testing
- CI=true npm test -- ActiveEnemyQuickList

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916621a17a0832ea3e2ac041c4361bd)