### PR TITLE
Support multi-line Reckless Attack badge and make Reckless Attack a manual toggle

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -7816,6 +7816,11 @@ h1 {
   font-weight: 800;
   line-height: 1;
   color: rgba(247, 239, 224, 0.74);
+  text-align: center;
+}
+
+.combat-hud-resource-tile__name-line {
+  display: block;
 }
 
 .combat-hud-resource-tile__value {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -571,7 +571,7 @@ export const buildFooterConditions = (character, normalizeCollection) => {
   const conditions = normalize(character?.conditions || character?.statusConditions);
   const recklessActive = getRecklessAttackState(character).active;
   const withReckless = recklessActive && !conditions.some((condition) => String(condition?.name || condition?.label || condition?.id || '').toLowerCase() === 'reckless attack')
-    ? [{ id: 'reckless-attack-effect', icon: '⚔️', name: 'Reckless Attack', color: '#f59e0b' }, ...conditions]
+    ? [{ id: 'reckless-attack-effect', icon: '⚔️', name: 'Reckless Attack', displayLines: ['Reckless', 'Attack'], color: '#f59e0b' }, ...conditions]
     : conditions;
   if (!getRageState(character).active) {
     return withReckless;
@@ -5319,7 +5319,7 @@ export default function ZombiesCharacterSheet() {
     const rageState = getRageState(form);
     pushResource({ id: 'rage', icon: '🔥', name: 'Rage', current: rageState.current, max: rageState.max, color: '#f0733f', active: rageState.active });
     const recklessState = getRecklessAttackState(form);
-    if (getBarbarianLevel(form) >= 2) pushResource({ id: 'reckless-attack', icon: '⚔️', name: 'Reckless Attack', current: recklessState.active ? 'On' : 'Off', max: '∞', color: '#f59e0b', active: recklessState.active, disabled: recklessState.firstAttackMade && !recklessState.active });
+    if (getBarbarianLevel(form) >= 2 && recklessState.active) pushResource({ id: 'reckless-attack', icon: '⚔️', name: 'Reckless Attack', displayLines: ['Reckless', 'Attack'], current: recklessState.active ? 'On' : 'Off', max: '∞', color: '#f59e0b', active: recklessState.active });
     if (classLevels.bard) pushResource({ id: 'bardic-inspiration', icon: '🎵', name: 'Bardic Inspiration', current: abilityModifier(form?.cha), max: abilityModifier(form?.cha), color: '#d7b46a' });
     if (classLevels.sorcerer) pushResource({ id: 'sorcery-points', icon: '✦', name: 'Sorcery Points', current: classLevels.sorcerer >= 2 ? classLevels.sorcerer : 0, max: classLevels.sorcerer >= 2 ? classLevels.sorcerer : 0, color: '#b85cff' });
     if (classLevels.cleric) pushResource({ id: 'channel-divinity', icon: '☀', name: 'Channel Divinity', current: classLevels.cleric >= 18 ? 3 : classLevels.cleric >= 6 ? 2 : classLevels.cleric >= 2 ? 1 : 0, max: classLevels.cleric >= 18 ? 3 : classLevels.cleric >= 6 ? 2 : classLevels.cleric >= 2 ? 1 : 0, color: '#f3d98a' });
@@ -5967,8 +5967,10 @@ export default function ZombiesCharacterSheet() {
                             disabled={(!isFocusResource && !isRageResource && !isRecklessAttackResource) || resource.disabled || (isRageResource && !resource.active && (Number(resource.current) <= 0 || hasHeavyArmorEquipped(form)))}
                           >
                             <span className="combat-hud-resource-tile__icon" aria-hidden="true">{resource.icon}</span>
-                            <span className="combat-hud-resource-tile__name">{resource.name}</span>
-                            <span className="combat-hud-resource-tile__value">{resource.current ?? '—'}/{resource.max ?? '—'}</span>
+                            <span className="combat-hud-resource-tile__name">{(Array.isArray(resource.displayLines) && resource.displayLines.length > 0 ? resource.displayLines : [resource.name]).map((line, lineIndex) => (<span className="combat-hud-resource-tile__name-line" key={`${resource.id || resource.name}-line-${lineIndex}`}>{line}</span>))}</span>
+                            {!Array.isArray(resource.displayLines) && (
+                              <span className="combat-hud-resource-tile__value">{resource.current ?? '—'}/{resource.max ?? '—'}</span>
+                            )}
                           </button>
                         );
                       })}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -132,6 +132,19 @@ describe('footer condition helpers', () => {
     expect(buildFooterConditions({ ...active, classState: { barbarian: { rage: { active: false, current: 1 } } } }, normalize)).toEqual([]);
   });
 
+
+  test('adds Reckless Attack as a multi-line active condition only while manually toggled on', () => {
+    const active = {
+      classState: { barbarian: { recklessAttack: { active: true, declared: true } } },
+      occupation: [{ Name: 'Barbarian', Level: 2 }],
+      conditions: [],
+    };
+    expect(buildFooterConditions(active, normalize)).toEqual([
+      { id: 'reckless-attack-effect', icon: '⚔️', name: 'Reckless Attack', displayLines: ['Reckless', 'Attack'], color: '#f59e0b' },
+    ]);
+    expect(buildFooterConditions({ ...active, classState: { barbarian: { recklessAttack: { active: false } } } }, normalize)).toEqual([]);
+  });
+
   test('does not duplicate rage and preserves other conditions', () => {
     const character = {
       classState: { barbarian: { rage: { active: true, current: 1 } } },

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -378,8 +378,9 @@ export const getRecklessAttackState = (character) => {
 export const declareRecklessAttack = (character) => {
   if (getBarbarianLevel(character) < 2) return character;
   const state = getRecklessAttackState(character);
-  if (state.active || state.firstAttackMade) return character;
+  if (state.active) return character;
   return withRecklessAttack(character, {
+    ...state,
     active: true,
     declared: true,
     firstAttackMade: false,
@@ -393,12 +394,7 @@ export const endRecklessAttack = (character) => {
   return withRecklessAttack(character, { active: false, declared: false, firstAttackMade: false });
 };
 
-export const markBarbarianAttackRoll = (character) => {
-  if (getBarbarianLevel(character) < 2) return character;
-  const state = getRecklessAttackState(character);
-  if (state.firstAttackMade) return character;
-  return withRecklessAttack(character, { ...state, firstAttackMade: true });
-};
+export const markBarbarianAttackRoll = (character) => character;
 
 export const getRecklessAttackAdvantageSources = (character, attack = {}) => {
   const state = getRecklessAttackState(character);

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -15,6 +15,7 @@ import {
   resolveSavingThrowRollMode,
   declareRecklessAttack,
   endRecklessAttack,
+  getRecklessAttackAdvantageSources,
   getRecklessAttackState,
   markBarbarianAttackRoll,
   resolveAttackRollMode,
@@ -226,14 +227,15 @@ describe("barbarian level 2 features", () => {
     expect(resolveSavingThrowRollMode(barbarian2(), "dex", { advantageSources: ["Help"] })).toMatchObject({ mode: "advantage", advantageSources: ["Help", "Danger Sense"] });
   });
 
-  it("declares Reckless Attack before the first attack, does not spend rage, and resets", () => {
+  it("toggles Reckless Attack manually, does not spend rage, and does not track first attacks", () => {
     const declared = declareRecklessAttack(barbarian2());
     expect(getRecklessAttackState(declared)).toMatchObject({ active: true, declared: true, firstAttackMade: false });
     expect(getRageState(declared).current).toBe(2);
     const attacked = markBarbarianAttackRoll(declared);
-    expect(getRecklessAttackState(attacked).firstAttackMade).toBe(true);
+    expect(attacked).toBe(declared);
+    expect(getRecklessAttackState(attacked).firstAttackMade).toBe(false);
+    expect(getRecklessAttackAdvantageSources(attacked, { ability: "str", type: "weapon attack" })).toEqual(["Reckless Attack"]);
     const reset = endRecklessAttack(attacked);
-    expect(declareRecklessAttack(markBarbarianAttackRoll(barbarian2()))).toMatchObject(markBarbarianAttackRoll(barbarian2()));
     expect(getRecklessAttackState(reset)).toMatchObject({ active: false, firstAttackMade: false });
   });
 


### PR DESCRIPTION
### Motivation
- Remove the `Off/∞` text from the Reckless Attack badge and display the label across two centered lines to match the Rage badge style while keeping the badge size and visuals unchanged. 
- Keep Reckless Attack as a simple manual on/off toggle so offensive Advantage can be tested before turn/expiration systems are implemented. 
- Preserve the existing active-effect, condition, and status-badge architecture and keep the badge renderer generic for future multi-line labels.

### Description
- Added optional `displayLines` support to resource/condition rendering so badges render one centered line per `displayLines` entry while preserving single-line behavior when `displayLines` is absent. (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`, `client/src/App.scss`)
- Updated Reckless Attack to provide `displayLines: ['Reckless','Attack']` for both the active-condition entry and the HUD resource so the icon remains centered above two lines and the `Off/∞` value is not shown while active. (`buildFooterConditions` and resource `pushResource` in `ZombiesCharacterSheet.js`)
- Kept Reckless Attack state in `classState.barbarian.recklessAttack` and made `markBarbarianAttackRoll` a no-op so there is no automatic first-attack tracking or expiration yet; `declareRecklessAttack` and `endRecklessAttack` remain the manual toggles. (`client/src/components/Zombies/utils/barbarian.js`)
- Preserved backward compatibility by only using the new multi-line rendering when `displayLines` exists and rendering existing effects/resources exactly as before otherwise. (`ZombiesCharacterSheet.js` and CSS additions in `App.scss`)
- Tests added/updated to cover multi-line rendering and manual Reckless Attack behavior: `barbarian.test.js` and `ZombiesCharacterSheet.test.js` were updated to assert the multi-line data and that Advantage is granted while Reckless Attack is manually active. (`client/src/components/Zombies/utils/barbarian.test.js`, `client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`)

### Testing
- Ran the unit tests for the modified areas with `npm --prefix client test -- --runTestsByPath src/components/Zombies/utils/barbarian.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js --watchAll=false`. 
- Both test files passed (`PASS src/components/Zombies/utils/barbarian.test.js` and `PASS src/components/Zombies/pages/ZombiesCharacterSheet.test.js`).
- Test output included unrelated React `act(...)` console warnings from the larger character sheet tests but no failing assertions related to the changes. 
- Verified that while Reckless Attack is toggled on the badge renders as icon + two centered lines and qualifying Strength attack rolls receive Advantage, and that no automatic expiration or first-attack tracking occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518dced8d48323995d47cd3ca5d1ea)