### PR TITLE
Prioritize active enemy in map side panel

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -383,7 +383,24 @@ export function ActiveEnemyQuickList({
 }) {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
 
-  if (!Array.isArray(summaries) || summaries.length === 0) {
+  const normalizedSummaries = Array.isArray(summaries) ? summaries : [];
+  const orderedSummaries = React.useMemo(() => {
+    const activeSummaries = [];
+    const inactiveSummaries = [];
+
+    normalizedSummaries.forEach((summary) => {
+      if (summary?.isActiveTurn) {
+        activeSummaries.push(summary);
+        return;
+      }
+
+      inactiveSummaries.push(summary);
+    });
+
+    return [...activeSummaries, ...inactiveSummaries];
+  }, [normalizedSummaries]);
+
+  if (normalizedSummaries.length === 0) {
     return null;
   }
 
@@ -483,7 +500,7 @@ export function ActiveEnemyQuickList({
         data-testid="active-map-enemies-list"
         hidden={isCollapsed}
       >
-        {summaries.map((summary) => (
+        {orderedSummaries.map((summary) => (
           <ActiveEnemyQuickCard
             key={summary.enemy.enemyId || summary.enemy._id}
             enemy={summary.enemy}

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -137,6 +137,34 @@ describe('ActiveEnemyQuickList', () => {
     expect(screen.getByText('Active Turn')).toBeInTheDocument();
   });
 
+  it('moves the active turn enemy to the top of the visible list', () => {
+    renderList({
+      summaries: [
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-1', name: 'Goblin' },
+          isActiveTurn: false,
+        },
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-2', name: 'Owlbear' },
+          isActiveTurn: true,
+        },
+        {
+          ...baseSummary,
+          enemy: { ...baseSummary.enemy, enemyId: 'enemy-3', name: 'Skeleton' },
+          isActiveTurn: false,
+        },
+      ],
+    });
+
+    const cards = screen.getAllByTestId('active-map-enemy-card');
+    expect(within(cards[0]).getByText('Owlbear')).toBeInTheDocument();
+    expect(cards[0]).toHaveClass('enemy-quick-card--active-turn');
+    expect(within(cards[1]).getByText('Goblin')).toBeInTheDocument();
+    expect(within(cards[2]).getByText('Skeleton')).toBeInTheDocument();
+  });
+
   it('displays attack actions within a modal when available', async () => {
     const formatAttackBonus = jest.fn((bonus) => (bonus >= 0 ? `+${bonus}` : `${bonus}`));
     const getEnemyActionDamageString = jest.fn((action) =>


### PR DESCRIPTION
### Motivation
- Ensure the enemy whose turn is currently active is immediately visible in the DM side panel so the DM doesn't need to scroll to find the active participant.

### Description
- Normalize the incoming `summaries` and build an `orderedSummaries` array that places any summaries with `isActiveTurn` before inactive summaries while preserving relative ordering.
- Use `React.useMemo` to compute `orderedSummaries` from `normalizedSummaries` to avoid recomputing on each render.
- Render the list from `orderedSummaries` instead of `summaries` in `ActiveEnemyQuickList` (`client/src/components/Zombies/components/ActiveEnemyQuickList.js`).
- Add a regression test that verifies an active-turn enemy in the middle of the input array is rendered as the first visible card (`client/src/components/Zombies/components/ActiveEnemyQuickList.test.js`).

### Testing
- Ran the component unit tests with `CI=true npm --prefix client test -- --runTestsByPath src/components/Zombies/components/ActiveEnemyQuickList.test.js --watchAll=false`, and the test file passed.
- The test run reported `9 passed, 9 total` for the `ActiveEnemyQuickList` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff1e3f764832e9095e0b25f835497)