### PR TITLE
Add enemy attack roll support and integrate Dice Box for damage rolls with UI updates

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -22,6 +22,7 @@ export function ActiveEnemyQuickCard({
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
   onEnemyDamageRoll,
+  onEnemyAttackRoll,
   formatAttackBonus,
   getEnemyActionDamageString,
   latestEnemyRoll,
@@ -247,6 +248,7 @@ export function ActiveEnemyQuickCard({
                 quickAttacks={quickAttacks}
                 enemy={enemy}
                 onEnemyDamageRoll={onEnemyDamageRoll}
+                onEnemyAttackRoll={onEnemyAttackRoll}
                 latestEnemyRoll={latestEnemyRoll}
                 normalizedEnemyId={normalizedEnemyId}
                 modalAriaLabel={`${label} Attacks`}
@@ -303,6 +305,7 @@ function EnemyQuickAttacksModal({
   quickAttacks,
   enemy,
   onEnemyDamageRoll,
+  onEnemyAttackRoll,
   latestEnemyRoll,
   normalizedEnemyId,
   modalAriaLabel,
@@ -312,54 +315,85 @@ function EnemyQuickAttacksModal({
   }
 
   return (
-    <Modal show={show} onHide={onHide} centered animation={false} aria-label={modalAriaLabel}>
-      <Modal.Header closeButton>
-        <Modal.Title>{`${enemyLabel} Attacks`}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <div className="enemy-card__section-title text-uppercase text-muted small fw-semibold mb-2">
-          Attacks
-        </div>
-        <div className="d-flex flex-column gap-2">
-          {quickAttacks.map(
-            ({ action, actionLabel, attackBonusDisplay, damageDisplay, actionKey, isLatestRoll }) => (
-              <div key={actionKey} className="enemy-card__attack enemy-card__attack--compact">
-                <div className="enemy-card__attack-header">
-                  <div className="fw-semibold small text-body">{actionLabel}</div>
-                  <div className="small text-muted">Attack Bonus: {attackBonusDisplay ?? '—'}</div>
-                  <div className="small text-muted">Damage: {damageDisplay || '—'}</div>
-                </div>
-                <div className="enemy-card__attack-actions">
-                  <Button
-                    variant="outline-primary"
-                    size="sm"
-                    onClick={() =>
-                      normalizedEnemyId && onEnemyDamageRoll && onEnemyDamageRoll(enemy, action)
-                    }
-                    disabled={!onEnemyDamageRoll || !normalizedEnemyId}
-                  >
-                    Roll
-                  </Button>
-                </div>
-                {isLatestRoll && latestEnemyRoll?.breakdown && (
-                  <div className="mt-2 small fw-semibold text-primary">
-                    {`Result: ${latestEnemyRoll.total} damage (${latestEnemyRoll.breakdown})`}
+    <Modal
+      show={show}
+      onHide={onHide}
+      centered
+      size="lg"
+      className="dnd-modal modern-modal"
+      animation={false}
+      aria-label={modalAriaLabel}
+    >
+      <Card className="modern-card">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">{`${enemyLabel} Attacks`}</Card.Title>
+        </Card.Header>
+        <Card.Body>
+          <Card.Title className="modal-title">Attacks</Card.Title>
+          <div className="attack-card-grid enemy-card__attack-grid">
+            {quickAttacks.map(
+              ({ action, actionLabel, attackBonusDisplay, damageDisplay, actionKey, isLatestRoll }) => (
+                <div key={actionKey} className="attack-card enemy-card__attack-card">
+                  <div className="attack-card__title">{actionLabel}</div>
+                  <div className="attack-card__details">
+                    <div className="attack-card__row">
+                      <span className="attack-card__label">Attack Bonus</span>
+                      <span className="attack-card__value">{attackBonusDisplay ?? '—'}</span>
+                    </div>
+                    <div className="attack-card__row">
+                      <span className="attack-card__label">Damage</span>
+                      <span className="attack-card__value">{damageDisplay || '—'}</span>
+                    </div>
                   </div>
-                )}
-              </div>
-            )
-          )}
-        </div>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onHide}>
-          Close
-        </Button>
-      </Modal.Footer>
+                  <div className="attack-card__actions">
+                    <Button
+                      variant="link"
+                      className="attack-card__roll"
+                      onClick={() => {
+                        onHide();
+                        if (normalizedEnemyId && onEnemyAttackRoll) {
+                          onEnemyAttackRoll(enemy, action);
+                        }
+                      }}
+                      disabled={!onEnemyAttackRoll || !normalizedEnemyId}
+                      aria-label={`Roll attack for ${actionLabel}`}
+                    >
+                      <i className="fa-solid fa-bullseye" aria-hidden="true"></i>
+                    </Button>
+                    <Button
+                      variant="link"
+                      className="attack-card__roll"
+                      onClick={() => {
+                        onHide();
+                        if (normalizedEnemyId && onEnemyDamageRoll) {
+                          onEnemyDamageRoll(enemy, action);
+                        }
+                      }}
+                      disabled={!onEnemyDamageRoll || !normalizedEnemyId}
+                      aria-label={`Roll damage for ${actionLabel}`}
+                    >
+                      <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
+                    </Button>
+                  </div>
+                  {isLatestRoll && latestEnemyRoll?.breakdown && (
+                    <div className="mt-2 small fw-semibold text-primary">
+                      {`${latestEnemyRoll.rollType === 'attack' ? 'Attack' : 'Damage'}: ${latestEnemyRoll.total} (${latestEnemyRoll.breakdown})`}
+                    </div>
+                  )}
+                </div>
+              )
+            )}
+          </div>
+        </Card.Body>
+        <Card.Footer className="d-flex justify-content-end">
+          <Button className="close-btn" variant="secondary" onClick={onHide}>
+            Close
+          </Button>
+        </Card.Footer>
+      </Card>
     </Modal>
   );
 }
-
 export function ActiveEnemyQuickList({
   summaries,
   activeMapTitle,
@@ -377,6 +411,7 @@ export function ActiveEnemyQuickList({
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
   onEnemyDamageRoll,
+  onEnemyAttackRoll,
   formatAttackBonus,
   getEnemyActionDamageString,
   latestEnemyRoll,
@@ -521,6 +556,7 @@ export function ActiveEnemyQuickList({
             onResetEnemyHealth={onResetEnemyHealth}
             isActiveTurn={summary.isActiveTurn}
             onEnemyDamageRoll={onEnemyDamageRoll}
+            onEnemyAttackRoll={onEnemyAttackRoll}
             formatAttackBonus={formatAttackBonus}
             getEnemyActionDamageString={getEnemyActionDamageString}
             latestEnemyRoll={latestEnemyRoll}

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -26,6 +26,8 @@ import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import { calculateDamage } from '../attributes/PlayerTurnActions';
+import { rollSkillWithDiceBox } from '../attributes/Skills';
+import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
 import D20RollerModal, { DEFAULT_DICE_COLOR } from '../common/D20RollerModal';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import ShopVisibilityManager from '../attributes/ShopVisibilityManager';
@@ -542,6 +544,7 @@ function EnemyCard({
   legendaryActionsList,
   latestEnemyRoll,
   onEnemyDamageRoll,
+  onEnemyAttackRoll,
   onEnemyAdjustmentInputChange,
   onApplyEnemyHealthAdjustment,
   onResetEnemyHealth,
@@ -704,7 +707,7 @@ function EnemyCard({
             <h6 className="enemy-card__section-title text-uppercase text-muted small fw-semibold mb-2">
               Attacks
             </h6>
-            <div className="d-flex flex-column gap-2">
+            <div className="attack-card-grid enemy-card__attack-grid">
               {damagingActions.map((action, actionIndex) => {
                 const actionLabel = action?.name || 'Action';
                 const attackBonusDisplay = formatAttackBonus(action?.attack_bonus);
@@ -715,24 +718,39 @@ function EnemyCard({
                   latestEnemyRoll?.actionName === actionLabel;
 
                 return (
-                  <div key={actionKey} className="enemy-card__attack">
-                    <div className="enemy-card__attack-header">
-                      <div className="fw-semibold small text-body">{actionLabel}</div>
-                      <div className="small text-muted">Attack Bonus: {attackBonusDisplay ?? '—'}</div>
-                      <div className="small text-muted">Damage: {damageLine || '—'}</div>
+                  <div key={actionKey} className="attack-card enemy-card__attack-card">
+                    <div className="attack-card__title">{actionLabel}</div>
+                    <div className="attack-card__details">
+                      <div className="attack-card__row">
+                        <span className="attack-card__label">Attack Bonus</span>
+                        <span className="attack-card__value">{attackBonusDisplay ?? '—'}</span>
+                      </div>
+                      <div className="attack-card__row">
+                        <span className="attack-card__label">Damage</span>
+                        <span className="attack-card__value">{damageLine || '—'}</span>
+                      </div>
                     </div>
-                    <div className="enemy-card__attack-actions">
+                    <div className="attack-card__actions">
                       <Button
-                        variant="outline-primary"
-                        size="sm"
-                        onClick={() => onEnemyDamageRoll(enemy, action)}
+                        variant="link"
+                        className="attack-card__roll"
+                        onClick={() => onEnemyAttackRoll(enemy, action)}
+                        aria-label={`Roll attack for ${actionLabel}`}
                       >
-                        Roll
+                        <i className="fa-solid fa-bullseye" aria-hidden="true"></i>
+                      </Button>
+                      <Button
+                        variant="link"
+                        className="attack-card__roll"
+                        onClick={() => onEnemyDamageRoll(enemy, action)}
+                        aria-label={`Roll damage for ${actionLabel}`}
+                      >
+                        <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
                       </Button>
                     </div>
                     {isLatestRoll && latestEnemyRoll?.breakdown && (
                       <div className="mt-2 small fw-semibold text-primary">
-                        {`Result: ${latestEnemyRoll.total} damage (${latestEnemyRoll.breakdown})`}
+                        {`${latestEnemyRoll.rollType === 'attack' ? 'Attack' : 'Damage'}: ${latestEnemyRoll.total} (${latestEnemyRoll.breakdown})`}
                       </div>
                     )}
                   </div>
@@ -1591,6 +1609,7 @@ export default function ZombiesDM() {
     const [mapPlacementSaving, setMapPlacementSaving] = useState(false);
     const [mapPlacementError, setMapPlacementError] = useState(null);
     const [showDiceRoller, setShowDiceRoller] = useState(false);
+    const [enemyRollPopup, setEnemyRollPopup] = useState(null);
     const socketRef = useRef(null);
     const mapTokensRef = useRef(mapTokens);
     const activeMapTokensRef = useRef(activeMapTokens);
@@ -2651,8 +2670,66 @@ export default function ZombiesDM() {
       return numeric.toString();
     }, []);
 
+    const handleEnemyAttackRoll = useCallback(
+      async (enemy, action) => {
+        if (!enemy || !action) {
+          return;
+        }
+
+        const rawBonus = Number(action.attack_bonus);
+        const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
+        const { result, d20 } = await rollSkillWithDiceBox(bonus, {
+          diceColor: DEFAULT_DICE_COLOR,
+        });
+        const enemyName = enemy.name || enemy.displayType || enemy.enemyId || 'Enemy';
+        const actionName = action.name || 'Action';
+        const segments = [`${d20} (d20)`];
+        if (bonus) {
+          const sign = bonus >= 0 ? '+' : '-';
+          segments.push(`${sign} ${Math.abs(bonus)} Attack Bonus`);
+        }
+
+        window.dispatchEvent(
+          new CustomEvent('damage-roll', {
+            detail: {
+              value: result,
+              breakdown: segments.join(' '),
+              source: `${enemyName} ${actionName} Attack Roll`,
+              critical: d20 === 20,
+              fumble: d20 === 1,
+              rollLabel: 'Attack Roll',
+              diceRolls: [
+                {
+                  sides: 20,
+                  value: d20,
+                  type: 'Attack Roll',
+                  category: 'base',
+                },
+              ],
+            },
+          })
+        );
+
+        setEnemyRollPopup({
+          value: result,
+          label: 'Attack Roll',
+          timestamp: Date.now(),
+        });
+        setLatestEnemyRoll({
+          enemyId: enemy.enemyId,
+          enemyName,
+          actionName,
+          total: result,
+          breakdown: segments.join(' '),
+          rollType: 'attack',
+        });
+        setStatus({ type: 'info', message: `${enemyName} rolls ${result} to hit with ${actionName}.` });
+      },
+      [setStatus]
+    );
+
     const handleEnemyDamageRoll = useCallback(
-      (enemy, action) => {
+      async (enemy, action) => {
         if (!enemy || !action) {
           return;
         }
@@ -2666,7 +2743,62 @@ export default function ZombiesDM() {
           return;
         }
 
-        const result = calculateDamage(damageString);
+        const validation = calculateDamage(damageString);
+        if (!validation) {
+          setStatus({
+            type: 'warning',
+            message: 'Unable to roll damage for this action.',
+          });
+          return;
+        }
+
+        let result = validation;
+        const diceRequests = Array.isArray(validation.diceRolls)
+          ? validation.diceRolls.reduce((requests, die) => {
+              const sides = Number(die?.sides);
+              if (!Number.isFinite(sides) || sides < 2) {
+                return requests;
+              }
+              const existing = requests.find((request) => request.sides === sides);
+              if (existing) {
+                existing.count += 1;
+              } else {
+                requests.push({ count: 1, sides });
+              }
+              return requests;
+            }, [])
+          : [];
+
+        if (diceRequests.length > 0) {
+          try {
+            setDiceBoxThemeColor(DEFAULT_DICE_COLOR);
+            const { rolls } = await rollDiceWithBox(diceRequests);
+            const rolledValuesBySides = new Map();
+            diceRequests.forEach((request, requestIndex) => {
+              const rawGroup = Array.isArray(rolls) ? rolls[requestIndex] : undefined;
+              const values = Array.isArray(rawGroup) ? rawGroup : [rawGroup];
+              rolledValuesBySides.set(
+                request.sides,
+                values
+                  .map((value) => Number(value))
+                  .filter((value) => Number.isFinite(value))
+              );
+            });
+
+            result = calculateDamage(damageString, 0, false, (count, sides) => {
+              const queue = rolledValuesBySides.get(sides) || [];
+              return Array.from({ length: count }, () => {
+                const nextValue = queue.shift();
+                return Number.isFinite(nextValue)
+                  ? nextValue
+                  : Math.floor(Math.random() * sides) + 1;
+              });
+            });
+          } catch (error) {
+            console.error('Enemy damage roll using dice box failed', error);
+          }
+        }
+
         if (!result) {
           setStatus({
             type: 'warning',
@@ -2679,6 +2811,27 @@ export default function ZombiesDM() {
         const actionName = action.name || 'Action';
         const message = `${enemyName} deals ${result.total} damage with ${actionName} (${result.breakdown}).`;
 
+        window.dispatchEvent(
+          new CustomEvent('damage-roll', {
+            detail: {
+              value: result.total,
+              breakdown: result.breakdown,
+              source: `${enemyName} ${actionName}`,
+              rollLabel: 'Damage',
+              diceRolls: result.diceRolls,
+              sourceLabel: `${enemyName} ${actionName}`,
+              actionLabel: 'Damage',
+              expression: damageString,
+            },
+          })
+        );
+
+        setEnemyRollPopup({
+          value: result.total,
+          label: 'Damage',
+          timestamp: Date.now(),
+        });
+
         setLatestEnemyRoll({
           enemyId: enemy.enemyId,
           enemyName,
@@ -2686,6 +2839,7 @@ export default function ZombiesDM() {
           total: result.total,
           breakdown: result.breakdown,
           damageFormula: damageString,
+          rollType: 'damage',
         });
 
         setStatus({ type: 'info', message });
@@ -6522,6 +6676,21 @@ const resolveIcon = (category, iconMap, fallback) => {
           />
         </div>
 
+        {enemyRollPopup && (
+          <div className="combat-hud-damage-popup" role="status" aria-live="polite">
+            <button
+              type="button"
+              className="combat-hud-damage-popup__close"
+              onClick={() => setEnemyRollPopup(null)}
+              aria-label="Close enemy roll popup"
+            >
+              ×
+            </button>
+            <span className="combat-hud-damage-popup__label">{enemyRollPopup.label || 'Damage'}</span>
+            <strong className="combat-hud-damage-popup__value">{enemyRollPopup.value}</strong>
+          </div>
+        )}
+
         <ActiveEnemyQuickList
           summaries={activeMapEnemySummaries}
           activeMapTitle={activeMapTitle}
@@ -6539,6 +6708,7 @@ const resolveIcon = (category, iconMap, fallback) => {
           onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
           onResetEnemyHealth={handleResetEnemyHealth}
           onEnemyDamageRoll={handleEnemyDamageRoll}
+          onEnemyAttackRoll={handleEnemyAttackRoll}
           formatAttackBonus={formatAttackBonus}
           getEnemyActionDamageString={getEnemyActionDamageString}
           latestEnemyRoll={latestEnemyRoll}
@@ -7724,6 +7894,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                       legendaryActionsList={legendaryActionsList}
                       latestEnemyRoll={latestEnemyRoll}
                       onEnemyDamageRoll={handleEnemyDamageRoll}
+                      onEnemyAttackRoll={handleEnemyAttackRoll}
                       onEnemyAdjustmentInputChange={handleEnemyAdjustmentInputChange}
                       onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
                       onResetEnemyHealth={handleResetEnemyHealth}


### PR DESCRIPTION
### Motivation
- Provide explicit attack roll functionality for enemies alongside damage rolls to improve combat resolution clarity.
- Surface richer attack/damage UI in both the quick-list modal and detailed enemy cards to make rolling actions more discoverable.
- Integrate the Dice Box so damage dice results can be rolled via the shared dice UI and produce deterministic, reportable roll output.

### Description
- Introduce `onEnemyAttackRoll` and wire it through `ActiveEnemyQuickList`, `ActiveEnemyQuickCard`, and enemy detail views, and add attack roll buttons with icons to attack UI.
- Replace the old compact attacks modal with a larger card-styled modal (`EnemyQuickAttacksModal`) and add separate buttons for attack and damage rolls, accessible labels, and improved layout classes.
- Implement `handleEnemyAttackRoll` using `rollSkillWithDiceBox` to roll a d20 plus attack bonus, dispatch a `damage-roll` `CustomEvent`, update `latestEnemyRoll` with `rollType: 'attack'`, and show a transient `enemyRollPopup` UI entry.
- Enhance `handleEnemyDamageRoll` to validate damage expressions, optionally use `rollDiceWithBox` to obtain dice results from the Dice Box, compute final damage via `calculateDamage`, dispatch a `damage-roll` event, and set `latestEnemyRoll` with `rollType: 'damage'`.

### Testing
- Ran the frontend test suite with `yarn test` and the tests passed.
- Ran linting with `yarn lint` and static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff5a37134832ea565c9afc082eaf0)