### PR TITLE
Feature modal: render formatted multiline descriptions and add full Barbarian Rage text

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10849,3 +10849,36 @@ body.character-select-scroll-enabled {
     top: calc(env(safe-area-inset-top, 0px) + 0.65rem) !important;
   }
 }
+
+.feature-modal-description {
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.feature-modal-description p {
+  margin: 0 0 1rem;
+}
+
+.feature-modal-description p:last-child,
+.feature-modal-description ul:last-child {
+  margin-bottom: 0;
+}
+
+.feature-modal-description__heading {
+  margin: 1.1rem 0 0.35rem !important;
+}
+
+.feature-modal-description__heading:first-child {
+  margin-top: 0 !important;
+}
+
+.feature-modal-description ul {
+  margin: 0 0 1rem 1.25rem;
+  padding-left: 1rem;
+}
+
+.feature-modal-description li + li {
+  margin-top: 0.35rem;
+}

--- a/client/src/components/Zombies/attributes/FeatureModal.js
+++ b/client/src/components/Zombies/attributes/FeatureModal.js
@@ -1,10 +1,58 @@
 import React from 'react';
 import { Modal, Card, Button } from 'react-bootstrap';
 
+function renderInlineFormatting(text) {
+  return String(text)
+    .split(/(\*\*[^*]+\*\*)/g)
+    .filter(Boolean)
+    .map((part, index) => {
+      if (part.startsWith('**') && part.endsWith('**')) {
+        return <strong key={index}>{part.slice(2, -2)}</strong>;
+      }
+      return part;
+    });
+}
+
+function renderFeatureDescription(description) {
+  if (!description) return <p>Feature details unavailable</p>;
+
+  const blocks = String(description)
+    .split(/\n\s*\n/g)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  if (blocks.length === 0) return <p>Feature details unavailable</p>;
+
+  return (
+    <div className="feature-modal-description">
+      {blocks.map((block, index) => {
+        const lines = block.split('\n').map((line) => line.trim()).filter(Boolean);
+        const isList = lines.length > 0 && lines.every((line) => /^[-*]\s+/.test(line));
+        if (isList) {
+          return (
+            <ul key={index}>
+              {lines.map((line, lineIndex) => (
+                <li key={lineIndex}>{renderInlineFormatting(line.replace(/^[-*]\s+/, ''))}</li>
+              ))}
+            </ul>
+          );
+        }
+
+        const isHeading = lines.length === 1 && /^\*\*[^*]+\*\*$/.test(lines[0]);
+        if (isHeading) {
+          return <p key={index} className="feature-modal-description__heading">{renderInlineFormatting(lines[0])}</p>;
+        }
+
+        return <p key={index}>{renderInlineFormatting(lines.join('\n'))}</p>;
+      })}
+    </div>
+  );
+}
+
 export default function FeatureModal({ show, onHide, feature }) {
   if (!show || !feature) return null;
   const description = Array.isArray(feature.desc)
-    ? feature.desc.join('\n')
+    ? feature.desc.join('\n\n')
     : (feature.description || feature.desc);
   return (
     <Modal
@@ -18,11 +66,11 @@ export default function FeatureModal({ show, onHide, feature }) {
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">{feature.name}</Card.Title>
           </Card.Header>
-          <Card.Body>
+          <Card.Body className="modal-body">
             {typeof feature.renderDetails === 'function' ? (
               feature.renderDetails()
             ) : (
-              <p>{description || 'Feature details unavailable'}</p>
+              renderFeatureDescription(description)
             )}
           </Card.Body>
           <Card.Footer className="modal-footer">

--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -139,7 +139,43 @@ const barbarianFeatures = {
   1: [
     {
       name: 'Rage',
-      description: 'In battle, you fight with primal ferocity.'
+      description: `**Rage**
+
+You can imbue yourself with a primal power called Rage, a force that grants you extraordinary might and resilience. You can enter it as a Bonus Action if you aren't wearing Heavy Armor.
+
+You can enter your Rage the number of times shown for your Barbarian level. You regain one expended use when you finish a Short Rest, and you regain all expended uses when you finish a Long Rest.
+
+While active, your Rage grants the following benefits:
+
+**Damage Resistance**
+
+You have Resistance to Bludgeoning, Piercing, and Slashing damage.
+
+**Rage Damage**
+
+When you make an attack using Strength with either a weapon or an Unarmed Strike and deal damage, you gain the Rage Damage bonus appropriate for your Barbarian level.
+
+**Strength Advantage**
+
+You have Advantage on Strength checks and Strength saving throws.
+
+**No Concentration or Spells**
+
+You can't maintain Concentration, and you can't cast spells while raging.
+
+**Duration**
+
+Rage lasts until the end of your next turn and ends early if you wear Heavy Armor or gain the Incapacitated condition.
+
+If your Rage is still active on your next turn, you can extend it for another round by doing one of the following:
+
+- Make an attack roll against an enemy.
+- Force an enemy to make a saving throw.
+- Take a Bonus Action to extend your Rage.
+
+Each time Rage is extended, it lasts until the end of your next turn.
+
+A Rage can last for up to 10 minutes.`
     },
     {
       name: 'Unarmored Defense',


### PR DESCRIPTION
### Motivation
- Replace the placeholder Rage text with the full rules content while keeping feature descriptions centralized so UI code does not hardcode rule text. 
- Make the existing feature information dialog render any feature-provided multiline, formatted description (bold headings, paragraphs, bulleted lists) so the pattern can be reused for other features.

### Description
- Added the full, formatted Rage description to the centralized feature data at `server/data/classFeatures.js` under the Barbarian level 1 feature entry. 
- Updated the shared feature information modal at `client/src/components/Zombies/attributes/FeatureModal.js` to generically render feature-provided descriptions, parsing blank-line-separated paragraphs, `**bold**` headings, and `-`/`*` bulleted lists without special-casing Rage. 
- Added styles in `client/src/App.scss` to ensure readable spacing, wrapping, and vertical scrolling for long multiline descriptions without horizontal clipping. 
- Files changed: `server/data/classFeatures.js`, `client/src/components/Zombies/attributes/FeatureModal.js`, and `client/src/App.scss`.

### Testing
- Ran server API tests with `npm test -- --runInBand server/__tests__/classFeatures.test.js` and the suite passed. 
- Attempted a component-level test run for the FeatureModal file (`CI=true npm test -- --runInBand src/components/Zombies/attributes/FeatureModal.js`) but no matching test file exists for that component. 
- Ran existing UI tests `npm test -- --runInBand src/components/Zombies/attributes/CharacterInfo.test.js --watchAll=false` and they passed. 
- Verified there are no `git diff --check` issues and the new modal styling allows formatted multiline descriptions to render without horizontal scrolling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a514229c57083239a13936ec3005f97)