### PR TITLE
Redesign mobile combat footer: compact collapsed state + expandable resources drawer

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -5932,3 +5932,212 @@ h1 {
   align-items: flex-end;
 }
 
+
+.footer-character-slot__resources-drawer {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  width: min(96vw, 980px);
+  max-height: min(52vh, 430px);
+  transform: translate(-50%, 18px) scale(0.98);
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: 18px;
+  border: 1px solid rgba(104, 144, 216, 0.38);
+  background: linear-gradient(145deg, rgba(10, 18, 38, 0.98), rgba(13, 26, 54, 0.96));
+  box-shadow: 0 20px 38px rgba(3, 6, 14, 0.55), inset 0 0 0 1px rgba(128, 166, 236, 0.08);
+  backdrop-filter: blur(10px);
+  transition: opacity 0.22s ease, transform 0.24s ease;
+  z-index: 5;
+}
+
+.footer-character-slot--resources-open .footer-character-slot__resources-drawer {
+  transform: translate(-50%, 0) scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.footer-character-slot__resources-scroll {
+  max-height: inherit;
+  overflow-y: auto;
+  padding: 28px 18px 18px;
+  scrollbar-width: thin;
+}
+
+.footer-character-slot__resources-grip {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 42px;
+  height: 4px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: rgba(190, 204, 238, 0.28);
+}
+
+.footer-character-slot__resources-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid rgba(130, 166, 238, 0.45);
+  background: rgba(20, 34, 68, 0.8);
+  color: rgba(245, 248, 255, 0.96);
+  z-index: 2;
+}
+
+.footer-resources-drawer-content {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  gap: 0;
+  min-height: 220px;
+}
+
+.footer-resources-section {
+  padding: 0 18px;
+  border-left: 1px solid rgba(114, 143, 202, 0.28);
+  min-width: 0;
+}
+
+.footer-resources-section:first-child {
+  border-left: 0;
+}
+
+.footer-resources-section h3 {
+  margin: 0 0 14px;
+  font-size: 0.78rem;
+  line-height: 1.1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 255, 0.95);
+}
+
+.footer-resources-section--spell-slots .spell-slot-container {
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.footer-resources-section--spell-slots .spell-slot {
+  width: 38px;
+  height: 60px;
+}
+
+.footer-resources-list {
+  display: grid;
+  gap: 12px;
+}
+
+.footer-resource-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  color: rgba(242, 246, 255, 0.94);
+  font-size: 0.92rem;
+}
+
+.footer-resource-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  color: #65a8ff;
+}
+
+.footer-resource-row__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.footer-resource-row__pips {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.footer-resource-row__pips span {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  opacity: 0.55;
+}
+
+.footer-resource-row__pips span.is-filled {
+  background: currentColor;
+  opacity: 1;
+}
+
+.footer-resource-row__value,
+.footer-resource-row__duration {
+  color: rgba(205, 214, 235, 0.72);
+  font-weight: 700;
+}
+
+.footer-character-slot__resources-toggle.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.footer-character-slot__resources-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 28px;
+  border-radius: 9px;
+  background: linear-gradient(135deg, rgba(185, 36, 216, 0.95), rgba(109, 38, 190, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(245, 206, 255, 0.3);
+  font-weight: 800;
+}
+
+.footer-character-slot__resources-chevron {
+  transition: transform 0.22s ease;
+}
+
+.footer-character-slot--resources-open .footer-character-slot__resources-chevron {
+  transform: rotate(180deg);
+}
+
+@media (max-width: 760px) {
+  .footer-character-slot__resources-drawer {
+    width: min(96vw, 560px);
+    max-height: min(58vh, 420px);
+  }
+
+  .footer-resources-drawer-content {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    row-gap: 22px;
+  }
+
+  .footer-resources-section:nth-child(odd) {
+    border-left: 0;
+  }
+}
+
+@media (max-width: 576px) {
+  .footer-character-slot {
+    min-height: 116px;
+    max-height: 116px;
+  }
+
+  .footer-character-slot__resources-toggle.btn {
+    min-height: 34px;
+    padding: 5px 10px;
+    font-size: 0.78rem;
+  }
+
+  .footer-character-slot__resources-count {
+    min-width: 24px;
+    min-height: 24px;
+  }
+}

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -21,6 +21,9 @@ export default function SpellSlots({
   onToggleSlot,
   actionCount: propActionCount,
   bonusCount: propBonusCount,
+  showTurnSlots = true,
+  showSpellSlots = true,
+  showFocusSlot = true,
 }) {
 
   const occupations = form.occupation || [];
@@ -150,6 +153,7 @@ export default function SpellSlots({
       role="group"
       aria-label="Spell slots and action tracking"
     >
+      {showTurnSlots && (
       <div className="spell-slot action-slot">
           <div className="slot-level">A</div>
           <div className="slot-boxes">
@@ -169,6 +173,8 @@ export default function SpellSlots({
             })}
           </div>
         </div>
+      )}
+      {showTurnSlots && (
       <div className="spell-slot bonus-slot">
         <div className="slot-level">B</div>
         <div className="slot-boxes">
@@ -188,7 +194,8 @@ export default function SpellSlots({
           })}
         </div>
       </div>
-      {hasMonkFocus && (
+      )}
+      {showFocusSlot && hasMonkFocus && (
         <div className="spell-slot focus-slot">
           <div
             className="focus-icon-wrapper"
@@ -217,8 +224,8 @@ export default function SpellSlots({
           </div>
         </div>
       )}
-      {regularLevels.length > 0 && renderGroup(slotData, 'regular')}
-      {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
+      {showSpellSlots && regularLevels.length > 0 && renderGroup(slotData, 'regular')}
+      {showSpellSlots && warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
     </div>
   );
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5107,6 +5107,117 @@ export default function ZombiesCharacterSheet() {
     },
   );
 
+
+  const normalizeFooterCollection = useCallback((value) => {
+    if (!value) return [];
+    const source = Array.isArray(value) ? value : Object.values(value);
+    return source
+      .filter(Boolean)
+      .map((entry, index) => {
+        if (typeof entry === 'string') {
+          return { id: `${entry}-${index}`, name: entry };
+        }
+        return {
+          id: entry.id || entry.key || entry.name || entry.label || index,
+          icon: entry.icon || entry.symbol || '✦',
+          name: entry.name || entry.label || entry.type || 'Resource',
+          current: entry.current ?? entry.remaining ?? entry.value ?? entry.count,
+          max: entry.max ?? entry.total,
+          duration: entry.duration ?? entry.remainingDuration,
+          color: entry.color,
+        };
+      })
+      .filter((entry) => entry.name);
+  }, []);
+
+  const footerClassResources = useMemo(
+    () => normalizeFooterCollection(form?.classResources || form?.resources),
+    [form?.classResources, form?.resources, normalizeFooterCollection]
+  );
+  const footerActiveBonuses = useMemo(
+    () => normalizeFooterCollection(form?.activeBonuses || form?.bonuses || form?.activeEffects),
+    [form?.activeBonuses, form?.bonuses, form?.activeEffects, normalizeFooterCollection]
+  );
+  const footerConditions = useMemo(
+    () => normalizeFooterCollection(form?.conditions || form?.statusConditions),
+    [form?.conditions, form?.statusConditions, normalizeFooterCollection]
+  );
+
+  const hasFooterSpellSlots = hasSpellcasting || (form?.occupation || []).some((cls) => {
+    const name = (cls.Name || cls.Occupation || '').toLowerCase();
+    return name === 'warlock' && (Number(cls.Level) || 0) > 0;
+  });
+
+  const footerHiddenResourceCount =
+    footerClassResources.length + footerActiveBonuses.length + footerConditions.length +
+    (hasFooterSpellSlots ? 1 : 0);
+
+  const footerResourcesDrawer = form && footerHiddenResourceCount > 0 ? (
+    <div className="footer-resources-drawer-content">
+      {hasFooterSpellSlots && (
+        <section className="footer-resources-section footer-resources-section--spell-slots">
+          <h3>Spell Slots</h3>
+          <SpellSlots
+            form={form}
+            used={usedSlots}
+            onToggleSlot={handleCastSpell}
+            showTurnSlots={false}
+            showFocusSlot={false}
+          />
+        </section>
+      )}
+      {footerClassResources.length > 0 && (
+        <section className="footer-resources-section">
+          <h3>Class Resources</h3>
+          <div className="footer-resources-list">
+            {footerClassResources.map((resource) => (
+              <div className="footer-resource-row" key={resource.id}>
+                <span className="footer-resource-row__icon" style={{ color: resource.color }}>{resource.icon}</span>
+                <span className="footer-resource-row__name">{resource.name}</span>
+                <span className="footer-resource-row__pips" aria-hidden="true">
+                  {Number.isFinite(Number(resource.max)) && Array.from({ length: Math.min(Number(resource.max), 8) }).map((_, i) => (
+                    <span key={i} className={i < Number(resource.current || 0) ? 'is-filled' : ''} />
+                  ))}
+                </span>
+                <span className="footer-resource-row__value">
+                  {resource.current ?? '—'}{resource.max ? `/${resource.max}` : ''}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+      {footerActiveBonuses.length > 0 && (
+        <section className="footer-resources-section">
+          <h3>Active Bonuses</h3>
+          <div className="footer-resources-list">
+            {footerActiveBonuses.map((bonus) => (
+              <div className="footer-resource-row" key={bonus.id}>
+                <span className="footer-resource-row__icon" style={{ color: bonus.color }}>{bonus.icon}</span>
+                <span className="footer-resource-row__name">{bonus.name}</span>
+                <span className="footer-resource-row__duration">{bonus.duration || '—'}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+      {footerConditions.length > 0 && (
+        <section className="footer-resources-section">
+          <h3>Conditions</h3>
+          <div className="footer-resources-list">
+            {footerConditions.map((condition) => (
+              <div className="footer-resource-row" key={condition.id}>
+                <span className="footer-resource-row__icon" style={{ color: condition.color }}>{condition.icon}</span>
+                <span className="footer-resource-row__name">{condition.name}</span>
+                <span className="footer-resource-row__duration">{condition.duration || '—'}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  ) : null;
+
   const DOCKABLE_MODAL_CONFIG = useMemo(
     () => ({
       characterInfo: {
@@ -5590,9 +5701,13 @@ export default function ZombiesCharacterSheet() {
                         longRestCount={longRestCount}
                         shortRestCount={shortRestCount}
                         onActionSurge={handleActionSurge}
+                        showSpellSlots={false}
+                        showFocusSlot={false}
                       />
                     ) : null
                   }
+                  resourcesDrawer={footerResourcesDrawer}
+                  hiddenResourceCount={footerHiddenResourceCount}
                   actions={
                     <div className="footer-actions-wrapper">
                       <div className="footer-actions-inline">

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -27,6 +27,8 @@ const FooterCharacterSlot = ({
   onHealthChange,
   actions,
   spellSlots,
+  resourcesDrawer,
+  hiddenResourceCount,
   damageSummary,
   onToggleCritical,
   onOpenDamageLog,
@@ -35,6 +37,7 @@ const FooterCharacterSlot = ({
   const [error, setError] = useState(null);
   const [pendingHealth, setPendingHealth] = useState(null);
   const [damageHighlightClass, setDamageHighlightClass] = useState('');
+  const [isResourcesOpen, setIsResourcesOpen] = useState(false);
 
   const { resolvedCurrent, resolvedMax } = useMemo(() => {
     const numericCurrent = Number(currentHealth);
@@ -110,12 +113,16 @@ const FooterCharacterSlot = ({
     : '—';
 
   const hasSpellSlots = Boolean(spellSlots);
+  const hasResourcesDrawer = Boolean(resourcesDrawer);
+  const availableHiddenResources = Number.isFinite(Number(hiddenResourceCount))
+    ? Math.max(0, Number(hiddenResourceCount))
+    : 0;
   const hasActions = Boolean(actions);
   const hasDamageDisplay =
     hasDamageValue ||
     typeof onToggleCritical === 'function' ||
     typeof onOpenDamageLog === 'function';
-  const hasFooterContent = hasActions || hasDamageDisplay;
+  const hasFooterContent = hasActions || hasDamageDisplay || hasResourcesDrawer;
   const hasHudContent = hasSpellSlots || hasFooterContent;
 
   const damageClassName = [
@@ -136,6 +143,9 @@ const FooterCharacterSlot = ({
       onOpenDamageLog();
     }
   }, [onOpenDamageLog]);
+  const handleResourcesToggle = useCallback(() => {
+    setIsResourcesOpen((current) => !current);
+  }, []);
   const canDecrease = !isUpdating && numericCurrent > 0;
   const canIncrease =
     !isUpdating &&
@@ -255,7 +265,31 @@ const FooterCharacterSlot = ({
   }, [damageTimestamp]);
 
   return (
-    <div className="footer-character-slot" data-allow-pointer-events="true">
+    <div
+      className={`footer-character-slot ${isResourcesOpen ? 'footer-character-slot--resources-open' : ''}`}
+      data-allow-pointer-events="true"
+    >
+      {hasResourcesDrawer ? (
+        <div
+          id="footer-resources-drawer"
+          className="footer-character-slot__resources-drawer"
+          aria-hidden={!isResourcesOpen}
+          data-allow-pointer-events="true"
+        >
+          <button
+            type="button"
+            className="footer-character-slot__resources-close"
+            onClick={handleResourcesToggle}
+            aria-label="Collapse bonuses drawer"
+          >
+            <i className="fas fa-times" aria-hidden="true" />
+          </button>
+          <div className="footer-character-slot__resources-grip" aria-hidden="true" />
+          <div className="footer-character-slot__resources-scroll">
+            {resourcesDrawer}
+          </div>
+        </div>
+      ) : null}
       <div className="footer-character-slot__profile-card">
         <div className="footer-character-slot__profile">
           <div className="footer-character-slot__portrait">
@@ -391,6 +425,25 @@ const FooterCharacterSlot = ({
                     {actions}
                   </div>
                 ) : null}
+                {hasResourcesDrawer ? (
+                  <Button
+                    type="button"
+                    variant="outline-light"
+                    className="footer-character-slot__resources-toggle footer-pass-log-button"
+                    onClick={handleResourcesToggle}
+                    aria-expanded={isResourcesOpen}
+                    aria-controls="footer-resources-drawer"
+                    title={isResourcesOpen ? 'Hide resources' : 'Show resources'}
+                  >
+                    <span className="footer-character-slot__resources-toggle-icon" aria-hidden="true">✦</span>
+                    <span>Bonuses</span>
+                    <span className="footer-character-slot__resources-count">
+                      {isResourcesOpen ? '−' : `+${availableHiddenResources}`}
+                    </span>
+                    <i className="fas fa-chevron-up footer-character-slot__resources-chevron" aria-hidden="true" />
+                  </Button>
+                ) : null}
+
               </div>
             </div>
           ) : null}
@@ -417,6 +470,8 @@ FooterCharacterSlot.propTypes = {
   onHealthChange: PropTypes.func,
   actions: PropTypes.node,
   spellSlots: PropTypes.node,
+  resourcesDrawer: PropTypes.node,
+  hiddenResourceCount: PropTypes.number,
   damageSummary: PropTypes.shape({
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     isCritical: PropTypes.bool,
@@ -437,6 +492,8 @@ FooterCharacterSlot.defaultProps = {
   onHealthChange: undefined,
   actions: null,
   spellSlots: null,
+  resourcesDrawer: null,
+  hiddenResourceCount: 0,
   damageSummary: null,
   onToggleCritical: undefined,
   onOpenDamageLog: undefined,


### PR DESCRIPTION
### Motivation
- Reduce the footer height on mobile while keeping turn-critical controls (HP, AC, damage, crit toggle, pass turn) always available in a fixed-height collapsed footer.
- Provide an expandable, scrollable resources drawer for arbitrarily many spell slots, class resources, temporary bonuses, and conditions so the footer doesn't grow with character complexity.
- Drive the UI from character-provided collections (spellSlots / warlock slots / classResources / activeBonuses / conditions) so new resources require no class-specific UI changes.

### Description
- Added an upward-sliding resources drawer and toggle into `FooterCharacterSlot` with new props `resourcesDrawer` and `hiddenResourceCount`, local `isResourcesOpen` state, and a drawer DOM node with `id="footer-resources-drawer"` (changes in `client/src/components/Zombies/pages/components/FooterCharacterSlot.js`).
- Made the existing `SpellSlots` component configurable with flags `showTurnSlots`, `showSpellSlots`, and `showFocusSlot` so the collapsed footer can keep action/bonus indicators while the drawer reuses the 2×2 spell-slot grid (changes in `client/src/components/Zombies/attributes/SpellSlots.js`).
- Composed a data-driven drawer in `ZombiesCharacterSheet` by normalizing collections via `normalizeFooterCollection` and rendering four dynamic sections: `Spell Slots`, `Class Resources`, `Active Bonuses`, and `Conditions`, and passed `footerResourcesDrawer` + `footerHiddenResourceCount` into the footer (changes in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Added responsive and animated styles for the drawer (absolute positioning above the footer, maximum height, internal vertical scroll, slide/fade animation, responsive grid columns) and the drawer toggle / count UI to `client/src/App.scss` so the footer height remains fixed and only the drawer scrolls.

### Testing
- Ran `npx eslint` on modified files which completed successfully but reported pre-existing warnings in `ZombiesCharacterSheet.js` (no new lint errors).
- Ran `npm test` targeted at the modified footer component which returned "No tests found" and exited successfully (no unit tests were exercised for these changes).
- Ran `npm run build` which failed in this environment due to a missing dependency: `Module not found: Can't resolve '@3d-dice/dice-box'` (build issue unrelated to the footer changes and present in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aab83f71c832e97eab93d2ad8e644)