### PR TITLE
DM Command Center redesign: styles, map aspect-ratio handling, and dock icons

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10217,3 +10217,519 @@ body.character-select-scroll-enabled {
   object-fit: cover;
   object-position: center top;
 }
+
+/* DM Command Center redesign: map-first premium VTT chrome */
+.zombies-dm-page {
+  --dm-ink: #030711;
+  --dm-panel: rgba(8, 16, 31, 0.82);
+  --dm-panel-strong: rgba(5, 10, 22, 0.94);
+  --dm-line: rgba(121, 184, 255, 0.22);
+  --dm-blue: #65d8ff;
+  --dm-gold: #d7b46a;
+  --dm-red: #ff5b62;
+  --dm-green: #58d986;
+  --dm-purple: #b58cff;
+  background:
+    radial-gradient(circle at 20% 8%, rgba(60, 184, 255, 0.18), transparent 34rem),
+    radial-gradient(circle at 82% 18%, rgba(215, 180, 106, 0.12), transparent 28rem),
+    linear-gradient(135deg, rgba(2, 6, 14, 0.75), rgba(4, 8, 18, 0.9));
+  color: #eef7ff;
+  overflow: hidden;
+}
+
+.zombies-dm-page__map-surface::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.54), transparent 22%, transparent 66%, rgba(0, 0, 0, 0.72)),
+    radial-gradient(circle at 50% 45%, transparent 0 36%, rgba(1, 5, 12, 0.44) 100%);
+}
+
+.zombies-dm-page__map-heading,
+.zombies-dm-page__combat-header .combat-turn-header__active-indicator,
+.zombies-dm-active-enemies,
+.zombies-dm-bottom-bar {
+  border: 1px solid var(--dm-line);
+  background:
+    linear-gradient(135deg, rgba(99, 206, 255, 0.08), transparent 36%),
+    linear-gradient(180deg, rgba(10, 22, 42, 0.86), rgba(3, 8, 18, 0.9));
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.48), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(16px) saturate(130%);
+}
+
+.zombies-dm-page__map-heading {
+  border-radius: 20px;
+  padding: 0.85rem 1.1rem;
+  max-width: min(92vw, 25rem);
+}
+
+.zombies-dm-page__map-heading-label,
+.zombies-dm-active-enemies__label {
+  color: var(--dm-blue);
+  opacity: 1;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.zombies-dm-page__map-heading-title {
+  color: #fff8df;
+  font-family: 'Cinzel', serif;
+  text-shadow: 0 0 18px rgba(101, 216, 255, 0.28);
+}
+
+.zombies-dm-page__map-heading-meta {
+  color: rgba(224, 240, 255, 0.78);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+}
+
+.zombies-dm-page__combat-header {
+  top: calc(env(safe-area-inset-top, 0px) + 1.15rem);
+  width: min(58vw, 860px);
+}
+
+.zombies-dm-page__combat-header .combat-turn-header__active-indicator {
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+}
+
+.combat-turn-header__active-name { color: var(--dm-gold); }
+
+.combat-turn-header__card {
+  border-radius: 16px !important;
+  background: linear-gradient(155deg, rgba(15, 29, 52, 0.92), rgba(6, 11, 23, 0.94)) !important;
+  border: 1px solid rgba(121, 184, 255, 0.2) !important;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.07) !important;
+}
+
+.combat-turn-header__card:has(.combat-turn-header__figurine--active) {
+  border-color: rgba(215, 180, 106, 0.84) !important;
+  box-shadow: 0 0 22px rgba(215, 180, 106, 0.32), 0 12px 30px rgba(0, 0, 0, 0.5) !important;
+}
+
+.zombies-dm-active-enemies {
+  left: auto;
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 6.7rem);
+  transform: none;
+  width: min(440px, calc(100vw - 1.5rem));
+  max-height: min(68vh, 720px);
+  border-radius: 24px;
+  padding: 1rem;
+  animation: dmPanelSlideIn 260ms ease both;
+}
+
+.zombies-dm-active-enemies__header { align-items: center; }
+.zombies-dm-active-enemies__count { color: rgba(238, 247, 255, 0.86); }
+.zombies-dm-active-enemies__actions { gap: 0.45rem; }
+.zombies-dm-active-enemies__actions .d-inline-flex { flex-wrap: wrap; }
+
+.zombies-dm-active-enemies .btn,
+.enemy-quick-card .btn,
+.zombies-dm-bottom-bar__button {
+  border-radius: 999px;
+  border-color: rgba(121, 184, 255, 0.32);
+  background: rgba(7, 15, 29, 0.72);
+  color: #eef7ff;
+  font-weight: 800;
+  letter-spacing: 0.035em;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.06);
+}
+
+.zombies-dm-active-enemies .btn:hover,
+.enemy-quick-card .btn:hover,
+.zombies-dm-bottom-bar__button:hover {
+  border-color: rgba(101, 216, 255, 0.72);
+  color: #fff8df;
+  transform: translateY(-1px);
+  box-shadow: 0 0 20px rgba(101, 216, 255, 0.16), inset 0 1px 0 rgba(255,255,255,0.08);
+}
+
+.zombies-dm-active-enemies__actions .btn:nth-of-type(4) { background: linear-gradient(135deg, rgba(215, 180, 106, 0.34), rgba(101, 216, 255, 0.16)); }
+
+.zombies-dm-active-enemies__list {
+  grid-template-columns: 1fr;
+  gap: 0.85rem;
+  max-height: calc(min(68vh, 720px) - 8.5rem);
+  scrollbar-color: rgba(101, 216, 255, 0.45) transparent;
+}
+
+.enemy-quick-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(121, 184, 255, 0.2) !important;
+  border-radius: 20px !important;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(181, 140, 255, 0.16), transparent 42%),
+    linear-gradient(150deg, rgba(16, 29, 49, 0.95), rgba(5, 10, 20, 0.97)) !important;
+  color: #f3f8ff;
+  box-shadow: 0 18px 36px rgba(0,0,0,0.42), inset 0 1px 0 rgba(255,255,255,0.07);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.enemy-quick-card:hover { transform: translateY(-2px); border-color: rgba(101, 216, 255, 0.52) !important; }
+.enemy-quick-card--active-turn { border-color: rgba(215, 180, 106, 0.9) !important; animation: dmActivePulse 1800ms ease-in-out infinite; }
+.enemy-quick-card .card-title { color: #fff8df; font-family: 'Cinzel', serif; }
+.enemy-quick-card .card-subtitle, .enemy-card__summary-label { color: rgba(224, 240, 255, 0.68) !important; }
+.enemy-quick-card__badge { background: rgba(101, 216, 255, 0.16) !important; border: 1px solid rgba(101, 216, 255, 0.26); }
+.enemy-quick-card__active-badge { background: linear-gradient(135deg, #f5cf7b, #b9852d) !important; color: #160e05 !important; }
+.enemy-card__health-bar { background: rgba(0,0,0,0.55); border: 1px solid rgba(255,255,255,0.12); height: 0.7rem; }
+.enemy-card__health-bar-fill { background: linear-gradient(90deg, var(--dm-red), #ffb457 45%, var(--dm-green)); box-shadow: 0 0 14px rgba(88, 217, 134, 0.38); }
+.enemy-card__health-text { color: #eaf7ef; font-weight: 800; }
+.enemy-card__health-adjustment { border-radius: 999px; background: rgba(0,0,0,0.35); border: 1px solid rgba(121,184,255,0.28); color: #fff; text-align: center; }
+
+.zombies-dm-bottom-bar {
+  inset: auto 50% calc(env(safe-area-inset-bottom, 0px) + 0.85rem) auto;
+  transform: translateX(50%);
+  width: min(1120px, calc(100vw - 2rem));
+  border-radius: 28px;
+  padding: 0.55rem;
+  gap: 0.35rem;
+}
+
+.zombies-dm-bottom-bar__button {
+  min-width: 92px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.72rem;
+  text-transform: none;
+}
+
+.zombies-dm-bottom-bar__button.btn-primary,
+.zombies-dm-bottom-bar__button[aria-selected='true'] {
+  border-color: rgba(215, 180, 106, 0.82);
+  background: radial-gradient(circle at 50% 0%, rgba(215, 180, 106, 0.28), transparent 72%), rgba(10, 23, 43, 0.92);
+  color: #fff8df;
+  box-shadow: 0 0 24px rgba(215, 180, 106, 0.22), inset 0 1px 0 rgba(255,255,255,0.12);
+}
+
+.zombies-dm-bottom-bar__icon { font-size: 1.25rem; color: var(--dm-blue); }
+.zombies-dm-bottom-bar__button[aria-selected='true'] .zombies-dm-bottom-bar__icon { color: var(--dm-gold); }
+
+.zombies-dm-resource-modal .modal-dialog { margin-top: calc(env(safe-area-inset-top, 0px) + 3.5rem); }
+.zombies-dm-resource-modal .modal-content,
+.dnd-modal .modal-content {
+  border-radius: 26px !important;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(101, 216, 255, 0.12), transparent 34rem),
+    linear-gradient(145deg, rgba(9, 20, 38, 0.98), rgba(3, 8, 18, 0.99)) !important;
+  border: 1px solid rgba(121, 184, 255, 0.2) !important;
+  color: #eef7ff !important;
+}
+
+.zombies-dm-resource-modal .modal-header,
+.zombies-dm-resource-modal .modal-footer,
+.dnd-modal .modal-header,
+.dnd-modal .modal-footer { border-color: rgba(121, 184, 255, 0.16) !important; }
+
+.zombies-dm-resource-modal .modal-title,
+.dnd-modal .modal-title { font-family: 'Cinzel', serif; color: #fff8df; }
+
+@media (max-width: 768px) {
+  .zombies-dm-page__map-heading { top: calc(env(safe-area-inset-top, 0px) + 0.7rem); left: 0.7rem; right: 0.7rem; max-width: none; }
+  .zombies-dm-page__combat-header { top: calc(env(safe-area-inset-top, 0px) + 6.2rem); width: calc(100vw - 1rem); padding: 0; }
+  .zombies-dm-active-enemies { left: 0.5rem; right: 0.5rem; bottom: calc(env(safe-area-inset-bottom, 0px) + 5.65rem); width: auto; max-height: 44vh; border-radius: 22px; }
+  .zombies-dm-active-enemies__actions { width: 100%; justify-content: stretch; }
+  .zombies-dm-active-enemies__actions .btn { flex: 1 1 auto; min-height: 40px; }
+  .zombies-dm-bottom-bar { width: 100%; inset: auto 0 0 0; transform: none; border-radius: 22px 22px 0 0; overflow-x: auto; justify-content: flex-start; flex-wrap: nowrap; }
+  .zombies-dm-bottom-bar__button { min-width: 76px; min-height: 58px; padding-inline: 0.55rem; }
+  .zombies-dm-resource-modal .modal-dialog { margin: auto 0 0; max-width: none; min-height: 72vh; display: flex; align-items: flex-end; }
+  .zombies-dm-resource-modal .modal-content { border-radius: 26px 26px 0 0 !important; min-height: 72vh; max-height: 92vh; }
+}
+
+@keyframes dmPanelSlideIn { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes dmActivePulse { 0%, 100% { box-shadow: 0 0 0 rgba(215, 180, 106, 0), 0 18px 36px rgba(0,0,0,0.42); } 50% { box-shadow: 0 0 28px rgba(215, 180, 106, 0.34), 0 18px 36px rgba(0,0,0,0.5); } }
+
+/* DM Command Center mobile corrections */
+.zombies-dm-page__map-board.campaign-map-board {
+  height: 100dvh;
+  min-height: 100dvh;
+  padding: 0;
+  background: #030711;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__stage,
+.zombies-dm-page__map-board .campaign-map-board__image-wrapper {
+  width: 100%;
+  height: 100%;
+  min-height: 100dvh;
+  border-radius: 0;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__image {
+  object-fit: cover;
+}
+
+.zombies-dm-active-enemies {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.zombies-dm-active-enemies__header {
+  flex: 0 0 auto;
+}
+
+.zombies-dm-active-enemies__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 0.35rem;
+}
+
+.zombies-dm-active-enemies .btn:hover,
+.zombies-dm-active-enemies .btn:focus,
+.zombies-dm-active-enemies .btn:active,
+.zombies-dm-active-enemies .btn-outline-light:hover,
+.zombies-dm-active-enemies .btn-outline-light:focus,
+.zombies-dm-active-enemies .btn-outline-light:active,
+.enemy-quick-card .btn:hover,
+.enemy-quick-card .btn:focus,
+.enemy-quick-card .btn:active,
+.zombies-dm-bottom-bar__button:hover,
+.zombies-dm-bottom-bar__button:focus,
+.zombies-dm-bottom-bar__button:active {
+  background: linear-gradient(135deg, rgba(12, 25, 48, 0.96), rgba(8, 16, 32, 0.98)) !important;
+  border-color: rgba(101, 216, 255, 0.78) !important;
+  color: #fff8df !important;
+}
+
+.zombies-dm-bottom-bar__button span {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .zombies-dm-page__map-surface,
+  .zombies-dm-page__map-board {
+    width: 100vw;
+    height: 100dvh;
+    min-height: 100dvh;
+  }
+
+  .zombies-dm-page__map-surface::after {
+    background:
+      linear-gradient(180deg, rgba(0, 0, 0, 0.34), transparent 28%, transparent 62%, rgba(0, 0, 0, 0.68)),
+      radial-gradient(circle at 50% 50%, transparent 0 42%, rgba(1, 5, 12, 0.38) 100%);
+  }
+
+  .zombies-dm-page__map-heading {
+    left: 0.75rem;
+    right: 0.75rem;
+    padding: 0.75rem 0.95rem;
+    border-radius: 18px;
+  }
+
+  .zombies-dm-page__combat-header {
+    top: calc(env(safe-area-inset-top, 0px) + 5.4rem);
+  }
+
+  .combat-turn-header__card {
+    width: clamp(82px, 26vw, 108px);
+    min-width: clamp(82px, 26vw, 108px);
+    padding: 0.55rem 0.5rem !important;
+  }
+
+  .zombies-dm-active-enemies {
+    max-height: min(52dvh, 520px);
+    overflow: hidden;
+  }
+
+  .zombies-dm-active-enemies[aria-expanded='true'] .zombies-dm-active-enemies__list {
+    max-height: none;
+  }
+
+  .zombies-dm-active-enemies__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .zombies-dm-active-enemies__actions .d-inline-flex {
+    display: contents !important;
+  }
+
+  .zombies-dm-active-enemies__actions .btn {
+    width: 100%;
+    min-width: 0;
+    padding-inline: 0.55rem;
+    white-space: nowrap;
+  }
+
+  .zombies-dm-bottom-bar {
+    gap: 0.3rem;
+    padding: 0.45rem 0.5rem calc(env(safe-area-inset-bottom, 0px) + 0.45rem);
+    scrollbar-width: none;
+  }
+
+  .zombies-dm-bottom-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .zombies-dm-bottom-bar__button {
+    flex: 0 0 64px;
+    min-width: 64px;
+    max-width: 64px;
+    min-height: 56px;
+    gap: 0.12rem;
+    padding: 0.4rem 0.25rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.01em;
+  }
+
+  .zombies-dm-bottom-bar__icon {
+    font-size: 1.08rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .zombies-dm-bottom-bar__button {
+    flex-basis: 58px;
+    min-width: 58px;
+    max-width: 58px;
+    font-size: 0.52rem;
+  }
+}
+
+/* DM Command Center mobile follow-up: preserve map framing and restore compact controls */
+.zombies-dm-page__map-board .campaign-map-board__image {
+  object-fit: contain;
+}
+
+@media (max-width: 768px) {
+  .zombies-dm-page__map-board .campaign-map-board__image-wrapper {
+    background: rgba(0, 0, 0, 0.28);
+  }
+
+  .zombies-dm-active-enemies {
+    max-height: min(60dvh, 640px);
+  }
+
+  .zombies-dm-active-enemies__actions > .d-inline-flex:not(button) {
+    display: contents !important;
+  }
+
+  .zombies-dm-active-enemies__actions button.d-inline-flex,
+  .zombies-dm-active-enemies__actions .btn.d-inline-flex {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    border-color: rgba(101, 216, 255, 0.48) !important;
+    background: linear-gradient(135deg, rgba(13, 29, 54, 0.94), rgba(5, 12, 26, 0.98)) !important;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 0 0 1px rgba(101,216,255,0.08);
+  }
+
+  .enemy-quick-card .card-body {
+    gap: 0.55rem !important;
+    padding: 0.85rem !important;
+  }
+
+  .enemy-card__health-controls--compact {
+    display: grid !important;
+    grid-template-columns: 42px minmax(54px, 1fr) 42px minmax(64px, auto);
+    gap: 0.35rem;
+    align-items: center;
+  }
+
+  .enemy-card__health-input--compact,
+  .enemy-card__health-adjustment {
+    min-width: 0 !important;
+    width: 100%;
+  }
+
+  .enemy-card__health-button,
+  .enemy-card__health-button--reset {
+    min-height: 36px;
+    padding-inline: 0.45rem !important;
+  }
+
+  .enemy-quick-card__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.4rem;
+  }
+
+  .enemy-quick-card__actions .btn {
+    width: 100%;
+    min-width: 0;
+    min-height: 36px;
+    padding-inline: 0.45rem !important;
+    white-space: normal;
+  }
+}
+
+@media (max-width: 420px) {
+  .enemy-card__health-controls--compact {
+    grid-template-columns: 38px minmax(48px, 1fr) 38px 58px;
+  }
+
+  .enemy-card__health-button,
+  .enemy-card__health-button--reset {
+    font-size: 0.72rem;
+  }
+}
+
+/* DM Command Center map parity: keep the board aspect-ratio identical to character-sheet maps */
+.zombies-dm-page__map-board.campaign-map-board {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100vw;
+  height: 100dvh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__stage {
+  width: min(100vw, calc(100dvh * var(--campaign-map-stage-aspect-ratio, 1)));
+  max-width: 100vw;
+  height: auto !important;
+  min-height: 0 !important;
+  margin-inline: auto;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__image-wrapper {
+  width: 100%;
+  height: auto !important;
+  min-height: 0 !important;
+  aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
+  border-radius: 0;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__grid-overlay,
+.zombies-dm-page__map-board .campaign-map-board__tokens-layer {
+  inset: 0;
+}
+
+/* DM Command Center mobile map cover: preserve square grid while filling the viewport */
+@media (max-width: 768px) {
+  .zombies-dm-page__map-board .campaign-map-board__stage {
+    width: max(100vw, calc(100dvh * var(--campaign-map-stage-aspect-ratio, 1)));
+    max-width: none;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .zombies-dm-page__map-board .campaign-map-board__image-wrapper {
+    width: 100%;
+    aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
+  }
+}
+
+/* DM Command Center mobile map cover fix: use numeric stage ratio for reliable viewport math */
+@media (max-width: 768px) {
+  .zombies-dm-page__map-board .campaign-map-board__stage {
+    width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
+  }
+}

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -595,13 +595,16 @@ const CampaignMapBoard = ({
     () => resolveGridDimensions(map),
     [map]
   );
-  const stageAspectRatio = useMemo(() => {
+  const stageAspectRatioData = useMemo(() => {
     const metricsWidth = Number(mapImageMetrics?.width);
     const metricsHeight = Number(mapImageMetrics?.height);
 
     if (Number.isFinite(metricsWidth) && Number.isFinite(metricsHeight)) {
       if (metricsWidth > 0 && metricsHeight > 0) {
-        return `${metricsWidth} / ${metricsHeight}`;
+        return {
+          cssRatio: `${metricsWidth} / ${metricsHeight}`,
+          numericRatio: metricsWidth / metricsHeight,
+        };
       }
     }
 
@@ -616,8 +619,14 @@ const CampaignMapBoard = ({
       return null;
     }
 
-    return `${safeColumns} / ${safeRows}`;
+    return {
+      cssRatio: `${safeColumns} / ${safeRows}`,
+      numericRatio: safeColumns / safeRows,
+    };
   }, [gridColumns, gridRows, mapImageMetrics?.height, mapImageMetrics?.width]);
+
+  const stageAspectRatio = stageAspectRatioData?.cssRatio ?? null;
+  const stageAspectRatioNumber = stageAspectRatioData?.numericRatio ?? null;
   const metadataSquareSize = useMemo(() => resolveSquareSizeFromMetadata(map), [map]);
 
   useEffect(() => {
@@ -792,8 +801,12 @@ const CampaignMapBoard = ({
       style['--campaign-map-stage-aspect-ratio'] = stageAspectRatio;
     }
 
+    if (Number.isFinite(stageAspectRatioNumber) && stageAspectRatioNumber > 0) {
+      style['--campaign-map-stage-ratio-number'] = stageAspectRatioNumber;
+    }
+
     return style;
-  }, [mapPanOffset.x, mapPanOffset.y, stageAspectRatio]);
+  }, [mapPanOffset.x, mapPanOffset.y, stageAspectRatio, stageAspectRatioNumber]);
 
   useEffect(() => {
     mapPanStateRef.current = null;

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -4422,15 +4422,15 @@ export default function ZombiesDM() {
 
     const RESOURCE_TABS = useMemo(
       () => [
-        { key: 'characters', title: 'Characters' },
-        { key: 'players', title: 'Players' },
-        { key: 'map', title: 'Map' },
-        { key: 'enemies', title: 'Enemies' },
-        { key: 'weapons', title: 'Weapons' },
-        { key: 'armor', title: 'Armor' },
-        { key: 'items', title: 'Items' },
-        { key: 'accessories', title: 'Accessories' },
-        { key: 'shop', title: 'Shop' },
+        { key: 'characters', title: 'Characters', icon: GiCharacter },
+        { key: 'players', title: 'Players', icon: GiHolyGrail },
+        { key: 'map', title: 'Map', icon: GiTreasureMap },
+        { key: 'enemies', title: 'Enemies', icon: GiPentagramRose },
+        { key: 'weapons', title: 'Weapons', icon: GiBroadsword },
+        { key: 'armor', title: 'Armor', icon: GiArmorVest },
+        { key: 'items', title: 'Items', icon: GiBackpack },
+        { key: 'accessories', title: 'Accessories', icon: GiSpellBook },
+        { key: 'shop', title: 'Shop', icon: GiHolyGrail },
       ],
       [calculateCharacterInitiative]
     );
@@ -6505,9 +6505,12 @@ const resolveIcon = (category, iconMap, fallback) => {
 
         {campaignTitle && (
           <div className="zombies-dm-page__map-heading">
-            <span className="zombies-dm-page__map-heading-label">Campaign</span>
+            <span className="zombies-dm-page__map-heading-label">DM Command Center</span>
             <span className="zombies-dm-page__map-heading-title">
               {campaignTitle}
+            </span>
+            <span className="zombies-dm-page__map-heading-meta">
+              {activeMapTitle || 'No battleground selected'} • {combatParticipantCount ? `${combatParticipantCount} in initiative` : 'Encounter idle'}
             </span>
           </div>
         )}
@@ -6547,7 +6550,7 @@ const resolveIcon = (category, iconMap, fallback) => {
         role="toolbar"
         aria-label="Dungeon Master resources"
       >
-        {RESOURCE_TABS.map(({ key, title }) => {
+        {RESOURCE_TABS.map(({ key, title, icon: DockIcon }) => {
           const isActiveTab = activeResourceTab === key;
           const tabClassName = `zombies-dm-bottom-bar__button btn ${
             isActiveTab ? 'btn-primary' : 'btn-outline-light'
@@ -6563,7 +6566,8 @@ const resolveIcon = (category, iconMap, fallback) => {
               aria-selected={isActiveTab}
               aria-pressed={isActiveTab}
             >
-              {title}
+              {DockIcon && <DockIcon className="zombies-dm-bottom-bar__icon" aria-hidden="true" />}
+              <span>{title}</span>
             </button>
           );
         })}


### PR DESCRIPTION
### Motivation
- Introduce a new DM Command Center visual design and improve map framing behavior for campaign maps. 
- Ensure the campaign map board can expose both a CSS aspect-ratio string and a numeric ratio for reliable viewport math. 
- Surface dock icons and richer heading metadata in the DM bottom-bar to improve usability.

### Description
- Added a comprehensive set of DM Command Center styles to `client/src/App.scss` under the `.zombies-dm-*` namespace to implement new chrome, panels, animations, responsive mobile behavior, modal styling, and map parity rules. 
- Updated `client/src/components/Zombies/attributes/CampaignMapBoard.js` to return both a CSS ratio string (`cssRatio`) and a numeric ratio (`numericRatio`) for the stage aspect ratio, and expose the numeric ratio as the CSS variable `--campaign-map-stage-ratio-number` to support accurate viewport calculations. 
- Modified `client/src/components/Zombies/pages/ZombiesDM.js` to add icons to the resource dock entries (`RESOURCE_TABS`), render the dock icons in the bottom bar, change the map heading label to `DM Command Center`, and display map/initiative metadata in the heading.

### Testing
- Ran the frontend unit test suite with `yarn test` and observed success. 
- Performed a local production build with `yarn build` to validate CSS and bundling and the build completed successfully. 
- Performed a basic automated lint pass (`yarn lint`) which reported no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec775dfe0832e9f5388d0f91344c3)