### PR TITLE
Add turn-action tracker to combat HUD and adjust resource rail layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8701,10 +8701,38 @@ h1 {
   grid-template-columns: repeat(4, 58px);
   grid-auto-rows: 48px;
   width: 244px;
-  height: 58px;
-  max-height: 58px;
+  height: 104px;
+  max-height: 104px;
   overflow: hidden;
   align-items: stretch;
+}
+
+.combat-hud-dock__turn-slots {
+  display: flex;
+  justify-content: center;
+  width: 244px;
+  min-height: 46px;
+}
+
+.combat-hud-dock__turn-slots .spell-slot-container {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  min-height: 46px;
+  height: 46px;
+  padding: 0;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.combat-hud-dock__turn-slots .spell-slot {
+  width: 74px;
+  min-width: 74px;
+  height: 42px;
+  min-height: 42px;
+  padding: 4px 6px;
 }
 
 .combat-hud-resource-tile {
@@ -8824,5 +8852,51 @@ h1 {
 
   .combat-hud-dock__resources.is-mobile-open .combat-hud-resource-tile__value {
     font-size: 0.54rem;
+  }
+}
+
+/* Keep the desktop combat HUD layout stable while adding turn trackers above class resources. */
+@media (min-width: 901px) {
+  .combat-hud-dock__resources {
+    grid-template-columns: 244px minmax(340px, auto);
+    grid-template-rows: 150px;
+    align-items: stretch;
+  }
+
+  .combat-hud-dock__turn-slots {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: start;
+    justify-self: center;
+    min-height: 40px;
+    height: 40px;
+    z-index: 1;
+  }
+
+  .combat-hud-dock__turn-slots .spell-slot-container {
+    min-height: 40px;
+    height: 40px;
+  }
+
+  .combat-hud-dock__turn-slots .spell-slot {
+    width: 62px;
+    min-width: 62px;
+    height: 36px;
+    min-height: 36px;
+    padding: 3px 6px;
+  }
+
+  .combat-hud-dock__resource-rail {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: end;
+    justify-self: center;
+    margin-top: 46px;
+  }
+
+  .combat-hud-dock__resources > .spell-slot-container {
+    grid-column: 2;
+    grid-row: 1;
+    align-self: center;
   }
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5723,6 +5723,22 @@ export default function ZombiesCharacterSheet() {
                 </Panel>
 
                 <Panel className={`combat-hud-dock__resources ${mobileHudPanel === 'resources' ? 'is-mobile-open' : ''}`} aria-label="Combat resources">
+                  {form && (
+                    <div className="combat-hud-dock__turn-slots" aria-label="Turn action tracking">
+                      <SpellSlots
+                        form={form}
+                        used={usedSlots}
+                        onToggleSlot={handleCastSpell}
+                        actionCount={actionCount}
+                        longRestCount={longRestCount}
+                        shortRestCount={shortRestCount}
+                        onActionSurge={handleActionSurge}
+                        showTurnSlots
+                        showSpellSlots={false}
+                        showFocusSlot={false}
+                      />
+                    </div>
+                  )}
                   {footerClassResources.length > 0 && (
                     <div className="combat-hud-dock__resource-rail" aria-label="Class resources">
                       {footerClassResources.map((resource) => {


### PR DESCRIPTION
### Motivation
- Surface turn/action tracking above class resources in the combat HUD so players can see and toggle per-turn slots without losing the existing resource layout.
- Preserve and improve HUD fit on desktop and mobile by increasing resource rail capacity and tuning sizes so labels remain visible.

### Description
- Added a conditional `SpellSlots` render inside `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` wrapped in a `.combat-hud-dock__turn-slots` container that passes `form`, `used`, `onToggleSlot` (`handleCastSpell`), `actionCount`, `longRestCount`, `shortRestCount`, and `onActionSurge`, and sets `showTurnSlots`, `showSpellSlots: false`, and `showFocusSlot: false`.
- Expanded and reorganized HUD styles in `client/src/App.scss` by increasing `.combat-hud-dock__resource-rail` height from `58px` to `104px` and adding a new `.combat-hud-dock__turn-slots` block with sizes and spacing for mobile and desktop.
- Added a desktop `@media (min-width: 901px)` rule that lays out `.combat-hud-dock__resources` as a two-column grid and positions `.combat-hud-dock__turn-slots` above the resource rail while keeping the resource rail aligned and tucked under as before.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c3d53f2bc832e819b0501017935cc)