### PR TITLE
Add height-aware responsive styles for home and auth layouts

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9718,6 +9718,150 @@ h1 {
   }
 }
 
+@media (min-width: 721px) and (max-height: 900px) {
+  .realm-home-layout {
+    min-height: 100dvh;
+    padding-block: clamp(14px, 3vh, 28px);
+    gap: clamp(12px, 2vh, 18px);
+  }
+
+  .realm-home-hero {
+    gap: 0.35rem;
+  }
+
+  .realm-home-hero__sigil {
+    width: clamp(44px, 6vh, 52px);
+    height: clamp(44px, 6vh, 52px);
+    border-radius: 16px;
+  }
+
+  .realm-home-hero h1 {
+    font-size: clamp(2.65rem, 8vh, 5rem);
+    line-height: 0.92;
+  }
+
+  .realm-home-hero__subtitle {
+    font-size: clamp(0.92rem, 1.8vh, 1.08rem);
+  }
+
+  .realm-home-hero__version {
+    padding-block: 0.28rem;
+  }
+
+  .realm-home-command {
+    padding: clamp(12px, 2vh, 18px);
+  }
+
+  .realm-home-command__intro {
+    margin-bottom: 0.75rem;
+  }
+
+  .realm-home-actions,
+  .realm-home-lower,
+  .realm-home-sidecar,
+  .realm-home-recent__list {
+    gap: 0.7rem;
+  }
+
+  .realm-home-action-card {
+    min-height: clamp(122px, 17vh, 152px);
+    padding: 0.8rem;
+  }
+
+  .realm-home-action-card__icon {
+    width: clamp(46px, 6vh, 52px);
+    height: clamp(46px, 6vh, 52px);
+    border-radius: 16px;
+    font-size: 1.45rem;
+  }
+
+  .realm-home-action-card__content {
+    gap: 0.25rem;
+  }
+
+  .realm-home-action-card__title {
+    font-size: 1.05rem;
+  }
+
+  .realm-home-action-card__description {
+    font-size: 0.9rem;
+    line-height: 1.25;
+  }
+
+  .realm-home-recent,
+  .realm-profile-summary {
+    padding: 0.8rem;
+  }
+
+  .realm-home-section-heading {
+    margin-bottom: 0.55rem;
+  }
+
+  .realm-home-empty-state {
+    min-height: clamp(94px, 14vh, 118px);
+    gap: 0.35rem;
+  }
+
+  .realm-recent-campaign-card {
+    grid-template-columns: 58px 1fr auto;
+    gap: 0.75rem;
+    padding: 0.6rem;
+  }
+
+  .realm-recent-campaign-card__art {
+    height: 52px;
+  }
+
+  .realm-profile-summary {
+    gap: 0.65rem;
+  }
+
+  .realm-profile-summary__avatar {
+    width: 46px;
+    height: 46px;
+  }
+
+  .realm-profile-summary__logout {
+    min-height: 42px;
+  }
+}
+
+@media (min-width: 721px) and (max-height: 760px) {
+  .realm-home-layout {
+    padding-block: 12px;
+    gap: 10px;
+  }
+
+  .realm-home-hero__subtitle,
+  .realm-home-hero__version,
+  .realm-home-action-card__description,
+  .realm-profile-summary__stats {
+    display: none;
+  }
+
+  .realm-home-hero h1 {
+    font-size: clamp(2.25rem, 7.5vh, 3.6rem);
+  }
+
+  .realm-home-command__intro,
+  .realm-home-section-heading {
+    margin-bottom: 0.45rem;
+  }
+
+  .realm-home-action-card {
+    min-height: clamp(92px, 15vh, 116px);
+  }
+
+  .realm-profile-summary {
+    grid-template-columns: auto 1fr;
+  }
+
+  .realm-profile-summary__logout {
+    grid-column: 1 / -1;
+    grid-row: auto;
+  }
+}
+
 .realm-home-hero h1,
 .realm-home-action-card__title,
 .realm-home-action-card__description,

--- a/client/src/components/Login/Login.css
+++ b/client/src/components/Login/Login.css
@@ -17,11 +17,13 @@
 .auth-layout {
   position: relative;
   isolation: isolate;
+  box-sizing: border-box;
   min-height: 100vh;
   min-height: 100dvh;
   display: grid;
   grid-template-columns: minmax(0, 1.12fr) minmax(420px, 0.88fr);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: hidden;
   color: var(--hud-text, #f7efe0);
   font-family: Raleway, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -640,11 +642,111 @@
     font-size: clamp(2.6rem, 6vw, 4.8rem);
   }
 }
+@media (min-width: 821px) {
+  .auth-layout {
+    height: 100vh;
+    height: 100dvh;
+  }
+}
+@media (min-width: 821px) and (max-height: 900px) {
+  .auth-brand-panel,
+  .auth-form-panel {
+    padding-block: clamp(1rem, 3vh, 2rem);
+  }
+  .auth-brand-panel__content {
+    gap: clamp(0.65rem, 1.5vh, 1rem);
+  }
+  .auth-brand-panel__logo-frame {
+    width: clamp(132px, 16vh, 180px);
+    padding: clamp(0.7rem, 1.4vh, 1rem);
+    border-radius: 24px;
+  }
+  .auth-brand-panel h1 {
+    font-size: clamp(2.45rem, 6.2vh, 4.25rem);
+    line-height: 0.92;
+  }
+  .auth-brand-panel__copy {
+    font-size: clamp(0.92rem, 1.7vh, 1.08rem);
+    line-height: 1.4;
+  }
+  .auth-brand-panel__features {
+    gap: 0.55rem;
+  }
+  .auth-brand-panel__features span {
+    min-height: 36px;
+    padding-inline: 0.72rem;
+  }
+  .auth-card {
+    max-height: calc(100dvh - 2rem);
+    padding: clamp(1rem, 2.25vh, 1.7rem);
+  }
+  .auth-header {
+    gap: 0.35rem;
+    margin-bottom: 0.9rem;
+  }
+  .auth-header h2 {
+    font-size: clamp(1.75rem, 4.8vh, 2.45rem);
+  }
+  .auth-header p {
+    line-height: 1.32;
+  }
+  .auth-form {
+    gap: 0.7rem;
+  }
+  .auth-input input {
+    min-height: 54px;
+    padding-block: 22px 8px;
+  }
+  .auth-input__icon {
+    top: 1.08rem;
+  }
+  .auth-input__toggle {
+    top: 0.45rem;
+  }
+  .auth-button {
+    min-height: 48px;
+  }
+  .auth-divider {
+    margin-block: 0.75rem 0.55rem;
+  }
+}
+@media (min-width: 821px) and (max-height: 760px) {
+  .auth-brand-panel__copy,
+  .auth-brand-panel__features {
+    display: none;
+  }
+  .auth-brand-panel__logo-frame {
+    width: clamp(112px, 16vh, 150px);
+  }
+  .auth-card {
+    padding: 1rem;
+    border-radius: 24px;
+  }
+  .auth-card::before {
+    inset: 8px;
+    border-radius: 18px;
+  }
+  .auth-header__eyebrow {
+    font-size: 0.7rem;
+  }
+  .auth-header h2 {
+    font-size: clamp(1.55rem, 4.5vh, 2rem);
+  }
+  .auth-header p {
+    font-size: 0.9rem;
+  }
+  .auth-form__options {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}
 @media (max-width: 820px) {
   .auth-layout {
     min-height: 100dvh;
     grid-template-columns: 1fr;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
   .auth-background::after {
     background: linear-gradient(


### PR DESCRIPTION
### Motivation

- Ensure the home dashboard and login/auth pages render and scale correctly on devices with limited viewport height. 
- Prevent vertical overflow and layout clipping by using `100dvh` where supported and by constraining paddings, gaps, and element sizes for mid-height viewports. 
- Improve touch scrolling behavior and box model consistency for the auth layout.

### Description

- Added height-aware media queries to `client/src/App.scss` to adjust spacing, font sizes, card sizes, and grid layouts for `min-width: 721px` with `max-height` thresholds (`900px` and `760px`).
- Hid lower-priority elements (like subtitles, versions, and descriptions) at tighter heights and adjusted grid placements for `.realm-profile-summary` to avoid overflow. 
- Updated `client/src/components/Login/Login.css` to set `box-sizing: border-box` on `.auth-layout`, split `overflow` into `overflow-x`/`overflow-y`, and enforce `height: 100dvh` for larger viewports. 
- Added multiple height-sensitive media queries for the auth panels to scale paddings, logo sizing, form input heights, and to hide non-essential copy at constrained heights, plus enabled `-webkit-overflow-scrolling: touch` for mobile flows.

### Testing

- Ran the style linter using `npm run lint:css` and it completed successfully. 
- Built the client bundle with `npm run build` and the build succeeded with no errors. 
- Ran unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e642236b4832eb56060d118262e42)