### PR TITLE
Fix DM map viewport aspect ratio

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10767,25 +10767,27 @@ body.character-select-scroll-enabled {
 .zombies-dm-page__map-board .campaign-map-board__stage {
   position: relative;
   flex: 0 0 auto;
-  width: 100vw;
-  max-width: 100vw;
+  width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)));
+  max-width: none;
   height: auto !important;
   min-height: 0 !important;
   margin: 0;
-  transform: none;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .zombies-dm-page__map-board .campaign-map-board__image-wrapper {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   width: 100%;
-  height: 100% !important;
+  height: auto !important;
   min-height: 0 !important;
+  aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1);
   border-radius: 0;
   background: transparent;
 }
 
 .zombies-dm-page__map-board .campaign-map-board__image {
-  object-fit: fill;
+  object-fit: contain;
   object-position: center;
 }
 


### PR DESCRIPTION
### Motivation
- The DM map on the command center was being squeezed/offset and did not match the character-sheet map framing or preserve square grid cells.
- The goal is to make the DM map fill the viewport while keeping the same aspect-ratio and grid sizing behavior used by the campaign map so grid squares remain perfect squares.

### Description
- Updated DM-specific map CSS in `client/src/App.scss` to size the `.campaign-map-board__stage` using the numeric stage ratio via `width: max(100vw, calc(100dvh * var(--campaign-map-stage-ratio-number, 1)))` and horizontally center it with `left: 50%` and `transform: translateX(-50%)`.
- Restored the image wrapper to use a fixed `aspect-ratio: var(--campaign-map-stage-aspect-ratio, 1 / 1)` and made it `flex: 0 0 auto` so the stage controls sizing consistently with the character-sheet map.
- Changed the map image rendering to `object-fit: contain` so the image and the grid scale uniformly and grid cells remain square.
- All edits are contained to `client/src/App.scss` to preserve parity between DM and character-sheet maps.

### Testing
- Ran the CampaignMapBoard unit tests with `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/CampaignMapBoard.test.js`, which passed (`13` tests, `1` suite passed).
- Built the client with `npm --prefix client run build`, which produced a successful production build (compiled with warnings but completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5186b7df34832ea4618031550c127f)