### PR TITLE
Respect per-model image style support and retry without style on provider errors

### DIFF
--- a/server/__tests__/ai.test.js
+++ b/server/__tests__/ai.test.js
@@ -421,6 +421,50 @@ describe('AI map route', () => {
     expect(payload.style).toBeUndefined();
   });
 
+  test('omits style for dall-e-2 by default', async () => {
+    process.env.OPENAI_IMAGE_MODEL = 'dall-e-2';
+    delete process.env.OPENAI_IMAGE_STYLE_MODELS;
+
+    mockGenerate.mockResolvedValue({
+      data: [
+        {
+          url: 'https://example.com/map.png',
+        },
+      ],
+    });
+
+    await request(app).post('/ai/map').send({ prompt: 'classic map' });
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    const payload = mockGenerate.mock.calls[0][0];
+    expect(payload.style).toBeUndefined();
+  });
+
+  test('retries without style when OpenAI rejects the parameter', async () => {
+    process.env.OPENAI_IMAGE_MODEL = 'dall-e-3';
+    process.env.OPENAI_IMAGE_STYLE = 'vivid';
+
+    const styleError = new Error("400 Unknown parameter: 'style'.");
+    styleError.status = 400;
+    mockGenerate
+      .mockRejectedValueOnce(styleError)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            url: 'https://example.com/map.png',
+          },
+        ],
+      });
+
+    const res = await request(app).post('/ai/map').send({ prompt: 'retry map' });
+
+    expect(res.status).toBe(200);
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(mockGenerate.mock.calls[0][0].style).toBe('vivid');
+    expect(mockGenerate.mock.calls[1][0].style).toBeUndefined();
+    expect(res.body.imageUrl).toBe('https://example.com/map.png');
+  });
+
   test('includes style when explicitly enabled for model', async () => {
     process.env.OPENAI_IMAGE_MODEL = 'dall-e-3';
     process.env.OPENAI_IMAGE_STYLE_MODELS = 'dall-e-3, gpt-image-1';

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -332,15 +332,11 @@ module.exports = (router) => {
         .split(',')
         .map((value) => value.trim())
         .filter(Boolean);
-
-      let includeStyle = Boolean(configuredStyle);
-      if (includeStyle) {
-        if (styleModelList.length > 0) {
-          includeStyle = styleModelList.includes(model);
-        } else {
-          includeStyle = model !== 'gpt-image-1';
-        }
-      }
+      const defaultStyleModels = ['dall-e-3'];
+      const styleSupportedModels =
+        styleModelList.length > 0 ? styleModelList : defaultStyleModels;
+      const includeStyle =
+        Boolean(configuredStyle) && styleSupportedModels.includes(model);
 
       if (includeStyle) {
         requestPayload.style = configuredStyle;
@@ -350,7 +346,25 @@ module.exports = (router) => {
         requestPayload.quality = quality;
       }
 
-      const response = await openai.images.generate(requestPayload);
+      let response;
+      try {
+        response = await openai.images.generate(requestPayload);
+      } catch (error) {
+        const unknownStyleParameter =
+          requestPayload.style &&
+          (error?.status === 400 || error?.code === 'unknown_parameter') &&
+          typeof error?.message === 'string' &&
+          error.message.toLowerCase().includes('style');
+
+        if (!unknownStyleParameter) {
+          throw error;
+        }
+
+        const retryPayload = { ...requestPayload };
+        delete retryPayload.style;
+        response = await openai.images.generate(retryPayload);
+      }
+
       const image = Array.isArray(response?.data) ? response.data[0] : null;
 
       if (!image) {


### PR DESCRIPTION
### Motivation

- Ensure the image `style` parameter is only sent to models that support it and provide a safer fallback when the provider rejects the parameter.

### Description

- Centralized style model selection to use an explicit list from `OPENAI_IMAGE_STYLE_MODELS` or a default list containing `dall-e-3` and only include `style` when `model` is in that list and `OPENAI_IMAGE_STYLE` is set.
- Added a try/catch around `openai.images.generate` to detect provider rejections caused by an unknown `style` parameter and retry the request without the `style` field.
- Updated tests to cover omitting style for `dall-e-2` by default and retrying without `style` when the provider returns a 400 unknown-parameter error, while keeping existing style-related tests.

### Testing

- Ran the server unit test suite with `npm test` (Jest) including the new tests; all tests completed successfully.
- Verified the new tests `omits style for dall-e-2 by default` and `retries without style when OpenAI rejects the parameter` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a84933e98832ebc4e9d9ba22b9dea)