### PR TITLE
Redesign RealmTracker login experience

### DIFF
--- a/client/src/components/Login/Login.css
+++ b/client/src/components/Login/Login.css
@@ -1,23 +1,736 @@
 .login-background {
-  background-image: url('../../images/loginbg.png');
+  background-image: url("../../images/loginbg.png");
   background-size: cover;
   background-position: center;
-  height: 100vh;
+  min-height: 100vh;
 }
-
 .raleway-font {
-  font-family: 'Raleway, sans-serif';
+  font-family: "Raleway, sans-serif";
 }
-
-.login-overlay {
-  background-color: rgba(0, 0, 0, 0.7);
-}
-
 .logo-image {
   max-height: 200px;
   max-width: 200px;
 }
-
 .form-width {
   max-width: 200px;
+}
+.auth-layout {
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(420px, 0.88fr);
+  overflow: hidden;
+  color: var(--hud-text, #f7efe0);
+  font-family: Raleway, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: radial-gradient(
+      circle at 24% 12%,
+      rgba(56, 232, 255, 0.18),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 82% 88%,
+      rgba(184, 92, 255, 0.14),
+      transparent 30rem
+    ),
+    linear-gradient(
+      145deg,
+      var(--realm-charcoal, #090c12),
+      var(--realm-navy, #07111f) 52%,
+      #02050b
+    );
+}
+.auth-background,
+.auth-background::before,
+.auth-background::after {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.auth-background {
+  z-index: -2;
+  background-image: linear-gradient(rgba(5, 8, 14, 0.32), rgba(5, 8, 14, 0.78)),
+    url("../../images/loginbg.png");
+  background-position: center;
+  background-size: cover;
+}
+.auth-background::before {
+  content: "";
+  background: var(
+      --realm-rune-lines,
+      radial-gradient(
+        circle at 18% 22%,
+        rgba(56, 232, 255, 0.08),
+        transparent 24%
+      )
+    ),
+    repeating-linear-gradient(
+      115deg,
+      transparent 0 84px,
+      rgba(215, 180, 106, 0.035) 85px 86px,
+      transparent 87px 168px
+    ),
+    radial-gradient(
+      circle at 30% 45%,
+      transparent 0 13rem,
+      rgba(143, 200, 255, 0.08) 13.05rem 13.12rem,
+      transparent 13.18rem
+    ),
+    radial-gradient(
+      circle at 30% 45%,
+      transparent 0 19rem,
+      rgba(215, 180, 106, 0.055) 19.05rem 19.12rem,
+      transparent 19.18rem
+    );
+  opacity: 0.86;
+}
+.auth-background::after {
+  content: "";
+  background: radial-gradient(
+      circle at 18% 78%,
+      rgba(56, 232, 255, 0.22),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 72% 18%,
+      rgba(215, 180, 106, 0.12),
+      transparent 20rem
+    ),
+    linear-gradient(
+      90deg,
+      rgba(2, 5, 11, 0.05),
+      rgba(2, 5, 11, 0.58) 58%,
+      rgba(2, 5, 11, 0.9)
+    );
+}
+.auth-background__mist,
+.auth-background__particles,
+.auth-background__constellation,
+.auth-background__circle {
+  position: absolute;
+  pointer-events: none;
+}
+.auth-background__mist {
+  inset: 0;
+  background: linear-gradient(
+    95deg,
+    transparent,
+    rgba(143, 200, 255, 0.075),
+    transparent 62%
+  );
+  filter: blur(1px);
+  transform: translateX(-42%);
+  animation: authMist 19s ease-in-out infinite;
+}
+.auth-background__circle {
+  width: min(64vw, 780px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 1px solid rgba(143, 200, 255, 0.1);
+  box-shadow: inset 0 0 0 64px rgba(143, 200, 255, 0.014),
+    inset 0 0 0 66px rgba(215, 180, 106, 0.032);
+  animation: authSpin 95s linear infinite;
+}
+.auth-background__circle--one {
+  left: 6%;
+  top: 12%;
+}
+.auth-background__circle--two {
+  right: -18%;
+  bottom: -28%;
+  animation-direction: reverse;
+  opacity: 0.58;
+}
+.auth-background__constellation {
+  top: 10%;
+  left: 10%;
+  width: 42%;
+  height: 44%;
+  opacity: 0.32;
+  background-image: radial-gradient(
+    circle,
+    rgba(247, 239, 224, 0.9) 0 1px,
+    transparent 1.6px
+  );
+  background-size: 82px 58px;
+  mask-image: linear-gradient(120deg, transparent, #000 22% 72%, transparent);
+}
+.auth-background__particles {
+  inset: 0;
+  background-image: radial-gradient(
+    circle,
+    rgba(143, 200, 255, 0.6) 0 1px,
+    transparent 1.5px
+  );
+  background-size: 64px 64px;
+  opacity: 0.2;
+  animation: authParticles 16s linear infinite;
+}
+.auth-brand-panel,
+.auth-form-panel {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+.auth-brand-panel {
+  display: flex;
+  align-items: center;
+  padding: clamp(2rem, 6vw, 5.5rem);
+}
+.auth-brand-panel__content {
+  width: min(680px, 100%);
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.35rem);
+  animation: authEnter 560ms ease-out both;
+}
+.auth-brand-panel__logo-frame {
+  width: clamp(172px, 22vw, 280px);
+  padding: clamp(0.9rem, 2vw, 1.35rem);
+  border: 1px solid rgba(143, 200, 255, 0.22);
+  border-radius: 32px;
+  background: rgba(8, 18, 36, 0.38);
+  box-shadow: 0 0 44px rgba(56, 232, 255, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+}
+.auth-logo {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(0 0 24px rgba(56, 232, 255, 0.24));
+}
+.auth-brand-panel__eyebrow,
+.auth-header__eyebrow {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--realm-cyan, #38e8ff);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.auth-brand-panel h1 {
+  max-width: 760px;
+  margin: 0;
+  font-size: clamp(3rem, 7vw, 6.4rem);
+  font-weight: 900;
+  letter-spacing: 0.025em;
+  line-height: 0.94;
+  text-shadow: 0 0 30px rgba(56, 232, 255, 0.28),
+    0 18px 44px rgba(0, 0, 0, 0.72);
+}
+.auth-brand-panel__copy {
+  max-width: 600px;
+  margin: 0;
+  color: rgba(247, 239, 224, 0.78);
+  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  line-height: 1.55;
+}
+.auth-brand-panel__features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.auth-brand-panel__features span {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.85rem;
+  border: 1px solid rgba(143, 200, 255, 0.18);
+  border-radius: 999px;
+  color: rgba(247, 239, 224, 0.82);
+  background: rgba(255, 255, 255, 0.052);
+  backdrop-filter: blur(10px);
+}
+.auth-form-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 4rem);
+}
+.auth-card {
+  position: relative;
+  width: min(100%, 480px);
+  padding: clamp(1.35rem, 3vw, 2.25rem);
+  overflow: hidden;
+  border: 1px solid rgba(143, 200, 255, 0.22);
+  border-radius: 30px;
+  color: var(--hud-text, #f7efe0);
+  background: radial-gradient(
+      circle at 50% 0%,
+      rgba(56, 232, 255, 0.16),
+      transparent 18rem
+    ),
+    linear-gradient(145deg, rgba(10, 22, 42, 0.88), rgba(4, 9, 18, 0.96));
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.58),
+    0 0 0 1px rgba(255, 255, 255, 0.035) inset,
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(22px) saturate(1.12);
+  animation: authCardEnter 620ms cubic-bezier(0.2, 1.2, 0.35, 1) 80ms both;
+}
+.auth-card::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border: 1px solid rgba(216, 183, 106, 0.13);
+  border-radius: 22px;
+  background: linear-gradient(
+      90deg,
+      rgba(216, 183, 106, 0.25),
+      transparent 18%,
+      transparent 82%,
+      rgba(216, 183, 106, 0.25)
+    )
+    top/100% 1px no-repeat;
+  pointer-events: none;
+}
+.auth-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 12% -28% 12%;
+  height: 40%;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(56, 232, 255, 0.18),
+    transparent 70%
+  );
+  filter: blur(10px);
+  pointer-events: none;
+}
+.auth-header,
+.auth-form,
+.auth-divider,
+.auth-footer {
+  position: relative;
+  z-index: 1;
+}
+.auth-header {
+  display: grid;
+  gap: 0.55rem;
+  margin-bottom: 1.4rem;
+  text-align: left;
+}
+.auth-header h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 24px rgba(78, 161, 255, 0.28);
+}
+.auth-header p {
+  margin: 0;
+  color: rgba(247, 239, 224, 0.7);
+  line-height: 1.45;
+}
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+.auth-input {
+  position: relative;
+  display: block;
+  margin: 0;
+}
+.auth-input input {
+  width: 100%;
+  min-height: 64px;
+  padding: 25px 3.2rem 10px 3.15rem;
+  color: var(--hud-text, #f7efe0);
+  border: 1px solid rgba(143, 200, 255, 0.22);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.062);
+  outline: 0;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  transition: border-color 180ms ease, box-shadow 180ms ease,
+    background 180ms ease, transform 180ms ease;
+}
+.auth-input input:focus {
+  border-color: rgba(143, 200, 255, 0.62);
+  background: rgba(255, 255, 255, 0.078);
+  box-shadow: 0 0 0 4px rgba(56, 232, 255, 0.13),
+    0 0 28px rgba(56, 232, 255, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+.auth-input__icon {
+  position: absolute;
+  left: 1.05rem;
+  top: 1.35rem;
+  z-index: 1;
+  color: var(--realm-cyan, #38e8ff);
+  filter: drop-shadow(0 0 10px rgba(56, 232, 255, 0.34));
+}
+.auth-input__label {
+  position: absolute;
+  left: 3.15rem;
+  top: 1.18rem;
+  color: rgba(247, 239, 224, 0.54);
+  pointer-events: none;
+  transition: transform 160ms ease, color 160ms ease, font-size 160ms ease,
+    letter-spacing 160ms ease;
+}
+.auth-input input:focus + .auth-input__label,
+.auth-input input:not(:placeholder-shown) + .auth-input__label {
+  color: var(--realm-cyan, #38e8ff);
+  font-size: 0.73rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transform: translateY(-12px);
+}
+.auth-input__toggle {
+  position: absolute;
+  right: 0.85rem;
+  top: 0.72rem;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 13px;
+  color: rgba(247, 239, 224, 0.72);
+  background: transparent;
+}
+.auth-input__toggle:hover,
+.auth-input__toggle:focus-visible {
+  color: #fff;
+  border-color: rgba(143, 200, 255, 0.24);
+  background: rgba(255, 255, 255, 0.06);
+  outline: 0;
+}
+.auth-input--error input {
+  border-color: var(--realm-danger, #ff5c72);
+}
+.auth-input__error {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--realm-danger, #ff5c72);
+}
+.auth-form__options {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.auth-check {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: rgba(247, 239, 224, 0.78);
+  font-weight: 700;
+  cursor: pointer;
+}
+.auth-check input {
+  width: 19px;
+  height: 19px;
+  accent-color: var(--realm-cyan, #38e8ff);
+}
+.auth-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 44px;
+  padding: 0;
+  border: 0;
+  color: rgba(247, 239, 224, 0.68);
+  background: transparent;
+  font: inherit;
+  font-weight: 800;
+  text-decoration: none;
+  transition: color 160ms ease, transform 160ms ease, text-shadow 160ms ease;
+}
+.auth-link:hover,
+.auth-link:focus-visible {
+  color: var(--realm-cyan, #38e8ff);
+  text-shadow: 0 0 14px rgba(56, 232, 255, 0.32);
+  outline: 0;
+  transform: translateY(-1px);
+}
+.auth-link--strong {
+  color: var(--realm-cyan, #38e8ff);
+}
+.auth-alert {
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(255, 92, 114, 0.42);
+  border-radius: 16px;
+  color: #ffd9df;
+  background: rgba(255, 92, 114, 0.12);
+}
+.auth-button {
+  min-height: 54px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  border-radius: 17px;
+  border: 1px solid rgba(143, 200, 255, 0.48);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform 180ms cubic-bezier(0.2, 1.35, 0.35, 1),
+    box-shadow 180ms ease, filter 180ms ease, opacity 180ms ease;
+}
+.auth-button--primary {
+  color: #04111f;
+  background: linear-gradient(
+    135deg,
+    var(--realm-cyan, #38e8ff),
+    var(--realm-icy, #8fc8ff)
+  );
+  box-shadow: 0 0 28px rgba(56, 232, 255, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+.auth-button--secondary {
+  color: rgba(247, 239, 224, 0.72);
+  border-color: rgba(143, 200, 255, 0.16);
+  background: rgba(255, 255, 255, 0.05);
+  letter-spacing: 0.03em;
+  text-transform: none;
+}
+.auth-button:hover:not(:disabled),
+.auth-button:focus-visible:not(:disabled) {
+  transform: translateY(-3px);
+  filter: brightness(1.08);
+  box-shadow: 0 0 30px rgba(56, 232, 255, 0.28), 0 14px 30px rgba(0, 0, 0, 0.32);
+  outline: 0;
+}
+.auth-button:active:not(:disabled) {
+  transform: translateY(0) scale(0.98);
+}
+.auth-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+.auth-button__soon {
+  color: var(--realm-gold, #d7b46a);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.auth-button__spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(4, 17, 31, 0.28);
+  border-top-color: #04111f;
+  border-radius: 50%;
+  animation: authSpin 800ms linear infinite;
+}
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.1rem 0 0.85rem;
+  color: rgba(247, 239, 224, 0.46);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(143, 200, 255, 0.24),
+    transparent
+  );
+}
+.auth-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem 0.7rem;
+  color: rgba(247, 239, 224, 0.68);
+}
+.auth-modal .modal-content {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.auth-card--modal {
+  width: min(100%, 520px);
+  margin: auto;
+}
+.auth-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 3;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(143, 200, 255, 0.22);
+  border-radius: 14px;
+  color: rgba(247, 239, 224, 0.78);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 1.55rem;
+  line-height: 1;
+}
+.auth-modal__close:hover,
+.auth-modal__close:focus-visible {
+  color: #fff;
+  border-color: rgba(143, 200, 255, 0.48);
+  outline: 0;
+}
+.auth-modal__actions {
+  display: grid;
+  gap: 0.75rem;
+}
+@keyframes authEnter {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes authCardEnter {
+  from {
+    opacity: 0;
+    transform: translateY(22px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes authMist {
+  0%,
+  100% {
+    opacity: 0.18;
+    transform: translateX(-42%);
+  }
+  50% {
+    opacity: 0.46;
+    transform: translateX(28%);
+  }
+}
+@keyframes authParticles {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-64px);
+  }
+}
+@keyframes authSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (max-width: 1040px) {
+  .auth-layout {
+    grid-template-columns: 0.9fr 1fr;
+  }
+  .auth-brand-panel {
+    padding: clamp(1.5rem, 4vw, 3rem);
+  }
+  .auth-brand-panel h1 {
+    font-size: clamp(2.6rem, 6vw, 4.8rem);
+  }
+}
+@media (max-width: 820px) {
+  .auth-layout {
+    min-height: 100dvh;
+    grid-template-columns: 1fr;
+    overflow-y: auto;
+  }
+  .auth-background::after {
+    background: linear-gradient(
+      180deg,
+      rgba(2, 5, 11, 0.18),
+      rgba(2, 5, 11, 0.86)
+    );
+  }
+  .auth-brand-panel {
+    align-items: end;
+    justify-content: center;
+    padding: max(1.25rem, env(safe-area-inset-top)) 1rem 0;
+    text-align: center;
+  }
+  .auth-brand-panel__content {
+    justify-items: center;
+    gap: 0.65rem;
+  }
+  .auth-brand-panel__logo-frame {
+    width: clamp(142px, 36vw, 210px);
+    border-radius: 24px;
+  }
+  .auth-brand-panel h1 {
+    max-width: 620px;
+    font-size: clamp(2.15rem, 8vw, 3.65rem);
+  }
+  .auth-brand-panel__copy {
+    max-width: 36rem;
+    font-size: 0.98rem;
+  }
+  .auth-brand-panel__features {
+    justify-content: center;
+  }
+  .auth-form-panel {
+    align-items: start;
+    padding: 1rem 1rem max(1.25rem, env(safe-area-inset-bottom));
+  }
+  .auth-card {
+    width: min(100%, 540px);
+    border-radius: 26px;
+  }
+}
+@media (max-width: 560px) {
+  .auth-brand-panel__copy,
+  .auth-brand-panel__features {
+    display: none;
+  }
+  .auth-form-panel {
+    padding-inline: 0.7rem;
+  }
+  .auth-card {
+    padding: 1.15rem;
+    border-radius: 24px;
+  }
+  .auth-card::before {
+    inset: 8px;
+    border-radius: 18px;
+  }
+  .auth-header {
+    margin-bottom: 1rem;
+  }
+  .auth-header h2 {
+    font-size: 2rem;
+  }
+  .auth-input input {
+    min-height: 60px;
+  }
+  .auth-form__options {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .auth-button {
+    min-height: 56px;
+  }
+  .auth-footer {
+    flex-direction: column;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -1,11 +1,21 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import Button from 'react-bootstrap/Button';
-import Form from 'react-bootstrap/Form';
-import Modal from 'react-bootstrap/Modal';
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import Modal from "react-bootstrap/Modal";
+import {
+  FaArrowRight as ArrowRight,
+  FaEye as Eye,
+  FaEyeSlash as EyeOff,
+  FaKey as KeyRound,
+  FaEnvelope as Mail,
+  FaScroll as ScrollText,
+  FaShieldAlt as ShieldCheck,
+  FaMagic as Sparkles,
+  FaUser as User,
+  FaUsers as Users,
+} from "react-icons/fa";
 import logoLight from "../../images/logo-light.png";
 import apiFetch from "../../utils/apiFetch";
-import './Login.css';
+import "./Login.css";
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
@@ -14,18 +24,18 @@ function capitalizeFirstLetter(string) {
 async function loginUser(credentials) {
   credentials.username = capitalizeFirstLetter(credentials.username);
   try {
-    const response = await apiFetch('/login', {
-      method: 'POST',
+    const response = await apiFetch("/login", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json",
       },
-      body: JSON.stringify(credentials)
+      body: JSON.stringify(credentials),
     });
     if (!response.ok) {
-      throw new Error('Login failed');
+      throw new Error("Login failed");
     }
   } catch (error) {
-    console.error('Login error:', error);
+    console.error("Login error:", error);
     throw error;
   }
 }
@@ -33,161 +43,396 @@ async function loginUser(credentials) {
 async function createUser(newUser) {
   newUser.username = capitalizeFirstLetter(newUser.username);
   try {
-    const response = await apiFetch('/users/add', {
-      method: 'POST',
+    const response = await apiFetch("/users/add", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(newUser),
     });
     const data = await response.json();
     if (!response.ok || data.errors) {
       const message = data.errors
-        ? data.errors.map(e => e.msg).join(', ')
-        : data.message || 'Failed to create user';
+        ? data.errors.map((e) => e.msg).join(", ")
+        : data.message || "Failed to create user";
       throw new Error(message);
     }
     return data;
   } catch (error) {
-    console.error('Create user error:', error);
+    console.error("Create user error:", error);
     throw error;
   }
+}
+
+function AuthLayout({ children }) {
+  return (
+    <main className="auth-layout">
+      <div className="auth-background" aria-hidden="true">
+        <div className="auth-background__mist" />
+        <div className="auth-background__circle auth-background__circle--one" />
+        <div className="auth-background__circle auth-background__circle--two" />
+        <div className="auth-background__constellation" />
+        <div className="auth-background__particles" />
+      </div>
+      <section
+        className="auth-brand-panel"
+        aria-label="RealmTracker introduction"
+      >
+        <div className="auth-brand-panel__content">
+          <div className="auth-brand-panel__logo-frame">
+            <img src={logoLight} alt="RealmTracker" className="auth-logo" />
+          </div>
+          <p className="auth-brand-panel__eyebrow">
+            <Sparkles size={16} /> Premium fantasy VTT
+          </p>
+          <h1>Build worlds. Track adventures. Play together.</h1>
+          <p className="auth-brand-panel__copy">
+            A command center for Dungeon Masters and players with cinematic
+            combat tools, living character sheets, and campaign-grade
+            organization.
+          </p>
+          <div
+            className="auth-brand-panel__features"
+            aria-label="RealmTracker highlights"
+          >
+            <span>
+              <ShieldCheck size={18} /> Secure campaign hub
+            </span>
+            <span>
+              <ScrollText size={18} /> Character-first workflows
+            </span>
+            <span>
+              <Users size={18} /> Table-ready collaboration
+            </span>
+          </div>
+        </div>
+      </section>
+      <section className="auth-form-panel" aria-label="Authentication">
+        {children}
+      </section>
+    </main>
+  );
+}
+
+function AuthCard({ children, className = "" }) {
+  return <div className={`auth-card ${className}`.trim()}>{children}</div>;
+}
+
+function AuthHeader({ eyebrow, title, subtitle }) {
+  return (
+    <header className="auth-header">
+      <span className="auth-header__eyebrow">{eyebrow}</span>
+      <h2>{title}</h2>
+      <p>{subtitle}</p>
+    </header>
+  );
+}
+
+function AuthInput({
+  id,
+  icon: Icon,
+  label,
+  type = "text",
+  value,
+  onChange,
+  autoComplete,
+  error,
+  trailing,
+}) {
+  return (
+    <label
+      className={`auth-input ${error ? "auth-input--error" : ""}`}
+      htmlFor={id}
+    >
+      <Icon className="auth-input__icon" size={20} aria-hidden="true" />
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={onChange}
+        placeholder=" "
+        autoComplete={autoComplete}
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? `${id}-error` : undefined}
+      />
+      <span className="auth-input__label">{label}</span>
+      {trailing}
+      {error && (
+        <small id={`${id}-error`} className="auth-input__error">
+          {error}
+        </small>
+      )}
+    </label>
+  );
+}
+
+function AuthButton({
+  children,
+  loading = false,
+  variant = "primary",
+  ...props
+}) {
+  return (
+    <button
+      className={`auth-button auth-button--${variant}`}
+      disabled={loading || props.disabled}
+      {...props}
+    >
+      {loading && <span className="auth-button__spinner" aria-hidden="true" />}
+      <span>{children}</span>
+    </button>
+  );
+}
+
+function AuthDivider({ children }) {
+  return (
+    <div className="auth-divider">
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function AuthFooter({ onCreateAccount }) {
+  return (
+    <footer className="auth-footer">
+      <span>New to RealmTracker?</span>
+      <button
+        type="button"
+        className="auth-link auth-link--strong"
+        onClick={onCreateAccount}
+      >
+        Sign up — Create your account <ArrowRight size={16} />
+      </button>
+    </footer>
+  );
 }
 
 export default function Login({ onLogin }) {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [keepSignedIn, setKeepSignedIn] = useState(true);
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [newUser, setNewUser] = useState({
-    username: '',
-    password: '',
-    confirmPassword: '',
+    username: "",
+    password: "",
+    confirmPassword: "",
   });
-  const [loginError, setLoginError] = useState('');
-  const [signupError, setSignupError] = useState('');
+  const [loginError, setLoginError] = useState("");
+  const [signupError, setSignupError] = useState("");
 
-  const updateForm = (value) => setNewUser(prev => ({ ...prev, ...value }));
+  const updateForm = (value) => setNewUser((prev) => ({ ...prev, ...value }));
 
-  const handleLogin = async () => {
+  const handleLogin = async (event) => {
+    event?.preventDefault();
+    setIsLoggingIn(true);
     try {
       await loginUser({ username, password });
-      const res = await apiFetch('/me');
+      const res = await apiFetch("/me");
       if (res.ok) {
         const user = await res.json();
         onLogin(user);
-        setLoginError('');
+        setLoginError("");
       } else {
-        throw new Error('Failed to fetch user');
+        throw new Error("Failed to fetch user");
       }
     } catch (error) {
-      console.error('Login error:', error);
-      setLoginError('Failed to log in. Please check your credentials and try again.');
+      console.error("Login error:", error);
+      setLoginError(
+        "Failed to log in. Please check your credentials and try again."
+      );
+    } finally {
+      setIsLoggingIn(false);
     }
   };
 
   const onSubmit = async (e) => {
     e.preventDefault();
     if (newUser.password !== newUser.confirmPassword) {
-      setSignupError('Passwords do not match!');
+      setSignupError("Passwords do not match!");
       return;
     }
     try {
-      await createUser({ username: newUser.username, password: newUser.password });
-      setSignupError('');
+      await createUser({
+        username: newUser.username,
+        password: newUser.password,
+      });
+      setSignupError("");
       handleClose();
-      setNewUser({ username: '', password: '', confirmPassword: '' });
+      setNewUser({ username: "", password: "", confirmPassword: "" });
     } catch (error) {
-      console.error('Signup error:', error);
+      console.error("Signup error:", error);
       setSignupError(error.message);
     }
   };
+
   return (
-<div className="login-background d-flex justify-content-center align-items-center vh-100">
-  <div className="login-overlay p-4 text-center" style={{ maxWidth: "400px", width: "100%" }}>
-    <div className="text-center">
-      <img src={logoLight} alt="logo" className="py-3 logo-image" />
-      {/* <h1 className="mt-5 mb-5 pb-1 text-light" style={{ fontFamily: 'Raleway, sans-serif' }}>Realm Tracker</h1> */}
-    </div>
-    <p className="text-light">Please login to your account</p>
-
-    <Form className="w-100 mb-3">
-      <Form.Group controlId="formUsername">
-        <Form.Label>Username</Form.Label>
-        <Form.Control
-          type="text"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-          placeholder="Enter username"
+    <AuthLayout>
+      <AuthCard>
+        <AuthHeader
+          eyebrow="Realm access"
+          title="Enter the table"
+          subtitle="Sign in to continue your campaigns, encounters, maps, and characters."
         />
-      </Form.Group>
-      <Form.Group className="mb-3" controlId="formPassword">
-        <Form.Label>Password</Form.Label>
-        <Form.Control
-          type="password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          placeholder="Password"
-        />
-      </Form.Group>
-      {loginError && <div className="text-danger mb-3">{loginError}</div>}
-      <div className="text-center pt-1 mb-5 pb-1">
-        <Button className="mb-2 w-100" variant="primary" onClick={handleLogin}>
-          Login
-        </Button>
-        <a className="text-light" href="#!">Forgot password?</a>
-      </div>
-    </Form>
 
-    <div className="d-flex flex-row align-items-center justify-content-center pb-4 mb-4">
-      <p className="mb-0 text-light">Don't have an account?</p>
-      <Button variant="success" className="mx-2" onClick={handleShow}>Sign up</Button>
-    </div>
-  </div>
+        <form className="auth-form" onSubmit={handleLogin} noValidate>
+          <AuthInput
+            id="login-username"
+            icon={User}
+            label="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+          />
+          <AuthInput
+            id="login-password"
+            icon={KeyRound}
+            label="Password"
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            trailing={
+              <button
+                type="button"
+                className="auth-input__toggle"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                onClick={() => setShowPassword((prev) => !prev)}
+              >
+                {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+              </button>
+            }
+          />
 
-  {/* Signup Modal */}
-  <Modal className="dnd-modal" show={show} onHide={handleClose} centered>
-    <Modal.Header closeButton>
-      <Modal.Title>Sign up</Modal.Title>
-    </Modal.Header>
-    <Modal.Body>
-      <Form onSubmit={onSubmit} className="px-5">
-        <Form.Group className="mb-3 pt-3" controlId="signupUsername">
-          <Form.Label className="text-dark">Username</Form.Label>
-          <Form.Control
-            onChange={(e) => updateForm({ username: e.target.value })}
-            type="text"
-            placeholder="Enter username"
+          <div className="auth-form__options">
+            <label className="auth-check" htmlFor="keep-signed-in">
+              <input
+                id="keep-signed-in"
+                type="checkbox"
+                checked={keepSignedIn}
+                onChange={(e) => setKeepSignedIn(e.target.checked)}
+              />
+              <span>Keep me signed in</span>
+            </label>
+            <a className="auth-link" href="#!">
+              Forgot password?
+            </a>
+          </div>
+
+          {loginError && (
+            <div className="auth-alert" role="alert">
+              {loginError}
+            </div>
+          )}
+
+          <AuthButton type="submit" loading={isLoggingIn}>
+            Login
+          </AuthButton>
+          <AuthButton type="button" variant="secondary" disabled>
+            Continue as Guest <span className="auth-button__soon">Soon</span>
+          </AuthButton>
+        </form>
+
+        <AuthDivider>or</AuthDivider>
+        <AuthFooter onCreateAccount={handleShow} />
+      </AuthCard>
+
+      <Modal
+        className="dnd-modal auth-modal"
+        show={show}
+        onHide={handleClose}
+        centered
+      >
+        <AuthCard className="auth-card--modal">
+          <button
+            type="button"
+            className="auth-modal__close"
+            onClick={handleClose}
+            aria-label="Close sign up"
+          >
+            ×
+          </button>
+          <AuthHeader
+            eyebrow="Begin your legend"
+            title="Create account"
+            subtitle="Reserve your RealmTracker identity for future adventures."
           />
-        </Form.Group>
-        <Form.Group className="mb-3" controlId="signupPassword">
-          <Form.Label className="text-dark">Password</Form.Label>
-          <Form.Control
-            onChange={(e) => updateForm({ password: e.target.value })}
-            type="password"
-            placeholder="Enter password"
-          />
-        </Form.Group>
-        <Form.Group className="mb-3" controlId="signupConfirmPassword">
-          <Form.Label className="text-dark">Confirm Password</Form.Label>
-          <Form.Control
-            onChange={(e) => updateForm({ confirmPassword: e.target.value })}
-            type="password"
-            placeholder="Confirm password"
-          />
-        </Form.Group>
-        {signupError && <div className="text-danger mb-3">{signupError}</div>}
-        <div className="text-center">
-          <Button variant="primary" type="submit">Submit</Button>
-          <Button className="ms-4" variant="secondary" onClick={handleClose}>Close</Button>
-        </div>
-      </Form>
-    </Modal.Body>
-  </Modal>
-</div>
-  )
+          <form onSubmit={onSubmit} className="auth-form">
+            <AuthInput
+              id="signupUsername"
+              icon={User}
+              label="Username"
+              value={newUser.username}
+              onChange={(e) => updateForm({ username: e.target.value })}
+              autoComplete="username"
+            />
+            <AuthInput
+              id="signupPassword"
+              icon={Mail}
+              label="Password"
+              type="password"
+              value={newUser.password}
+              onChange={(e) => updateForm({ password: e.target.value })}
+              autoComplete="new-password"
+            />
+            <AuthInput
+              id="signupConfirmPassword"
+              icon={KeyRound}
+              label="Confirm password"
+              type="password"
+              value={newUser.confirmPassword}
+              onChange={(e) => updateForm({ confirmPassword: e.target.value })}
+              autoComplete="new-password"
+            />
+            {signupError && (
+              <div className="auth-alert" role="alert">
+                {signupError}
+              </div>
+            )}
+            <div className="auth-modal__actions">
+              <AuthButton type="submit">Submit Create Account</AuthButton>
+              <button type="button" className="auth-link" onClick={handleClose}>
+                Cancel
+              </button>
+            </div>
+          </form>
+        </AuthCard>
+      </Modal>
+    </AuthLayout>
+  );
 }
+
+AuthLayout.propTypes = { children: PropTypes.node.isRequired };
+AuthCard.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+AuthHeader.propTypes = {
+  eyebrow: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+};
+AuthInput.propTypes = {
+  id: PropTypes.string.isRequired,
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  autoComplete: PropTypes.string,
+  error: PropTypes.string,
+  trailing: PropTypes.node,
+};
+AuthButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  loading: PropTypes.bool,
+  variant: PropTypes.string,
+};
+AuthDivider.propTypes = { children: PropTypes.node.isRequired };
+AuthFooter.propTypes = { onCreateAccount: PropTypes.func.isRequired };
 
 Login.propTypes = {
   onLogin: PropTypes.func.isRequired,


### PR DESCRIPTION
### Motivation
- Replace the old prototype login form with a premium, brand-first authentication entry that matches the new homepage and HUD language. 
- Surface the product identity immediately so first-time users perceive RealmTracker as a polished fantasy VTT. 
- Provide a reusable, consistent set of auth primitives to be shared across future auth flows (register, forgot password, verify, etc.).

### Description
- Added a new split-screen auth layout and reusable auth primitives: `AuthLayout`, `AuthCard`, `AuthHeader`, `AuthInput`, `AuthButton`, `AuthDivider`, and `AuthFooter` implemented in `client/src/components/Login/Login.js`. 
- Replaced the legacy form with modern inputs featuring floating labels, leading icons, a password visibility toggle, `Keep me signed in` checkbox, a loading state on login, and a disabled placeholder `Continue as Guest` action. 
- Reworked signup to reuse the same auth components inside a modal and improved alert/validation presentation. 
- Implemented a premium visual layer and responsive styles in `client/src/components/Login/Login.css` including arcane backdrop layers, glass card treatment, refined focus states, hover/entrance animations, mobile/tablet breakpoints, and `prefers-reduced-motion` support.

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runInBand Login.test.js App.test.js`, and relevant test suites passed locally. 
- Built a production bundle with `npm run build`; the build completed successfully (the output includes unrelated lint/autoprefixer/browserslist warnings from other files). 
- Verified the new login component behavior via the existing component tests (`Login.test.js`) which exercise login failure and signup failure flows and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d96ed9220832e87bf507f9525156b)