### PR TITLE
Fix active enemy card control clipping

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10351,6 +10351,7 @@ body.character-select-scroll-enabled {
 
 .zombies-dm-active-enemies__list {
   grid-template-columns: 1fr;
+  align-items: start;
   gap: 0.85rem;
   max-height: calc(min(68vh, 720px) - 8.5rem);
   scrollbar-color: rgba(101, 216, 255, 0.45) transparent;
@@ -10358,7 +10359,8 @@ body.character-select-scroll-enabled {
 
 .enemy-quick-card {
   position: relative;
-  overflow: hidden;
+  min-height: max-content;
+  overflow: visible;
   border: 1px solid rgba(121, 184, 255, 0.2) !important;
   border-radius: 20px !important;
   background:
@@ -10367,6 +10369,10 @@ body.character-select-scroll-enabled {
   color: #f3f8ff;
   box-shadow: 0 18px 36px rgba(0,0,0,0.42), inset 0 1px 0 rgba(255,255,255,0.07);
   transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.enemy-quick-card .card-body {
+  min-height: max-content;
 }
 
 .enemy-quick-card:hover { transform: translateY(-2px); border-color: rgba(101, 216, 255, 0.52) !important; }


### PR DESCRIPTION
### Motivation
- Active map enemy quick cards were cropping DM controls because grid rows were stretching and cards had overflow hidden, making buttons inaccessible on desktop and mobile.

### Description
- Update `client/src/App.scss` to align the active enemy list grid items to the start by adding `align-items: start` to `.zombies-dm-active-enemies__list` so cards don’t stretch vertically.
- Allow quick enemy cards to size to their content by setting `.enemy-quick-card` to `min-height: max-content` and `overflow: visible`, and ensure the card body can expand via `.enemy-quick-card .card-body { min-height: max-content; }` so controls are not clipped.

### Testing
- Ran unit tests with `npm --prefix client test -- --watchAll=false ActiveEnemyQuickList` and all tests passed (8 passed).
- Attempted production build with `npm --prefix client run build`, which failed due to an existing missing dependency (`lucide-react`) unrelated to these CSS changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fcc2ee8d8832ea7d9d40034fc4780)