### PR TITLE
Switch enemy quick-card list to flex column and fix card-body sizing

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10350,7 +10350,9 @@ body.character-select-scroll-enabled {
 .zombies-dm-active-enemies__actions .btn:nth-of-type(4) { background: linear-gradient(135deg, rgba(215, 180, 106, 0.34), rgba(101, 216, 255, 0.16)); }
 
 .zombies-dm-active-enemies__list {
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.85rem;
   max-height: calc(min(68vh, 720px) - 8.5rem);
   scrollbar-color: rgba(101, 216, 255, 0.45) transparent;
@@ -10367,6 +10369,10 @@ body.character-select-scroll-enabled {
   color: #f3f8ff;
   box-shadow: 0 18px 36px rgba(0,0,0,0.42), inset 0 1px 0 rgba(255,255,255,0.07);
   transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.enemy-quick-card .card-body {
+  flex: 0 0 auto;
 }
 
 .enemy-quick-card:hover { transform: translateY(-2px); border-color: rgba(101, 216, 255, 0.52) !important; }


### PR DESCRIPTION
### Motivation
- Ensure the enemies list stacks vertically and each enemy card sizes correctly in the DM UI to avoid layout and stretching issues caused by the previous grid setup.

### Description
- Replace `grid-template-columns: 1fr;` on `.zombies-dm-active-enemies__list` with a flex column layout using `display: flex`, `flex-direction: column`, and `align-items: stretch` and retain the `gap` and `max-height` settings.
- Add `.enemy-quick-card .card-body { flex: 0 0 auto; }` to prevent card body content from stretching unexpectedly inside the flex context.

### Testing
- Ran a production build with `npm run build` and the build completed successfully.
- Ran the test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fcc2ee8d8832ea7d9d40034fc4780)