### PR TITLE
Refine combat HUD layout, hide damage until roll, and add map pinch-zoom handling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8687,3 +8687,102 @@ h1 {
     padding-inline: 18px;
   }
 }
+
+/* User-requested HUD fit fixes: keep spell labels visible, make resources four-wide, and tuck pact magic under level IX. */
+#damageAmount.damage-roller--hidden {
+  display: none;
+}
+
+#damageAmount.damage-roller--visible {
+  display: block;
+}
+
+.combat-hud-dock__resource-rail {
+  grid-template-columns: repeat(4, 58px);
+  grid-auto-rows: 48px;
+  width: 244px;
+  height: 58px;
+  max-height: 58px;
+  overflow: hidden;
+  align-items: stretch;
+}
+
+.combat-hud-resource-tile {
+  min-height: 48px;
+  padding: 3px;
+}
+
+.combat-hud-resource-tile__icon {
+  font-size: 1.15rem;
+}
+
+.combat-hud-resource-tile__name {
+  font-size: 0.48rem;
+  line-height: 1.05;
+}
+
+.combat-hud-resource-tile__value {
+  font-size: 0.56rem;
+}
+
+.combat-hud-dock .spell-slot-container {
+  min-width: 340px;
+  height: auto;
+  min-height: 118px;
+  overflow: visible;
+}
+
+.combat-hud-dock .spell-slot-section--regular {
+  min-width: 320px;
+}
+
+.combat-hud-dock .spell-slot-section__label {
+  padding-left: 8px;
+  overflow: visible;
+}
+
+.combat-hud-dock .spell-slot-section--regular > .spell-slot-section__grid {
+  grid-template-columns: repeat(5, 48px);
+  grid-template-rows: repeat(2, 48px);
+  grid-auto-flow: row;
+  overflow: visible;
+}
+
+.combat-hud-dock .spell-slot-section--pact-inline {
+  display: flex;
+  grid-column: 5;
+  grid-row: 2;
+  width: 48px;
+  min-width: 48px;
+  max-width: 48px;
+  min-height: 48px;
+  gap: 2px;
+  align-self: stretch;
+  justify-self: center;
+  transform: translateY(2px);
+}
+
+.combat-hud-dock .spell-slot-section--pact-inline .spell-slot-section__label {
+  max-width: 68px;
+  margin-left: -10px;
+  padding: 0;
+  font-size: 0.52rem;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.combat-hud-dock .spell-slot-section--pact-inline .spell-slot-section__grid {
+  display: grid;
+  grid-template-columns: 48px;
+  grid-template-rows: 48px;
+  gap: 0;
+}
+
+.campaign-map-board,
+.campaign-map-board__stage,
+.campaign-map-board__image-wrapper {
+  touch-action: none;
+  overscroll-behavior: contain;
+}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -100,6 +100,20 @@ const DEFAULT_GRID_DIMENSION = 24;
 const MAP_ZOOM_EPSILON = 0.0005;
 const MAP_ZOOM_ANIMATION_TIME_CONSTANT_MS = 90;
 
+const getTouchDistance = (touches) => {
+  if (!touches || touches.length < 2) {
+    return null;
+  }
+
+  const first = touches[0];
+  const second = touches[1];
+  const deltaX = Number(second.clientX) - Number(first.clientX);
+  const deltaY = Number(second.clientY) - Number(first.clientY);
+  const distance = Math.hypot(deltaX, deltaY);
+
+  return Number.isFinite(distance) && distance > 0 ? distance : null;
+};
+
 const resolveElementScale = (element) => {
   if (!element || typeof element.getBoundingClientRect !== 'function') {
     return { x: 1, y: 1 };
@@ -535,6 +549,7 @@ const CampaignMapBoard = ({
   const mapZoomRafRef = useRef(null);
   const mapZoomTargetRef = useRef(MAP_ZOOM_DEFAULT);
   const mapZoomAnimationStateRef = useRef({ lastTimestamp: null });
+  const touchZoomStateRef = useRef(null);
   const resolvedMapZoom = useMemo(() => clampMapZoom(mapZoom), [mapZoom]);
   const rotationDragStateRef = useRef(null);
   const rotationMoveHandlerRef = useRef(null);
@@ -872,6 +887,74 @@ const CampaignMapBoard = ({
     },
     [allowWheelZoom, scheduleMapZoomUpdate]
   );
+
+
+  const handleTouchStart = useCallback(
+    (event) => {
+      if (!allowWheelZoom) {
+        return;
+      }
+
+      const touches = event?.touches;
+      const distance = getTouchDistance(touches);
+      if (distance === null) {
+        touchZoomStateRef.current = null;
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      touchZoomStateRef.current = {
+        distance,
+        zoom: clampMapZoom(mapZoomTargetRef.current),
+      };
+    },
+    [allowWheelZoom]
+  );
+
+  const handleTouchMove = useCallback(
+    (event) => {
+      if (!allowWheelZoom) {
+        return;
+      }
+
+      const distance = getTouchDistance(event?.touches);
+      const state = touchZoomStateRef.current;
+      if (distance === null || !state || !Number.isFinite(state.distance) || state.distance <= 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      const nextZoom = clampMapZoom(state.zoom * (distance / state.distance));
+      scheduleMapZoomUpdate(nextZoom);
+    },
+    [allowWheelZoom, scheduleMapZoomUpdate]
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    touchZoomStateRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const boardElement = boardRef.current;
+
+    if (!boardElement || !allowWheelZoom) {
+      return () => {};
+    }
+
+    const preventNativePinchZoom = (event) => {
+      if (event?.touches && event.touches.length >= 2) {
+        event.preventDefault();
+      }
+    };
+
+    boardElement.addEventListener('touchmove', preventNativePinchZoom, { passive: false });
+
+    return () => {
+      boardElement.removeEventListener('touchmove', preventNativePinchZoom);
+    };
+  }, [allowWheelZoom]);
 
   useEffect(() => {
     const boardElement = boardRef.current;
@@ -1993,6 +2076,10 @@ const CampaignMapBoard = ({
       )}
       style={boardStyle}
       onWheel={handleWheel}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
     >
       {title && <h5 className="campaign-map-board__title">{title}</h5>}
       {imageSrc ? (

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1962,6 +1962,7 @@ const sortedSpells = useMemo(() => {
 
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const [damageValue, setDamageValue] = useState(0);
+  const [hasDamageRoll, setHasDamageRoll] = useState(false);
   const [damageLog, setDamageLog] = useState([]);
   const [showLog, setShowLog] = useState(false);
   const [activeDice, setActiveDice] = useState([]);
@@ -2032,6 +2033,7 @@ const updateDamageValueWithAnimation = (
 ) => {
   setPulseClass('');
   setDamageValue(newValue);
+  setHasDamageRoll(newValue !== undefined);
   const details = Array.isArray(extra?.diceRolls) ? extra.diceRolls : [];
   triggerDiceAnimation(details);
   setLastRollTimestamp(Date.now());
@@ -2307,7 +2309,7 @@ const damageAmountStyle = {
           id="damageAmount"
           ref={damageAmountRef}
           style={damageAmountStyle}
-          className={`${pulseClass} ${isCritical ? 'critical-active' : ''} ${
+          className={`${hasDamageRoll ? 'damage-roller--visible' : 'damage-roller--hidden'} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${
             isFumble ? 'critical-failure' : ''
           }`}
         >

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -229,10 +229,18 @@ export default function SpellSlots({
           <div className="spell-slot-section__label">Spell Levels</div>
           <div className="spell-slot-section__grid">
             {renderGroup(slotData, 'regular')}
+            {warlockLevels.length > 0 && (
+              <div className="spell-slot-section spell-slot-section--pact spell-slot-section--pact-inline" aria-label="Pact magic spell slots">
+                <div className="spell-slot-section__label">Pact Magic</div>
+                <div className="spell-slot-section__grid">
+                  {renderGroup(warlockData, 'warlock')}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}
-      {showSpellSlots && warlockLevels.length > 0 && (
+      {showSpellSlots && regularLevels.length === 0 && warlockLevels.length > 0 && (
         <div className="spell-slot-section spell-slot-section--pact" aria-label="Pact magic spell slots">
           <div className="spell-slot-section__label">Pact Magic</div>
           <div className="spell-slot-section__grid">


### PR DESCRIPTION
### Motivation
- Fix the footer HUD layout so spell levels are not clipped and Pact Magic can occupy the empty space under level IX to reduce wasted space.
- Keep the damage display hidden until a damage roll occurs to reduce visual clutter.
- Compact the Ki/focus/action surge/resources area to a 4-wide resource rail with smaller readable tiles.
- Prevent the entire app from pinch-zooming on touch devices by applying two-finger pinch gestures only to the map and updating map zoom accordingly.

### Description
- Spell slots: render Warlock (Pact Magic) slots inline under the regular spell-slot grid when regular slots exist, and keep a standalone Pact Magic section when only warlock slots are present (`client/src/components/Zombies/attributes/SpellSlots.js`).
- Damage display: add `hasDamageRoll` state and set it when `updateDamageValueWithAnimation` runs, and toggle `#damageAmount` visibility classes so the damage roller is hidden until a roll occurs (`client/src/components/Zombies/attributes/PlayerTurnActions.js` plus CSS). 
- HUD layout and resources: add CSS overrides to make the resource rail four-wide, reduce tile/icon/text sizing, prevent spell label clipping, and add classes to hide/show the damage roller (`client/src/App.scss`).
- Map touch zoom: implement two-finger pinch detection and handling with `getTouchDistance`, `handleTouchStart`, `handleTouchMove`, and `handleTouchEnd`, attach touch handlers to the board, and prevent native page pinch-zoom while interacting with the map (`client/src/components/Zombies/attributes/CampaignMapBoard.js`).

### Testing
- Ran the SpellSlots unit suite with `npm test -- --runTestsByPath src/components/Zombies/attributes/SpellSlots.test.js --watchAll=false` which passed.
- Ran targeted tests for the map and damage UI with `npm test -- --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js src/components/Zombies/attributes/PlayerTurnActions.test.js --watchAll=false` which surfaced failures in existing expectations (those suites failed after the change).
- Attempted a production build with `npm run build`, which failed due to a missing dependency (`lucide-react`) in the client environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c2bc8f71c832eba4aa48f68329a19)