### PR TITLE
Style clear-dice HUD button as a clear/“no” button

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8025,6 +8025,55 @@ h1 {
   border-radius: 14px;
 }
 
+.hud-action-button--clear-dice.btn {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(248, 113, 113, 0.62);
+  color: #fee2e2;
+  background:
+    linear-gradient(135deg, rgba(127, 29, 29, 0.68), rgba(15, 23, 42, 0.88)) !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 18px rgba(127, 29, 29, 0.22);
+}
+
+.hud-action-button--clear-dice.btn::before {
+  content: '';
+  position: absolute;
+  inset: 9px;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  opacity: 0.95;
+}
+
+.hud-action-button--clear-dice.btn::after {
+  content: '';
+  position: absolute;
+  width: 3px;
+  height: 35px;
+  border-radius: 999px;
+  background: currentColor;
+  transform: rotate(45deg);
+  box-shadow: 0 0 8px rgba(254, 226, 226, 0.58);
+}
+
+.hud-action-button--clear-dice.btn:hover,
+.hud-action-button--clear-dice.btn:focus-visible {
+  border-color: rgba(252, 165, 165, 0.9);
+  color: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(185, 28, 28, 0.78), rgba(30, 41, 59, 0.92)) !important;
+}
+
+.hud-clear-dice-button__icon {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  font-size: 1.1rem;
+  transform: translate(-2px, 2px);
+  opacity: 0.84;
+}
+
 .hud-action-button--attack.btn,
 .hud-pass-turn-button.btn {
   min-height: 56px;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5800,7 +5800,7 @@ export default function ZombiesCharacterSheet() {
                 </Panel>
 
                 <Toolbar className="combat-hud-dock__primary" aria-label="Primary combat actions">
-                  <IconButton label="Clear rolled dice" className="hud-action-button" onClick={() => handleFooterQuickAction(clearDamageDice)}><FaDiceD20 /></IconButton>
+                  <IconButton label="Clear rolled dice" className="hud-action-button hud-action-button--clear-dice" onClick={() => handleFooterQuickAction(clearDamageDice)}><span className="hud-clear-dice-button__icon" aria-hidden="true"><FaDiceD20 /></span></IconButton>
                   <IconButton label="Open dice roller" className="hud-action-button" onClick={() => handleFooterQuickAction(openDiceRoller)}><Dice5 size={24} /></IconButton>
                   <IconButton label="Open attack actions" className="hud-action-button hud-action-button--attack" onClick={() => handleFooterQuickAction(openAttackModal)}><Swords size={28} /></IconButton>
                   <HudButton


### PR DESCRIPTION
### Motivation
- Make the player action bar’s “Clear rolled dice” control more clearly communicate a clearing action by styling it as a red-tinted clear/no button with a ring and diagonal slash.

### Description
- Updated `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` to add the `hud-action-button--clear-dice` class to the Clear rolled dice `IconButton` and wrap the die icon in a `<span className="hud-clear-dice-button__icon">` for targeted styling.
- Added CSS rules to `client/src/App.scss` for `.hud-action-button--clear-dice.btn`, its `::before` (ring) and `::after` (diagonal slash) pseudo-elements, hover/focus states, and the `.hud-clear-dice-button__icon` adjustment to create the clear-button visual treatment.

### Testing
- Ran `npm run build` in the `client` directory to validate the frontend build, which failed due to a missing dependency error (`Can't resolve 'lucide-react'`), indicating an environment/dependency issue rather than a syntax error from these changes.
- No additional automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d7230340c832eb2b4039fd84cbd01)