### PR TITLE
Align DM map viewport with character map full-width layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10741,9 +10741,9 @@ body.character-select-scroll-enabled {
   }
 }
 
-/* DM map viewport parity: use the same aspect-ratio constrained board as character maps. */
+/* DM map viewport parity: match the character sheet's full-width map surface without stretching. */
 .zombies-dm-page__map-surface {
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
 }
 
@@ -10751,19 +10751,24 @@ body.character-select-scroll-enabled {
   position: absolute;
   inset: 0;
   display: flex;
-  align-items: flex-start;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   width: 100vw;
   height: 100dvh;
+  max-width: none;
+  max-height: none;
   min-height: 100dvh;
   padding: 0;
   overflow: hidden;
+  background: transparent;
+  border: none;
+  box-shadow: none;
 }
 
 .zombies-dm-page__map-board .campaign-map-board__stage {
   position: relative;
   flex: 0 0 auto;
-  width: min(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
+  width: 100vw;
   max-width: 100vw;
   height: auto !important;
   min-height: 0 !important;
@@ -10777,6 +10782,7 @@ body.character-select-scroll-enabled {
   min-height: 0 !important;
   aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
   border-radius: 0;
+  background: transparent;
 }
 
 .zombies-dm-page__map-board .campaign-map-board__image {


### PR DESCRIPTION
### Motivation

- Ensure the DM Command Center map surface matches the character sheet's full-width map layout so the DM map does not stretch or misalign across viewports.
- Remove visual chrome and sizing constraints that caused clipping and unreliable viewport math on mobile devices.

### Description

- Change ` .zombies-dm-page__map-surface` alignment to `align-items: flex-start` to match the character map stacking behavior.
- Update ` .zombies-dm-page__map-board.campaign-map-board` to use `flex-direction: column`, center alignment, `width: 100vw`, `height: 100dvh`, and remove `max-width`/`max-height` while clearing background, border, and box-shadow.
- Set ` .zombies-dm-page__map-board .campaign-map-board__stage` width to `100vw` and remove the previous `calc()` constraints to prevent stretching and ensure consistent sizing.
- Ensure ` .campaign-map-board__image-wrapper` uses `width: 100%`, `height: auto`, preserves `aspect-ratio`, and has a transparent background for parity with character maps.

### Testing

- Ran `npm run lint` and the linter passed without errors.
- Executed `npm run build` and the production build completed successfully.
- Ran unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a516a101280832ea612950253cc6823)