### PR TITLE
Implement Barbarian Level 1: Rage, Unarmored Defense, Weapon Mastery

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -43,6 +43,7 @@ import Features from "../attributes/Features";
 import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import { getMonkFocusPoints } from '../../../utils/monk';
+import { activateRage, applyRageRest, endRage, getRageBenefits, getRageState, hasHeavyArmorEquipped } from '../utils/barbarian';
 import { FaDiceD20 } from "react-icons/fa";
 import { Backpack, BookOpen, CircleHelp, Dice5, Dumbbell, Gem, HeartPulse, Package, Settings, Shield, Sparkles, Swords, UserRound } from "lucide-react";
 import { Button as HudButton, Dock, IconButton, Panel, Toolbar } from "../common/HudPrimitives";
@@ -827,6 +828,29 @@ export default function ZombiesCharacterSheet() {
     setUsedSlots(nextState);
     usedSlotsHydrationRef.current = true;
   }, [characterId, getStoredUsedSlots]);
+
+  useEffect(() => {
+    const benefits = getRageBenefits(form);
+    if (!benefits.blocksConcentration) {
+      return;
+    }
+    setActiveEffects((prev) => {
+      const next = prev.filter((effect) => String(effect?.name || '').toLowerCase() !== 'concentration');
+      return next.length === prev.length ? prev : next;
+    });
+  }, [form]);
+
+  useEffect(() => {
+    if (!form || !getRageState(form).active) {
+      return;
+    }
+    const incapacitated = (form?.conditions || form?.statusConditions || []).some(
+      (condition) => String(condition?.name || condition?.label || condition).toLowerCase() === 'incapacitated'
+    );
+    if (hasHeavyArmorEquipped(form) || incapacitated) {
+      setForm((prev) => endRage(prev));
+    }
+  }, [form]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !characterId) {
@@ -2796,10 +2820,20 @@ export default function ZombiesCharacterSheet() {
 
   const handleLongRest = useCallback(() => {
     setLongRestCount((c) => c + 1);
+    setForm((prev) => applyRageRest(prev, 'long'));
   }, []);
 
   const handleShortRest = useCallback(() => {
     setShortRestCount((c) => c + 1);
+    setForm((prev) => applyRageRest(prev, 'short'));
+  }, []);
+
+  const handleActivateRage = useCallback(() => {
+    setForm((prev) => activateRage(prev));
+  }, []);
+
+  const handleEndRage = useCallback(() => {
+    setForm((prev) => endRage(prev));
   }, []);
 
   const rollSpellDamage = useCallback(
@@ -4882,8 +4916,9 @@ export default function ZombiesCharacterSheet() {
       calculateCharacterArmorClass(form, {
         dexMod: statMods.dex,
         wisMod: statMods.wis,
+        conMod: statMods.con,
       }),
-    [form, statMods.dex, statMods.wis]
+    [form, statMods.con, statMods.dex, statMods.wis]
   );
 
   const SPELLCASTING_ABILITIES = {
@@ -5180,7 +5215,8 @@ export default function ZombiesCharacterSheet() {
 
     const monkFocusMax = getMonkFocusPoints(form);
     pushResource({ id: 'monk-focus', icon: '✋', name: 'Ki / Focus', current: Math.max(monkFocusMax - (Number(usedSlots?.focus) || 0), 0), max: monkFocusMax, color: '#38e8ff' });
-    pushResource({ id: 'rage', icon: '🔥', name: 'Rage', current: classLevels.barbarian >= 20 ? '∞' : (classLevels.barbarian >= 17 ? 6 : classLevels.barbarian >= 12 ? 5 : classLevels.barbarian >= 6 ? 4 : classLevels.barbarian >= 3 ? 3 : classLevels.barbarian >= 1 ? 2 : 0), max: classLevels.barbarian >= 20 ? '∞' : (classLevels.barbarian >= 17 ? 6 : classLevels.barbarian >= 12 ? 5 : classLevels.barbarian >= 6 ? 4 : classLevels.barbarian >= 3 ? 3 : classLevels.barbarian >= 1 ? 2 : 0), color: '#f0733f' });
+    const rageState = getRageState(form);
+    pushResource({ id: 'rage', icon: '🔥', name: rageState.active ? 'Raging' : 'Rage', current: rageState.current, max: rageState.max, color: '#f0733f', active: rageState.active });
     if (classLevels.bard) pushResource({ id: 'bardic-inspiration', icon: '🎵', name: 'Bardic Inspiration', current: abilityModifier(form?.cha), max: abilityModifier(form?.cha), color: '#d7b46a' });
     if (classLevels.sorcerer) pushResource({ id: 'sorcery-points', icon: '✦', name: 'Sorcery Points', current: classLevels.sorcerer >= 2 ? classLevels.sorcerer : 0, max: classLevels.sorcerer >= 2 ? classLevels.sorcerer : 0, color: '#b85cff' });
     if (classLevels.cleric) pushResource({ id: 'channel-divinity', icon: '☀', name: 'Channel Divinity', current: classLevels.cleric >= 18 ? 3 : classLevels.cleric >= 6 ? 2 : classLevels.cleric >= 2 ? 1 : 0, max: classLevels.cleric >= 18 ? 3 : classLevels.cleric >= 6 ? 2 : classLevels.cleric >= 2 ? 1 : 0, color: '#f3d98a' });
@@ -5754,8 +5790,18 @@ export default function ZombiesCharacterSheet() {
                     <div className="combat-hud-dock__resource-rail" aria-label="Class resources">
                       {footerClassResources.map((resource) => {
                         const isFocusResource = resource.id === 'monk-focus';
+                        const isRageResource = resource.id === 'rage';
                         const resourceMax = Number(resource.max);
                         const handleResourceActivate = (event, action = 'spend') => {
+                          if (isRageResource) {
+                            event.preventDefault();
+                            if (resource.active) {
+                              handleEndRage();
+                            } else {
+                              handleActivateRage();
+                            }
+                            return;
+                          }
                           if (!isFocusResource || !Number.isFinite(resourceMax) || resourceMax <= 0) {
                             return;
                           }
@@ -5769,12 +5815,12 @@ export default function ZombiesCharacterSheet() {
                             type="button"
                             className="combat-hud-resource-tile"
                             style={{ '--hud-resource-accent': resource.color }}
-                            title={isFocusResource ? `${resource.name}: click to spend, right-click to restore, double-click to reset` : `${resource.name}: ${resource.current ?? '—'}/${resource.max ?? '—'}`}
+                            title={isRageResource ? (resource.active ? `End Rage: ${resource.current ?? '—'}/${resource.max ?? '—'} uses remaining` : hasHeavyArmorEquipped(form) ? 'Cannot rage while wearing Heavy Armor' : Number(resource.current) <= 0 ? 'No Rage uses remaining' : `Activate Rage: ${resource.current ?? '—'}/${resource.max ?? '—'} uses remaining`) : isFocusResource ? `${resource.name}: click to spend, right-click to restore, double-click to reset` : `${resource.name}: ${resource.current ?? '—'}/${resource.max ?? '—'}`}
                             aria-label={`${resource.name}: ${resource.current ?? '—'} of ${resource.max ?? '—'}`}
                             onClick={(event) => handleResourceActivate(event, event.shiftKey ? 'restore' : 'spend')}
                             onContextMenu={(event) => handleResourceActivate(event, 'restore')}
                             onDoubleClick={(event) => handleResourceActivate(event, 'reset')}
-                            disabled={!isFocusResource}
+                            disabled={(!isFocusResource && !isRageResource) || (isRageResource && !resource.active && (Number(resource.current) <= 0 || hasHeavyArmorEquipped(form)))}
                           >
                             <span className="combat-hud-resource-tile__icon" aria-hidden="true">{resource.icon}</span>
                             <span className="combat-hud-resource-tile__name">{resource.name}</span>

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -1,0 +1,248 @@
+export const BARBARIAN_PROGRESSION = [
+  { level: 1, rageUses: 2, rageDamage: 2, weaponMasteryCount: 2 },
+];
+
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+
+export const getBarbarianLevel = (character) => {
+  if (!Array.isArray(character?.occupation)) return 0;
+  return character.occupation.reduce((total, entry) => {
+    const name = normalize(
+      entry?.Name ?? entry?.Occupation ?? entry?.name ?? entry?.occupation
+    );
+    if (name !== "barbarian") return total;
+    const level = Number(entry?.Level ?? entry?.level ?? 0);
+    return total + (Number.isFinite(level) && level > 0 ? level : 0);
+  }, 0);
+};
+
+export const getBarbarianProgression = (levelOrCharacter) => {
+  const level =
+    typeof levelOrCharacter === "number"
+      ? levelOrCharacter
+      : getBarbarianLevel(levelOrCharacter);
+  return BARBARIAN_PROGRESSION.reduce(
+    (best, row) => (level >= row.level ? row : best),
+    null
+  );
+};
+
+export const hasHeavyArmorEquipped = (character) => {
+  const items = [
+    ...Object.values(character?.equipment || {}),
+    ...(Array.isArray(character?.armor) ? character.armor : []),
+  ].filter(Boolean);
+  return items.some((item) => {
+    if (Array.isArray(item)) return normalize(item[0]).includes("heavy");
+    const text = [
+      item.category,
+      item.type,
+      item.armorType,
+      item.name,
+      item.__source,
+      item.source,
+    ]
+      .map(normalize)
+      .join(" ");
+    return (
+      text.includes("heavy armor") ||
+      text === "heavy" ||
+      text.includes(" heavy ")
+    );
+  });
+};
+
+export const isRageActive = (character) =>
+  Boolean(
+    character?.classState?.barbarian?.rage?.active ??
+      character?.barbarian?.rage?.active
+  );
+export const getRageUsesRemaining = (character) => {
+  const max = getBarbarianProgression(character)?.rageUses || 0;
+  const raw =
+    character?.classState?.barbarian?.rage?.current ??
+    character?.barbarian?.rage?.current;
+  const current = Number(raw);
+  return Number.isFinite(current)
+    ? Math.max(0, Math.min(max, Math.floor(current)))
+    : max;
+};
+
+export const getRageState = (character) => {
+  const progression = getBarbarianProgression(character);
+  const max = progression?.rageUses || 0;
+  return {
+    active: isRageActive(character),
+    current: getRageUsesRemaining(character),
+    max,
+    rageDamage: progression?.rageDamage || 0,
+  };
+};
+
+const withRage = (character, rage) => ({
+  ...character,
+  classState: {
+    ...(character?.classState || {}),
+    barbarian: { ...(character?.classState?.barbarian || {}), rage },
+  },
+});
+
+export const activateRage = (character) => {
+  const state = getRageState(character);
+  if (state.active || state.current <= 0 || hasHeavyArmorEquipped(character))
+    return character;
+  return withRage(character, { active: true, current: state.current - 1 });
+};
+
+export const endRage = (character) => {
+  const state = getRageState(character);
+  if (!state.active) return character;
+  return withRage(character, { active: false, current: state.current });
+};
+
+export const applyRageRest = (character, restType) => {
+  const state = getRageState(character);
+  if (!state.max) return character;
+  const long = restType === "long";
+  const next = withRage(character, {
+    active: long ? false : state.active,
+    current: long ? state.max : Math.min(state.max, state.current + 1),
+  });
+  if (!long) return next;
+  return withWeaponMasteries(next, {
+    ...(next?.classState?.barbarian?.weaponMasteries || {}),
+    canReplaceAfterLongRest: true,
+  });
+};
+
+export const getRageBenefits = (character) =>
+  isRageActive(character)
+    ? {
+        resistances: ["bludgeoning", "piercing", "slashing"],
+        advantage: { abilityChecks: ["str"], savingThrows: ["str"] },
+        blocksSpellcasting: true,
+        blocksConcentration: true,
+      }
+    : {
+        resistances: [],
+        advantage: { abilityChecks: [], savingThrows: [] },
+        blocksSpellcasting: false,
+        blocksConcentration: false,
+      };
+
+export const getRageDamageBonus = (character, attack = {}) => {
+  if (!isRageActive(character)) return 0;
+  const ability = normalize(attack.ability ?? attack.abilityKey ?? attack.stat);
+  const kind = normalize(attack.kind ?? attack.type ?? attack.attackType);
+  const isQualifyingKind =
+    kind.includes("weapon") ||
+    kind.includes("unarmed") ||
+    attack.isWeaponAttack ||
+    attack.isUnarmedStrike;
+  if (
+    ability !== "str" ||
+    attack.isSpellAttack ||
+    !isQualifyingKind ||
+    attack.dealsDamage === false
+  )
+    return 0;
+  return getBarbarianProgression(character)?.rageDamage || 0;
+};
+
+export const isEligibleBarbarianWeaponMastery = (weapon) => {
+  const category = normalize(weapon?.category ?? weapon?.weaponCategory);
+  const name = normalize(weapon?.name ?? weapon?.type);
+  return (
+    Boolean(name) &&
+    (category === "simple melee" ||
+      category === "martial melee" ||
+      category.includes("simple melee") ||
+      category.includes("martial melee"))
+  );
+};
+
+export const validateBarbarianWeaponMasteries = (
+  character,
+  selections = []
+) => {
+  const count = getBarbarianProgression(character)?.weaponMasteryCount || 0;
+  const seen = new Set();
+  const valid = [];
+  for (const weapon of selections) {
+    const key = normalize(weapon?.type ?? weapon?.name ?? weapon);
+    if (!key || seen.has(key)) continue;
+    if (typeof weapon === "object" && !isEligibleBarbarianWeaponMastery(weapon))
+      continue;
+    seen.add(key);
+    valid.push(key);
+  }
+  return {
+    valid: valid.slice(0, count),
+    count,
+    hasDuplicates: seen.size < selections.length,
+  };
+};
+
+export const getWeaponMasteryState = (character) => {
+  const progression = getBarbarianProgression(character);
+  const count = progression?.weaponMasteryCount || 0;
+  const selections =
+    character?.classState?.barbarian?.weaponMasteries?.selections || [];
+  return {
+    selections: validateBarbarianWeaponMasteries(character, selections).valid,
+    count,
+    canReplaceAfterLongRest: Boolean(
+      character?.classState?.barbarian?.weaponMasteries?.canReplaceAfterLongRest
+    ),
+  };
+};
+
+const withWeaponMasteries = (character, weaponMasteries) => ({
+  ...character,
+  classState: {
+    ...(character?.classState || {}),
+    barbarian: { ...(character?.classState?.barbarian || {}), weaponMasteries },
+  },
+});
+
+export const setWeaponMasterySelections = (character, selections = []) => {
+  const result = validateBarbarianWeaponMasteries(character, selections);
+  if (result.valid.length !== selections.length || result.hasDuplicates) {
+    return character;
+  }
+  return withWeaponMasteries(character, {
+    ...(character?.classState?.barbarian?.weaponMasteries || {}),
+    selections: result.valid,
+  });
+};
+
+export const replaceWeaponMasteryAfterLongRest = (
+  character,
+  fromKey,
+  replacementWeapon
+) => {
+  const state = getWeaponMasteryState(character);
+  if (!state.canReplaceAfterLongRest) return character;
+  const normalizedFrom = normalize(fromKey);
+  const normalizedReplacement = normalize(
+    replacementWeapon?.type ?? replacementWeapon?.name ?? replacementWeapon
+  );
+  if (!normalizedFrom || !state.selections.includes(normalizedFrom))
+    return character;
+  if (
+    typeof replacementWeapon === "object" &&
+    !isEligibleBarbarianWeaponMastery(replacementWeapon)
+  )
+    return character;
+  if (state.selections.includes(normalizedReplacement)) return character;
+  const selections = state.selections.map((entry) =>
+    entry === normalizedFrom ? normalizedReplacement : entry
+  );
+  return withWeaponMasteries(character, {
+    selections,
+    canReplaceAfterLongRest: false,
+  });
+};

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -1,0 +1,160 @@
+import {
+  activateRage,
+  applyRageRest,
+  endRage,
+  getBarbarianProgression,
+  getRageBenefits,
+  getRageDamageBonus,
+  getRageState,
+  isEligibleBarbarianWeaponMastery,
+  validateBarbarianWeaponMasteries,
+  getWeaponMasteryState,
+  setWeaponMasterySelections,
+  replaceWeaponMasteryAfterLongRest,
+} from "./barbarian";
+
+const barbarian = (extra = {}) => ({
+  occupation: [{ Name: "Barbarian", Level: 1 }],
+  ...extra,
+});
+
+describe("barbarian rage", () => {
+  it("initializes level 1 rage from progression", () => {
+    expect(getBarbarianProgression(1)).toMatchObject({
+      rageUses: 2,
+      rageDamage: 2,
+      weaponMasteryCount: 2,
+    });
+    expect(getRageState(barbarian())).toEqual({
+      active: false,
+      current: 2,
+      max: 2,
+      rageDamage: 2,
+    });
+  });
+
+  it("activates once, persists active state, and does not double spend", () => {
+    const active = activateRage(barbarian());
+    expect(getRageState(active)).toMatchObject({ active: true, current: 1 });
+    expect(activateRage(active)).toBe(active);
+    expect(getRageState(activateRage(active)).current).toBe(1);
+  });
+
+  it("cannot activate with zero uses or heavy armor", () => {
+    const empty = barbarian({
+      classState: { barbarian: { rage: { active: false, current: 0 } } },
+    });
+    expect(activateRage(empty)).toBe(empty);
+    const armored = barbarian({
+      equipment: {
+        body: { name: "Plate", category: "Heavy Armor", source: "armor" },
+      },
+    });
+    expect(activateRage(armored)).toBe(armored);
+  });
+
+  it("ends without refunding and rests recover correctly", () => {
+    const active = activateRage(barbarian());
+    const ended = endRage(active);
+    expect(getRageState(ended)).toMatchObject({ active: false, current: 1 });
+    expect(getRageState(applyRageRest(ended, "short")).current).toBe(2);
+    expect(getRageState(applyRageRest(barbarian(), "short")).current).toBe(2);
+    expect(getRageState(applyRageRest(active, "long"))).toMatchObject({
+      active: false,
+      current: 2,
+    });
+  });
+
+  it("reports active rage benefits and damage restrictions", () => {
+    const active = activateRage(barbarian());
+    expect(getRageBenefits(active).resistances).toEqual([
+      "bludgeoning",
+      "piercing",
+      "slashing",
+    ]);
+    expect(getRageBenefits(active).advantage.savingThrows).toContain("str");
+    expect(getRageBenefits(active).blocksSpellcasting).toBe(true);
+    expect(
+      getRageDamageBonus(active, {
+        ability: "str",
+        type: "weapon attack",
+        dealsDamage: true,
+      })
+    ).toBe(2);
+    expect(
+      getRageDamageBonus(active, {
+        ability: "str",
+        type: "unarmed strike",
+        dealsDamage: true,
+      })
+    ).toBe(2);
+    expect(
+      getRageDamageBonus(active, {
+        ability: "dex",
+        type: "weapon attack",
+        dealsDamage: true,
+      })
+    ).toBe(0);
+    expect(
+      getRageDamageBonus(active, {
+        ability: "str",
+        type: "spell attack",
+        isSpellAttack: true,
+      })
+    ).toBe(0);
+    expect(getRageBenefits(endRage(active)).resistances).toEqual([]);
+  });
+
+  it("persists selections and allows one replacement after a long rest", () => {
+    const selected = setWeaponMasterySelections(barbarian(), [
+      { type: "longsword", category: "martial melee" },
+      { type: "dagger", category: "simple melee" },
+    ]);
+    expect(getWeaponMasteryState(selected).selections).toEqual([
+      "longsword",
+      "dagger",
+    ]);
+    expect(
+      setWeaponMasterySelections(selected, [
+        { type: "longbow", category: "martial ranged" },
+      ])
+    ).toBe(selected);
+
+    const rested = applyRageRest(selected, "long");
+    expect(getWeaponMasteryState(rested).canReplaceAfterLongRest).toBe(true);
+    const replaced = replaceWeaponMasteryAfterLongRest(rested, "dagger", {
+      type: "handaxe",
+      category: "simple melee",
+    });
+    expect(getWeaponMasteryState(replaced)).toMatchObject({
+      selections: ["longsword", "handaxe"],
+      canReplaceAfterLongRest: false,
+    });
+  });
+});
+
+describe("barbarian weapon mastery", () => {
+  it("accepts only simple or martial melee weapon definitions and rejects duplicates", () => {
+    expect(
+      isEligibleBarbarianWeaponMastery({
+        name: "Longsword",
+        category: "martial melee",
+      })
+    ).toBe(true);
+    expect(
+      isEligibleBarbarianWeaponMastery({
+        name: "Longbow",
+        category: "martial ranged",
+      })
+    ).toBe(false);
+    const result = validateBarbarianWeaponMasteries(barbarian(), [
+      { type: "longsword", category: "martial melee" },
+      { type: "longsword", category: "martial melee" },
+      { type: "dagger", category: "simple melee" },
+      { type: "longbow", category: "martial ranged" },
+    ]);
+    expect(result.valid).toEqual(["longsword", "dagger"]);
+    expect(result.count).toBe(2);
+    expect(result.hasDuplicates).toBe(true);
+  });
+});

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -6,6 +6,7 @@ import {
   isExplicitlyUnowned,
   STAT_KEYS,
 } from './derivedStats';
+import { getBarbarianLevel } from './barbarian';
 
 const toFiniteNumberOrNull = (value) => {
   if (value === null || value === undefined || value === '') {
@@ -327,6 +328,10 @@ export const calculateCharacterArmorClass = (character, overrides = {}) => {
     ? overrides.wisMod
     : Math.floor((abilities.wis - 10) / 2);
 
+  const baseConMod = Number.isFinite(overrides.conMod)
+    ? overrides.conMod
+    : Math.floor((abilities.con - 10) / 2);
+
   const hasShieldEquipped = armorItems.some((item) => isShieldItem(item));
   const hasArmorEquipped = armorItems.some((item) => {
     if (!item) {
@@ -346,12 +351,17 @@ export const calculateCharacterArmorClass = (character, overrides = {}) => {
   });
 
   const monkLevel = resolveMonkLevel(character);
-  const wisdomBonus =
-    !hasArmorEquipped && !hasShieldEquipped && (hasUnarmoredDefense(character) || monkLevel > 0)
-      ? baseWisMod
-      : 0;
+  const barbarianLevel = getBarbarianLevel(character);
+  const unarmoredBaseBonuses = [];
+  if (!hasArmorEquipped && !hasShieldEquipped && (hasUnarmoredDefense(character) || monkLevel > 0)) {
+    unarmoredBaseBonuses.push(baseWisMod);
+  }
+  if (!hasArmorEquipped && barbarianLevel > 0) {
+    unarmoredBaseBonuses.push(baseConMod);
+  }
+  const unarmoredAbilityBonus = unarmoredBaseBonuses.length > 0 ? Math.max(...unarmoredBaseBonuses) : 0;
 
-  const armorClass = 10 + armorAcBonus + featAcBonus + additionalAcBonus + dexContribution + wisdomBonus;
+  const armorClass = 10 + armorAcBonus + featAcBonus + additionalAcBonus + dexContribution + unarmoredAbilityBonus;
   const normalized = Number(armorClass);
   return Number.isFinite(normalized) ? normalized : null;
 };

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -1,4 +1,4 @@
-import { calculateCharacterHitPoints } from './characterMetrics';
+import { calculateCharacterArmorClass, calculateCharacterHitPoints } from './characterMetrics';
 
 describe('calculateCharacterHitPoints', () => {
   it('calculates current and max hp using con and level', () => {
@@ -168,5 +168,22 @@ describe('calculateCharacterHitPoints', () => {
     );
 
     expect(result.maxHp).toBe(character.health + expectedConMod * totalLevel);
+  });
+});
+
+
+describe('calculateCharacterArmorClass barbarian unarmored defense', () => {
+  const base = { dex: 14, con: 16, wis: 18, occupation: [{ Name: 'Barbarian', Level: 1 }] };
+
+  it('uses 10 + dex + con while unarmored and allows shields', () => {
+    expect(calculateCharacterArmorClass(base)).toBe(15);
+    expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Shield', category: 'Shield', acBonus: 2 }] })).toBe(17);
+  });
+
+  it('is disabled by armor and does not stack with monk wisdom', () => {
+    expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Leather', category: 'Light Armor', source: 'armor', acBonus: 1 }] })).toBe(13);
+    expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Hide', category: 'Medium Armor', source: 'armor', acBonus: 2, maxDex: 2 }] })).toBe(14);
+    expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Plate', category: 'Heavy Armor', source: 'armor', acBonus: 8, maxDex: 0 }] })).toBe(20);
+    expect(calculateCharacterArmorClass({ ...base, occupation: [{ Name: 'Barbarian', Level: 1 }, { Name: 'Monk', Level: 1 }] })).toBe(16);
   });
 });


### PR DESCRIPTION
### Motivation
- Provide Barbarian Level 1 class features (Rage, Unarmored Defense, Weapon Mastery) using existing game systems and keep rules data-driven. 
- Make Rage a persistent, manually toggled resource with uses and active-state that survives persistence and rests. 
- Reuse existing resource UI, rest handlers, AC resolver, resistance/advantage systems, and weapon definitions rather than adding new Barbarian-only infrastructure. 

### Description
- Added a new utility `client/src/components/Zombies/utils/barbarian.js` that defines `BARBARIAN_PROGRESSION` and exposes helpers for detecting Barbarian level, reading/writing persistent Rage (`activateRage`, `endRage`, `applyRageRest`), exposing Rage benefits, calculating Rage damage bonuses, and validating/managing Weapon Mastery selections. 
- Integrated Rage into the character sheet by wiring the resource rail to show `Rage`/`Raging`, adding `Activate`/`End` interactions, preventing activation when zero uses or Heavy Armor is equipped, consuming one use on activation, persisting active state, and ending Rage on long rest, equipping Heavy Armor, or becoming Incapacitated; also clears Concentration effects when Rage blocks concentration (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`). 
- Implemented Barbarian Unarmored Defense in the AC calculation path by adding a Barbarian-based unarmored option (10 + Dex mod + Con mod) that is only applied while unarmored (shields allowed) and chooses the best eligible unarmored ability contribution without stacking with other base AC calculations (`client/src/components/Zombies/utils/characterMetrics.js`). 
- Added Weapon Mastery state handling and helpers to validate eligible melee choices, persist selections, and allow a single replacement after a Long Rest via the helper API in `barbarian.js`. 
- Tests and small test-support updates added in `client/src/components/Zombies/utils/barbarian.test.js` and `client/src/components/Zombies/utils/characterMetrics.test.js` to verify Rage, Rage benefits/damage gating, Unarmored Defense behavior, and weapon mastery selection/replacement. 

### Testing
- Ran the new/updated unit tests `client/src/components/Zombies/utils/barbarian.test.js` and `client/src/components/Zombies/utils/characterMetrics.test.js`, and both test files passed. 
- Executed the targeted test command `npm test -- --watch=false src/components/Zombies/utils/barbarian.test.js src/components/Zombies/utils/characterMetrics.test.js` and observed all assertions in those suites succeed. 
- Ran a broader client test run which exposed unrelated existing failures in other suites (notably `ZombiesDM` and some `ZombiesCharacterSheet` integration tests) that are outside the scope of these changes; the new/modified Barbarian and AC tests remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511524e3e4832381653f5505a809c6)