### PR TITLE
Add turn-action trackers to combat HUD and adjust resource layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8701,10 +8701,38 @@ h1 {
   grid-template-columns: repeat(4, 58px);
   grid-auto-rows: 48px;
   width: 244px;
-  height: 58px;
-  max-height: 58px;
+  height: 104px;
+  max-height: 104px;
   overflow: hidden;
   align-items: stretch;
+}
+
+.combat-hud-dock__turn-slots {
+  display: flex;
+  justify-content: center;
+  width: 244px;
+  min-height: 46px;
+}
+
+.combat-hud-dock__turn-slots .spell-slot-container {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  min-height: 46px;
+  height: 46px;
+  padding: 0;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.combat-hud-dock__turn-slots .spell-slot {
+  width: 74px;
+  min-width: 74px;
+  height: 42px;
+  min-height: 42px;
+  padding: 4px 6px;
 }
 
 .combat-hud-resource-tile {
@@ -8825,4 +8853,73 @@ h1 {
   .combat-hud-dock__resources.is-mobile-open .combat-hud-resource-tile__value {
     font-size: 0.54rem;
   }
+}
+
+/* Keep the desktop combat HUD layout stable while adding turn trackers above class resources. */
+@media (min-width: 901px) {
+  .combat-hud-dock__resources {
+    grid-template-columns: 244px minmax(340px, auto);
+    grid-template-rows: 150px;
+    align-items: stretch;
+  }
+
+  .combat-hud-dock__turn-slots {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: start;
+    justify-self: center;
+    min-height: 40px;
+    height: 40px;
+    z-index: 1;
+  }
+
+  .combat-hud-dock__turn-slots .spell-slot-container {
+    min-height: 40px;
+    height: 40px;
+  }
+
+  .combat-hud-dock__turn-slots .spell-slot {
+    width: 62px;
+    min-width: 62px;
+    height: 36px;
+    min-height: 36px;
+    padding: 3px 6px;
+  }
+
+  .combat-hud-dock__resource-rail {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: end;
+    justify-self: center;
+    margin-top: 46px;
+  }
+
+  .combat-hud-dock__resources > .spell-slot-container {
+    grid-column: 2;
+    grid-row: 1;
+    align-self: center;
+  }
+}
+
+/* Color-code turn action trackers in the combat HUD. */
+.combat-hud-dock__turn-slots .action-slot {
+  border-color: rgba(74, 222, 128, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.14), 0 0 18px rgba(34, 197, 94, 0.2);
+}
+
+.combat-hud-dock__turn-slots .bonus-slot {
+  border-color: rgba(250, 204, 21, 0.76);
+  box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.14), 0 0 18px rgba(234, 179, 8, 0.22);
+}
+
+.combat-hud-dock__turn-slots .action-circle.slot-active {
+  background: radial-gradient(circle at 32% 28%, #dcfce7, #22c55e 38%, #15803d 78%);
+  border-color: rgba(187, 247, 208, 0.96);
+  box-shadow: 0 0 8px rgba(74, 222, 128, 0.92), 0 0 18px rgba(34, 197, 94, 0.48), inset 0 0 7px rgba(255, 255, 255, 0.34);
+}
+
+.combat-hud-dock__turn-slots .bonus-circle.slot-active {
+  background: radial-gradient(circle at 32% 28%, #fef9c3, #facc15 38%, #ca8a04 78%);
+  border-color: rgba(254, 240, 138, 0.96);
+  box-shadow: 0 0 8px rgba(250, 204, 21, 0.92), 0 0 18px rgba(234, 179, 8, 0.5), inset 0 0 7px rgba(255, 255, 255, 0.34);
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5723,6 +5723,22 @@ export default function ZombiesCharacterSheet() {
                 </Panel>
 
                 <Panel className={`combat-hud-dock__resources ${mobileHudPanel === 'resources' ? 'is-mobile-open' : ''}`} aria-label="Combat resources">
+                  {form && (
+                    <div className="combat-hud-dock__turn-slots" aria-label="Turn action tracking">
+                      <SpellSlots
+                        form={form}
+                        used={usedSlots}
+                        onToggleSlot={handleCastSpell}
+                        actionCount={actionCount}
+                        longRestCount={longRestCount}
+                        shortRestCount={shortRestCount}
+                        onActionSurge={handleActionSurge}
+                        showTurnSlots
+                        showSpellSlots={false}
+                        showFocusSlot={false}
+                      />
+                    </div>
+                  )}
                   {footerClassResources.length > 0 && (
                     <div className="combat-hud-dock__resource-rail" aria-label="Class resources">
                       {footerClassResources.map((resource) => {


### PR DESCRIPTION
### Motivation
- Surface per-turn action/bonus tracking in the combat HUD so players can see turn actions above class resources.
- Prevent HUD content from shifting by adapting the resources rail height and desktop layout when adding turn trackers.

### Description
- Added `.combat-hud-dock__turn-slots` styles and responsive desktop rules in `client/src/App.scss` to provide a dedicated row for turn action/bonus trackers, with color-coded active/inactive states and layout tweaks for mobile and desktop.
- Increased `.combat-hud-dock__resource-rail` height from `58px` to `104px` and adjusted `max-height` to accommodate the new turn tracker row without collapsing resources.
- Updated `ZombiesCharacterSheet` in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` to render a `SpellSlots` component inside a new `combat-hud-dock__turn-slots` container when `form` is present, passing `showTurnSlots`, `showSpellSlots: false`, and `showFocusSlot: false` plus existing handlers like `onToggleSlot` and `onActionSurge`.

### Testing
- Ran unit and snapshot tests with `yarn test` and observed all tests passing.
- Ran linting with `yarn lint` with no new violations reported.
- Verified client build with `yarn build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c3d53f2bc832e819b0501017935cc)