### PR TITLE
Fix map image style parameter gating

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -421,6 +421,25 @@ describe('AI map route', () => {
     expect(payload.style).toBeUndefined();
   });
 
+  test('omits style for dall-e-2 by default', async () => {
+    process.env.OPENAI_IMAGE_MODEL = 'dall-e-2';
+    delete process.env.OPENAI_IMAGE_STYLE_MODELS;
+
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          url: 'https://example.com/map.png',
+        },
+      ],
+    });
+
+    await request(app).post('/ai/map').send({ prompt: 'classic map' });
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    const payload = mockGenerate.mock.calls[0][0];
+    expect(payload.style).toBeUndefined();
+  });
+
   test('includes style when explicitly enabled for model', async () => {
     process.env.OPENAI_IMAGE_MODEL = 'dall-e-3';
     process.env.OPENAI_IMAGE_STYLE_MODELS = 'dall-e-3, gpt-image-1';

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -332,15 +332,11 @@ module.exports = (router) => {
         .split(',')
         .map((value) => value.trim())
         .filter(Boolean);
-
-      let includeStyle = Boolean(configuredStyle);
-      if (includeStyle) {
-        if (styleModelList.length > 0) {
-          includeStyle = styleModelList.includes(model);
-        } else {
-          includeStyle = model !== 'gpt-image-1';
-        }
-      }
+      const defaultStyleModels = ['dall-e-3'];
+      const styleSupportedModels =
+        styleModelList.length > 0 ? styleModelList : defaultStyleModels;
+      const includeStyle =
+        Boolean(configuredStyle) && styleSupportedModels.includes(model);
 
       if (includeStyle) {
         requestPayload.style = configuredStyle;


### PR DESCRIPTION
### Motivation
- Map generation was failing with a `400 unknown parameter: 'style'` when the `style` parameter was sent to providers/models that don't accept it.  
- The goal is to only send the OpenAI image `style` parameter for models known to support it while preserving explicit opt-in via `OPENAI_IMAGE_STYLE_MODELS`.

### Description
- Adjusted the style gating logic in `server/routes/ai.js` to build a `styleSupportedModels` list from `OPENAI_IMAGE_STYLE_MODELS` or a default `['dall-e-3']` and only set `requestPayload.style` when the current `model` is included.  
- Replaced the previous heuristic that excluded `gpt-image-1` with an explicit default whitelist of models that support `style`.  
- Added a regression test `omits style for dall-e-2 by default` to `server/__tests__/ai.test.js` to ensure `style` is not sent for `dall-e-2` unless explicitly enabled via `OPENAI_IMAGE_STYLE_MODELS`.

### Testing
- Ran the map AI tests with `npm test -- --runTestsByPath __tests__/ai.test.js` and the test suite passed.  
- The `__tests__/ai.test.js` suite reports all tests passing (`13 passed`).  
- Modified files: `server/routes/ai.js` and `server/__tests__/ai.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a84933e98832ebc4e9d9ba22b9dea)