### PR TITLE
Show active-turn enemy first in ActiveEnemyQuickList and add test

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -382,8 +382,24 @@ export function ActiveEnemyQuickList({
   latestEnemyRoll,
 }) {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
+  const orderedSummaries = React.useMemo(() => {
+    if (!Array.isArray(summaries) || summaries.length === 0) {
+      return [];
+    }
 
-  if (!Array.isArray(summaries) || summaries.length === 0) {
+    const activeTurnSummary = summaries.find((summary) => summary?.isActiveTurn);
+
+    if (!activeTurnSummary) {
+      return summaries;
+    }
+
+    return [
+      activeTurnSummary,
+      ...summaries.filter((summary) => summary !== activeTurnSummary),
+    ];
+  }, [summaries]);
+
+  if (orderedSummaries.length === 0) {
     return null;
   }
 
@@ -483,7 +499,7 @@ export function ActiveEnemyQuickList({
         data-testid="active-map-enemies-list"
         hidden={isCollapsed}
       >
-        {summaries.map((summary) => (
+        {orderedSummaries.map((summary) => (
           <ActiveEnemyQuickCard
             key={summary.enemy.enemyId || summary.enemy._id}
             enemy={summary.enemy}

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -137,6 +137,30 @@ describe('ActiveEnemyQuickList', () => {
     expect(screen.getByText('Active Turn')).toBeInTheDocument();
   });
 
+  it('moves the active turn enemy to the first card', () => {
+    renderList({
+      summaries: [
+        baseSummary,
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-2', name: 'Orc' },
+          isActiveTurn: true,
+        },
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-3', name: 'Kobold' },
+        },
+      ],
+    });
+
+    const cards = screen.getAllByTestId('active-map-enemy-card');
+    expect(cards).toHaveLength(3);
+    expect(within(cards[0]).getByText('Orc')).toBeInTheDocument();
+    expect(cards[0]).toHaveClass('enemy-quick-card--active-turn');
+    expect(within(cards[1]).getByText('Goblin')).toBeInTheDocument();
+    expect(within(cards[2]).getByText('Kobold')).toBeInTheDocument();
+  });
+
   it('displays attack actions within a modal when available', async () => {
     const formatAttackBonus = jest.fn((bonus) => (bonus >= 0 ? `+${bonus}` : `${bonus}`));
     const getEnemyActionDamageString = jest.fn((action) =>


### PR DESCRIPTION
### Motivation

- Improve the Active Enemy quick list UX by ensuring the enemy whose turn is active is presented first for visibility.

### Description

- Added an `orderedSummaries` `useMemo` in `ActiveEnemyQuickList` to move the `isActiveTurn` summary to the front of the list while preserving the rest order.  
- Switched list rendering and empty checks to use `orderedSummaries` instead of the original `summaries` array.  
- Kept the deployed count display using the original `summaries.length` to avoid altering displayed counts.  
- Added a unit test in `ActiveEnemyQuickList.test.js` to verify the active-turn enemy is rendered as the first card.

### Testing

- Ran the component unit test suite with Jest for `ActiveEnemyQuickList`, and the tests including the new `moves the active turn enemy to the first card` test passed.  
- Existing tests such as `renders nothing when summaries are empty` and `highlights the active enemy card` were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fea457128832e8f0c08b302385320)