### PR TITLE
Show roll-type labels in damage display (Damage / Attack Roll / Roll / Skill Roll / Stat Roll)

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -441,6 +441,7 @@ const PlayerTurnActions = React.forwardRef(
         : undefined,
       modifierValues: undefined,
       usedFallback,
+      rollLabel: 'Roll',
     });
 
     setShowDiceRoller(false);
@@ -1764,6 +1765,7 @@ const manualCriticalRef = useRef(false);
           source: `${weaponLabel} Attack Roll`,
           critical: d20 === 20,
           fumble: d20 === 1,
+          rollLabel: 'Attack Roll',
           diceRolls: [
             {
               sides: 20,
@@ -1806,6 +1808,7 @@ const manualCriticalRef = useRef(false);
             source: `${spell?.name || 'Spell'} Spell Attack Roll`,
             critical: d20 === 20,
             fumble: d20 === 1,
+            rollLabel: 'Attack Roll',
             diceRolls: [
               {
                 sides: 20,
@@ -1963,6 +1966,7 @@ const sortedSpells = useMemo(() => {
 // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
 const [damageValue, setDamageValue] = useState(0);
   const [hasDamageRoll, setHasDamageRoll] = useState(false);
+  const [damageRollLabel, setDamageRollLabel] = useState('Damage');
   const [damageLog, setDamageLog] = useState([]);
   const [showLog, setShowLog] = useState(false);
   const [activeDice, setActiveDice] = useState([]);
@@ -2034,6 +2038,11 @@ const updateDamageValueWithAnimation = (
   setPulseClass('');
   setDamageValue(newValue);
   setHasDamageRoll(newValue !== undefined);
+  setDamageRollLabel(
+    typeof extra?.rollLabel === 'string' && extra.rollLabel.trim()
+      ? extra.rollLabel.trim()
+      : 'Damage'
+  );
   const details = Array.isArray(extra?.diceRolls) ? extra.diceRolls : [];
   triggerDiceAnimation(details);
   setLastRollTimestamp(Date.now());
@@ -2099,6 +2108,7 @@ useEffect(() => {
     if (!hasDamageRoll) {
       onDamageSummaryChange({
         value: null,
+        label: 'Damage',
         isCritical: false,
         isFumble: false,
         timestamp: null,
@@ -2108,12 +2118,21 @@ useEffect(() => {
 
     onDamageSummaryChange({
       value: damageValue,
+      label: damageRollLabel,
       isCritical,
       isFumble,
       timestamp: lastRollTimestamp || null,
     });
   }
-}, [onDamageSummaryChange, hasDamageRoll, damageValue, isCritical, isFumble, lastRollTimestamp]);
+}, [
+  onDamageSummaryChange,
+  hasDamageRoll,
+  damageValue,
+  damageRollLabel,
+  isCritical,
+  isFumble,
+  lastRollTimestamp,
+]);
 
 useEffect(() => {
   if (!lastRollTimestamp) {

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -426,6 +426,7 @@ export default function Skills({
           value: result,
           breakdown: breakdownParts.join(' '),
           source: skillLabel,
+          rollLabel: 'Skill Roll',
           critical: d20 === 20,
           fumble: d20 === 1,
           diceRolls,

--- a/client/src/components/Zombies/attributes/Stats.js
+++ b/client/src/components/Zombies/attributes/Stats.js
@@ -189,6 +189,7 @@ export default function Stats({
             value: result,
             breakdown: breakdownParts.join(' '),
             source: statLabel,
+            rollLabel: 'Stat Roll',
             critical: d20 === 20,
             fumble: d20 === 1,
             diceRolls,

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -3487,6 +3487,7 @@ export default function ZombiesCharacterSheet() {
   const [isDamagePopupDismissed, setIsDamagePopupDismissed] = useState(false);
   const [footerDamageSummary, setFooterDamageSummary] = useState({
     value: null,
+    label: 'Damage',
     isCritical: false,
     isFumble: false,
     timestamp: null,
@@ -3495,10 +3496,15 @@ export default function ZombiesCharacterSheet() {
   const handleDamageSummaryChange = useCallback((summary) => {
     setFooterDamageSummary((prev) => {
       if (!summary || typeof summary !== 'object') {
-        if (prev.value === null && !prev.isCritical && !prev.isFumble) {
+        if (
+          prev.value === null &&
+          (prev.label === 'Damage' || !prev.label) &&
+          !prev.isCritical &&
+          !prev.isFumble
+        ) {
           return prev;
         }
-        return { value: null, isCritical: false, isFumble: false, timestamp: null };
+        return { value: null, label: 'Damage', isCritical: false, isFumble: false, timestamp: null };
       }
 
       const next = {
@@ -3507,6 +3513,10 @@ export default function ZombiesCharacterSheet() {
           summary.value !== undefined
             ? summary.value
             : null,
+        label:
+          typeof summary.label === 'string' && summary.label.trim()
+            ? summary.label.trim()
+            : 'Damage',
         isCritical: Boolean(summary.isCritical),
         isFumble: Boolean(summary.isFumble),
         timestamp:
@@ -3517,6 +3527,7 @@ export default function ZombiesCharacterSheet() {
 
       if (
         prev.value === next.value &&
+        prev.label === next.label &&
         prev.isCritical === next.isCritical &&
         prev.isFumble === next.isFumble &&
         prev.timestamp === next.timestamp
@@ -5660,7 +5671,7 @@ export default function ZombiesCharacterSheet() {
               >
                 ×
               </button>
-              <span className="combat-hud-damage-popup__label">Damage</span>
+              <span className="combat-hud-damage-popup__label">{footerDamageSummary.label || 'Damage'}</span>
               <strong className="combat-hud-damage-popup__value">{footerDamageSummary.value}</strong>
               <button
                 type="button"

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -91,13 +91,14 @@ const FooterCharacterSlot = ({
 
   const normalizedDamageSummary = useMemo(() => {
     if (!damageSummary || typeof damageSummary !== 'object') {
-      return { value: null, isCritical: false, isFumble: false, timestamp: null };
+      return { value: null, label: 'Damage', isCritical: false, isFumble: false, timestamp: null };
     }
 
-    const { value, isCritical, isFumble, timestamp } = damageSummary;
+    const { value, label, isCritical, isFumble, timestamp } = damageSummary;
 
     return {
       value: value !== undefined ? value : null,
+      label: typeof label === 'string' && label.trim() ? label.trim() : 'Damage',
       isCritical: Boolean(isCritical),
       isFumble: Boolean(isFumble),
       timestamp:
@@ -107,6 +108,7 @@ const FooterCharacterSlot = ({
 
   const {
     value: damageSummaryValue,
+    label: damageLabel,
     isCritical: damageIsCritical,
     isFumble: damageIsFumble,
     timestamp: damageTimestamp,
@@ -470,7 +472,7 @@ const FooterCharacterSlot = ({
                 {hasDamageDisplay ? (
                   <div className={damageClassName} role="status" aria-live="polite">
                     <div className="footer-character-slot__damage-header">
-                      <span className="footer-character-slot__damage-label">Damage</span>
+                      <span className="footer-character-slot__damage-label">{damageLabel}</span>
                       {typeof onToggleCritical === 'function' ? (
                         <Button
                           type="button"


### PR DESCRIPTION
### Motivation
- Make the footer/combat HUD damage label reflect the type of roll that produced the value instead of always showing “Damage”.
- Provide distinct user-facing labels for manual dice rolls, weapon/spell attack rolls, skill checks, and stat checks to improve clarity in gameplay feedback.
- Keep the existing behavior as the default by falling back to “Damage” when no specific roll type is provided.

### Description
- Added a `damageRollLabel` state in the damage roller and propagated a `rollLabel` field through `updateDamageValueWithAnimation` and the `damage-roll` CustomEvent payload. 
- Emit `rollLabel: 'Roll'` for manual dice roller results, `rollLabel: 'Attack Roll'` for weapon and spell attack roll handlers, `rollLabel: 'Skill Roll'` for skill checks, and `rollLabel: 'Stat Roll'` for stat checks. 
- Updated the damage summary object used by the footer so `onDamageSummaryChange` now includes a `label` property and consumers normalize and display that label with a default of `Damage`.
- Updated `FooterCharacterSlot` and the combat HUD popup in `ZombiesCharacterSheet` to render the dynamic label (falling back to `Damage`).

### Testing
- Ran ESLint with `npx eslint <modified files>` which completed with no errors but preserved existing repository warnings. 
- Ran the focused test command `npm test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/Stats.test.js src/components/Zombies/attributes/Skills.test.js src/components/Zombies/attributes/PlayerTurnActions.test.js`, where `Stats` and `Skills` suites passed and `PlayerTurnActions` tests failed with assertions unrelated to the label propagation changes. 
- Performed a quick `git diff --check` style validation (no diff-check issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c49c7d694832eae333db03a56bda3)