### PR TITLE
Fix Barbarian Rage UI, Rage damage, and Unarmored Defense

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -34,6 +34,7 @@ import {
   normalizeDiceColor,
   resolveDamageTypeColor,
 } from '../../../utils/diceColors';
+import { getRageDamageBonus } from '../utils/barbarian';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -290,7 +291,8 @@ export function calculateDamage(
   crit = false,
   roll = rollDice,
   extraDice,
-  levelsAbove = 0
+  levelsAbove = 0,
+  options = {}
 ) {
   const parts = damageString.split(/\s+\+\s+/);
   const results = [];
@@ -380,8 +382,18 @@ export function calculateDamage(
     results.push({ value: damageSum + modifier + abilityBonus, type });
   }
 
+  const rageBonus = getRageDamageBonus(options?.character, options?.attack);
+  if (rageBonus > 0) {
+    results.push({ value: rageBonus, type: 'Rage' });
+  }
+
   const total = results.reduce((sum, r) => sum + r.value, 0);
-  return { total, breakdown: formatDamageRolls(results), diceRolls };
+  return {
+    total,
+    breakdown: formatDamageRolls(results),
+    diceRolls,
+    modifiers: rageBonus > 0 ? [{ label: 'Rage', value: rageBonus }] : [],
+  };
 }
 
 const PlayerTurnActions = React.forwardRef(
@@ -1316,6 +1328,7 @@ const manualCriticalRef = useRef(false);
       crit = false,
       extraDice,
       levelsAbove = 0,
+      options,
     }) => {
       if (typeof damageString !== 'string') return null;
       const trimmed = damageString.trim();
@@ -1332,6 +1345,7 @@ const manualCriticalRef = useRef(false);
         },
         extraDice,
         levelsAbove,
+        options,
       );
 
       if (!validation) {
@@ -1478,6 +1492,7 @@ const manualCriticalRef = useRef(false);
           rollDice,
           extraDice,
           levelsAbove,
+          options,
         );
         return staticResult ? { ...staticResult, rollValues: undefined } : null;
       }
@@ -1654,6 +1669,7 @@ const manualCriticalRef = useRef(false);
           applyRolls,
           extraDice,
           levelsAbove,
+          options,
         );
 
         const appliedValues = collectRollValues(appliedRollGroups);
@@ -1670,6 +1686,7 @@ const manualCriticalRef = useRef(false);
           rollDice,
           extraDice,
           levelsAbove,
+          options,
         );
         return fallbackResult ? { ...fallbackResult, rollValues: undefined } : null;
       }
@@ -1686,6 +1703,7 @@ const manualCriticalRef = useRef(false);
   const handleWeaponAttack = useCallback(
     async (slot, weapon) => {
       const ability = abilityForWeapon(weapon, slot);
+      const abilityKey = getAbilityKeyForWeapon(slot, weapon);
       const damageString = getDamageStringForHandSelection(slot, weapon);
       if (typeof damageString !== 'string' || !damageString.trim()) return;
 
@@ -1693,6 +1711,16 @@ const manualCriticalRef = useRef(false);
         damageString,
         ability,
         crit: isCritical,
+        options: {
+          character: form,
+          attack: {
+            ability: abilityKey,
+            kind: isUnarmedAttack(weapon) ? 'unarmed' : 'weapon',
+            isWeaponAttack: !isUnarmedAttack(weapon),
+            isUnarmedStrike: isUnarmedAttack(weapon),
+            dealsDamage: true,
+          },
+        },
       });
       if (!result) return;
 
@@ -1704,7 +1732,6 @@ const manualCriticalRef = useRef(false);
 
       let modifierValues;
       if (Number.isFinite(ability) && ability !== 0) {
-        const abilityKey = getAbilityKeyForWeapon(slot, weapon);
         const abilityName =
           abilityKey === 'dex'
             ? 'DEX'
@@ -1723,7 +1750,13 @@ const manualCriticalRef = useRef(false);
         sourceLabel: weaponLabel,
         actionLabel: 'Damage',
         expression: expression || undefined,
-        modifierValues,
+        modifierValues: [
+          ...(modifierValues || []),
+          ...((result.modifiers || []).map((modifier) => {
+            const sign = modifier.value >= 0 ? '+' : '-';
+            return `${sign}${Math.abs(modifier.value)} ${modifier.label}`;
+          })),
+        ],
       };
 
       updateDamageValueWithAnimation(
@@ -1738,7 +1771,9 @@ const manualCriticalRef = useRef(false);
       getAbilityKeyForWeapon,
       getDamageStringForHandSelection,
       getWeaponDisplayName,
+      form,
       isCritical,
+      isUnarmedAttack,
       rollDamageExpression,
     ],
   );

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -115,6 +115,43 @@ describe('calculateDamage parser', () => {
       ],
     });
   });
+
+  test('applies barbarian rage damage only to qualifying strength damage', () => {
+    const activeLevel3 = {
+      occupation: [{ Name: 'Barbarian', Level: 3 }],
+      classState: { barbarian: { rage: { active: true, current: 1 } } },
+    };
+    const inactiveLevel3 = {
+      ...activeLevel3,
+      classState: { barbarian: { rage: { active: false, current: 1 } } },
+    };
+
+    const qualifying = { ability: 'str', kind: 'unarmed', isUnarmedStrike: true, dealsDamage: true };
+    expect(calculateDamage('1d4 Bludgeoning', 3, false, fixedRoll, undefined, 0, { character: inactiveLevel3, attack: qualifying }).total).toBe(4);
+    expect(calculateDamage('1d4 Bludgeoning', 3, false, fixedRoll, undefined, 0, { character: activeLevel3, attack: qualifying })).toMatchObject({
+      total: 6,
+      breakdown: '4 Bludgeoning + 2 Rage',
+      modifiers: [{ label: 'Rage', value: 2 }],
+    });
+    expect(calculateDamage('1d8 Slashing', 3, false, fixedRoll, undefined, 0, { character: activeLevel3, attack: { ability: 'str', kind: 'weapon', isWeaponAttack: true, dealsDamage: true } }).total).toBe(6);
+    expect(calculateDamage('1d8 Piercing', 3, false, fixedRoll, undefined, 0, { character: activeLevel3, attack: { ability: 'dex', kind: 'weapon', isWeaponAttack: true, dealsDamage: true } }).total).toBe(4);
+    expect(calculateDamage('1d10 Fire', 3, false, fixedRoll, undefined, 0, { character: activeLevel3, attack: { ability: 'str', kind: 'spell', isSpellAttack: true, dealsDamage: true } }).total).toBe(4);
+  });
+
+  test('scales rage damage from barbarian class level', () => {
+    const raging = (barbarianLevel, otherLevel = 0) => ({
+      occupation: [
+        { Name: 'Barbarian', Level: barbarianLevel },
+        ...(otherLevel ? [{ Name: 'Fighter', Level: otherLevel }] : []),
+      ],
+      classState: { barbarian: { rage: { active: true, current: 1 } } },
+    });
+    const attack = { ability: 'str', kind: 'weapon', isWeaponAttack: true, dealsDamage: true };
+    expect(calculateDamage('1d4 Slashing', 3, false, fixedRoll, undefined, 0, { character: raging(9), attack }).total).toBe(7);
+    expect(calculateDamage('1d4 Slashing', 3, false, fixedRoll, undefined, 0, { character: raging(16), attack }).total).toBe(8);
+    expect(calculateDamage('1d4 Slashing', 3, false, fixedRoll, undefined, 0, { character: raging(3, 13), attack }).total).toBe(6);
+  });
+
 });
 
 describe('PlayerTurnActions weapon damage display', () => {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -540,6 +540,27 @@ const SPELLCASTING_CLASSES = {
   ranger: 'half',
 };
 
+
+export const getFooterConditionLabel = (count) => {
+  const numericCount = Number(count) || 0;
+  if (numericCount <= 0) return 'No conditions';
+  return `${numericCount} ${numericCount === 1 ? 'condition' : 'conditions'}`;
+};
+
+export const buildFooterConditions = (character, normalizeCollection) => {
+  const normalize = typeof normalizeCollection === 'function' ? normalizeCollection : (value) => value || [];
+  const conditions = normalize(character?.conditions || character?.statusConditions);
+  if (!getRageState(character).active) {
+    return conditions;
+  }
+  const hasRageCondition = conditions.some((condition) =>
+    String(condition?.name || condition?.label || condition?.id || '').toLowerCase() === 'rage'
+  );
+  return hasRageCondition
+    ? conditions
+    : [{ id: 'rage-condition', icon: '🔥', name: 'Rage', color: '#f0733f' }, ...conditions];
+};
+
 export default function ZombiesCharacterSheet() {
   const params = useParams();
   const characterId = params.id;
@@ -5216,7 +5237,7 @@ export default function ZombiesCharacterSheet() {
     const monkFocusMax = getMonkFocusPoints(form);
     pushResource({ id: 'monk-focus', icon: '✋', name: 'Ki / Focus', current: Math.max(monkFocusMax - (Number(usedSlots?.focus) || 0), 0), max: monkFocusMax, color: '#38e8ff' });
     const rageState = getRageState(form);
-    pushResource({ id: 'rage', icon: '🔥', name: rageState.active ? 'Raging' : 'Rage', current: rageState.current, max: rageState.max, color: '#f0733f', active: rageState.active });
+    pushResource({ id: 'rage', icon: '🔥', name: 'Rage', current: rageState.current, max: rageState.max, color: '#f0733f', active: rageState.active });
     if (classLevels.bard) pushResource({ id: 'bardic-inspiration', icon: '🎵', name: 'Bardic Inspiration', current: abilityModifier(form?.cha), max: abilityModifier(form?.cha), color: '#d7b46a' });
     if (classLevels.sorcerer) pushResource({ id: 'sorcery-points', icon: '✦', name: 'Sorcery Points', current: classLevels.sorcerer >= 2 ? classLevels.sorcerer : 0, max: classLevels.sorcerer >= 2 ? classLevels.sorcerer : 0, color: '#b85cff' });
     if (classLevels.cleric) pushResource({ id: 'channel-divinity', icon: '☀', name: 'Channel Divinity', current: classLevels.cleric >= 18 ? 3 : classLevels.cleric >= 6 ? 2 : classLevels.cleric >= 2 ? 1 : 0, max: classLevels.cleric >= 18 ? 3 : classLevels.cleric >= 6 ? 2 : classLevels.cleric >= 2 ? 1 : 0, color: '#f3d98a' });
@@ -5231,18 +5252,10 @@ export default function ZombiesCharacterSheet() {
     () => normalizeFooterCollection(form?.activeBonuses || form?.bonuses || form?.activeEffects),
     [form?.activeBonuses, form?.bonuses, form?.activeEffects, normalizeFooterCollection]
   );
-  const footerConditions = useMemo(() => {
-    const conditions = normalizeFooterCollection(form?.conditions || form?.statusConditions);
-    if (!getRageState(form).active) {
-      return conditions;
-    }
-    const hasRageCondition = conditions.some((condition) =>
-      String(condition?.name || condition?.label || condition?.id || '').toLowerCase() === 'rage'
-    );
-    return hasRageCondition
-      ? conditions
-      : [{ id: 'rage-condition', icon: '🔥', name: 'Rage', color: '#f0733f' }, ...conditions];
-  }, [form, normalizeFooterCollection]);
+  const footerConditions = useMemo(
+    () => buildFooterConditions(form, normalizeFooterCollection),
+    [form, normalizeFooterCollection]
+  );
 
   const hasFooterSpellSlots = hasSpellcasting || (form?.occupation || []).some((cls) => {
     const name = (cls.Name || cls.Occupation || '').toLowerCase();
@@ -5773,7 +5786,7 @@ export default function ZombiesCharacterSheet() {
                   <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
                     <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>
                     <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
-                    <span className="combat-hud-pill"><Sparkles size={16} /> {footerConditions.length || 'No'} conditions</span>
+                    <span className="combat-hud-pill"><Sparkles size={16} /> {getFooterConditionLabel(footerConditions.length)}</span>
                     {footerConditions.length > 0 && (
                       <div className="combat-hud-conditions-list" aria-label="Active conditions">
                         {footerConditions.map((condition) => (

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -115,7 +115,39 @@ jest.mock('../attributes/Features', () => (props) => {
   return null;
 });
 
-import ZombiesCharacterSheet from './ZombiesCharacterSheet';
+import ZombiesCharacterSheet, { buildFooterConditions, getFooterConditionLabel } from './ZombiesCharacterSheet';
+
+describe('footer condition helpers', () => {
+  const normalize = (value) => (Array.isArray(value) ? value : []);
+
+  test('includes active rage in the condition collection and removes inactive rage', () => {
+    const active = {
+      classState: { barbarian: { rage: { active: true, current: 1 } } },
+      occupation: [{ Name: 'Barbarian', Level: 3 }],
+      conditions: [],
+    };
+    expect(buildFooterConditions(active, normalize)).toEqual([
+      { id: 'rage-condition', icon: '🔥', name: 'Rage', color: '#f0733f' },
+    ]);
+    expect(buildFooterConditions({ ...active, classState: { barbarian: { rage: { active: false, current: 1 } } } }, normalize)).toEqual([]);
+  });
+
+  test('does not duplicate rage and preserves other conditions', () => {
+    const character = {
+      classState: { barbarian: { rage: { active: true, current: 1 } } },
+      occupation: [{ Name: 'Barbarian', Level: 3 }],
+      conditions: [{ id: 'rage', name: 'Rage' }, { id: 'poisoned', name: 'Poisoned' }],
+    };
+    expect(buildFooterConditions(character, normalize)).toEqual(character.conditions);
+  });
+
+  test('formats empty, singular, and plural condition labels', () => {
+    expect(getFooterConditionLabel(0)).toBe('No conditions');
+    expect(getFooterConditionLabel(1)).toBe('1 condition');
+    expect(getFooterConditionLabel(2)).toBe('2 conditions');
+  });
+});
+
 const { rollDiceWithBox } = require('../../../utils/diceBoxManager');
 
 const getFooterButtonByLabel = (label) =>

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -225,13 +225,16 @@ const isArmorItem = (item) => {
   if (Array.isArray(item)) {
     const [name, acBonus, maxDex, category] = item;
     const text = String(`${name ?? ''} ${category ?? ''}`).toLowerCase();
+    if (text.includes('no armor') || text.includes('unarmored') || text.includes('none')) {
+      return false;
+    }
     return (
       text.includes('armor') ||
       text.includes('light') ||
       text.includes('medium') ||
       text.includes('heavy') ||
-      (Number.isFinite(Number(acBonus)) && !String(name ?? '').toLowerCase().includes('shield')) ||
-      Number.isFinite(Number(maxDex))
+      (Number.isFinite(Number(acBonus)) && Number(acBonus) > 0 && !String(name ?? '').toLowerCase().includes('shield')) ||
+      (Number.isFinite(Number(maxDex)) && Number(maxDex) > 0)
     );
   }
 

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -180,9 +180,11 @@ describe('calculateCharacterArmorClass barbarian unarmored defense', () => {
     expect(calculateCharacterArmorClass(base)).toBe(15);
     expect(calculateCharacterArmorClass(requestedBase)).toBe(16);
     expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Shield', category: 'Shield', acBonus: 2 }] })).toBe(17);
+    expect(calculateCharacterArmorClass({ ...requestedBase, armor: [{ name: 'Shield', category: 'Shield', acBonus: 2 }] })).toBe(18);
   });
 
   it('is disabled by armor and does not stack with monk wisdom', () => {
+    expect(calculateCharacterArmorClass({ ...base, armor: [['No Armor', 0, 0]] })).toBe(15);
     expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Leather', category: 'Light Armor', source: 'armor', acBonus: 1 }] })).toBe(13);
     expect(calculateCharacterArmorClass({ ...requestedBase, armor: [{ name: 'Leather', category: 'Light Armor', acBonus: 1 }] })).toBe(14);
     expect(calculateCharacterArmorClass({ ...base, armor: [{ name: 'Hide', category: 'Medium Armor', source: 'armor', acBonus: 2, maxDex: 2 }] })).toBe(14);


### PR DESCRIPTION
### Motivation
- Rage was shown as a separate HUD pill and not part of the normalized Conditions collection, causing duplicate/incorrect UI behavior.
- The centralized damage resolver did not apply the Barbarian Rage damage bonus, so qualifying Strength weapon/unarmed attacks were missing the Rage contribution.
- Unarmored Defense was not applying when characters had explicit “no armor” or placeholder armor entries, causing incorrect AC calculation for Barbarians.

### Description
- Render Rage through the shared footer condition collection by adding `buildFooterConditions` and `getFooterConditionLabel`, and use that list in the Conditions box so active Rage appears inside the box and the singular/plural label reads correctly. (client/src/components/Zombies/pages/ZombiesCharacterSheet.js)
- Apply Rage damage in the authoritative damage pipeline by adding an optional `options` parameter to `calculateDamage` and appending `getRageDamageBonus(...)` once to the resolved damage and breakdown; pass attack/character metadata from weapon attack paths so the bonus only applies to qualifying Strength weapon or Unarmed Strike attacks. (client/src/components/Zombies/attributes/PlayerTurnActions.js)
- Fix Unarmored Defense integration by improving `isArmorItem` detection so explicit placeholders like `['No Armor', 0, 0]` or zero ac/maxDex entries are not treated as equipped armor, allowing the Barbarian Con-based unarmored calculation to be selected while keeping shields additive. (client/src/components/Zombies/utils/characterMetrics.js)
- Tests added/updated to cover the changes: condition helper tests for Rage placement and labels, `calculateDamage` parser tests that verify Rage bonus eligibility and scaling, and AC tests for Barbarian Unarmored Defense and shield interaction. (client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js, client/src/components/Zombies/attributes/PlayerTurnActions.test.js, client/src/components/Zombies/utils/characterMetrics.test.js)

### Testing
- Ran focused tests: `ZombiesCharacterSheet` footer-condition helpers, `characterMetrics` AC tests, and `PlayerTurnActions` calculateDamage parser tests; focused tests covering Rage placement, Rage damage eligibility/scaling, and Barbarian Unarmored Defense passed.
- Ran the small targeted test groups: `npm test -- --runInBand src/components/Zombies/pages/ZombiesCharacterSheet.test.js -t "footer condition helpers"`, `src/components/Zombies/utils/characterMetrics.test.js`, and `src/components/Zombies/attributes/PlayerTurnActions.test.js -t "calculateDamage parser"` — all succeeded.
- Full client test suite was executed and completed but includes pre-existing unrelated failures in broader UI suites (not introduced by this change) such as `ZombiesDM` and `ActiveEnemyQuickList` and higher-level `PlayerTurnActions` UI tests; the focused new/updated tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51273334f48323a9f337124b268bbc)