### PR TITLE
Show active-turn enemy first in ActiveEnemyQuickList

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -391,6 +391,18 @@ export function ActiveEnemyQuickList({
     ? 'Expand active enemy display'
     : 'Collapse active enemy display';
   const listId = 'active-map-enemies-list';
+  const orderedSummaries = React.useMemo(() => {
+    const activeTurnSummary = summaries.find((summary) => summary?.isActiveTurn);
+
+    if (!activeTurnSummary) {
+      return summaries;
+    }
+
+    return [
+      activeTurnSummary,
+      ...summaries.filter((summary) => summary !== activeTurnSummary),
+    ];
+  }, [summaries]);
 
   return (
     <div
@@ -483,7 +495,7 @@ export function ActiveEnemyQuickList({
         data-testid="active-map-enemies-list"
         hidden={isCollapsed}
       >
-        {summaries.map((summary) => (
+        {orderedSummaries.map((summary) => (
           <ActiveEnemyQuickCard
             key={summary.enemy.enemyId || summary.enemy._id}
             enemy={summary.enemy}

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -137,6 +137,30 @@ describe('ActiveEnemyQuickList', () => {
     expect(screen.getByText('Active Turn')).toBeInTheDocument();
   });
 
+  it('moves the active turn enemy to the first card', () => {
+    renderList({
+      summaries: [
+        baseSummary,
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-2', name: 'Orc' },
+          isActiveTurn: true,
+        },
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-3', name: 'Kobold' },
+        },
+      ],
+    });
+
+    const cards = screen.getAllByTestId('active-map-enemy-card');
+    expect(cards).toHaveLength(3);
+    expect(within(cards[0]).getByText('Orc')).toBeInTheDocument();
+    expect(cards[0]).toHaveClass('enemy-quick-card--active-turn');
+    expect(within(cards[1]).getByText('Goblin')).toBeInTheDocument();
+    expect(within(cards[2]).getByText('Kobold')).toBeInTheDocument();
+  });
+
   it('displays attack actions within a modal when available', async () => {
     const formatAttackBonus = jest.fn((bonus) => (bonus >= 0 ? `+${bonus}` : `${bonus}`));
     const getEnemyActionDamageString = jest.fn((action) =>


### PR DESCRIPTION
### Motivation
- Make it easier for the DM to see which enemy has the active turn by showing that enemy as the first card so they don't have to scroll.

### Description
- Add `orderedSummaries` computed with `React.useMemo` to find a summary with `isActiveTurn` and place it first while preserving the order of the remaining summaries in `ActiveEnemyQuickList.js`.
- Replace the `summaries.map` rendering with `orderedSummaries.map` to apply the new ordering.
- Add a unit test `moves the active turn enemy to the first card` to `ActiveEnemyQuickList.test.js` to prevent regressions.
- Preserve previous behavior when no summary has `isActiveTurn`.

### Testing
- Ran `CI=true npm --prefix client test -- ActiveEnemyQuickList.test.js --watchAll=false` and all tests passed (1 test suite, 9 tests, 9 passed).
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fea457128832e8f0c08b302385320)