### PR TITLE
Show active-turn enemy first in ActiveEnemyQuickList

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -360,6 +360,23 @@ function EnemyQuickAttacksModal({
   );
 }
 
+function getActiveTurnFirstSummaries(summaries) {
+  if (!Array.isArray(summaries) || summaries.length === 0) {
+    return [];
+  }
+
+  const activeTurnSummary = summaries.find((summary) => summary?.isActiveTurn);
+
+  if (!activeTurnSummary) {
+    return summaries;
+  }
+
+  return [
+    activeTurnSummary,
+    ...summaries.filter((summary) => summary !== activeTurnSummary),
+  ];
+}
+
 export function ActiveEnemyQuickList({
   summaries,
   activeMapTitle,
@@ -382,8 +399,9 @@ export function ActiveEnemyQuickList({
   latestEnemyRoll,
 }) {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
+  const orderedSummaries = getActiveTurnFirstSummaries(summaries);
 
-  if (!Array.isArray(summaries) || summaries.length === 0) {
+  if (orderedSummaries.length === 0) {
     return null;
   }
 
@@ -483,7 +501,7 @@ export function ActiveEnemyQuickList({
         data-testid="active-map-enemies-list"
         hidden={isCollapsed}
       >
-        {summaries.map((summary) => (
+        {orderedSummaries.map((summary) => (
           <ActiveEnemyQuickCard
             key={summary.enemy.enemyId || summary.enemy._id}
             enemy={summary.enemy}

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -137,6 +137,30 @@ describe('ActiveEnemyQuickList', () => {
     expect(screen.getByText('Active Turn')).toBeInTheDocument();
   });
 
+  it('moves the active turn enemy to the first card', () => {
+    renderList({
+      summaries: [
+        baseSummary,
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-2', name: 'Orc' },
+          isActiveTurn: true,
+        },
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-3', name: 'Kobold' },
+        },
+      ],
+    });
+
+    const cards = screen.getAllByTestId('active-map-enemy-card');
+    expect(cards).toHaveLength(3);
+    expect(within(cards[0]).getByText('Orc')).toBeInTheDocument();
+    expect(cards[0]).toHaveClass('enemy-quick-card--active-turn');
+    expect(within(cards[1]).getByText('Goblin')).toBeInTheDocument();
+    expect(within(cards[2]).getByText('Kobold')).toBeInTheDocument();
+  });
+
   it('displays attack actions within a modal when available', async () => {
     const formatAttackBonus = jest.fn((bonus) => (bonus >= 0 ? `+${bonus}` : `${bonus}`));
     const getEnemyActionDamageString = jest.fn((action) =>


### PR DESCRIPTION
### Motivation
- Ensure the enemy whose turn is active is shown first in the quick list so the DM can spot and interact with them more easily.
- Keep the existing display behavior and counts but change ordering for clarity during combat.

### Description
- Add `getActiveTurnFirstSummaries` helper to reorder the `summaries` array so the item with `isActiveTurn` appears first.
- Use the reordered `orderedSummaries` in `ActiveEnemyQuickList` for empty checks and rendering instead of the original `summaries` order.
- Add a unit test `moves the active turn enemy to the first card` to assert the active enemy is rendered as the first card and marked as active.

### Testing
- Ran the component unit tests with `yarn test ActiveEnemyQuickList.test.js` and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fea457128832e8f0c08b302385320)