### PR TITLE
Fix DM map grid aspect ratio

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10741,7 +10741,7 @@ body.character-select-scroll-enabled {
   }
 }
 
-/* DM map viewport parity: match the character-sheet background map sizing. */
+/* DM map viewport parity: use the same aspect-ratio constrained board as character maps. */
 .zombies-dm-page__map-surface {
   align-items: center;
   justify-content: center;
@@ -10749,41 +10749,38 @@ body.character-select-scroll-enabled {
 
 .zombies-dm-page__map-board.campaign-map-board {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  inset: 0;
   display: flex;
-  align-items: stretch;
-  justify-content: stretch;
-  width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
-  height: max(100dvh, calc(100vw / var(--campaign-map-stage-ratio-number, 1)));
-  min-height: 0;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100vw;
+  height: 100dvh;
+  min-height: 100dvh;
   padding: 0;
-  transform: translate(-50%, -50%);
   overflow: hidden;
 }
 
 .zombies-dm-page__map-board .campaign-map-board__stage {
   position: relative;
-  left: auto;
-  flex: 1 1 auto;
-  width: 100%;
-  max-width: none;
-  height: 100% !important;
+  flex: 0 0 auto;
+  width: min(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
+  max-width: 100vw;
+  height: auto !important;
   min-height: 0 !important;
-  margin: 0;
+  margin: 0 auto;
   transform: none;
 }
 
 .zombies-dm-page__map-board .campaign-map-board__image-wrapper {
   width: 100%;
-  height: 100% !important;
+  height: auto !important;
   min-height: 0 !important;
-  aspect-ratio: auto;
+  aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
   border-radius: 0;
 }
 
 .zombies-dm-page__map-board .campaign-map-board__image {
-  object-fit: cover;
+  object-fit: contain;
   object-position: center;
 }
 


### PR DESCRIPTION
### Motivation
- The DM map view was stretching/cropping the background which made grid squares look rectangular and token coordinates misaligned compared to the character-sheet map.

### Description
- Reworked DM map board layout in `client/src/App.scss` to use an aspect-ratio-constrained stage like the character-sheet maps so the map area preserves its true proportions.
- Updated `.zombies-dm-page__map-board` to use `inset: 0` and viewport-sized dimensions (`width: 100vw`, `height: 100dvh`) and centered the aspect-constrained stage instead of translating and stretching the stage to fit.
- Changed the stage to `flex: 0 0 auto` with `width: min(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)))` and set the image-wrapper `aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1)` to keep square grid cells.
- Restored `object-fit: contain` for the DM map image so the grid overlay and token layer align with the displayed map image instead of a cropped/covered image.

### Testing
- Ran `npm --prefix client test -- --runTestsByPath src/components/Zombies/utils/mapImages.test.js --watchAll=false` and the test suite passed (12 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50189066e8832e805e565f0e1d1dc9)