### PR TITLE
Centralize and upgrade item icons with ItemIcon component

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9496,3 +9496,35 @@ h1 {
   z-index: 4;
   pointer-events: none;
 }
+
+.item-icon {
+  --item-icon-accent: #8b7355;
+  --item-icon-glow: rgba(139, 115, 85, 0.18);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--item-icon-size, 40px);
+  height: var(--item-icon-size, 40px);
+  flex: 0 0 var(--item-icon-size, 40px);
+  color: #2f261b;
+  border: 1px solid color-mix(in srgb, var(--item-icon-accent) 65%, #1f160e);
+  border-radius: 0.8rem;
+  background:
+    radial-gradient(circle at 35% 25%, rgba(255, 255, 255, 0.48), transparent 38%),
+    linear-gradient(145deg, #f4ead7, #cfb98e 58%, #9a774d);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+    0 0 0 2px rgba(50, 36, 21, 0.08),
+    0 0 16px var(--item-icon-glow);
+}
+
+.item-icon svg {
+  display: block;
+  filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.35));
+}
+
+.item-icon--uncommon { --item-icon-accent: #2e9f5c; --item-icon-glow: rgba(46, 159, 92, 0.28); }
+.item-icon--rare { --item-icon-accent: #2f79d1; --item-icon-glow: rgba(47, 121, 209, 0.32); }
+.item-icon--very-rare { --item-icon-accent: #8b5bd6; --item-icon-glow: rgba(139, 91, 214, 0.34); }
+.item-icon--legendary { --item-icon-accent: #d8892f; --item-icon-glow: rgba(216, 137, 47, 0.42); }
+.item-icon--artifact { --item-icon-accent: #d43f5f; --item-icon-glow: rgba(212, 63, 95, 0.46); }

--- a/client/src/components/Accessories/AccessoryList.js
+++ b/client/src/components/Accessories/AccessoryList.js
@@ -1,16 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Card, Row, Col, Alert, Button, Badge, Modal } from 'react-bootstrap';
-import {
-  GiNecklace,
-  GiBelt,
-  GiBracers,
-  GiCape,
-  GiSteampunkGoggles,
-  GiCarnivalMask,
-  GiRing,
-  GiWrappedHeart,
-  GiTreasureMap,
-} from 'react-icons/gi';
+import ItemIcon from '../common/ItemIcon';
 import apiFetch from '../../utils/apiFetch';
 import { STATS } from '../Zombies/statSchema';
 import { SKILLS } from '../Zombies/skillSchema';
@@ -33,19 +23,6 @@ const SLOT_LABELS = EQUIPMENT_SLOT_LAYOUT.flat().reduce((acc, slot) => {
   return acc;
 }, {});
 
-const categoryIcons = {
-  amulet: GiNecklace,
-  belt: GiBelt,
-  bracelet: GiBracers,
-  brooch: GiTreasureMap,
-  cape: GiCape,
-  cloak: GiCape,
-  goggles: GiSteampunkGoggles,
-  mask: GiCarnivalMask,
-  ring: GiRing,
-  sash: GiBelt,
-  wrap: GiWrappedHeart,
-};
 
 const renderBonuses = (bonuses, labels) =>
   Object.entries(bonuses || {})
@@ -530,17 +507,12 @@ function AccessoryList({
             copyIndex,
             copyCount,
           }) => {
-            const categoryKey =
-              typeof accessory.category === 'string'
-                ? accessory.category.toLowerCase()
-                : '';
-            const Icon = categoryIcons[categoryKey] || GiTreasureMap;
             return (
               <Col key={reactKey}>
                 <Card className="item-card h-100">
                   <Card.Body className="d-flex flex-column">
                     <div className="d-flex justify-content-center mb-2">
-                      <Icon size={40} title={accessory.category} />
+                      <ItemIcon item={accessory} itemType="accessory" category={accessory.category} size={44} />
                     </div>
                     <Card.Title>
                       {accessory.displayName || accessory.name}

--- a/client/src/components/Armor/ArmorList.js
+++ b/client/src/components/Armor/ArmorList.js
@@ -1,12 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Form, Alert, Row, Col, Button, Badge, Modal } from 'react-bootstrap';
-import {
-  GiLeatherArmor,
-  GiBreastplate,
-  GiChainMail,
-  GiShield,
-  GiArmorVest,
-} from 'react-icons/gi';
+import ItemIcon from '../common/ItemIcon';
 import apiFetch from '../../utils/apiFetch';
 
 /** @typedef {import('../../../../types/armor').Armor} Armor */
@@ -349,12 +343,6 @@ function ArmorList({
     return <div>Loading...</div>;
   }
 
-  const categoryIcons = {
-    light: GiLeatherArmor,
-    medium: GiBreastplate,
-    heavy: GiChainMail,
-    shield: GiShield,
-  };
 
   const handleAddToCart = (piece) => () => {
     const payload = {
@@ -509,13 +497,12 @@ function ArmorList({
       ) : (
         <Row className="g-2">
           {expandedEntries.map(({ reactKey, dataKey, piece, copyIndex, copyCount }) => {
-            const Icon = categoryIcons[piece.category] || GiArmorVest;
             return (
               <Col xs={6} md={4} key={reactKey}>
                 <Card className="armor-card h-100">
                   <Card.Body className="d-flex flex-column">
                   <div className="d-flex justify-content-center mb-2">
-                    <Icon size={40} title={piece.category} />
+                    <ItemIcon item={piece} itemType="armor" category={piece.category || piece.type} size={44} />
                   </div>
                   <Card.Title as="h6">{piece.displayName || piece.name}</Card.Title>
                   <Card.Text>

--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -1,16 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Row, Col, Alert, Button, Modal, Badge, Form } from 'react-bootstrap';
-import {
-  GiAmmoBox,
-  GiBackpack,
-  GiChariot,
-  GiHammerNails,
-  GiHorseHead,
-  GiPotionBall,
-  GiSaddle,
-  GiSailboat,
-  GiTreasureMap,
-} from 'react-icons/gi';
+import ItemIcon from '../common/ItemIcon';
 import apiFetch from '../../utils/apiFetch';
 import { rollDiceWithBox, setDiceBoxThemeColor } from '../../utils/diceBoxManager';
 import {
@@ -30,17 +20,6 @@ const SKILL_LABELS = SKILLS.reduce((acc, { key, label }) => {
   return acc;
 }, {});
 
-const categoryIcons = {
-  'adventuring gear': GiBackpack,
-  ammunition: GiAmmoBox,
-  consumable: GiPotionBall,
-  tool: GiHammerNails,
-  mount: GiHorseHead,
-  'tack and harness': GiSaddle,
-  vehicle: GiChariot,
-  'water vehicle': GiSailboat,
-  custom: GiTreasureMap,
-};
 
 const renderBonuses = (bonuses, labels) =>
   Object.entries(bonuses || {})
@@ -790,11 +769,6 @@ function ItemList({
       ) : (
         <Row className="row-cols-2 row-cols-lg-3 g-3">
           {displayEntries.map(({ reactKey, dataKey, item }) => {
-            const categoryKey =
-              typeof item.category === 'string'
-                ? item.category.toLowerCase()
-                : '';
-            const Icon = categoryIcons[categoryKey] || GiTreasureMap;
             const canUseItem = ownedOnly && isConsumableItem(item);
             const quantity = ownedOnly ? item.ownedCount ?? 0 : 0;
             return (
@@ -807,7 +781,7 @@ function ItemList({
                   ) : null}
                   <Card.Body className="d-flex flex-column">
                     <div className="d-flex justify-content-center mb-2">
-                      <Icon size={40} title={item.category} />
+                      <ItemIcon item={item} itemType="item" category={item.category} size={44} />
                     </div>
                     <Card.Title>{item.displayName || item.name}</Card.Title>
                     <Card.Text>Category: {item.category}</Card.Text>

--- a/client/src/components/Weapons/WeaponList.js
+++ b/client/src/components/Weapons/WeaponList.js
@@ -1,12 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Row, Col, Form, Alert, Button, Badge, Modal } from 'react-bootstrap';
-import {
-  GiStoneAxe,
-  GiBowArrow,
-  GiBroadsword,
-  GiCrossbow,
-  GiCrossedSwords,
-} from 'react-icons/gi';
+import ItemIcon from '../common/ItemIcon';
 import apiFetch from '../../utils/apiFetch';
 
 /** @typedef {import('../../../../types/weapon').Weapon} Weapon */
@@ -327,12 +321,6 @@ function WeaponList({
     return <div>Loading...</div>;
   }
 
-  const categoryIcons = {
-    'simple melee': GiStoneAxe,
-    'simple ranged': GiBowArrow,
-    'martial melee': GiBroadsword,
-    'martial ranged': GiCrossbow,
-  };
 
   const handleAddToCart = (weapon) => () => {
     const payload = {
@@ -476,13 +464,12 @@ function WeaponList({
             copyIndex,
             copyCount,
           }) => {
-            const Icon = categoryIcons[weapon.category] || GiCrossedSwords;
             return (
               <Col key={reactKey}>
                 <Card className="weapon-card h-100">
                   <Card.Body className="d-flex flex-column">
                   <div className="d-flex justify-content-center mb-2">
-                    <Icon size={40} title={weapon.category} />
+                    <ItemIcon item={weapon} itemType="weapon" category={weapon.category} size={44} />
                   </div>
                   <Card.Title>{weapon.displayName || weapon.name}</Card.Title>
                   <Card.Text>Damage: {weapon.damage}</Card.Text>

--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback } from 'react';
 import { Form, Button } from 'react-bootstrap';
 import { EQUIPMENT_SLOT_LAYOUT } from './equipmentSlots';
+import ItemIcon from '../../common/ItemIcon';
 import styles from './EquipmentRack.module.scss';
 
 const FLAT_SLOTS = EQUIPMENT_SLOT_LAYOUT.flat();
@@ -188,25 +189,6 @@ const SLOT_LAYOUT = {
   bottomRow: ['mainHand', 'offHand', 'ranged', 'ringLeft', 'ringRight'],
 };
 
-const SLOT_ICONS = {
-  head: '🪖',
-  eyes: '👁️',
-  neck: '🧿',
-  shoulders: '🛡️',
-  chest: '👕',
-  back: '🎒',
-  arms: '💪',
-  wrists: '⛓️',
-  hands: '🧤',
-  waist: '🧷',
-  legs: '🦵',
-  feet: '🥾',
-  mainHand: '⚔️',
-  offHand: '🛡️',
-  ranged: '🏹',
-  ringLeft: '💍',
-  ringRight: '💍',
-};
 
 const getItemName = (item) => {
   if (!item) return '';
@@ -357,11 +339,12 @@ export default function EquipmentRack({
     return (
       <div key={slot.key} className={styles.slot}>
         <div className={styles.slotHeader}>
-          {SLOT_ICONS[slot.key] ? (
-            <span aria-hidden="true" className={styles.slotIcon}>
-              {SLOT_ICONS[slot.key]}
-            </span>
-          ) : null}
+          <ItemIcon
+            equipmentSlot={slot.key}
+            size={28}
+            className={styles.slotIcon}
+            title={slot.label}
+          />
           <span className={styles.slotLabel}>{slot.label}</span>
         </div>
         <div

--- a/client/src/components/common/ItemIcon.js
+++ b/client/src/components/common/ItemIcon.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import {
+  Archive, Axe, Backpack, Badge, Beef, BookOpen, Box, Briefcase, ChevronUp,
+  CircleDot, Coins, Crosshair, Diamond, Drum, Eye, FlaskConical, Footprints,
+  Gem, Glasses, Hammer, Hand, KeyRound, Landmark, Map, Milk, Package,
+  Pickaxe, ScrollText, Shield, Shirt, Sparkles, Sword, Swords, Utensils,
+  Wand2, Wallet, Wrench,
+} from 'lucide-react';
+
+const normalize = (value) =>
+  typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/[’']/g, '').replace(/[\s_-]+/g, ' ')
+    : '';
+
+const splitTerms = (value) => {
+  if (Array.isArray(value)) return value.map(normalize).filter(Boolean);
+  const normalized = normalize(value);
+  return normalized ? [normalized] : [];
+};
+
+const makeSvg = (paths) => (props) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    {paths.map((d) => <path key={d} d={d} />)}
+  </svg>
+);
+
+const CUSTOM_ICONS = {
+  bow: makeSvg(['M17 3c-4 3.6-4 14.4 0 18', 'M17 3c2.5 4.7 2.5 13.3 0 18', 'M6 12h11', 'm10 8-4 4 4 4']),
+  crossbow: makeSvg(['M4 7c4 3 12 3 16 0', 'M4 7c3-3 13-3 16 0', 'M12 6v13', 'M8 19h8', 'M5 12h14', 'm17 10 2 2-2 2']),
+  dagger: makeSvg(['m14 3 7 7-8.5 5.5L8.5 11.5 14 3Z', 'm4 20 5-5', 'm7 13 4 4']),
+  staff: makeSvg(['M12 22V8', 'M12 2 9 6l3 4 3-4-3-4Z', 'M8 12h8']),
+  helmet: makeSvg(['M4 13a8 8 0 0 1 16 0v3H4v-3Z', 'M4 16v3h5v-3', 'M15 16v3h5v-3', 'M12 5v11']),
+  ring: makeSvg(['M8 10 12 4l4 6', 'M7 14a5 5 0 1 0 10 0 5 5 0 0 0-10 0Z', 'M9 10h6']),
+  amulet: makeSvg(['M6 3c0 5 12 5 12 0', 'M12 8v4', 'm9 14 3-3 3 3-3 6-3-6']),
+  cloak: makeSvg(['M8 4h8l3 17-7-3-7 3L8 4Z', 'M9 4c1.5 2 4.5 2 6 0']),
+  boots: makeSvg(['M7 3v12l-3 3v3h8v-3l-2-3V3', 'M15 3v11l-2 3v3h7v-3l-2-3V3']),
+  belt: makeSvg(['M3 9h18v6H3z', 'M10 8h4v8h-4z', 'M14 12h3']),
+  torch: makeSvg(['M12 8c-2-2 1-4 0-6 4 2 5 5 2 8', 'M10 9h6l-2 12h-2L10 9Z', 'M9 13h6']),
+};
+
+const ICON_RULES = [
+  { terms: ['crossbow'], icon: CUSTOM_ICONS.crossbow }, { terms: ['longbow', 'shortbow', 'bow'], icon: CUSTOM_ICONS.bow },
+  { terms: ['dagger', 'knife', 'dart'], icon: CUSTOM_ICONS.dagger }, { terms: ['greatsword', 'longsword', 'shortsword', 'scimitar', 'rapier', 'sword'], icon: Sword },
+  { terms: ['battleaxe', 'handaxe', 'greataxe', 'axe'], icon: Axe }, { terms: ['warhammer', 'maul', 'hammer', 'mace', 'club'], icon: Hammer },
+  { terms: ['spear', 'javelin', 'lance', 'pike', 'halberd', 'glaive', 'quarterstaff', 'staff'], icon: CUSTOM_ICONS.staff },
+  { terms: ['shield', 'buckler'], icon: Shield }, { terms: ['ammunition', 'arrow', 'bolt', 'sling bullet', 'ammo'], icon: Crosshair },
+  { terms: ['potion', 'flask', 'vial', 'elixir', 'poison', 'acid', 'oil'], icon: FlaskConical }, { terms: ['scroll', 'parchment'], icon: ScrollText },
+  { terms: ['spellbook', 'book', 'tome', 'manual', 'grimoire'], icon: BookOpen }, { terms: ['wand'], icon: Wand2 },
+  { terms: ['rod', 'focus', 'arcane focus', 'druidic focus', 'holy symbol', 'orb', 'crystal'], icon: Sparkles },
+  { terms: ['helmet', 'helm', 'hat', 'circlet', 'crown', 'headband', 'head'], icon: CUSTOM_ICONS.helmet },
+  { terms: ['armor', 'breastplate', 'plate', 'mail', 'chain', 'leather', 'robe', 'chest'], icon: Shirt },
+  { terms: ['glove', 'gauntlet', 'hand'], icon: Hand }, { terms: ['boot', 'shoe', 'feet', 'foot'], icon: CUSTOM_ICONS.boots },
+  { terms: ['belt', 'sash', 'girdle', 'waist'], icon: CUSTOM_ICONS.belt }, { terms: ['bracer', 'bracelet', 'wrist', 'vambrace'], icon: Badge },
+  { terms: ['ring', 'band', 'signet'], icon: CUSTOM_ICONS.ring }, { terms: ['amulet', 'necklace', 'pendant', 'torc', 'neck'], icon: CUSTOM_ICONS.amulet },
+  { terms: ['cloak', 'cape', 'mantle', 'back'], icon: CUSTOM_ICONS.cloak }, { terms: ['goggles', 'glasses', 'lens', 'eye', 'visor'], icon: Glasses },
+  { terms: ['tool', 'artisan', 'kit', 'lockpick', 'thieves', 'supplies'], icon: Wrench }, { terms: ['instrument', 'lute', 'flute', 'drum', 'horn', 'music'], icon: Drum },
+  { terms: ['gaming set', 'dice', 'cards', 'game'], icon: CircleDot }, { terms: ['backpack', 'pack', 'adventuring gear'], icon: Backpack },
+  { terms: ['torch', 'lantern', 'candle'], icon: CUSTOM_ICONS.torch }, { terms: ['map'], icon: Map }, { terms: ['key'], icon: KeyRound },
+  { terms: ['chest', 'treasure chest', 'container', 'box', 'case', 'pouch', 'bag'], icon: Box }, { terms: ['coin', 'currency', 'gold', 'silver', 'copper', 'platinum'], icon: Coins },
+  { terms: ['gem', 'jewel', 'diamond', 'treasure'], icon: Gem }, { terms: ['food', 'ration', 'meat', 'bread'], icon: Beef },
+  { terms: ['material', 'crafting', 'ore', 'ingot'], icon: Pickaxe }, { terms: ['quest', 'relic', 'artifact'], icon: Diamond },
+  { terms: ['mount', 'vehicle', 'saddle', 'tack'], icon: Briefcase }, { terms: ['clothes', 'clothing'], icon: Shirt },
+];
+
+const SLOT_ICON_OVERRIDES = { head: CUSTOM_ICONS.helmet, eyes: Eye, neck: CUSTOM_ICONS.amulet, shoulders: ChevronUp, chest: Shirt, back: CUSTOM_ICONS.cloak, arms: Badge, wrists: Badge, hands: Hand, waist: CUSTOM_ICONS.belt, legs: Footprints, feet: CUSTOM_ICONS.boots, mainHand: Sword, offHand: Shield, ranged: CUSTOM_ICONS.bow, ringLeft: CUSTOM_ICONS.ring, ringRight: CUSTOM_ICONS.ring };
+const CATEGORY_FALLBACKS = { weapon: Swords, armor: Shirt, item: Package, accessory: Diamond, currency: Coins, treasure: Gem, consumable: FlaskConical, tool: Wrench, container: Archive, document: ScrollText, location: Landmark, food: Utensils, drink: Milk, valuables: Wallet };
+
+const getSearchTerms = (props) => [
+  ...splitTerms(props.equipmentSlot), ...splitTerms(props.weaponType), ...splitTerms(props.armorType), ...splitTerms(props.consumableType), ...splitTerms(props.magicItemType),
+  ...splitTerms(props.category), ...splitTerms(props.itemType), ...splitTerms(props.item?.type), ...splitTerms(props.item?.category), ...splitTerms(props.item?.categories),
+  ...splitTerms(props.item?.subtype || props.item?.subType), ...splitTerms(props.item?.slot), ...splitTerms(props.item?.equipmentSlot), ...splitTerms(props.item?.targetSlot), ...splitTerms(props.item?.targetSlots), ...splitTerms(props.item?.tags),
+  ...splitTerms(props.item?.displayName || props.item?.name || props.item?.itemName || props.item?.weaponName || props.item?.armorName || props.item?.accessoryName),
+];
+
+export const resolveItemIcon = (props = {}) => {
+  if (props.equipmentSlot && SLOT_ICON_OVERRIDES[props.equipmentSlot]) return SLOT_ICON_OVERRIDES[props.equipmentSlot];
+  const terms = getSearchTerms(props);
+  const rule = ICON_RULES.find(({ terms: candidates }) => candidates.some((candidate) => terms.some((term) => term.includes(candidate))));
+  if (rule) return rule.icon;
+  return CATEGORY_FALLBACKS[normalize(props.itemType || props.category)] || Package;
+};
+
+export default function ItemIcon({ item, itemType, category, rarity, equipmentSlot, weaponType, armorType, consumableType, magicItemType, size = 40, className = '', title, decorative = true }) {
+  const Icon = resolveItemIcon({ item, itemType, category, equipmentSlot, weaponType, armorType, consumableType, magicItemType });
+  const normalizedRarity = normalize(rarity || item?.rarity || 'common').replace(/\s+/g, '-');
+  const label = title || item?.displayName || item?.name || category || itemType || equipmentSlot || 'Item';
+  return <span className={`item-icon item-icon--${normalizedRarity} ${className}`.trim()} title={label} aria-hidden={decorative ? 'true' : undefined} role={decorative ? undefined : 'img'} aria-label={decorative ? undefined : label} style={{ '--item-icon-size': `${size}px` }}><Icon size={Math.round(size * 0.6)} strokeWidth={1.9} /></span>;
+}


### PR DESCRIPTION
### Motivation
- Inventory and shop cards used inconsistent, generic icons that didn’t clearly communicate fantasy equipment types. 
- The app needed a single visual language and a centralized resolver so new items and equipment slots render correct icons without per-component hardcoding. 
- Icons must support subtle rarity treatments and match the RPG/fantasy aesthetic while remaining crisp and minimal. 

### Description
- Added a centralized resolver component `client/src/components/common/ItemIcon.js` that uses the existing `lucide-react` set plus a small set of custom Lucide-style inline SVGs and mapping rules (`ICON_RULES`, `SLOT_ICON_OVERRIDES`, `CATEGORY_FALLBACKS`) to pick suitable icons from item metadata (name, category, slot, types). 
- Replaced per-file `react-icons/gi` category maps in `WeaponList`, `ArmorList`, `ItemList`, and `AccessoryList` with the shared `ItemIcon` so cards render consistent RPG-style icons derived from item data. 
- Reworked equipment rack slot headers to use `ItemIcon` instead of emoji (`EquipmentRack.js`), and added a rarity-aware frame style in `client/src/App.scss` (`.item-icon`, `.item-icon--rare`, etc.) to support common→artifact visual treatments without altering icons. 
- Implemented intelligent fallbacks and search-term matching so unknown/untagged items still render an appropriate fallback icon rather than a missing or unrelated graphic. 

### Testing
- Ran `npm --prefix client install` and `npm --prefix client run build` to verify the client compiles and the production build completes successfully. 
- The build succeeded and produced the `build/` output; only existing lint/autoprefixer warnings (unrelated to these icon changes) were reported during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d618479f0832eb8467e1c903171f0)