### PR TITLE
Redesign character selection experience

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9905,3 +9905,129 @@ h1 {
     padding-bottom: 28px;
   }
 }
+
+.character-select-page {
+  min-height: 100vh;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  color: #f4f7ff;
+  font-family: 'Raleway', sans-serif;
+  background-color: #050b18;
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.character-select-page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 8%, rgba(93, 143, 255, 0.28), transparent 34rem),
+    radial-gradient(circle at 82% 12%, rgba(151, 92, 255, 0.22), transparent 30rem),
+    linear-gradient(135deg, rgba(3, 8, 20, 0.92), rgba(7, 17, 38, 0.88) 48%, rgba(10, 9, 26, 0.94));
+  pointer-events: none;
+}
+
+.character-select-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1720px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+
+.character-select-hero,
+.character-select-library,
+.character-select-create,
+.character-select-empty,
+.character-select-card {
+  border: 1px solid rgba(160, 190, 255, 0.22);
+  background: linear-gradient(145deg, rgba(12, 22, 45, 0.78), rgba(11, 14, 31, 0.68));
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px);
+}
+
+.character-select-hero {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.28fr) 1fr auto;
+  align-items: stretch;
+  gap: clamp(1rem, 2vw, 2rem);
+  border-radius: 32px;
+  padding: clamp(1rem, 2.5vw, 2rem);
+  overflow: hidden;
+}
+
+.character-select-hero__art {
+  min-height: 220px;
+  border-radius: 24px;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle, rgba(129, 170, 255, 0.8), transparent 32%),
+    conic-gradient(from 45deg, rgba(111, 75, 255, 0.5), rgba(26, 49, 98, 0.75), rgba(200, 170, 92, 0.25), rgba(111, 75, 255, 0.5));
+  box-shadow: inset 0 0 4rem rgba(7, 12, 28, 0.75), 0 0 3rem rgba(89, 132, 255, 0.24);
+}
+
+.character-select-hero__art span { font-size: clamp(4rem, 9vw, 8rem); text-shadow: 0 0 2rem rgba(255,255,255,.65); }
+.character-select-kicker { color: #91b7ff; letter-spacing: .18em; text-transform: uppercase; font-size: .78rem; font-weight: 800; margin-bottom: .35rem; }
+.character-select-hero h1 { font-size: clamp(2.4rem, 6vw, 5.7rem); line-height: .92; margin: 0 0 1rem; font-weight: 900; }
+.character-select-hero p, .character-select-create p, .character-select-empty p { color: rgba(230, 237, 255, 0.78); }
+.character-select-hero__facts { display: flex; flex-wrap: wrap; gap: .7rem; margin-top: 1.25rem; }
+.character-select-hero__facts span, .character-select-tools span, .character-select-card__chips span { border: 1px solid rgba(145,183,255,.22); background: rgba(10, 20, 45, .55); border-radius: 999px; padding: .45rem .75rem; color: rgba(238, 243, 255, .78); }
+.character-select-hero__facts strong { color: #fff; }
+.character-select-hero__actions, .character-select-create__actions { display: grid; align-content: center; gap: .75rem; min-width: 210px; }
+.character-select-hero__actions .btn, .character-select-create__actions .btn, .character-select-empty .btn, .character-select-card__continue { border: 0; border-radius: 999px; padding: .85rem 1.15rem; font-weight: 900; background: linear-gradient(135deg, #78a7ff, #8d6cff 55%, #c4a65a); color: #07111f; box-shadow: 0 .9rem 2.2rem rgba(92, 128, 255, .28); }
+
+.character-select-library { border-radius: 28px; padding: clamp(1rem, 2vw, 1.6rem); }
+.character-select-library__header { display: flex; justify-content: space-between; gap: 1rem; align-items: end; margin-bottom: 1rem; }
+.character-select-library h2, .character-select-create h2, .character-select-empty h2 { font-weight: 900; margin: 0; }
+.character-select-tools { display: flex; flex-wrap: wrap; gap: .5rem; justify-content: flex-end; }
+.character-select-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(285px, 1fr)); gap: 1rem; }
+.character-select-card { position: relative; border-radius: 26px; padding: 1rem; overflow: hidden; transition: transform .24s ease, border-color .24s ease, box-shadow .24s ease; animation: characterSelectFadeIn .45s ease both; }
+.character-select-card:hover { transform: translateY(-7px); border-color: rgba(142, 183, 255, .58); box-shadow: 0 2rem 4.5rem rgba(0,0,0,.48), 0 0 2rem rgba(109, 134, 255, .2); }
+.character-select-card__favorite { position: absolute; right: 1rem; top: 1rem; color: rgba(244, 221, 154, .82); font-size: .75rem; z-index: 2; }
+.character-select-portrait { width: 145px; aspect-ratio: 1; margin: 1.6rem auto 1rem; border-radius: 34px; display: grid; place-items: center; background: radial-gradient(circle at 45% 30%, rgba(255,255,255,.72), rgba(115, 143, 255, .5) 28%, rgba(67, 45, 116, .78) 62%, rgba(6, 11, 27, .95)); border: 2px solid rgba(196, 222, 255, .42); box-shadow: 0 0 2.5rem rgba(104, 139, 255, .35), inset 0 0 2rem rgba(255,255,255,.12); overflow: hidden; }
+.character-select-portrait img { width: 100%; height: 100%; object-fit: cover; }
+.character-select-portrait span { font-size: 2.7rem; font-weight: 900; color: #fff; }
+.character-select-card__body { text-align: center; }
+.character-select-card__eyebrow, .character-select-card__lineage { color: #9dbfff; margin-bottom: .25rem; font-weight: 800; }
+.character-select-card h3 { font-size: 1.75rem; font-weight: 900; margin: 0; }
+.character-select-card__chips, .character-select-card__meta { display: flex; flex-wrap: wrap; justify-content: center; gap: .45rem; margin-top: .8rem; }
+.character-select-card__stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: .5rem; margin-top: 1rem; }
+.character-select-card__stats span { border-radius: 16px; padding: .65rem .4rem; background: rgba(255,255,255,.06); color: #91b7ff; font-size: .72rem; }
+.character-select-card__stats strong { display: block; color: #fff; font-size: 1.25rem; }
+.character-select-card__meta span { color: rgba(230,237,255,.7); font-size: .78rem; }
+.character-select-card__meta strong { color: #fff; }
+.character-select-card__actions { display: grid; grid-template-columns: 1fr 1fr auto; gap: .55rem; margin-top: 1rem; align-items: center; }
+.character-select-card__ghost { border-radius: 999px; background: rgba(145,183,255,.12); border: 1px solid rgba(145,183,255,.25); color: #eef4ff; font-weight: 800; }
+.character-select-card__more { position: relative; }
+.character-select-card__more summary { list-style: none; cursor: pointer; border-radius: 999px; padding: .55rem .75rem; background: rgba(255,255,255,.08); }
+.character-select-card__more summary::-webkit-details-marker { display: none; }
+.character-select-card__more div { position: absolute; right: 0; bottom: 110%; display: grid; min-width: 120px; padding: .4rem; border-radius: 14px; background: rgba(5, 11, 24, .96); border: 1px solid rgba(145,183,255,.25); z-index: 5; }
+.character-select-card__more button { background: transparent; border: 0; color: rgba(255,255,255,.65); padding: .45rem; text-align: left; }
+.character-select-create, .character-select-empty { border-radius: 28px; padding: clamp(1.2rem, 2.4vw, 2rem); }
+.character-select-empty { text-align: center; padding-block: clamp(2.5rem, 6vw, 5rem); }
+.character-select-empty__sigil { font-size: 5rem; color: #91b7ff; text-shadow: 0 0 2rem rgba(145,183,255,.7); }
+
+@keyframes characterSelectFadeIn { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+
+@media (max-width: 980px) {
+  .character-select-hero { grid-template-columns: 1fr; }
+  .character-select-hero__art { min-height: 160px; }
+  .character-select-hero__actions, .character-select-create__actions { grid-template-columns: 1fr 1fr; }
+  .character-select-library__header { align-items: flex-start; flex-direction: column; }
+}
+
+@media (max-width: 640px) {
+  .character-select-page { padding: .75rem; }
+  .character-select-hero { border-radius: 24px; max-height: none; }
+  .character-select-hero__facts span, .character-select-tools span { width: 100%; }
+  .character-select-grid { grid-template-columns: 1fr; }
+  .character-select-card { padding: 1.1rem; }
+  .character-select-portrait { width: min(62vw, 210px); border-radius: 42px; }
+  .character-select-card__actions, .character-select-hero__actions, .character-select-create__actions { grid-template-columns: 1fr; }
+  .character-select-card__actions .btn { width: 100%; min-height: 48px; }
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import apiFetch from '../../../utils/apiFetch';
 import Button from 'react-bootstrap/Button';
-import { Table, Form, Modal, Card } from 'react-bootstrap';
+import { Form, Modal, Card } from 'react-bootstrap';
 import { useParams, useNavigate } from "react-router-dom";
 import '../../../App.scss';
 import loginbg from "../../../images/loginbg.png";
@@ -24,6 +24,149 @@ const getRaceSizeOptions = (race) => {
   }
   return [];
 };
+
+const getOccupationList = (character) => Array.isArray(character?.occupation) ? character.occupation : [];
+
+const getCharacterLevel = (character) =>
+  getOccupationList(character).reduce((total, job) => total + Number(job.Level || job.level || 0), 0) || 1;
+
+const getClassSummary = (character) => {
+  const classes = getOccupationList(character);
+  if (!classes.length) return "Wanderer";
+  return classes.map((job) => `${job.Level || job.level || 1} ${job.Occupation || job.name || "Adventurer"}`).join(" / ");
+};
+
+const getPrimaryClass = (character) => {
+  const classes = getOccupationList(character);
+  return classes[0]?.Occupation || classes[0]?.name || "Adventurer";
+};
+
+const formatCharacterDate = (value) => {
+  if (!value) return "Awaiting first quest";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Recently prepared";
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+};
+
+const getInitials = (name = "Hero") => name.split(/\s+/).filter(Boolean).slice(0, 2).map((part) => part[0]?.toUpperCase()).join("") || "RT";
+
+const CharacterPortrait = ({ character }) => {
+  const portrait = character?.portrait || character?.image || character?.avatar || character?.figurine?.imageUrl;
+  const name = character?.characterName || "Unnamed Hero";
+  return (
+    <div className="character-select-portrait" aria-label={`${name} portrait`}>
+      {portrait ? <img src={portrait} alt="" /> : <span>{getInitials(name)}</span>}
+    </div>
+  );
+};
+
+const CharacterStats = ({ character }) => {
+  const stats = [
+    ["STR", character?.str],
+    ["DEX", character?.dex],
+    ["CON", character?.con],
+  ];
+  return (
+    <div className="character-select-card__stats">
+      {stats.map(([label, value]) => (
+        <span key={label}><strong>{value || "—"}</strong>{label}</span>
+      ))}
+    </div>
+  );
+};
+
+const CharacterActions = ({ character, onContinue }) => (
+  <div className="character-select-card__actions">
+    <Button className="character-select-card__continue" onClick={() => onContinue(character._id)}>Continue Adventure</Button>
+    <Button className="character-select-card__ghost" onClick={() => onContinue(character._id)}>View Character</Button>
+    <details className="character-select-card__more">
+      <summary aria-label="More character actions">⋯</summary>
+      <div>
+        <button type="button" disabled>Duplicate</button>
+        <button type="button" disabled>Delete</button>
+      </div>
+    </details>
+  </div>
+);
+
+const CharacterCard = ({ character, onContinue }) => {
+  const name = character?.characterName || "Unnamed Hero";
+  const race = character?.race?.name || character?.race || "Unknown Lineage";
+  const background = character?.background?.name || character?.background || "Unwritten Legend";
+  const health = character?.health || character?.maxHealth || character?.hp;
+  return (
+    <article className="character-select-card">
+      <div className="character-select-card__favorite">☆ Future Favorite</div>
+      <CharacterPortrait character={character} />
+      <div className="character-select-card__body">
+        <p className="character-select-card__eyebrow">Level {getCharacterLevel(character)} • {getPrimaryClass(character)}</p>
+        <h3>{name}</h3>
+        <p className="character-select-card__lineage">{race}</p>
+        <div className="character-select-card__chips">
+          <span>{getClassSummary(character)}</span>
+          <span>{background}</span>
+          {character?.alignment && <span>{character.alignment}</span>}
+        </div>
+        <CharacterStats character={character} />
+        <div className="character-select-card__meta">
+          <span>Status <strong>Ready</strong></span>
+          {health && <span>HP <strong>{health}</strong></span>}
+          <span>Last played <strong>{formatCharacterDate(character?.lastPlayed || character?.updatedAt)}</strong></span>
+        </div>
+      </div>
+      <CharacterActions character={character} onContinue={onContinue} />
+    </article>
+  );
+};
+
+const CampaignHero = ({ campaignName, playerCount, onCreateManual, onCreateRandom }) => (
+  <section className="character-select-hero">
+    <div className="character-select-hero__art" aria-hidden="true"><span>✦</span></div>
+    <div className="character-select-hero__content">
+      <p className="character-select-kicker">RealmTracker Campaign</p>
+      <h1>{campaignName}</h1>
+      <p>Gather your party, choose the hero who will step through the portal, and continue the next chapter of the adventure.</p>
+      <div className="character-select-hero__facts">
+        <span>Dungeon Master <strong>{campaignName}</strong></span>
+        <span>Players <strong>{playerCount}</strong></span>
+        <span>System <strong>D&D 5e</strong></span>
+        <span>Recent activity <strong>Campaign roster updated</strong></span>
+      </div>
+    </div>
+    <div className="character-select-hero__actions">
+      <Button onClick={onCreateManual}>Create Manually</Button>
+      <Button onClick={onCreateRandom}>Generate Randomly</Button>
+    </div>
+  </section>
+);
+
+const EmptyState = ({ onCreateManual }) => (
+  <section className="character-select-empty">
+    <div className="character-select-empty__sigil">☾</div>
+    <h2>No heroes have joined this realm yet.</h2>
+    <p>Create the first champion for this campaign and begin building a legend worth remembering.</p>
+    <Button onClick={onCreateManual}>Create Your First Character</Button>
+  </section>
+);
+
+const CreateCharacterCard = ({ onCreateManual, onCreateRandom }) => (
+  <aside className="character-select-create">
+    <p className="character-select-kicker">New Hero</p>
+    <h2>Forge another legend</h2>
+    <p>Start from a blank sheet, let fate roll the dice, or reserve space for future imports.</p>
+    <div className="character-select-create__actions">
+      <Button onClick={onCreateManual}>Create Manually</Button>
+      <Button onClick={onCreateRandom}>Generate Randomly</Button>
+      <Button disabled>Future Import</Button>
+    </div>
+  </aside>
+);
+
+const CharacterGrid = ({ records, onContinue }) => (
+  <div className="character-select-grid">
+    {records.map((character) => <CharacterCard key={character._id} character={character} onContinue={onContinue} />)}
+  </div>
+);
 
 export default function RecordList() {
   const params = useParams();
@@ -1875,71 +2018,33 @@ const getAvailableSkillOptions = (index) => {
 };
 
   return (
-    <div className="pt-2 text-center" style={{ fontFamily: 'Raleway, sans-serif', backgroundImage: `url(${loginbg})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", height: "100vh"}}>
-      <div style={{paddingTop: '150px'}}>
-<div style={{ maxHeight: '500px', overflowY: 'auto', position: 'relative', zIndex: '4'}}>
-        <Table style={{ width: 'auto', position: "relative", zIndex: "4", margin: "0 auto" }} striped bordered condensed="true" className="zombieCharacterSelectTable dnd-background">
-          <thead>
-            <tr>
-                <th colSpan="4" style={{fontSize: 28}}>{params.campaign.toString()}</th>
-            </tr>
-            <tr>
-              <th colSpan="2">
-                  <Button
-                    className="fantasy-button"
-                    size="sm"
-                    style={{ width: 'auto', border: "none" }}
-                    variant="primary"
-                    onClick={(e) => { e.preventDefault(); bigMaff(); handleShow(); }}
-                  >
-                    Create Character Random
-                  </Button>
-              </th>
-                <th colSpan="2">
-                  <Button
-                    className="fantasy-button"
-                    size="sm"
-                    style={{ width: 'auto', border: "none" }}
-                    variant="primary"
-                    onClick={(e) => { e.preventDefault(); handleShow5();}}
-                  >
-                    Create Character Manual
-                  </Button>
-              </th>
-            </tr>
-            <tr>
-              <th>Character</th>
-              <th>Level</th>
-              <th>Class</th>
-              <th>View</th>
-            </tr>
-          </thead>
-          <tbody>
-          {records.map((Characters) => (
-              <tr key={Characters._id}>
-                <td>{Characters.characterName}</td>
-                <td>{Characters.occupation.reduce((total, el) => total + Number(el.Level), 0)}</td>
-                <td>
-                  {Characters.occupation.map((el, i) => (
-                    <span key={i}>{el.Level + " " + el.Occupation}<br></br></span>
-                  ))}
-                </td>
-                <td>
-                  <Button
-                    className="fantasy-button"
-                    size="sm"
-                    style={{ width: 'auto', border: "none" }}
-                    variant="primary"
-                    onClick={() => navigateToCharacter(Characters._id)}
-                  >
-                    View
-                  </Button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </Table>
-        </div>
+    <div className="character-select-page" style={{ backgroundImage: `url(${loginbg})` }}>
+      <div className="character-select-shell">
+        <CampaignHero
+          campaignName={params.campaign.toString()}
+          playerCount={records.length}
+          onCreateManual={(e) => { e.preventDefault(); handleShow5(); }}
+          onCreateRandom={(e) => { e.preventDefault(); bigMaff(); handleShow(); }}
+        />
+
+        <section className="character-select-library">
+          <div className="character-select-library__header">
+            <div>
+              <p className="character-select-kicker">Character Library</p>
+              <h2>Choose your hero</h2>
+            </div>
+            <div className="character-select-tools" aria-label="Future character search and filters">
+              <span>Search</span><span>Sort</span><span>Class</span><span>Level</span><span>Favorites</span>
+            </div>
+          </div>
+          {records.length ? <CharacterGrid records={records} onContinue={navigateToCharacter} /> : <EmptyState onCreateManual={handleShow5} />}
+        </section>
+
+        <CreateCharacterCard
+          onCreateManual={handleShow5}
+          onCreateRandom={(e) => { e.preventDefault(); bigMaff(); handleShow(); }}
+        />
+      </div>
     {/* ---------------------------Create Character (Random)------------------------------------------------------- */}
     <Modal className="dnd-modal" centered show={show} onHide={handleClose}>
        <div className="text-center">
@@ -2229,7 +2334,6 @@ const getAvailableSkillOptions = (index) => {
         </div>
        </Modal>
       </div>
-    </div>
 
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the outdated centered HTML table character list with a premium, full‑screen character selection that feels like choosing a hero for an adventure. 
- Improve visual hierarchy, spacing, and mobile UX so the page matches RealmTracker’s design system (deep navy, glass surfaces, magical highlights). 
- Provide a reusable component surface so character cards and the campaign hero can be reused elsewhere. 

### Description
- Replaced the table-based UI in `ZombiesCharacterSelect.js` with a new full-page layout and reusable components: `CampaignHero`, `CharacterGrid`, `CharacterCard`, `CharacterPortrait`, `CharacterStats`, `CharacterActions`, `EmptyState`, and `CreateCharacterCard`. 
- Implemented portrait fallbacks (initials/sigil) and enriched card metadata (level, class summary, race/background, alignment, HP, last played) plus primary actions (`Continue Adventure`, `View Character`) and a more-actions menu placeholder. 
- Integrated existing random/manual create flows and modals into the new layout so creation still uses the current `sendToDb`/`sendManualToDb` logic. 
- Added responsive RealmTracker styling and animations in `client/src/App.scss` (glass panels, gradients, card hover lift, portrait styling, responsive grid for desktop/tablet/mobile and mobile-first touch-friendly adjustments). 

### Testing
- Ran `npm --prefix client run build` which produced a production build successfully (compiled with lint warnings, build output created). 
- Ran `npm --prefix client test -- --watchAll=false ZombiesCharacterSelect.test.js` which exited with no matching test file (no tests found for that pattern). 
- Note: `npm --prefix client install` was executed as part of the build preparation to ensure dependencies were available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d926244e8832e9186e86edaf529a3)