### PR TITLE
Make login page fit shorter desktop viewports

### DIFF
--- a/client/src/components/Login/Login.css
+++ b/client/src/components/Login/Login.css
@@ -21,7 +21,8 @@
   min-height: 100dvh;
   display: grid;
   grid-template-columns: minmax(0, 1.12fr) minmax(420px, 0.88fr);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   color: var(--hud-text, #f7efe0);
   font-family: Raleway, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -638,6 +639,105 @@
   }
   .auth-brand-panel h1 {
     font-size: clamp(2.6rem, 6vw, 4.8rem);
+  }
+}
+@media (min-width: 821px) {
+  .auth-layout {
+    height: 100vh;
+    height: 100dvh;
+  }
+}
+@media (min-width: 821px) and (max-height: 900px) {
+  .auth-brand-panel,
+  .auth-form-panel {
+    padding-block: clamp(1rem, 3vh, 2rem);
+  }
+  .auth-brand-panel__content {
+    gap: clamp(0.65rem, 1.5vh, 1rem);
+  }
+  .auth-brand-panel__logo-frame {
+    width: clamp(132px, 16vh, 180px);
+    padding: clamp(0.7rem, 1.4vh, 1rem);
+    border-radius: 24px;
+  }
+  .auth-brand-panel h1 {
+    font-size: clamp(2.45rem, 6.2vh, 4.25rem);
+    line-height: 0.92;
+  }
+  .auth-brand-panel__copy {
+    font-size: clamp(0.92rem, 1.7vh, 1.08rem);
+    line-height: 1.4;
+  }
+  .auth-brand-panel__features {
+    gap: 0.55rem;
+  }
+  .auth-brand-panel__features span {
+    min-height: 36px;
+    padding-inline: 0.72rem;
+  }
+  .auth-card {
+    max-height: calc(100dvh - 2rem);
+    padding: clamp(1rem, 2.25vh, 1.7rem);
+  }
+  .auth-header {
+    gap: 0.35rem;
+    margin-bottom: 0.9rem;
+  }
+  .auth-header h2 {
+    font-size: clamp(1.75rem, 4.8vh, 2.45rem);
+  }
+  .auth-header p {
+    line-height: 1.32;
+  }
+  .auth-form {
+    gap: 0.7rem;
+  }
+  .auth-input input {
+    min-height: 54px;
+    padding-block: 22px 8px;
+  }
+  .auth-input__icon {
+    top: 1.08rem;
+  }
+  .auth-input__toggle {
+    top: 0.45rem;
+  }
+  .auth-button {
+    min-height: 48px;
+  }
+  .auth-divider {
+    margin-block: 0.75rem 0.55rem;
+  }
+}
+@media (min-width: 821px) and (max-height: 760px) {
+  .auth-brand-panel__copy,
+  .auth-brand-panel__features {
+    display: none;
+  }
+  .auth-brand-panel__logo-frame {
+    width: clamp(112px, 16vh, 150px);
+  }
+  .auth-card {
+    padding: 1rem;
+    border-radius: 24px;
+  }
+  .auth-card::before {
+    inset: 8px;
+    border-radius: 18px;
+  }
+  .auth-header__eyebrow {
+    font-size: 0.7rem;
+  }
+  .auth-header h2 {
+    font-size: clamp(1.55rem, 4.5vh, 2rem);
+  }
+  .auth-header p {
+    font-size: 0.9rem;
+  }
+  .auth-form__options {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
   }
 }
 @media (max-width: 820px) {


### PR DESCRIPTION
### Motivation
- Prevent the login page from being clipped on non-4k/shorter desktop displays by making the layout responsive to viewport height.
- Provide a safe vertical-scroll fallback while preserving horizontal overflow prevention and the current desktop grid layout.

### Description
- Updated `client/src/components/Login/Login.css` to change the root `.auth-layout` overflow behaviour from `overflow: hidden` to `overflow-x: hidden; overflow-y: auto;` so vertical content can scroll on short viewports.
- Added desktop height-based breakpoints (`@media (min-width: 821px) and (max-height: ...)`) that reduce panel padding, logo size, heading scale, card padding and gaps, input/button heights, and divider spacing to fit tighter heights.
- Added an extra-short desktop breakpoint that hides secondary brand copy/features and tightens card/header/options spacing for very short desktop heights.
- Ensured larger-desktop behaviour remains fixed to viewport height using `height: 100vh` / `100dvh` for screens above the breakpoint.

### Testing
- Ran the component unit tests with `npm test -- --watchAll=false Login.test.js`, which passed (2 tests passed).
- Built the production bundle with `npm run build`, which completed successfully; the output included pre-existing lint/warning messages unrelated to this CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e642236b4832eb56060d118262e42)