### PR TITLE
Keep map token rotation controls visible

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -5608,6 +5608,7 @@ h1 {
   }
 
   &__token.lastDragged &__rotation-controls,
+  &__token--rotation-visible &__rotation-controls,
   &__rotation-controls:focus-within {
     opacity: 1;
   }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1582,7 +1582,7 @@ const CampaignMapBoard = ({
     if (rotationMoveHandlerRef.current) {
       targets.forEach((target) => {
         if (target && typeof target.removeEventListener === 'function') {
-          if (pointerEventsSupported) {
+          if (typeof rotationMoveHandlerRef.current === 'function') {
             target.removeEventListener('pointermove', rotationMoveHandlerRef.current);
           } else {
             const handlers = rotationMoveHandlerRef.current;
@@ -1601,7 +1601,7 @@ const CampaignMapBoard = ({
     if (rotationUpHandlerRef.current) {
       targets.forEach((target) => {
         if (target && typeof target.removeEventListener === 'function') {
-          if (pointerEventsSupported) {
+          if (typeof rotationUpHandlerRef.current === 'function') {
             target.removeEventListener('pointerup', rotationUpHandlerRef.current);
           } else {
             const handlers = rotationUpHandlerRef.current;
@@ -1620,7 +1620,7 @@ const CampaignMapBoard = ({
     if (rotationCancelHandlerRef.current) {
       targets.forEach((target) => {
         if (target && typeof target.removeEventListener === 'function') {
-          if (pointerEventsSupported) {
+          if (typeof rotationCancelHandlerRef.current === 'function') {
             target.removeEventListener('pointercancel', rotationCancelHandlerRef.current);
           } else {
             const handlers = rotationCancelHandlerRef.current;
@@ -1963,7 +1963,11 @@ const CampaignMapBoard = ({
         stopRotationDrag();
       };
 
-      if (pointerEventsSupported) {
+      const usePointerEventListeners =
+        pointerEventsSupported ||
+        (typeof event?.type === 'string' && event.type.startsWith('pointer'));
+
+      if (usePointerEventListeners) {
         rotationMoveHandlerRef.current = handleMove;
         rotationUpHandlerRef.current = handleRelease;
         rotationCancelHandlerRef.current = handleCancel;
@@ -1992,7 +1996,7 @@ const CampaignMapBoard = ({
 
       targets.forEach((target) => {
         if (target && typeof target.addEventListener === 'function') {
-          if (pointerEventsSupported) {
+          if (usePointerEventListeners) {
             target.addEventListener('pointermove', handleMove, { passive: false });
             target.addEventListener('pointerup', handleRelease, { passive: false });
             target.addEventListener('pointercancel', handleCancel, { passive: false });
@@ -2062,7 +2066,7 @@ const CampaignMapBoard = ({
       return;
     }
 
-    setLastDraggedTokenId((prev) => (prev === tokenId ? null : prev));
+    setLastDraggedTokenId(tokenId);
   }, []);
 
   useEffect(() => {
@@ -2284,7 +2288,8 @@ const CampaignMapBoard = ({
                 const isRotationActive = lastDraggedTokenId === characterId;
                 const isRotationHovered = hoveredTokenId === characterId;
                 const isRotationDragging = draggingRotationTokenId === characterId;
-                const isRotationVisible = isRotationHovered || isRotationDragging;
+                const isRotationVisible =
+                  isRotationActive || isRotationHovered || isRotationDragging;
 
                 const labelClassName = classNames(
                   'campaign-map-board__figurine-label',
@@ -2306,6 +2311,7 @@ const CampaignMapBoard = ({
                       isActiveTurn && 'campaign-map-board__token--active-turn',
                       `campaign-map-board__token--size-${sizeKey}`,
                       isRotationActive && 'lastDragged',
+                      isRotationVisible && 'campaign-map-board__token--rotation-visible',
                       isRotationDragging && 'campaign-map-board__token--rotation-active'
                     )}
                     style={{
@@ -2339,17 +2345,23 @@ const CampaignMapBoard = ({
                     onPointerOver={() => {
                       if (!interactionDisabled && characterId) {
                         setHoveredTokenId(characterId);
+                        setLastDraggedTokenId((prev) =>
+                          prev && prev !== characterId ? null : prev
+                        );
                       }
                     }}
                     onPointerEnter={() => {
                       if (!interactionDisabled && characterId) {
                         setHoveredTokenId(characterId);
+                        setLastDraggedTokenId((prev) =>
+                          prev && prev !== characterId ? null : prev
+                        );
                       }
                     }}
                     onPointerLeave={(event) => {
                       if (
                         draggingRotationTokenId === characterId ||
-                        (event?.relatedTarget &&
+                        (event?.relatedTarget?.nodeType &&
                           event.currentTarget &&
                           event.currentTarget.contains(event.relatedTarget))
                       ) {
@@ -2389,7 +2401,7 @@ const CampaignMapBoard = ({
                       }
                       if (
                         draggingRotationTokenId === characterId ||
-                        (event?.relatedTarget &&
+                        (event?.relatedTarget?.nodeType &&
                           event.currentTarget &&
                           event.currentTarget.contains(event.relatedTarget))
                       ) {
@@ -2404,6 +2416,9 @@ const CampaignMapBoard = ({
                       }
                       if (!interactionDisabled && characterId) {
                         setHoveredTokenId(characterId);
+                        setLastDraggedTokenId((prev) =>
+                          prev && prev !== characterId ? null : prev
+                        );
                       }
                     }}
                     onMouseEnter={() => {
@@ -2412,6 +2427,9 @@ const CampaignMapBoard = ({
                       }
                       if (!interactionDisabled && characterId) {
                         setHoveredTokenId(characterId);
+                        setLastDraggedTokenId((prev) =>
+                          prev && prev !== characterId ? null : prev
+                        );
                       }
                     }}
                     onTouchStart={(event) => {

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -22,7 +22,7 @@ describe('CampaignMapBoard pointer interactions', () => {
     render(
       <CampaignMapBoard
         map={baseMap}
-        tokens={[{ ...baseToken, ...overrides.token }]}
+        tokens={overrides.tokens || [{ ...baseToken, ...overrides.token }]}
         onTokenDragStart={overrides.onTokenDragStart}
         onTokenDrag={overrides.onTokenDrag}
         onTokenDragEnd={overrides.onTokenDragEnd}
@@ -230,6 +230,94 @@ describe('CampaignMapBoard pointer interactions', () => {
     fireEvent(tokenElement, pointerUpEvent);
 
     expect(pointerUpEvent.defaultPrevented).toBe(true);
+  });
+
+  it('keeps rotation controls visible after a token click until background or another token hover', async () => {
+    const { container, findByRole, queryByRole } = renderBoard({
+      tokens: [
+        { ...baseToken },
+        {
+          ...baseToken,
+          characterId: 'enemy-1',
+          x: 0.55,
+          y: 0.55,
+          label: 'Enemy Token',
+          variant: 'enemy',
+        },
+      ],
+    });
+
+    const layer = container.querySelector('.campaign-map-board__tokens-layer');
+    expect(layer).not.toBeNull();
+    if (layer) {
+      layer.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 400,
+      });
+    }
+
+    let tokenElement = container.querySelector('[data-token-id="char-1"]');
+    expect(tokenElement).not.toBeNull();
+
+    fireEvent.pointerDown(tokenElement, {
+      button: 0,
+      pointerId: 1,
+      clientX: 100,
+      clientY: 100,
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent.pointerUp(tokenElement, {
+      button: 0,
+      pointerId: 1,
+      clientX: 100,
+      clientY: 100,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    const rotationHandle = await findByRole('button', { name: /rotate figurine/i });
+    expect(rotationHandle).not.toBeNull();
+
+    fireEvent.pointerLeave(tokenElement, {
+      pointerId: 1,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(queryByRole('button', { name: /rotate figurine/i })).not.toBeNull();
+
+    const enemyElement = container.querySelector('[data-token-id="enemy-1"]');
+    expect(enemyElement).not.toBeNull();
+    fireEvent.pointerOver(enemyElement, {
+      pointerId: 2,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-token-id="char-1"]')).not.toHaveClass('lastDragged');
+      expect(container.querySelector('[data-token-id="enemy-1"]')).toHaveClass(
+        'campaign-map-board__token--rotation-visible'
+      );
+    });
+
+    if (layer) {
+      fireEvent.pointerDown(layer, {
+        button: 0,
+        pointerId: 3,
+        clientX: 250,
+        clientY: 250,
+        bubbles: true,
+        cancelable: true,
+      });
+    }
+
+    await waitFor(() => {
+      expect(queryByRole('button', { name: /rotate figurine/i })).toBeNull();
+    });
   });
 
   it('marks the last dragged token and enables rotation controls', async () => {


### PR DESCRIPTION
### Motivation
- Make the rotate control remain visible after a token is clicked or selected so users can rotate without keeping the pointer on the token, and hide it only when the background is clicked or another token/enemy becomes active.

### Description
- Consider a token `rotation` control visible when it is the last-selected token, hovered, or actively dragging by changing `isRotationVisible` to include `lastDraggedTokenId` in `CampaignMapBoard.js` and add a `campaign-map-board__token--rotation-visible` class to tokens.
- Keep the rotate control visible by clearing the previous selected token when another token is hovered via modifications to pointer/mouse `onPointerOver`/`onMouseOver`/`onPointerEnter`/`onMouseEnter` handlers and adjust `lockRotation` behavior so selection persists until explicitly cleared.
- Ensure rotation pointer listeners are added/removed correctly by storing and checking handler types when cleaning up listeners and by preferring pointer event listeners when the initiating event is a pointer event in `CampaignMapBoard.js`.
- Add a CSS rule to reveal rotation controls for the new `--rotation-visible` state in `client/src/App.scss` and add a test that verifies visibility is preserved after click and cleared by background click or hovering another token in `CampaignMapBoard.test.js`.

### Testing
- Ran the component test suite for the map board with `npm test -- --runInBand CampaignMapBoard.test.js` and all tests passed (`13 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c4ba11358832e976504d79563b8d5)