### PR TITLE
Swap weapon action icons and add proficiency badge to combat HUD

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -7,6 +7,7 @@ import React, {
   useRef,
 } from 'react';
 import { Button, Modal, Card, OverlayTrigger, Popover, Form } from "react-bootstrap";
+import { Swords } from 'lucide-react';
 import spellsData from '../../../data/spells';
 import UpcastModal from './UpcastModal';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -2806,7 +2807,7 @@ const damageAmountStyle = {
                           aria-label="Roll to hit"
                           className="attack-card__roll"
                         >
-                          <i className="fa-solid fa-bullseye"></i>
+                          <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
                         </Button>
                         <Button
                           onClick={() => {
@@ -2817,7 +2818,7 @@ const damageAmountStyle = {
                           aria-label="Roll damage"
                           className="attack-card__roll"
                         >
-                          <i className="fa-solid fa-dice-d20"></i>
+                          <Swords size={18} aria-hidden="true" />
                         </Button>
                       </div>
                     </div>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -671,6 +671,110 @@ describe('PlayerTurnActions weapon damage display', () => {
     }
   });
 
+
+  test('weapon card action icons map attack to d20 and damage to sword across weapon variants', () => {
+    const weapons = {
+      mainHand: {
+        name: 'Longsword',
+        damage: '1d8 slashing',
+        category: 'martial melee weapon',
+        source: 'weapon',
+      },
+      offHand: {
+        name: 'Dagger',
+        damage: '1d4 piercing',
+        category: 'simple melee weapon',
+        properties: ['Thrown (20/60)'],
+        source: 'weapon',
+      },
+      ranged: {
+        name: 'Shortbow',
+        damage: '1d6 piercing',
+        category: 'simple ranged weapon',
+        source: 'weapon',
+      },
+    };
+
+    const { actionsRef } = render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', equipment: weapons, spells: [] }}
+        strMod={2}
+        dexMod={3}
+      />
+    );
+
+    openAttackModal(actionsRef);
+
+    ['Longsword', 'Dagger', 'Shortbow', 'Unarmed Strike'].forEach((weaponName) => {
+      const card = screen.getByText(weaponName).closest('.attack-card');
+      expect(card).not.toBeNull();
+      if (!card) throw new Error(`missing ${weaponName} card`);
+
+      const attackButton = within(card).getByLabelText(/Roll to hit/i);
+      const damageButton = within(card).getByLabelText(/Roll damage/i);
+      expect(attackButton.querySelector('.fa-dice-d20')).not.toBeNull();
+      expect(attackButton.querySelector('.fa-bullseye')).toBeNull();
+      expect(damageButton.querySelector('.lucide-swords')).not.toBeNull();
+      expect(damageButton.querySelector('.fa-dice-d20')).toBeNull();
+    });
+  });
+
+  test('weapon card action icon change keeps attack and damage handlers wired to their original buttons', async () => {
+    const weapon = {
+      name: 'Longsword',
+      damage: '1d8 slashing',
+      category: 'martial melee weapon',
+      source: 'weapon',
+      attackBonus: 1,
+    };
+
+    const { actionsRef } = render(
+      <PlayerTurnActions
+        form={{ diceColor: '#000000', equipment: { mainHand: weapon }, spells: [] }}
+        strMod={2}
+        dexMod={0}
+      />
+    );
+
+    openAttackModal(actionsRef);
+    let card = screen.getByText('Longsword').closest('.attack-card');
+    expect(card).not.toBeNull();
+    if (!card) throw new Error('missing Longsword card');
+
+    const attackButton = within(card).getByLabelText(/Roll to hit/i);
+    expect(attackButton.querySelector('.fa-dice-d20')).not.toBeNull();
+    rollDiceWithBox.mockImplementationOnce(() => Promise.resolve({ rolls: [[9]] }));
+
+    await act(async () => {
+      fireEvent.click(attackButton);
+    });
+
+    await waitFor(() => {
+      const valueNode = document.getElementById('damageValue');
+      if (!valueNode) throw new Error('missing damage value node');
+      expect(valueNode.textContent).toBe('14');
+    });
+
+    openAttackModal(actionsRef);
+    card = screen.getByText('Longsword').closest('.attack-card');
+    expect(card).not.toBeNull();
+    if (!card) throw new Error('missing Longsword card after reopen');
+
+    const damageButton = within(card).getByLabelText(/Roll damage/i);
+    expect(damageButton.querySelector('.lucide-swords')).not.toBeNull();
+    rollDiceWithBox.mockImplementationOnce(() => Promise.resolve({ rolls: [[4]] }));
+
+    await act(async () => {
+      fireEvent.click(damageButton);
+    });
+
+    await waitFor(() => {
+      const valueNode = document.getElementById('damageValue');
+      if (!valueNode) throw new Error('missing damage value node');
+      expect(valueNode.textContent).toBe('6');
+    });
+  });
+
   test('weapon attack roll adds attack bonus to d20 result', async () => {
     const weapon = {
       name: 'Longsword',

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -86,6 +86,16 @@ const DOCKABLE_MODAL_DEFINITIONS = {
   help: { label: 'Help', component: Help },
 };
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
+export const formatSignedBonus = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '—';
+  return `${numeric >= 0 ? '+' : ''}${numeric}`;
+};
+
+export const resolveFooterProficiencyBonus = (character, totalLevel) => {
+  const provided = Number(character?.proficiencyBonus);
+  return Number.isFinite(provided) ? provided : proficiencyBonus(totalLevel);
+};
 
 const CREATURE_SIZE_KEYS = ['gargantuan', 'huge', 'large', 'medium', 'small', 'tiny'];
 
@@ -5021,6 +5031,10 @@ export default function ZombiesCharacterSheet() {
       }),
     [form, statMods.con, statMods.dex, statMods.wis]
   );
+  const footerProficiencyBonus = useMemo(
+    () => resolveFooterProficiencyBonus(form, totalLevel),
+    [form, totalLevel]
+  );
 
   const SPELLCASTING_ABILITIES = {
     cleric: 'wis',
@@ -5883,6 +5897,7 @@ export default function ZombiesCharacterSheet() {
                   <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
                     <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>
                     <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
+                    <span className="combat-hud-pill" aria-label="Proficiency bonus">Pro {formatSignedBonus(footerProficiencyBonus)}</span>
                     <span className="combat-hud-pill" aria-label="Active conditions">
                       {hasActiveFooterConditions ? (
                         <IconButton

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -115,7 +115,7 @@ jest.mock('../attributes/Features', () => (props) => {
   return null;
 });
 
-import ZombiesCharacterSheet, { buildFooterConditions, getFooterConditionLabel, getFooterConditionSummary } from './ZombiesCharacterSheet';
+import ZombiesCharacterSheet, { buildFooterConditions, getFooterConditionLabel, getFooterConditionSummary, resolveFooterProficiencyBonus } from './ZombiesCharacterSheet';
 
 describe('footer condition helpers', () => {
   const normalize = (value) => (Array.isArray(value) ? value : []);
@@ -348,6 +348,61 @@ const defaultApiFetchImplementation = (url) => {
 
   return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`));
 };
+
+
+test('footer proficiency value updates from centralized level calculation as character level changes', () => {
+  expect(resolveFooterProficiencyBonus({}, 4)).toBe(2);
+  expect(resolveFooterProficiencyBonus({}, 5)).toBe(3);
+  expect(resolveFooterProficiencyBonus({}, 9)).toBe(4);
+  expect(resolveFooterProficiencyBonus({}, 13)).toBe(5);
+  expect(resolveFooterProficiencyBonus({}, 17)).toBe(6);
+});
+
+test('combat HUD restores proficiency badge between AC and conditions using derived character stats', async () => {
+  const character = {
+    _id: '1', characterId: '1', characterName: 'Hero', campaign: 'test-campaign',
+    health: 20, currentHp: 20, str: 10, dex: 12, con: 10, int: 10, wis: 10, cha: 10,
+    occupation: [{ Name: 'Fighter', Level: 1 }], conditions: [], classState: {}, feat: [], equipment: {},
+    proficiencyBonus: 4,
+  };
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({ ok: true, json: async () => character });
+    }
+    return defaultApiFetchImplementation(url);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  const statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByText(/AC 11/)).toBeInTheDocument();
+  expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Pro +4');
+  expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
+  expect(statPills).toHaveTextContent(/AC 11\s*Pro \+4\s*No conditions/);
+});
+
+test('combat HUD proficiency badge uses centralized proficiency calculation and preserves active conditions layout', async () => {
+  const character = {
+    _id: '1', characterId: '1', characterName: 'Hero', campaign: 'test-campaign',
+    health: 20, currentHp: 20, str: 10, dex: 12, con: 10, int: 10, wis: 10, cha: 10,
+    occupation: [{ Name: 'Barbarian', Level: 9 }], conditions: [],
+    classState: { barbarian: { rage: { active: true, current: 1 } } }, feat: [], equipment: {},
+  };
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({ ok: true, json: async () => character });
+    }
+    return defaultApiFetchImplementation(url);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  const statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Pro +4');
+  expect(statPills).toHaveTextContent(/AC 11\s*Pro \+4.*Rage/);
+});
 
 beforeEach(() => {
   apiFetch.mockReset();


### PR DESCRIPTION
### Motivation
- Improve clarity of weapon action buttons by using a d20 icon for attack rolls and a sword icon for damage rolls.
- Surface the character proficiency bonus in the combat HUD so it is visible alongside AC and conditions.
- Add unit tests to verify the new icon mapping and the proficiency badge behavior.

### Description
- Updated `PlayerTurnActions.js` to import `Swords` from `lucide-react` and swapped the action icons so the attack button displays a d20 icon and the damage button displays a sword icon. 
- Added new tests in `PlayerTurnActions.test.js` to assert that attack buttons show a d20 and damage buttons show a sword across weapon variants, and to ensure the original attack/damage handlers remain wired after the icon change. 
- Introduced `formatSignedBonus` and `resolveFooterProficiencyBonus` in `ZombiesCharacterSheet.js`, computed `footerProficiencyBonus` via `useMemo`, and added a proficiency pill to the combat HUD displaying `Pro +N`. 
- Added tests in `ZombiesCharacterSheet.test.js` to validate the `resolveFooterProficiencyBonus` mapping and to assert the proficiency badge renders correctly and preserves existing condition layout.

### Testing
- Ran component unit tests for `PlayerTurnActions` including the new icon mapping and handler-wiring tests, and they passed. 
- Ran unit tests for `ZombiesCharacterSheet` including the `resolveFooterProficiencyBonus` tests and combat HUD rendering tests, and they passed. 
- Ran the full test suite to ensure no regressions and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51961ae08c83238d87a4edea20e188)