### PR TITLE
Fix login layout on 1080p screens

### DIFF
--- a/client/src/components/Login/Login.css
+++ b/client/src/components/Login/Login.css
@@ -23,7 +23,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1.12fr) minmax(420px, 0.88fr);
   overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-y: auto;
   color: var(--hud-text, #f7efe0);
   font-family: Raleway, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -648,6 +648,24 @@
     height: 100dvh;
   }
 }
+
+@media (min-width: 821px) and (max-height: 1100px) {
+  .auth-brand-panel,
+  .auth-form-panel {
+    padding-block: clamp(1.5rem, 4vh, 3rem);
+  }
+  .auth-brand-panel__content {
+    gap: clamp(0.8rem, 1.7vh, 1.1rem);
+  }
+  .auth-brand-panel__logo-frame {
+    width: clamp(150px, 18vh, 220px);
+  }
+  .auth-brand-panel h1 {
+    font-size: clamp(3rem, 7.2vh, 4.85rem);
+    line-height: 0.92;
+  }
+}
+
 @media (min-width: 821px) and (max-height: 900px) {
   .auth-brand-panel,
   .auth-form-panel {


### PR DESCRIPTION
### Motivation
- Prevent the desktop login page from being clipped on 1080p / shorter-height viewports by allowing vertical scrolling and providing a compact-height layout variant.

### Description
- Update `client/src/components/Login/Login.css` to change `.auth-layout` `overflow-y` from `hidden` to `auto` and add an `@media (min-width: 821px) and (max-height: 1100px)` breakpoint that reduces vertical padding, spacing, logo width, and headline size so the login UI fits without cutting off.

### Testing
- Ran `npm run build` which completed successfully (with existing lint/warning output). 
- Ran `npm test -- --watchAll=false --runTestsByPath src/App.test.js` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fe606ed4c832eb5322425384de3b0)