### PR TITLE
Fix RealmTracker home page scroll behavior

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9707,8 +9707,15 @@ h1 {
 }
 
 .realm-home-shell {
+  height: 100vh;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
+}
+
+@supports (height: 100dvh) {
+  .realm-home-shell {
+    height: 100dvh;
+  }
 }
 
 .realm-home-hero h1,
@@ -9721,6 +9728,12 @@ h1 {
 }
 
 @media (max-width: 720px) {
+  .realm-home-shell {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+  }
+
   .realm-home-layout {
     min-height: auto;
     padding-bottom: calc(max(22px, env(safe-area-inset-bottom)) + 22px);


### PR DESCRIPTION
### Motivation
- Prevent the home page from scrolling unnecessarily on desktop while restoring touch-friendly scrolling on small screens so the logout button is reachable.
- Address layout/overflow regressions caused by the home shell stretching beyond the viewport and interfering with mobile safe-area ergonomics.

### Description
- Constrain the home shell to the viewport by adding `height: 100vh` and a `@supports (height: 100dvh)` fallback for true device-height handling in `client/src/App.scss`.
- Hide desktop vertical overflow by setting `.realm-home-shell { overflow-y: hidden; }` so the page no longer scrolls when content fits.
- Re-enable mobile vertical scrolling inside the shell for `@media (max-width: 720px)` and add `-webkit-overflow-scrolling: touch` and `overscroll-behavior-y: contain` to restore momentum scrolling and containment.
- All edits are in `client/src/App.scss` under the RealmTracker home styles.

### Testing
- Ran `git diff --check` with no issues.
- Ran `npm --prefix client test -- --watchAll=false --runTestsByPath src/App.test.js` and the test suite passed.
- Ran `npm --prefix client run build` and the production build completed successfully (build emits existing lint/warning messages but finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d8aefe2ec832e9e32ababb1984085)