### PR TITLE
Fix DM map fullscreen cover

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10741,7 +10741,7 @@ body.character-select-scroll-enabled {
   }
 }
 
-/* DM map viewport parity: use the same aspect-ratio constrained board as character maps. */
+/* DM map viewport cover: preserve the map/grid aspect ratio while filling the full screen. */
 .zombies-dm-page__map-surface {
   align-items: center;
   justify-content: center;
@@ -10751,7 +10751,7 @@ body.character-select-scroll-enabled {
   position: absolute;
   inset: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   width: 100vw;
   height: 100dvh;
@@ -10763,11 +10763,11 @@ body.character-select-scroll-enabled {
 .zombies-dm-page__map-board .campaign-map-board__stage {
   position: relative;
   flex: 0 0 auto;
-  width: min(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
-  max-width: 100vw;
+  width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
+  max-width: none;
   height: auto !important;
   min-height: 0 !important;
-  margin: 0 auto;
+  margin: 0;
   transform: none;
 }
 
@@ -10780,7 +10780,7 @@ body.character-select-scroll-enabled {
 }
 
 .zombies-dm-page__map-board .campaign-map-board__image {
-  object-fit: contain;
+  object-fit: cover;
   object-position: center;
 }
 


### PR DESCRIPTION
### Motivation

- The DM page map was no longer filling the full viewport and showed large empty bands on narrow/portrait viewports, reducing usability when running the DM Command Center.
- The intent is to preserve the map/grid aspect ratio while allowing the board to cover the full screen so the map appears full-bleed for the DM.

### Description

- Updated `client/src/App.scss` to center the DM map surface and make the DM map board fill the viewport while preserving the map aspect ratio by switching the stage `width` calculation and removing the `max-width` constraint.
- Changed the DM map image sizing to `object-fit: cover` so the image covers the available viewport and avoids letterboxing in narrow viewports.
- Adjusted stage margins and alignment to ensure the board is centered and fills the screen on desktop and mobile.

### Testing

- Ran `npm --prefix client run build` and the production build completed successfully with existing lint/autoprefixer warnings reported but no build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a516a101280832ea612950253cc6823)