### PR TITLE
Add attacks to active enemy quick cards

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -21,6 +21,10 @@ export function ActiveEnemyQuickCard({
   onEnemyAdjustmentInputChange,
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
+  onEnemyDamageRoll,
+  formatAttackBonus,
+  getEnemyActionDamageString,
+  latestEnemyRoll,
 }) {
   if (!enemy) {
     return null;
@@ -164,6 +168,17 @@ export function ActiveEnemyQuickCard({
             Reset
           </Button>
         </div>
+        {Array.isArray(enemy?.actions) && enemy.actions.length > 0 && (
+          <EnemyQuickAttacksSection
+            enemy={enemy}
+            actions={enemy.actions}
+            normalizedEnemyId={normalizedEnemyId}
+            onEnemyDamageRoll={onEnemyDamageRoll}
+            formatAttackBonus={formatAttackBonus}
+            getEnemyActionDamageString={getEnemyActionDamageString}
+            latestEnemyRoll={latestEnemyRoll}
+          />
+        )}
         <div className="enemy-quick-card__actions">
           <Button
             variant={inCombat ? 'success' : 'outline-primary'}
@@ -216,6 +231,102 @@ function FormControlButtonInput({ value, disabled, onChange }) {
   );
 }
 
+function EnemyQuickAttacksSection({
+  enemy,
+  actions,
+  normalizedEnemyId,
+  onEnemyDamageRoll,
+  formatAttackBonus,
+  getEnemyActionDamageString,
+  latestEnemyRoll,
+}) {
+  const quickAttacks = React.useMemo(() => {
+    if (!Array.isArray(actions) || actions.length === 0) {
+      return [];
+    }
+
+    return actions
+      .map((action, index) => {
+        const actionLabel = action?.name || 'Action';
+        const damageDisplay =
+          typeof getEnemyActionDamageString === 'function'
+            ? getEnemyActionDamageString(action)
+            : null;
+
+        if (!damageDisplay) {
+          return null;
+        }
+
+        const attackBonusDisplay =
+          typeof formatAttackBonus === 'function'
+            ? formatAttackBonus(action?.attack_bonus)
+            : null;
+        const actionKey = `${normalizedEnemyId || 'enemy'}-${actionLabel}-${index}`;
+        const isLatestRoll =
+          latestEnemyRoll &&
+          latestEnemyRoll.enemyId === normalizedEnemyId &&
+          latestEnemyRoll.actionName === actionLabel;
+
+        return {
+          action,
+          actionLabel,
+          attackBonusDisplay,
+          damageDisplay,
+          actionKey,
+          isLatestRoll,
+        };
+      })
+      .filter(Boolean);
+  }, [actions, formatAttackBonus, getEnemyActionDamageString, latestEnemyRoll, normalizedEnemyId]);
+
+  if (quickAttacks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="enemy-quick-card__attacks">
+      <div className="enemy-card__section-title text-uppercase text-muted small fw-semibold mb-2">
+        Attacks
+      </div>
+      <div className="d-flex flex-column gap-2">
+        {quickAttacks.map(({
+          action,
+          actionLabel,
+          attackBonusDisplay,
+          damageDisplay,
+          actionKey,
+          isLatestRoll,
+        }) => (
+          <div key={actionKey} className="enemy-card__attack enemy-card__attack--compact">
+            <div className="enemy-card__attack-header">
+              <div className="fw-semibold small text-body">{actionLabel}</div>
+              <div className="small text-muted">Attack Bonus: {attackBonusDisplay ?? '—'}</div>
+              <div className="small text-muted">Damage: {damageDisplay || '—'}</div>
+            </div>
+            <div className="enemy-card__attack-actions">
+              <Button
+                variant="outline-primary"
+                size="sm"
+                onClick={() =>
+                  normalizedEnemyId && onEnemyDamageRoll && onEnemyDamageRoll(enemy, action)
+                }
+                disabled={!onEnemyDamageRoll || !normalizedEnemyId}
+              >
+                Roll
+              </Button>
+            </div>
+            {isLatestRoll && latestEnemyRoll?.breakdown && (
+              <div className="mt-2 small fw-semibold text-primary">
+                {`Result: ${latestEnemyRoll.total} damage (${latestEnemyRoll.breakdown})`}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function ActiveEnemyQuickList({
   summaries,
   activeMapTitle,
@@ -232,6 +343,10 @@ export function ActiveEnemyQuickList({
   onEnemyAdjustmentInputChange,
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
+  onEnemyDamageRoll,
+  formatAttackBonus,
+  getEnemyActionDamageString,
+  latestEnemyRoll,
 }) {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
 
@@ -350,13 +465,17 @@ export function ActiveEnemyQuickList({
             onOpenMapPlacement={onOpenMapPlacement}
             onViewDetails={onViewDetails}
             enemyHealthAdjustments={enemyHealthAdjustments}
-          enemyHealthSaving={enemyHealthSaving}
-          onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
-          onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
-          onResetEnemyHealth={onResetEnemyHealth}
-          isActiveTurn={summary.isActiveTurn}
-        />
-      ))}
+            enemyHealthSaving={enemyHealthSaving}
+            onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
+            onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
+            onResetEnemyHealth={onResetEnemyHealth}
+            isActiveTurn={summary.isActiveTurn}
+            onEnemyDamageRoll={onEnemyDamageRoll}
+            formatAttackBonus={formatAttackBonus}
+            getEnemyActionDamageString={getEnemyActionDamageString}
+            latestEnemyRoll={latestEnemyRoll}
+          />
+        ))}
       </div>
     </div>
   );

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -32,6 +32,10 @@ describe('ActiveEnemyQuickList', () => {
       onEnemyAdjustmentInputChange: jest.fn(),
       onApplyEnemyHealthAdjustment: jest.fn(),
       onResetEnemyHealth: jest.fn(),
+      formatAttackBonus: undefined,
+      getEnemyActionDamageString: undefined,
+      onEnemyDamageRoll: undefined,
+      latestEnemyRoll: undefined,
       ...overrides,
     };
 
@@ -131,5 +135,52 @@ describe('ActiveEnemyQuickList', () => {
     const card = screen.getByTestId('active-map-enemy-card');
     expect(card).toHaveClass('enemy-quick-card--active-turn');
     expect(screen.getByText('Active Turn')).toBeInTheDocument();
+  });
+
+  it('displays attack actions with roll controls when available', async () => {
+    const formatAttackBonus = jest.fn((bonus) => (bonus >= 0 ? `+${bonus}` : `${bonus}`));
+    const getEnemyActionDamageString = jest.fn((action) =>
+      action?.name === 'Scimitar' ? '1d6 slashing' : null
+    );
+    const onEnemyDamageRoll = jest.fn();
+    const latestEnemyRoll = {
+      enemyId: 'enemy-1',
+      actionName: 'Scimitar',
+      total: 11,
+      breakdown: '1d6 (8) + 3',
+    };
+
+    const props = renderList({
+      formatAttackBonus,
+      getEnemyActionDamageString,
+      onEnemyDamageRoll,
+      latestEnemyRoll,
+      summaries: [
+        {
+          ...baseSummary,
+          enemy: {
+            ...baseSummary.enemy,
+            actions: [
+              { name: 'Scimitar', attack_bonus: 4 },
+              { name: 'Hide' },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(screen.getByText('Attacks')).toBeInTheDocument();
+    expect(screen.getByText('Scimitar')).toBeInTheDocument();
+    expect(screen.getByText('Attack Bonus: +4')).toBeInTheDocument();
+    expect(screen.getByText('Damage: 1d6 slashing')).toBeInTheDocument();
+
+    const rollButton = screen.getByRole('button', { name: /^Roll$/i });
+    await userEvent.click(rollButton);
+
+    expect(props.onEnemyDamageRoll).toHaveBeenCalledWith(
+      expect.objectContaining({ enemyId: 'enemy-1' }),
+      expect.objectContaining({ name: 'Scimitar' })
+    );
+    expect(screen.getByText('Result: 11 damage (1d6 (8) + 3)')).toBeInTheDocument();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6418,6 +6418,10 @@ const resolveIcon = (category, iconMap, fallback) => {
           onEnemyAdjustmentInputChange={handleEnemyAdjustmentInputChange}
           onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
           onResetEnemyHealth={handleResetEnemyHealth}
+          onEnemyDamageRoll={handleEnemyDamageRoll}
+          formatAttackBonus={formatAttackBonus}
+          getEnemyActionDamageString={getEnemyActionDamageString}
+          latestEnemyRoll={latestEnemyRoll}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- show each enemy attack within the active enemy quick cards, including damage and attack bonus details
- reuse the DM page attack rolling workflow from the quick cards, including latest roll feedback
- cover the new quick attack controls with unit tests

## Testing
- npm test -- ActiveEnemyQuickList --watchAll=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691666f30b68832ea1f6422d5c9abe66)