### PR TITLE
Display quick enemy attacks in a modal

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Button, Badge } from 'react-bootstrap';
+import { Card, Button, Badge, Modal } from 'react-bootstrap';
 import { FiList, FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import { sanitizeIdentifierForTestId } from '../utils/sanitizeIdentifierForTestId';
 
@@ -21,10 +21,16 @@ export function ActiveEnemyQuickCard({
   onEnemyAdjustmentInputChange,
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
+  onEnemyDamageRoll,
+  formatAttackBonus,
+  getEnemyActionDamageString,
+  latestEnemyRoll,
 }) {
   if (!enemy) {
     return null;
   }
+
+  const [showAttacksModal, setShowAttacksModal] = React.useState(false);
 
   const normalizedEnemyId =
     typeof enemy.enemyId === 'string' && enemy.enemyId.trim() !== ''
@@ -62,6 +68,59 @@ export function ActiveEnemyQuickCard({
   ]
     .filter(Boolean)
     .join(' ');
+
+  const quickAttacks = React.useMemo(() => {
+    if (!Array.isArray(enemy?.actions) || enemy.actions.length === 0) {
+      return [];
+    }
+
+    return enemy.actions
+      .map((action, index) => {
+        const actionLabel = action?.name || 'Action';
+        const damageDisplay =
+          typeof getEnemyActionDamageString === 'function'
+            ? getEnemyActionDamageString(action)
+            : null;
+
+        if (!damageDisplay) {
+          return null;
+        }
+
+        const attackBonusDisplay =
+          typeof formatAttackBonus === 'function'
+            ? formatAttackBonus(action?.attack_bonus)
+            : null;
+        const actionKey = `${normalizedEnemyId || 'enemy'}-${actionLabel}-${index}`;
+        const isLatestRoll =
+          latestEnemyRoll &&
+          latestEnemyRoll.enemyId === normalizedEnemyId &&
+          latestEnemyRoll.actionName === actionLabel;
+
+        return {
+          action,
+          actionLabel,
+          attackBonusDisplay,
+          damageDisplay,
+          actionKey,
+          isLatestRoll,
+        };
+      })
+      .filter(Boolean);
+  }, [
+    enemy?.actions,
+    formatAttackBonus,
+    getEnemyActionDamageString,
+    latestEnemyRoll,
+    normalizedEnemyId,
+  ]);
+
+  const hasQuickAttacks = quickAttacks.length > 0;
+
+  React.useEffect(() => {
+    if (!hasQuickAttacks && showAttacksModal) {
+      setShowAttacksModal(false);
+    }
+  }, [hasQuickAttacks, showAttacksModal]);
 
   return (
     <Card
@@ -173,8 +232,30 @@ export function ActiveEnemyQuickCard({
           >
             {inCombat ? 'Remove from Combat' : 'Add to Combat'}
           </Button>
+          {hasQuickAttacks && (
+            <>
+              <Button
+                variant="outline-primary"
+                size="sm"
+                onClick={() => setShowAttacksModal(true)}
+              >
+                View Attacks
+              </Button>
+              <EnemyQuickAttacksModal
+                show={showAttacksModal}
+                onHide={() => setShowAttacksModal(false)}
+                enemyLabel={label}
+                quickAttacks={quickAttacks}
+                enemy={enemy}
+                onEnemyDamageRoll={onEnemyDamageRoll}
+                latestEnemyRoll={latestEnemyRoll}
+                normalizedEnemyId={normalizedEnemyId}
+                modalAriaLabel={`${label} Attacks`}
+              />
+            </>
+          )}
           <Button
-            variant="outline-light"
+            variant="secondary"
             size="sm"
             onClick={() =>
               normalizedEnemyId &&
@@ -216,6 +297,70 @@ function FormControlButtonInput({ value, disabled, onChange }) {
   );
 }
 
+function EnemyQuickAttacksModal({
+  show,
+  onHide,
+  enemyLabel,
+  quickAttacks,
+  enemy,
+  onEnemyDamageRoll,
+  latestEnemyRoll,
+  normalizedEnemyId,
+  modalAriaLabel,
+}) {
+  if (!Array.isArray(quickAttacks) || quickAttacks.length === 0) {
+    return null;
+  }
+
+  return (
+    <Modal show={show} onHide={onHide} centered animation={false} aria-label={modalAriaLabel}>
+      <Modal.Header closeButton>
+        <Modal.Title>{`${enemyLabel} Attacks`}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="enemy-card__section-title text-uppercase text-muted small fw-semibold mb-2">
+          Attacks
+        </div>
+        <div className="d-flex flex-column gap-2">
+          {quickAttacks.map(
+            ({ action, actionLabel, attackBonusDisplay, damageDisplay, actionKey, isLatestRoll }) => (
+              <div key={actionKey} className="enemy-card__attack enemy-card__attack--compact">
+                <div className="enemy-card__attack-header">
+                  <div className="fw-semibold small text-body">{actionLabel}</div>
+                  <div className="small text-muted">Attack Bonus: {attackBonusDisplay ?? '—'}</div>
+                  <div className="small text-muted">Damage: {damageDisplay || '—'}</div>
+                </div>
+                <div className="enemy-card__attack-actions">
+                  <Button
+                    variant="outline-primary"
+                    size="sm"
+                    onClick={() =>
+                      normalizedEnemyId && onEnemyDamageRoll && onEnemyDamageRoll(enemy, action)
+                    }
+                    disabled={!onEnemyDamageRoll || !normalizedEnemyId}
+                  >
+                    Roll
+                  </Button>
+                </div>
+                {isLatestRoll && latestEnemyRoll?.breakdown && (
+                  <div className="mt-2 small fw-semibold text-primary">
+                    {`Result: ${latestEnemyRoll.total} damage (${latestEnemyRoll.breakdown})`}
+                  </div>
+                )}
+              </div>
+            )
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onHide}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
 export function ActiveEnemyQuickList({
   summaries,
   activeMapTitle,
@@ -232,6 +377,10 @@ export function ActiveEnemyQuickList({
   onEnemyAdjustmentInputChange,
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
+  onEnemyDamageRoll,
+  formatAttackBonus,
+  getEnemyActionDamageString,
+  latestEnemyRoll,
 }) {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
 
@@ -350,13 +499,17 @@ export function ActiveEnemyQuickList({
             onOpenMapPlacement={onOpenMapPlacement}
             onViewDetails={onViewDetails}
             enemyHealthAdjustments={enemyHealthAdjustments}
-          enemyHealthSaving={enemyHealthSaving}
-          onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
-          onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
-          onResetEnemyHealth={onResetEnemyHealth}
-          isActiveTurn={summary.isActiveTurn}
-        />
-      ))}
+            enemyHealthSaving={enemyHealthSaving}
+            onEnemyAdjustmentInputChange={onEnemyAdjustmentInputChange}
+            onApplyEnemyHealthAdjustment={onApplyEnemyHealthAdjustment}
+            onResetEnemyHealth={onResetEnemyHealth}
+            isActiveTurn={summary.isActiveTurn}
+            onEnemyDamageRoll={onEnemyDamageRoll}
+            formatAttackBonus={formatAttackBonus}
+            getEnemyActionDamageString={getEnemyActionDamageString}
+            latestEnemyRoll={latestEnemyRoll}
+          />
+        ))}
       </div>
     </div>
   );

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActiveEnemyQuickList } from './ActiveEnemyQuickList';
 
@@ -32,6 +32,10 @@ describe('ActiveEnemyQuickList', () => {
       onEnemyAdjustmentInputChange: jest.fn(),
       onApplyEnemyHealthAdjustment: jest.fn(),
       onResetEnemyHealth: jest.fn(),
+      formatAttackBonus: undefined,
+      getEnemyActionDamageString: undefined,
+      onEnemyDamageRoll: undefined,
+      latestEnemyRoll: undefined,
       ...overrides,
     };
 
@@ -131,5 +135,60 @@ describe('ActiveEnemyQuickList', () => {
     const card = screen.getByTestId('active-map-enemy-card');
     expect(card).toHaveClass('enemy-quick-card--active-turn');
     expect(screen.getByText('Active Turn')).toBeInTheDocument();
+  });
+
+  it('displays attack actions within a modal when available', async () => {
+    const formatAttackBonus = jest.fn((bonus) => (bonus >= 0 ? `+${bonus}` : `${bonus}`));
+    const getEnemyActionDamageString = jest.fn((action) =>
+      action?.name === 'Scimitar' ? '1d6 slashing' : null
+    );
+    const onEnemyDamageRoll = jest.fn();
+    const latestEnemyRoll = {
+      enemyId: 'enemy-1',
+      actionName: 'Scimitar',
+      total: 11,
+      breakdown: '1d6 (8) + 3',
+    };
+
+    const props = renderList({
+      formatAttackBonus,
+      getEnemyActionDamageString,
+      onEnemyDamageRoll,
+      latestEnemyRoll,
+      summaries: [
+        {
+          ...baseSummary,
+          enemy: {
+            ...baseSummary.enemy,
+            actions: [
+              { name: 'Scimitar', attack_bonus: 4 },
+              { name: 'Hide' },
+            ],
+          },
+        },
+      ],
+    });
+
+    const attacksButton = screen.getByRole('button', { name: /View Attacks/i });
+    await act(async () => {
+      await userEvent.click(attacksButton);
+    });
+
+    const dialog = await screen.findByRole('dialog', { name: /Goblin Attacks/i });
+    expect(within(dialog).getByText('Attacks')).toBeInTheDocument();
+    expect(within(dialog).getByText('Scimitar')).toBeInTheDocument();
+    expect(within(dialog).getByText('Attack Bonus: +4')).toBeInTheDocument();
+    expect(within(dialog).getByText('Damage: 1d6 slashing')).toBeInTheDocument();
+
+    const rollButton = within(dialog).getByRole('button', { name: /^Roll$/i });
+    await act(async () => {
+      await userEvent.click(rollButton);
+    });
+
+    expect(props.onEnemyDamageRoll).toHaveBeenCalledWith(
+      expect.objectContaining({ enemyId: 'enemy-1' }),
+      expect.objectContaining({ name: 'Scimitar' })
+    );
+    expect(within(dialog).getByText('Result: 11 damage (1d6 (8) + 3)')).toBeInTheDocument();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6418,6 +6418,10 @@ const resolveIcon = (category, iconMap, fallback) => {
           onEnemyAdjustmentInputChange={handleEnemyAdjustmentInputChange}
           onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
           onResetEnemyHealth={handleResetEnemyHealth}
+          onEnemyDamageRoll={handleEnemyDamageRoll}
+          formatAttackBonus={formatAttackBonus}
+          getEnemyActionDamageString={getEnemyActionDamageString}
+          latestEnemyRoll={latestEnemyRoll}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- open a modal from each quick enemy card to show attack details and roll controls instead of rendering them inline
- improve the quick card layout by closing the modal when no attacks remain and giving the reposition control a higher-contrast style
- adjust the quick card tests to exercise the modal interaction and confirm the attack workflow still functions

## Testing
- CI=true npm test -- ActiveEnemyQuickList --watchAll=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691666f30b68832ea1f6422d5c9abe66)