### PR TITLE
Style and markup for Clear Dice HUD button

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8025,6 +8025,58 @@ h1 {
   border-radius: 14px;
 }
 
+.hud-action-button--clear-dice.btn {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(248, 113, 113, 0.62);
+  color: #fee2e2;
+  background:
+    linear-gradient(135deg, rgba(127, 29, 29, 0.68), rgba(15, 23, 42, 0.88)) !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 18px rgba(127, 29, 29, 0.22);
+}
+
+.hud-action-button--clear-dice.btn::before {
+  content: '';
+  position: absolute;
+  inset: 9px;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  opacity: 0.95;
+}
+
+.hud-action-button--clear-dice.btn::after {
+  content: '';
+  position: absolute;
+  width: 3px;
+  height: 35px;
+  border-radius: 999px;
+  background: currentColor;
+  transform: rotate(45deg);
+  box-shadow: 0 0 8px rgba(254, 226, 226, 0.58);
+}
+
+.hud-action-button--clear-dice.btn:hover,
+.hud-action-button--clear-dice.btn:focus-visible {
+  border-color: rgba(252, 165, 165, 0.9);
+  color: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(185, 28, 28, 0.78), rgba(30, 41, 59, 0.92)) !important;
+}
+
+.hud-clear-dice-button__icon {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 1.1rem;
+  opacity: 0.84;
+}
+
 .hud-action-button--attack.btn,
 .hud-pass-turn-button.btn {
   min-height: 56px;

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5800,7 +5800,7 @@ export default function ZombiesCharacterSheet() {
                 </Panel>
 
                 <Toolbar className="combat-hud-dock__primary" aria-label="Primary combat actions">
-                  <IconButton label="Clear rolled dice" className="hud-action-button" onClick={() => handleFooterQuickAction(clearDamageDice)}><FaDiceD20 /></IconButton>
+                  <IconButton label="Clear rolled dice" className="hud-action-button hud-action-button--clear-dice" onClick={() => handleFooterQuickAction(clearDamageDice)}><span className="hud-clear-dice-button__icon" aria-hidden="true"><FaDiceD20 /></span></IconButton>
                   <IconButton label="Open dice roller" className="hud-action-button" onClick={() => handleFooterQuickAction(openDiceRoller)}><Dice5 size={24} /></IconButton>
                   <IconButton label="Open attack actions" className="hud-action-button hud-action-button--attack" onClick={() => handleFooterQuickAction(openAttackModal)}><Swords size={28} /></IconButton>
                   <HudButton


### PR DESCRIPTION
### Motivation
- Add a distinct, accessible visual style for the "Clear rolled dice" HUD action to improve discoverability and consistency with other HUD buttons.
- Provide decorative pseudo-elements to convey the "clear" action while keeping the icon accessible and screen-reader friendly.

### Description
- Added CSS rules for `.hud-action-button--clear-dice.btn`, its `::before` and `::after`, and `.hud-clear-dice-button__icon` in `client/src/App.scss` to implement gradient background, inset outline, slashed-line visual, hover/focus states, and proper sizing.
- Updated `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` to apply the `hud-action-button--clear-dice` class to the clear-dice `IconButton` and wrap the icon in a `span` with `hud-clear-dice-button__icon` and `aria-hidden="true"` to separate decoration from the accessible label.

### Testing
- Ran the frontend build with `yarn build` which completed successfully.
- Executed unit tests with `yarn test` and UI snapshot checks which passed without failures.
- Ran `yarn lint` to verify style and formatting and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d7230340c832eb2b4039fd84cbd01)