### PR TITLE
Highlight active enemy card in DM quick list

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -793,8 +793,25 @@
   align-items: flex-start;
 }
 
+.enemy-quick-card__badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
 .enemy-quick-card__badge {
   font-size: 0.75rem;
+}
+
+.enemy-quick-card__active-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-inline: 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.35);
 }
 
 .enemy-quick-card__meta-line {
@@ -802,6 +819,15 @@
   justify-content: space-between;
   gap: 0.5rem;
   font-size: 0.85rem;
+}
+
+.enemy-quick-card--active-turn {
+  border-color: rgba(255, 193, 7, 0.85);
+  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.3);
+}
+
+.enemy-quick-card--active-turn .enemy-card__health-bar-fill {
+  background: var(--bs-warning);
 }
 
 .enemy-quick-card__actions {

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -12,6 +12,7 @@ export function ActiveEnemyQuickCard({
   resolvedCurrentHp,
   healthSummary,
   inCombat,
+  isActiveTurn = false,
   onToggleParticipant,
   onOpenMapPlacement,
   onViewDetails,
@@ -52,13 +53,23 @@ export function ActiveEnemyQuickCard({
   const healthText = healthSummary;
   const identifier = sanitizeIdentifierForTestId(normalizedEnemyId, 'active-enemy');
   const label = enemy.name || enemy.displayType || normalizedEnemyId || 'enemy';
+  const cardClassName = [
+    'resource-card',
+    'enemy-card',
+    'enemy-quick-card',
+    'text-start',
+    isActiveTurn ? 'enemy-quick-card--active-turn' : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <Card
-      className="resource-card enemy-card enemy-quick-card text-start"
+      className={cardClassName}
       data-testid="active-map-enemy-card"
       data-enemy-id={normalizedEnemyId || undefined}
       id={identifier ? `active-enemy-${identifier}` : undefined}
+      aria-current={isActiveTurn ? 'true' : undefined}
     >
       <Card.Body className="d-flex flex-column gap-2">
         <div className="enemy-quick-card__header">
@@ -68,9 +79,16 @@ export function ActiveEnemyQuickCard({
               {[enemy.displayType, challengeText].filter(Boolean).join(' • ') || '—'}
             </Card.Subtitle>
           </div>
-          <Badge bg="secondary" className="enemy-quick-card__badge">
-            AC {armorClassDisplay}
-          </Badge>
+          <div className="enemy-quick-card__badges">
+            {isActiveTurn && (
+              <Badge bg="warning" text="dark" className="enemy-quick-card__active-badge">
+                Active Turn
+              </Badge>
+            )}
+            <Badge bg="secondary" className="enemy-quick-card__badge">
+              AC {armorClassDisplay}
+            </Badge>
+          </div>
         </div>
         <div className="enemy-quick-card__meta-line">
           <span className="enemy-card__summary-label">Size:</span>
@@ -332,12 +350,13 @@ export function ActiveEnemyQuickList({
             onOpenMapPlacement={onOpenMapPlacement}
             onViewDetails={onViewDetails}
             enemyHealthAdjustments={enemyHealthAdjustments}
-            enemyHealthSaving={enemyHealthSaving}
-            onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
-            onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
-            onResetEnemyHealth={onResetEnemyHealth}
-          />
-        ))}
+          enemyHealthSaving={enemyHealthSaving}
+          onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
+          onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
+          onResetEnemyHealth={onResetEnemyHealth}
+          isActiveTurn={summary.isActiveTurn}
+        />
+      ))}
       </div>
     </div>
   );

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -124,4 +124,12 @@ describe('ActiveEnemyQuickList', () => {
     renderList({ summaries: [] });
     expect(screen.queryByTestId('active-map-enemies')).not.toBeInTheDocument();
   });
+
+  it('highlights the active enemy card', () => {
+    renderList({ summaries: [{ ...baseSummary, isActiveTurn: true }] });
+
+    const card = screen.getByTestId('active-map-enemy-card');
+    expect(card).toHaveClass('enemy-quick-card--active-turn');
+    expect(screen.getByText('Active Turn')).toBeInTheDocument();
+  });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js
@@ -6,6 +6,7 @@ describe('createActiveMapEnemySummaries', () => {
     participantLookup: new Map(),
     formatArmorClass: () => '—',
     formatChallengeRatingValue: (value) => value,
+    activeParticipantId: null,
   };
 
   it('returns an empty array when no enemy tokens exist on the active map', () => {
@@ -59,6 +60,31 @@ describe('createActiveMapEnemySummaries', () => {
       healthSummary: '12 / 12',
       inCombat: true,
     });
+    expect(results[0].isActiveTurn).not.toBe(true);
+  });
+
+  it('marks the enemy whose turn is active', () => {
+    const results = createActiveMapEnemySummaries({
+      ...baseOptions,
+      activeParticipantId: 'enemy-2',
+      activeMapTokens: {
+        'enemy-1': { characterId: 'enemy-1' },
+        'enemy-2': { characterId: 'enemy-2' },
+      },
+      tokenMetaById: {
+        'enemy-1': { entityType: 'enemy' },
+        'enemy-2': { entityType: 'enemy' },
+      },
+      enemies: [
+        { enemyId: 'enemy-1', name: 'Goblin', hitPoints: 7 },
+        { enemyId: 'enemy-2', name: 'Orc', hitPoints: 15 },
+      ],
+    });
+
+    const active = results.find((entry) => entry.enemy.enemyId === 'enemy-2');
+    expect(active?.isActiveTurn).toBe(true);
+    const inactive = results.find((entry) => entry.enemy.enemyId === 'enemy-1');
+    expect(inactive?.isActiveTurn).not.toBe(true);
   });
 
   it('sorts summaries alphabetically by enemy name', () => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -881,6 +881,7 @@ export const createActiveMapEnemySummaries = ({
   participantLookup,
   formatArmorClass,
   formatChallengeRatingValue,
+  activeParticipantId,
 }) => {
   if (
     !Array.isArray(enemies) ||
@@ -910,6 +911,11 @@ export const createActiveMapEnemySummaries = ({
   if (activeEnemyIds.size === 0) {
     return [];
   }
+
+  const normalizedActiveParticipantId =
+    typeof activeParticipantId === 'string' && activeParticipantId.trim() !== ''
+      ? activeParticipantId.trim()
+      : null;
 
   const summaries = enemies
     .filter((enemy) => {
@@ -967,6 +973,15 @@ export const createActiveMapEnemySummaries = ({
         }
       }
 
+      const normalizedEnemyId =
+        typeof enemy.enemyId === 'string' && enemy.enemyId.trim() !== ''
+          ? enemy.enemyId.trim()
+          : null;
+      const isActiveTurn =
+        normalizedEnemyId &&
+        normalizedActiveParticipantId &&
+        normalizedEnemyId === normalizedActiveParticipantId;
+
       return {
         enemy,
         challengeText,
@@ -976,6 +991,7 @@ export const createActiveMapEnemySummaries = ({
         resolvedCurrentHp,
         healthSummary,
         inCombat,
+        ...(isActiveTurn ? { isActiveTurn: true } : {}),
       };
     });
 
@@ -4180,6 +4196,7 @@ export default function ZombiesDM() {
           participantLookup,
           formatArmorClass,
           formatChallengeRatingValue,
+          activeParticipantId: activeParticipant?.characterId,
         }),
       [
         activeMapTokens,
@@ -4187,6 +4204,7 @@ export default function ZombiesDM() {
         formatArmorClass,
         formatChallengeRatingValue,
         participantLookup,
+        activeParticipant?.characterId,
         tokenMetaById,
       ]
     );


### PR DESCRIPTION
## Summary
- surface the active combatant in `createActiveMapEnemySummaries` so quick cards know when a turn is active
- highlight the matching active enemy card with a badge, aria hint, and updated styling for quicker recognition
- extend the unit tests to cover the new active turn behaviour

## Testing
- CI=1 npm test -- --runTestsByPath src/components/Zombies/components/ActiveEnemyQuickList.test.js src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691663c90458832ea2cfb861343149a0)