### PR TITLE
Fix combat HUD resource overflow

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8701,10 +8701,38 @@ h1 {
   grid-template-columns: repeat(4, 58px);
   grid-auto-rows: 48px;
   width: 244px;
-  height: 58px;
-  max-height: 58px;
+  height: 104px;
+  max-height: 104px;
   overflow: hidden;
   align-items: stretch;
+}
+
+.combat-hud-dock__turn-slots {
+  display: flex;
+  justify-content: center;
+  width: 244px;
+  min-height: 46px;
+}
+
+.combat-hud-dock__turn-slots .spell-slot-container {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  min-height: 46px;
+  height: 46px;
+  padding: 0;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.combat-hud-dock__turn-slots .spell-slot {
+  width: 74px;
+  min-width: 74px;
+  height: 42px;
+  min-height: 42px;
+  padding: 4px 6px;
 }
 
 .combat-hud-resource-tile {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5723,6 +5723,22 @@ export default function ZombiesCharacterSheet() {
                 </Panel>
 
                 <Panel className={`combat-hud-dock__resources ${mobileHudPanel === 'resources' ? 'is-mobile-open' : ''}`} aria-label="Combat resources">
+                  {form && (
+                    <div className="combat-hud-dock__turn-slots" aria-label="Turn action tracking">
+                      <SpellSlots
+                        form={form}
+                        used={usedSlots}
+                        onToggleSlot={handleCastSpell}
+                        actionCount={actionCount}
+                        longRestCount={longRestCount}
+                        shortRestCount={shortRestCount}
+                        onActionSurge={handleActionSurge}
+                        showTurnSlots
+                        showSpellSlots={false}
+                        showFocusSlot={false}
+                      />
+                    </div>
+                  )}
                   {footerClassResources.length > 0 && (
                     <div className="combat-hud-dock__resource-rail" aria-label="Class resources">
                       {footerClassResources.map((resource) => {


### PR DESCRIPTION
### Motivation

- Class resources (Ki/Focus, Rage, Action Surge, etc.) were getting clipped to a single row and newly added resources such as `Rage` were not visible.  
- Action and bonus action tracking were removed during HUD updates and need to be restored above the resource rail for turn-based tracking.

### Description

- Restored the turn-action trackers by rendering a compact `SpellSlots` block above the class resources in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`.  
- Expanded the resource rail to support a two-row, four-column layout by increasing the rail height in `client/src/App.scss`.  
- Added styles for a new `.combat-hud-dock__turn-slots` container and tuned `.spell-slot` sizing so action/bonus circles fit in the open space above the resources in `client/src/App.scss`.  
- Kept existing resource rendering logic so derived resources (e.g., `monk-focus`, `rage`, `action-surge`, `second-wind`) continue to be generated and shown in the rail.

### Testing

- Ran `git diff --check` to validate whitespace and basic repo checks, which completed without errors.  
- Ran the component unit tests with `npm --prefix client test -- --watchAll=false --runInBand src/components/Zombies/attributes/SpellSlots.test.js --watch=false`, and the `SpellSlots` test suite passed (`10` tests passed).  
- Verified the `SpellSlots` behavior in CI-style test runs (non-watch) and observed all assertions succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c3d53f2bc832e819b0501017935cc)