### PR TITLE
Improve mobile responsiveness for combat header and footer UI

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -615,9 +615,19 @@
 }
 
 @media (max-width: 576px) {
+  .combat-turn-header {
+    --combat-turn-header-height: 52px;
+    margin-bottom: 4px;
+    padding-bottom: 0;
+  }
+
+  .combat-turn-header__track {
+    gap: 6px;
+  }
+
   .combat-turn-header__card {
-    width: clamp(88px, 28vw, 33.333%);
-    min-width: clamp(88px, 28vw, 33.333%);
+    width: clamp(76px, 23vw, 96px);
+    min-width: clamp(76px, 23vw, 96px);
     min-height: var(--combat-turn-header-height);
   }
 }
@@ -632,8 +642,8 @@
 
 @media (max-width: 576px) {
   .combat-turn-header__placeholder {
-    width: clamp(88px, 28vw, 33.333%);
-    min-width: clamp(88px, 28vw, 33.333%);
+    width: clamp(76px, 23vw, 96px);
+    min-width: clamp(76px, 23vw, 96px);
   }
 }
 
@@ -709,6 +719,39 @@
 
 .combat-turn-header__active-name {
   font-size: 0.85rem;
+}
+
+
+@media (max-width: 576px) {
+  .combat-turn-header__figurine-area {
+    margin-top: 0.25rem;
+  }
+
+  .combat-turn-header__figurine {
+    width: 30px;
+    height: 30px;
+  }
+
+  .combat-turn-header__figurine-initial {
+    font-size: 0.75rem;
+  }
+
+  .combat-turn-header__active-indicator {
+    gap: 0.25rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .combat-turn-header__active-label {
+    font-size: 0.56rem;
+  }
+
+  .combat-turn-header__active-name {
+    font-size: 0.72rem;
+    max-width: 58vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .zombies-dm-container--spaced {
@@ -4738,29 +4781,80 @@ h1 {
   .footer-character-slot {
     flex-direction: column;
     align-items: center;
-    gap: 10px;
-    --footer-character-portrait-size: clamp(88px, 44vw, 132px);
+    gap: 0;
+    --footer-character-portrait-size: clamp(56px, 18vw, 70px);
   }
 
   .footer-character-slot__profile-card {
-    width: calc(var(--footer-character-portrait-size) + 10px);
+    width: calc(var(--footer-character-portrait-size) + 6px);
     padding: 0;
-    margin-bottom: 0;
+    margin-bottom: -8px;
+    z-index: 2;
+  }
+
+  .footer-character-slot__portrait-ring {
+    padding: 4px;
+  }
+
+  .footer-character-slot__portrait-health {
+    bottom: 4px;
+    width: 92%;
+  }
+
+  .footer-character-slot__health-inline {
+    gap: 4px;
+    padding: 2px 5px;
+  }
+
+  .footer-character-slot__health-mini-button {
+    width: 18px;
+    height: 18px;
+    font-size: 0.65rem;
+  }
+
+  .footer-character-slot__health-readout {
+    min-width: 44px;
+    gap: 2px;
+    padding: 0;
+    font-size: 0.68rem;
+  }
+
+  .footer-character-slot__health-readout-values {
+    gap: 3px;
+  }
+
+  .footer-character-slot__health-current {
+    font-size: 0.78rem;
+  }
+
+  .footer-character-slot__health-max {
+    font-size: 0.64rem;
+  }
+
+  .footer-character-slot__armor-class {
+    min-width: 24px;
+    padding: 0 3px;
+    top: 4px;
+    right: 2px;
   }
 
   .footer-character-slot__footer-rail {
     width: 100%;
     justify-content: center;
+    gap: 4px;
+    padding: 7px 8px 6px;
   }
 
   .footer-character-slot__footer-rail-body {
     align-items: center;
     justify-content: center;
+    gap: 5px;
   }
 
   .footer-character-slot__actions {
     flex-wrap: wrap;
     justify-content: center;
+    gap: 4px;
   }
 }
 
@@ -4954,46 +5048,105 @@ h1 {
 }
 
 @media (max-width: 576px) {
-  .footer-character-slot__damage {
+  .footer-container {
+    width: min(100%, calc(100vw - 16px));
+    padding: 4px 8px calc(4px + env(safe-area-inset-bottom, 0));
+  }
+
+  .footer-nav,
+  .footer-character-slot {
     width: 100%;
+  }
+
+  .footer-character-slot__hud {
+    max-width: min(100%, 480px);
+  }
+
+  .footer-character-slot__footer-rail-body {
+    flex-direction: column;
+  }
+
+  .footer-character-slot__damage {
+    width: min(100%, 300px);
     min-width: 0;
     max-width: none;
-    padding: 8px 12px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    padding: 4px 7px;
+    gap: 6px;
+  }
+
+  .footer-character-slot__damage-header {
+    display: contents;
+  }
+
+  .footer-character-slot__damage-label {
+    font-size: 0.48rem;
+  }
+
+  .footer-character-slot__crit-button.btn {
+    order: 3;
+    padding: 1px 7px;
+    font-size: 0.48rem;
+  }
+
+  .footer-character-slot__damage-value {
+    order: 2;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .footer-character-slot__damage-log-button {
+    order: 4;
+    padding: 1px 6px;
+    margin-top: 0;
+    font-size: 0.55rem;
   }
 
   .footer-actions-wrapper {
-    gap: 2px;
+    gap: 3px;
   }
 
   .footer-actions-inline {
-    gap: 3px;
+    justify-content: center;
+    gap: 2px;
     align-items: center;
   }
 
   .footer-btn {
-    width: 22px;
-    height: 22px;
+    width: 20px;
+    height: 20px;
     padding: 0;
     box-sizing: border-box;
     line-height: 1;
     margin: 0 1px;
-    font-size: 0.85rem;
+    font-size: 0.72rem;
   }
 
   .footer-btn--clear-dice {
-    width: clamp(32px, 18vw, 46px);
-    height: clamp(32px, 18vw, 46px);
+    width: 26px;
+    height: 26px;
   }
 
   .footer-btn--attack {
-    --footer-attack-size: clamp(38px, 24vw, 52px);
+    --footer-attack-size: 30px;
     width: var(--footer-attack-size);
     height: var(--footer-attack-size);
   }
 
   .footer-btn--dice {
-    --footer-dice-size: clamp(56px, 30vw, 74px);
+    --footer-dice-size: 34px;
     margin-top: 0;
+  }
+
+  .footer-actions-menu {
+    gap: 3px;
+  }
+
+  .footer-pass-log-button {
+    padding: 2px 7px;
+    font-size: 0.64rem;
   }
 
   .footer-actions-popover {


### PR DESCRIPTION
### Motivation
- Reduce cramped layouts and overflowing text on small screens by adjusting sizes, spacing, and layout of the combat turn header and footer character slot UI.
- Improve touch targets and visual hierarchy for mobile users by scaling down icons and buttons and exposing safe-area padding.

### Description
- Added and refined `@media (max-width: 576px)` styles for `.combat-turn-header*` to reduce card widths, figurine sizes, gaps, and typography, and to add a compact header height and margin tweaks.
- Normalized the `.combat-turn-header__placeholder` and figurine text sizing and added truncation rules for `.combat-turn-header__active-name` to prevent overflow on narrow viewports.
- Updated `.footer-character-slot` responsive rules (under `@media (max-width: 600px)` and `@media (max-width: 576px)`) to shrink portrait sizes, adjust paddings/margins, change layout to grid for `.footer-character-slot__damage`, and tune many micro-sizes (buttons, readouts, armor/health positioning, gaps and z-index) for improved mobile spacing.
- Introduced a compact `.footer-container` and made footer/nav elements full width on small screens while reducing large call-to-action sizes (attack/dice/clear buttons) and tightening popover and action menu spacings.

### Testing
- Ran linting with `npm run lint` and the style changes produced no lint errors.
- Built the client with `npm run build` and the stylesheet compiled successfully without errors.
- Executed the test suite with `npm test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a943a6718832eb3102eb3dacacb92)