### PR TITLE
DM map: match character-sheet map sizing (fix mobile viewport)

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10733,3 +10733,49 @@ body.character-select-scroll-enabled {
     width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
   }
 }
+
+/* DM map viewport parity: match the character-sheet background map sizing. */
+.zombies-dm-page__map-surface {
+  align-items: center;
+  justify-content: center;
+}
+
+.zombies-dm-page__map-board.campaign-map-board {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
+  height: max(100dvh, calc(100vw / var(--campaign-map-stage-ratio-number, 1)));
+  min-height: 0;
+  padding: 0;
+  transform: translate(-50%, -50%);
+  overflow: hidden;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__stage {
+  position: relative;
+  left: auto;
+  flex: 1 1 auto;
+  width: 100%;
+  max-width: none;
+  height: 100% !important;
+  min-height: 0 !important;
+  margin: 0;
+  transform: none;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__image-wrapper {
+  width: 100%;
+  height: 100% !important;
+  min-height: 0 !important;
+  aspect-ratio: auto;
+  border-radius: 0;
+}
+
+.zombies-dm-page__map-board .campaign-map-board__image {
+  object-fit: cover;
+  object-position: center;
+}


### PR DESCRIPTION
### Motivation
- Ensure the DM Command Center map fills the viewport the same way the character-sheet map does so it uses the same framing on desktop and mobile.
- Fix the mobile issue where only a tiny portion of the map was visible at the top of the screen by making the DM board cover the full viewport and preserve map aspect framing.

### Description
- Added CSS rules in `client/src/App.scss` to center the DM map surface and make `.zombies-dm-page__map-board.campaign-map-board` size by viewport and the map stage ratio using `--campaign-map-stage-ratio-number`.
- Adjusted the board stage (`.campaign-map-board__stage`) and image wrapper (`.campaign-map-board__image-wrapper`) to stretch to the new board sizing and removed fixed aspect constraints that caused the mobile gap.
- Set the DM map image (`.campaign-map-board__image`) to `object-fit: cover` and centered it to keep consistent framing with the character-sheet map.

### Testing
- Ran the Campaign map unit suite with `CI=true npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js`, which passed. 
- Built the client with `npm --prefix client run build`, which completed successfully (build warnings unrelated to this CSS change were reported). 
- Attempted `npm test` against the DM page suite (`client/src/components/Zombies/pages/ZombiesDM.test.js`) where unrelated existing failures/timeouts were observed and are not caused by this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb85bb164832e981d423f9f139682)