### PR TITLE
Restore combat HUD proficiency bonus badge

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -86,6 +86,16 @@ const DOCKABLE_MODAL_DEFINITIONS = {
   help: { label: 'Help', component: Help },
 };
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
+export const formatSignedBonus = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '—';
+  return `${numeric >= 0 ? '+' : ''}${numeric}`;
+};
+
+export const resolveFooterProficiencyBonus = (character, totalLevel) => {
+  const provided = Number(character?.proficiencyBonus);
+  return Number.isFinite(provided) ? provided : proficiencyBonus(totalLevel);
+};
 
 const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
 
@@ -5021,6 +5031,10 @@ export default function ZombiesCharacterSheet() {
       }),
     [form, statMods.con, statMods.dex, statMods.wis]
   );
+  const footerProficiencyBonus = useMemo(
+    () => resolveFooterProficiencyBonus(form, totalLevel),
+    [form, totalLevel]
+  );
 
   const SPELLCASTING_ABILITIES = {
     cleric: 'wis',
@@ -5883,6 +5897,7 @@ export default function ZombiesCharacterSheet() {
                   <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
                     <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>
                     <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
+                    <span className="combat-hud-pill" aria-label="Proficiency bonus">Pro {formatSignedBonus(footerProficiencyBonus)}</span>
                     <span className="combat-hud-pill" aria-label="Active conditions">
                       {hasActiveFooterConditions ? (
                         <IconButton

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -115,7 +115,7 @@ jest.mock('../attributes/Features', () => (props) => {
   return null;
 });
 
-import ZombiesCharacterSheet, { buildFooterConditions, getFooterConditionLabel, getFooterConditionSummary } from './ZombiesCharacterSheet';
+import ZombiesCharacterSheet, { buildFooterConditions, getFooterConditionLabel, getFooterConditionSummary, resolveFooterProficiencyBonus } from './ZombiesCharacterSheet';
 
 describe('footer condition helpers', () => {
   const normalize = (value) => (Array.isArray(value) ? value : []);
@@ -348,6 +348,61 @@ const defaultApiFetchImplementation = (url) => {
 
   return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
 };
+
+
+test('footer proficiency value updates from centralized level calculation as character level changes', () => {
+  expect(resolveFooterProficiencyBonus({}, 4)).toBe(2);
+  expect(resolveFooterProficiencyBonus({}, 5)).toBe(3);
+  expect(resolveFooterProficiencyBonus({}, 9)).toBe(4);
+  expect(resolveFooterProficiencyBonus({}, 13)).toBe(5);
+  expect(resolveFooterProficiencyBonus({}, 17)).toBe(6);
+});
+
+test('combat HUD restores proficiency badge between AC and conditions using derived character stats', async () => {
+  const character = {
+    _id: '1', characterId: '1', characterName: 'Hero', campaign: 'test-campaign',
+    health: 20, currentHp: 20, str: 10, dex: 12, con: 10, int: 10, wis: 10, cha: 10,
+    occupation: [{ Name: 'Fighter', Level: 1 }], conditions: [], classState: {}, feat: [], equipment: {},
+    proficiencyBonus: 4,
+  };
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({ ok: true, json: async () => character });
+    }
+    return defaultApiFetchImplementation(url);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  const statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByText(/AC 11/)).toBeInTheDocument();
+  expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Pro +4');
+  expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
+  expect(statPills).toHaveTextContent(/AC 11\s*Pro \+4\s*No conditions/);
+});
+
+test('combat HUD proficiency badge uses centralized proficiency calculation and preserves active conditions layout', async () => {
+  const character = {
+    _id: '1', characterId: '1', characterName: 'Hero', campaign: 'test-campaign',
+    health: 20, currentHp: 20, str: 10, dex: 12, con: 10, int: 10, wis: 10, cha: 10,
+    occupation: [{ Name: 'Barbarian', Level: 9 }], conditions: [],
+    classState: { barbarian: { rage: { active: true, current: 1 } } }, feat: [], equipment: {},
+  };
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({ ok: true, json: async () => character });
+    }
+    return defaultApiFetchImplementation(url);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  const statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Pro +4');
+  expect(statPills).toHaveTextContent(/AC 11\s*Pro \+4.*Rage/);
+});
 
 beforeEach(() => {
   apiFetch.mockReset();


### PR DESCRIPTION
### Motivation

- Restore the missing Proficiency Bonus display in the combat HUD between the AC and Conditions badges so players can see the current `Pro` value at a glance. 
- Use the existing derived proficiency calculation and HUD primitives with the minimal UI change so the architecture isn't refactored and the value updates automatically with character level.

### Description

- Add `formatSignedBonus` helper and `resolveFooterProficiencyBonus(character, totalLevel)` to reuse `form.proficiencyBonus` when present and fall back to the shared `proficiencyBonus(totalLevel)` utility. 
- Compute `footerProficiencyBonus` in `ZombiesCharacterSheet` with `useMemo` and render a new compact pill: `<span className="combat-hud-pill" aria-label="Proficiency bonus">Pro {formatSignedBonus(footerProficiencyBonus)}</span>` placed between the AC and Conditions pills so it inherits the same height, border radius, typography, spacing and background treatment. 
- Keep all logic centralized (no proficiency progression hardcoded in the HUD) and rely on existing derived stats utilities for the value. 
- Files changed: `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` and `client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` (tests and small exported helpers added).

### Testing

- Added tests that assert the Pro pill appears between AC and Conditions, that it shows a signed value (e.g. `Pro +4`), that it reads from the centralized proficiency source, that it updates for different level ranges, and that AC/Conditions layout is preserved. 
- Ran the component test suite for the modified file with `npm test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --watchAll=false --silent` and all tests passed (`55 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51961ae08c83238d87a4edea20e188)