### PR TITLE
Add touch pinch-zoom to campaign map, HUD layout and spell/pact UI fixes, and damage-roller visibility handling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8687,3 +8687,142 @@ h1 {
     padding-inline: 18px;
   }
 }
+
+/* User-requested HUD fit fixes: keep spell labels visible, make resources four-wide, and tuck pact magic under level IX. */
+#damageAmount.damage-roller--hidden {
+  display: none;
+}
+
+#damageAmount.damage-roller--visible {
+  display: block;
+}
+
+.combat-hud-dock__resource-rail {
+  grid-template-columns: repeat(4, 58px);
+  grid-auto-rows: 48px;
+  width: 244px;
+  height: 58px;
+  max-height: 58px;
+  overflow: hidden;
+  align-items: stretch;
+}
+
+.combat-hud-resource-tile {
+  min-height: 48px;
+  padding: 3px;
+}
+
+.combat-hud-resource-tile__icon {
+  font-size: 1.15rem;
+}
+
+.combat-hud-resource-tile__name {
+  font-size: 0.48rem;
+  line-height: 1.05;
+}
+
+.combat-hud-resource-tile__value {
+  font-size: 0.56rem;
+}
+
+.combat-hud-dock .spell-slot-container {
+  min-width: 340px;
+  height: auto;
+  min-height: 118px;
+  overflow: visible;
+}
+
+.combat-hud-dock .spell-slot-section--regular {
+  min-width: 320px;
+}
+
+.combat-hud-dock .spell-slot-section__label {
+  padding-left: 8px;
+  overflow: visible;
+}
+
+.combat-hud-dock .spell-slot-section--regular > .spell-slot-section__grid {
+  grid-template-columns: repeat(5, 48px);
+  grid-template-rows: repeat(2, 48px);
+  grid-auto-flow: row;
+  overflow: visible;
+}
+
+.combat-hud-dock .spell-slot-section--pact-inline {
+  display: flex;
+  grid-column: 5;
+  grid-row: 2;
+  width: 48px;
+  min-width: 48px;
+  max-width: 48px;
+  min-height: 48px;
+  gap: 2px;
+  align-self: stretch;
+  justify-self: center;
+  transform: translateY(2px);
+}
+
+.combat-hud-dock .spell-slot-section--pact-inline .spell-slot-section__label {
+  max-width: 68px;
+  margin-left: -10px;
+  padding: 0;
+  font-size: 0.52rem;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.combat-hud-dock .spell-slot-section--pact-inline .spell-slot-section__grid {
+  display: grid;
+  grid-template-columns: 48px;
+  grid-template-rows: 48px;
+  gap: 0;
+}
+
+.campaign-map-board,
+.campaign-map-board__stage,
+.campaign-map-board__image-wrapper {
+  touch-action: none;
+  overscroll-behavior: contain;
+}
+
+/* Mobile follow-up: pact magic should be a normal spell cube, and opened resources should stay four-wide. */
+.combat-hud-dock .spell-slot-section--regular > .spell-slot-section__grid > .warlock-slot {
+  grid-column: 5;
+  grid-row: 2;
+  border-color: rgba(190, 98, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(190, 98, 255, 0.18), 0 0 18px rgba(190, 98, 255, 0.24);
+}
+
+.combat-hud-dock .spell-slot-section--regular > .spell-slot-section__grid > .warlock-slot .slot-small {
+  border-color: rgba(218, 147, 255, 0.92);
+  box-shadow: 0 0 8px rgba(202, 112, 255, 0.7), inset 0 0 5px rgba(255, 255, 255, 0.5);
+}
+
+@media (max-width: 900px) {
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__resource-rail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+    padding: 8px;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-resource-tile {
+    min-width: 0;
+    min-height: 48px;
+    padding: 3px 2px;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-resource-tile__icon {
+    font-size: 1.1rem;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-resource-tile__name {
+    font-size: 0.46rem;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-resource-tile__value {
+    font-size: 0.54rem;
+  }
+}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -100,6 +100,20 @@ const DEFAULT_GRID_DIMENSION = 24;
 const MAP_ZOOM_EPSILON = 0.0005;
 const MAP_ZOOM_ANIMATION_TIME_CONSTANT_MS = 90;
 
+const getTouchDistance = (touches) => {
+  if (!touches || touches.length < 2) {
+    return null;
+  }
+
+  const first = touches[0];
+  const second = touches[1];
+  const deltaX = Number(second.clientX) - Number(first.clientX);
+  const deltaY = Number(second.clientY) - Number(first.clientY);
+  const distance = Math.hypot(deltaX, deltaY);
+
+  return Number.isFinite(distance) && distance > 0 ? distance : null;
+};
+
 const resolveElementScale = (element) => {
   if (!element || typeof element.getBoundingClientRect !== 'function') {
     return { x: 1, y: 1 };
@@ -535,6 +549,7 @@ const CampaignMapBoard = ({
   const mapZoomRafRef = useRef(null);
   const mapZoomTargetRef = useRef(MAP_ZOOM_DEFAULT);
   const mapZoomAnimationStateRef = useRef({ lastTimestamp: null });
+  const touchZoomStateRef = useRef(null);
   const resolvedMapZoom = useMemo(() => clampMapZoom(mapZoom), [mapZoom]);
   const rotationDragStateRef = useRef(null);
   const rotationMoveHandlerRef = useRef(null);
@@ -872,6 +887,74 @@ const CampaignMapBoard = ({
     },
     [allowWheelZoom, scheduleMapZoomUpdate]
   );
+
+
+  const handleTouchStart = useCallback(
+    (event) => {
+      if (!allowWheelZoom) {
+        return;
+      }
+
+      const touches = event?.touches;
+      const distance = getTouchDistance(touches);
+      if (distance === null) {
+        touchZoomStateRef.current = null;
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      touchZoomStateRef.current = {
+        distance,
+        zoom: clampMapZoom(mapZoomTargetRef.current),
+      };
+    },
+    [allowWheelZoom]
+  );
+
+  const handleTouchMove = useCallback(
+    (event) => {
+      if (!allowWheelZoom) {
+        return;
+      }
+
+      const distance = getTouchDistance(event?.touches);
+      const state = touchZoomStateRef.current;
+      if (distance === null || !state || !Number.isFinite(state.distance) || state.distance <= 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      const nextZoom = clampMapZoom(state.zoom * (distance / state.distance));
+      scheduleMapZoomUpdate(nextZoom);
+    },
+    [allowWheelZoom, scheduleMapZoomUpdate]
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    touchZoomStateRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const boardElement = boardRef.current;
+
+    if (!boardElement || !allowWheelZoom) {
+      return () => {};
+    }
+
+    const preventNativePinchZoom = (event) => {
+      if (event?.touches && event.touches.length >= 2) {
+        event.preventDefault();
+      }
+    };
+
+    boardElement.addEventListener('touchmove', preventNativePinchZoom, { passive: false });
+
+    return () => {
+      boardElement.removeEventListener('touchmove', preventNativePinchZoom);
+    };
+  }, [allowWheelZoom]);
 
   useEffect(() => {
     const boardElement = boardRef.current;
@@ -1993,6 +2076,10 @@ const CampaignMapBoard = ({
       )}
       style={boardStyle}
       onWheel={handleWheel}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
     >
       {title && <h5 className="campaign-map-board__title">{title}</h5>}
       {imageSrc ? (

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1962,6 +1962,7 @@ const sortedSpells = useMemo(() => {
 
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const [damageValue, setDamageValue] = useState(0);
+  const [hasDamageRoll, setHasDamageRoll] = useState(false);
   const [damageLog, setDamageLog] = useState([]);
   const [showLog, setShowLog] = useState(false);
   const [activeDice, setActiveDice] = useState([]);
@@ -2032,6 +2033,7 @@ const updateDamageValueWithAnimation = (
 ) => {
   setPulseClass('');
   setDamageValue(newValue);
+  setHasDamageRoll(newValue !== undefined);
   const details = Array.isArray(extra?.diceRolls) ? extra.diceRolls : [];
   triggerDiceAnimation(details);
   setLastRollTimestamp(Date.now());
@@ -2094,6 +2096,16 @@ const [pulseClass, setPulseClass] = useState('');
 
 useEffect(() => {
   if (typeof onDamageSummaryChange === 'function') {
+    if (!hasDamageRoll) {
+      onDamageSummaryChange({
+        value: null,
+        isCritical: false,
+        isFumble: false,
+        timestamp: null,
+      });
+      return;
+    }
+
     onDamageSummaryChange({
       value: damageValue,
       isCritical,
@@ -2101,7 +2113,7 @@ useEffect(() => {
       timestamp: lastRollTimestamp || null,
     });
   }
-}, [onDamageSummaryChange, damageValue, isCritical, isFumble, lastRollTimestamp]);
+}, [onDamageSummaryChange, hasDamageRoll, damageValue, isCritical, isFumble, lastRollTimestamp]);
 
 useEffect(() => {
   if (!lastRollTimestamp) {
@@ -2307,7 +2319,7 @@ const damageAmountStyle = {
           id="damageAmount"
           ref={damageAmountRef}
           style={damageAmountStyle}
-          className={`${pulseClass} ${isCritical ? 'critical-active' : ''} ${
+          className={`${hasDamageRoll ? 'damage-roller--visible' : 'damage-roller--hidden'} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${
             isFumble ? 'critical-failure' : ''
           }`}
         >

--- a/client/src/components/Zombies/attributes/SpellSlots.js
+++ b/client/src/components/Zombies/attributes/SpellSlots.js
@@ -229,10 +229,11 @@ export default function SpellSlots({
           <div className="spell-slot-section__label">Spell Levels</div>
           <div className="spell-slot-section__grid">
             {renderGroup(slotData, 'regular')}
+            {warlockLevels.length > 0 && renderGroup(warlockData, 'warlock')}
           </div>
         </div>
       )}
-      {showSpellSlots && warlockLevels.length > 0 && (
+      {showSpellSlots && regularLevels.length === 0 && warlockLevels.length > 0 && (
         <div className="spell-slot-section spell-slot-section--pact" aria-label="Pact magic spell slots">
           <div className="spell-slot-section__label">Pact Magic</div>
           <div className="spell-slot-section__grid">


### PR DESCRIPTION
### Motivation
- Improve mobile map interaction by supporting two-finger pinch-to-zoom and preventing native pinch-zoom gestures. 
- Fix HUD layout so resource tiles and spell labels remain visible on constrained widths and keep resources four-wide on mobile. 
- Ensure damage summary callbacks reflect the absence of a recent roll and hide the damage UI when no roll is present. 
- Tuck pact magic into the regular spell grid when space permits to reduce visual clutter.

### Description
- Add pinch-to-zoom touch support to the campaign map by introducing `getTouchDistance`, `touchZoomStateRef`, and handlers `handleTouchStart`, `handleTouchMove`, and `handleTouchEnd`, and attach them to the board element via `onTouchStart`, `onTouchMove`, `onTouchEnd`, and `onTouchCancel`.
- Prevent the browser's native pinch-zoom on the board by adding a non-passive `touchmove` listener that calls `preventDefault` for multi-touch gestures.
- Add CSS adjustments in `App.scss` to: keep spell labels visible, make the resource rail four-wide (desktop and mobile), style compact resource tiles, and visually inline a pact-magic slot inside the regular spell-grid; include touch/overscroll behavior for campaign map elements.
- Update damage roller state in `PlayerTurnActions.js` by adding `hasDamageRoll`, setting it in `updateDamageValueWithAnimation`, toggling the DOM class to show/hide the damage panel, and changing `onDamageSummaryChange` to emit `null` when no roll exists.
- Modify `SpellSlots.js` rendering so warlock (pact) slots are injected into the regular grid when `regularLevels` exist and fall back to a separate `pact` section only when no regular levels are present.

### Testing
- Ran the frontend unit test suite with `yarn test` and all tests passed. 
- Performed a development build with `yarn build` which completed successfully. 
- Automated checks/linters configured in CI passed (type/style/build checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c2bc8f71c832eba4aa48f68329a19)