### PR TITLE
Add Barbarian Weapon Mastery feature

### DIFF
--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -19,7 +19,11 @@ export default function FeatureModal({ show, onHide, feature }) {
             <Card.Title className="modal-title">{feature.name}</Card.Title>
           </Card.Header>
           <Card.Body>
-            <p>{description || 'Feature details unavailable'}</p>
+            {typeof feature.renderDetails === 'function' ? (
+              feature.renderDetails()
+            ) : (
+              <p>{description || 'Feature details unavailable'}</p>
+            )}
           </Card.Body>
           <Card.Footer className="modal-footer">
             <Button className="action-btn close-btn" onClick={onHide}>

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
-import { Modal, Card, Button, Spinner } from 'react-bootstrap';
+import { Modal, Card, Button, Spinner, Form } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import UpcastModal from './UpcastModal';
@@ -10,6 +10,12 @@ import adrenalineRushIcon from '../../../images/adrenaline-rush.png';
 import speakWithAnimalIcon from '../../../images/speak-with-animal.png';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
 import DockControls from '../components/DockControls';
+import {
+  getBarbarianLevel,
+  getWeaponMasteryState,
+  setWeaponMasterySelections,
+  validateBarbarianWeaponMasteries,
+} from '../utils/barbarian';
 
 const LINEAGE_SPELLS = {
   'elf-drow-dancing-lights': {
@@ -126,6 +132,7 @@ export default function Features({
   onDockClose,
   onDockChange,
   characterId,
+  onCharacterChange,
 }) {
   const [features, setFeatures] = useState([]);
   const [modalFeature, setModalFeature] = useState(null);
@@ -145,6 +152,7 @@ export default function Features({
   });
   const [showUpcast, setShowUpcast] = useState(false);
   const [pendingSpell, setPendingSpell] = useState(null);
+  const [weaponData, setWeaponData] = useState({});
   const hasInitializedRestRef = useRef(false);
   const speakWithAnimalsUsesRef = useRef(speakWithAnimalsUses);
   const lineageSpellUsesRef = useRef(lineageSpellUses);
@@ -158,6 +166,38 @@ export default function Features({
       return sum + levelValue;
     }, 0);
   }, [form?.occupation]);
+
+
+  const barbarianLevel = useMemo(() => getBarbarianLevel(form), [form]);
+  const weaponMasteryState = useMemo(
+    () => getWeaponMasteryState(form),
+    [form]
+  );
+  const eligibleWeaponMasteryOptions = useMemo(() => {
+    const byKey = new Map();
+    Object.entries(weaponData || {}).forEach(([key, weapon]) => {
+      const normalizedKey = String(weapon?.type || key || '').trim().toLowerCase();
+      const category = String(weapon?.category || '').trim().toLowerCase();
+      if (
+        !normalizedKey ||
+        byKey.has(normalizedKey) ||
+        (category !== 'simple melee' && category !== 'martial melee')
+      ) {
+        return;
+      }
+      byKey.set(normalizedKey, {
+        key: normalizedKey,
+        name: weapon?.name || normalizedKey,
+        category,
+        mastery: weapon?.mastery,
+      });
+    });
+    return Array.from(byKey.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [weaponData]);
+  const eligibleWeaponMasteryMap = useMemo(
+    () => new Map(eligibleWeaponMasteryOptions.map((weapon) => [weapon.key, weapon])),
+    [eligibleWeaponMasteryOptions]
+  );
 
   const profBonus = useMemo(() => {
     const provided = Number(form?.proficiencyBonus);
@@ -1268,10 +1308,116 @@ export default function Features({
     normalizedTieflingLegacyKey,
   ]);
 
+  const classFeatures = useMemo(() => {
+    if (barbarianLevel < 1) return features;
+    const hasWeaponMastery = features.some(
+      (feature) =>
+        String(feature?.class || '').toLowerCase() === 'barbarian' &&
+        String(feature?.name || '').toLowerCase() === 'weapon mastery'
+    );
+    if (hasWeaponMastery) return features;
+    const weaponMasteryFeature = {
+      id: 'barbarian-weapon-mastery',
+      name: 'Weapon Mastery',
+      class: 'Barbarian',
+      level: 1,
+      hideUseButton: true,
+      isWeaponMasteryConfig: true,
+      description:
+        'Your training with weapons allows you to use the mastery property of selected simple or martial melee weapon types. You can replace one selection when you finish a Long Rest.',
+    };
+    return [...features, weaponMasteryFeature].sort(
+      (a, b) =>
+        (a.class || '').localeCompare(b.class || '') ||
+        (a.level || 0) - (b.level || 0)
+    );
+  }, [barbarianLevel, features]);
+
   const displayFeatures = useMemo(() => {
-    if (ancestryFeatures.length === 0) return features;
-    return [...ancestryFeatures, ...features];
-  }, [ancestryFeatures, features]);
+    if (ancestryFeatures.length === 0) return classFeatures;
+    return [...ancestryFeatures, ...classFeatures];
+  }, [ancestryFeatures, classFeatures]);
+
+
+  const displayedWeaponMasteryState = useMemo(() => {
+    if (eligibleWeaponMasteryMap.size === 0) return weaponMasteryState;
+    return {
+      ...weaponMasteryState,
+      selections: weaponMasteryState.selections.filter((key) =>
+        eligibleWeaponMasteryMap.has(key)
+      ),
+    };
+  }, [eligibleWeaponMasteryMap, weaponMasteryState]);
+
+  const handleWeaponMasteryChange = useCallback(
+    (slotIndex, nextKey) => {
+      if (!onCharacterChange) return;
+      const activeSelections = Array.from(
+        { length: displayedWeaponMasteryState.count },
+        (_, index) => displayedWeaponMasteryState.selections[index] || ''
+      );
+      activeSelections[slotIndex] = nextKey;
+      const selectedKeys = activeSelections.filter(Boolean);
+      const selectedWeapons = selectedKeys.map((key) => eligibleWeaponMasteryMap.get(key) || key);
+      const validation = validateBarbarianWeaponMasteries(form, selectedWeapons);
+      if (validation.valid.length !== selectedKeys.length || validation.hasDuplicates) return;
+      onCharacterChange((previous) => setWeaponMasterySelections(previous || form, selectedWeapons));
+    },
+    [eligibleWeaponMasteryMap, form, onCharacterChange, displayedWeaponMasteryState]
+  );
+
+  const renderWeaponMasteryDetails = useCallback(() => {
+    const activeSelections = Array.from(
+      { length: displayedWeaponMasteryState.count },
+      (_, index) => displayedWeaponMasteryState.selections[index] || ''
+    );
+    const activeSet = new Set(activeSelections.filter(Boolean));
+    const selectedNames = activeSelections
+      .filter(Boolean)
+      .map((key) => eligibleWeaponMasteryMap.get(key)?.name || key);
+    return (
+      <div className="text-start">
+        <p className="mb-2">
+          <strong>Barbarian Level 1.</strong> Current choices:{' '}
+          {displayedWeaponMasteryState.count}
+        </p>
+        <p className="text-muted small">
+          Choose simple or martial melee weapon types from the centralized weapon
+          list. One stored selection can be replaced after a Long Rest; the
+          current UI keeps the dropdowns editable so that pending replacement can
+          be enforced more strictly by a future rest-resolution workflow.
+        </p>
+        {Array.from({ length: displayedWeaponMasteryState.count }).map((_, index) => {
+          const selectedKey = activeSelections[index] || '';
+          return (
+            <Form.Group className="mb-3" controlId={`barbarian-weapon-mastery-${index}`} key={index}>
+              <Form.Label>{`Mastery ${index + 1}`}</Form.Label>
+              <Form.Select
+                aria-label={`Weapon Mastery ${index + 1}`}
+                value={selectedKey}
+                onChange={(event) => handleWeaponMasteryChange(index, event.target.value)}
+                disabled={!onCharacterChange}
+              >
+                <option value="">Select weapon</option>
+                {eligibleWeaponMasteryOptions.map((weapon) => {
+                  const disabled = activeSet.has(weapon.key) && weapon.key !== selectedKey;
+                  return (
+                    <option value={weapon.key} disabled={disabled} key={weapon.key}>
+                      {weapon.name}
+                      {weapon.mastery ? ` (${weapon.mastery})` : ''}
+                    </option>
+                  );
+                })}
+              </Form.Select>
+            </Form.Group>
+          );
+        })}
+        {selectedNames.length > 0 && (
+          <p className="small mb-0">Selected: {selectedNames.join(', ')}</p>
+        )}
+      </div>
+    );
+  }, [eligibleWeaponMasteryMap, eligibleWeaponMasteryOptions, handleWeaponMasteryChange, onCharacterChange, displayedWeaponMasteryState]);
 
   const pendingFreeCastConfig = pendingSpell?.freeCast || null;
   const pendingFreeCastRemaining = pendingFreeCastConfig
@@ -1281,6 +1427,26 @@ export default function Features({
       ? Math.max(0, Math.floor(pendingFreeCastConfig.remaining))
       : 0
     : 0;
+
+  useEffect(() => {
+    if (!showFeatures || barbarianLevel < 1) return;
+    let cancelled = false;
+    async function fetchWeapons() {
+      try {
+        const res = await apiFetch('/weapons');
+        if (!cancelled && res?.ok) {
+          const data = await res.json();
+          setWeaponData(data || {});
+        }
+      } catch (err) {
+        // Weapon Mastery uses the centralized weapon API when it is available.
+      }
+    }
+    fetchWeapons();
+    return () => {
+      cancelled = true;
+    };
+  }, [showFeatures, barbarianLevel]);
 
   useEffect(() => {
     if (!showFeatures) return;
@@ -1505,6 +1671,7 @@ export default function Features({
                     const isAdrenalineRush = feat.id === 'orc-adrenaline-rush';
                     const isSpeakWithAnimals =
                       feat.id === 'gnome-forest-speak-with-animals';
+                    const isWeaponMasteryConfig = Boolean(feat.isWeaponMasteryConfig);
                     const lineageSpellConfig =
                       LINEAGE_SPELLS[feat.id] || null;
                     const lineageSpellHasLimitedUses =
@@ -1826,7 +1993,11 @@ export default function Features({
                               size="sm"
                               className="view-link-btn"
                               onClick={() => {
-                                setModalFeature(feat);
+                                setModalFeature(
+                                  isWeaponMasteryConfig
+                                    ? { ...feat, renderDetails: renderWeaponMasteryDetails }
+                                    : feat
+                                );
                                 setShowModal(true);
                               }}
                             >
@@ -1834,6 +2005,11 @@ export default function Features({
                             </Button>
                           </div>
                         </div>
+                        {isWeaponMasteryConfig && (
+                          <div className="feature-card-uses text-muted small mt-2">
+                            {displayedWeaponMasteryState.selections.length} / {displayedWeaponMasteryState.count} selected
+                          </div>
+                        )}
                         {isAdrenalineRush && (
                           <div className="feature-card-uses text-muted small mt-2">
                             Uses remaining: {adrenalineRushUses}

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1993,3 +1993,89 @@ test('features are sorted by class then level', async () => {
   const order = featureNameNodes.map((node) => node.textContent);
   expect(order).toEqual(['Second Wind', 'Action Surge', 'Arcane Recovery']);
 });
+
+describe('barbarian weapon mastery feature UI', () => {
+  const weapons = {
+    club: { name: 'Club', type: 'club', category: 'simple melee', mastery: 'slow' },
+    handaxe: { name: 'Handaxe', type: 'handaxe', category: 'simple melee', mastery: 'vex' },
+    greataxe: { name: 'Greataxe', type: 'greataxe', category: 'martial melee', mastery: 'cleave' },
+    longbow: { name: 'Longbow', type: 'longbow', category: 'martial ranged', mastery: 'slow' },
+  };
+
+  const mockFeatureApi = () => {
+    apiFetch.mockImplementation((url) => {
+      if (url === '/weapons') {
+        return Promise.resolve({ ok: true, json: async () => weapons });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ features: [] }) });
+    });
+  };
+
+  test('appears for Barbarian level 1 and renders data-driven mastery slots', async () => {
+    mockFeatureApi();
+    render(
+      <Features
+        form={{ occupation: [{ Name: 'Barbarian', Level: 1 }] }}
+        showFeatures={true}
+        handleCloseFeatures={() => {}}
+        characterId={TEST_CHARACTER_ID}
+      />
+    );
+
+    const title = await screen.findByText('Weapon Mastery');
+    const card = title.closest('.feature-card');
+    expect(within(card).getByText('0 / 2 selected')).toBeInTheDocument();
+    await userEvent.click(within(card).getByRole('button', { name: /view feature/i }));
+    expect(screen.getByLabelText('Weapon Mastery 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Weapon Mastery 2')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Weapon Mastery 3')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('option', { name: /Greataxe/i }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('option', { name: /Longbow/i })).not.toBeInTheDocument();
+  });
+
+  test('does not appear for characters without Barbarian levels', async () => {
+    mockFeatureApi();
+    render(
+      <Features
+        form={{ occupation: [{ Name: 'Fighter', Level: 1 }] }}
+        showFeatures={true}
+        handleCloseFeatures={() => {}}
+        characterId={TEST_CHARACTER_ID}
+      />
+    );
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    expect(screen.queryByText('Weapon Mastery')).not.toBeInTheDocument();
+  });
+
+  test('uses Barbarian class level for progression and prevents duplicate saves', async () => {
+    mockFeatureApi();
+        let character = {
+      occupation: [
+        { Name: 'Barbarian', Level: 4 },
+        { Name: 'Wizard', Level: 6 },
+      ],
+      classState: { barbarian: { weaponMasteries: { selections: ['greataxe'] } } },
+    };
+    const handleCharacterChange = (updater) => {
+      character = typeof updater === 'function' ? updater(character) : updater;
+    };
+    render(
+      <Features
+        form={character}
+        showFeatures={true}
+        handleCloseFeatures={() => {}}
+        characterId={TEST_CHARACTER_ID}
+        onCharacterChange={handleCharacterChange}
+      />
+    );
+
+    const title = await screen.findByText('Weapon Mastery');
+    expect(within(title.closest('.feature-card')).getByText('1 / 3 selected')).toBeInTheDocument();
+    await userEvent.click(within(title.closest('.feature-card')).getByRole('button', { name: /view feature/i }));
+    expect(screen.getByLabelText('Weapon Mastery 3')).toBeInTheDocument();
+    const secondSelect = screen.getByLabelText('Weapon Mastery 2');
+    expect(within(secondSelect).getByRole('option', { name: /Greataxe/i })).toBeDisabled();
+    await userEvent.selectOptions(secondSelect, 'handaxe');
+    expect(character.classState.barbarian.weaponMasteries.selections).toEqual(['greataxe', 'handaxe']);
+  });
+});

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5352,6 +5352,7 @@ export default function ZombiesCharacterSheet() {
           handleCloseFeatures,
           onActionSurge: handleActionSurge,
           onLargeForm: handleLargeForm,
+          onCharacterChange: setForm,
           longRestCount,
           shortRestCount,
           onDockChange: (side) => handleDockChange('features', side),
@@ -6017,6 +6018,7 @@ export default function ZombiesCharacterSheet() {
           availableSlots={availableSlots}
           actionCount={actionCount}
           characterId={characterId}
+          onCharacterChange={setForm}
           dockedSide={getDockedSide('features')}
           onDockChange={(side) => handleDockChange('features', side)}
         />
@@ -6027,6 +6029,7 @@ export default function ZombiesCharacterSheet() {
           onTabChange={setInventoryTab}
           form={form}
           characterId={characterId}
+          onCharacterChange={setForm}
           dockedSide={getDockedSide('inventory')}
           onDockChange={(side) => handleDockChange('inventory', side)}
           onItemsChange={handleItemsChange}


### PR DESCRIPTION
### Motivation
- Provide a configurable persistent Barbarian class feature that lets players pick weapon type masteries starting at Barbarian level 1 using the existing feature UI and data flows. 
- Reuse the project’s canonical weapon data, class progression, feature card/modal UI, and character persistence rather than adding a separate subsystem. 

### Description
- Adds a `Weapon Mastery` feature card for the Barbarian class that appears when the character has at least one Barbarian level and opens in the existing feature modal for configuration. (files changed: `client/src/components/Zombies/attributes/Features.js`, `client/src/components/Zombies/attributes/FeatureModal.js`, `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`, `client/src/components/Zombies/attributes/Features.test.js`).
- Loads weapon data from the centralized `/weapons` endpoint and builds eligible options by normalizing keys and including only weapons whose `category` is `simple melee` or `martial melee`, deduplicating by normalized `type`/key. The UI shows one dropdown per mastery slot based on progression and displays weapon names but stores normalized keys. (`Features.js` uses `apiFetch('/weapons')` and filters by category). 
- Uses the existing Barbarian progression table as the single source of truth for counts (2 slots for levels 1–3, 3 for 4–9, 4 for 10+), so the modal renders `Array.from({ length: displayedWeaponMasteryState.count })` to produce slots via `getWeaponMasteryState`. 
- Persists selections in character state at `classState.barbarian.weaponMasteries.selections` using the provided helpers `validateBarbarianWeaponMasteries` and `setWeaponMasterySelections`, storing stable normalized weapon keys (e.g. `greataxe`). 
- Prevents duplicate selections in two layers: the UI disables options already chosen in other slots, and the save/update logic rejects duplicate or ineligible selections via `validateBarbarianWeaponMasteries` before calling `setWeaponMasterySelections`. 
- Integrates with the existing Long Rest flag: `applyRageRest(..., 'long')` already sets `canReplaceAfterLongRest`; the UI keeps dropdowns editable for now and documents this limitation, leaving stricter one-choice-per-long-rest enforcement to the rest-resolution workflow. 
- Exposes selections to the rest of the app (no new combat engine added); existing weapon/mastery rules can consume the `classState.barbarian.weaponMasteries.selections`. 

### Testing
- Ran targeted tests for the new UI and utility: `cd client && npm test -- --runTestsByPath src/components/Zombies/attributes/Features.test.js src/components/Zombies/utils/barbarian.test.js --watchAll=false`, and both test files passed. 
- Ran the full client test suite (`cd client && CI=true npm test -- --watchAll=false`) where the modified tests passed but the full suite surfaced pre-existing unrelated failures/timeouts in other suites (e.g. `ZombiesDM` and `ActiveEnemyQuickList`); these failures were not caused by the Weapon Mastery changes. 
- The diff includes added tests that verify: feature availability at Barbarian level 1, progression-driven slot counts, simple/martial melee filtering (excluding ranged/non-weapon items), duplicate prevention in UI and save logic, and persistence through the character update callback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5135e6c8b083238b72c30819675359)