### PR TITLE
Simplify combat HUD conditions display

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -554,25 +554,18 @@ const SPELLCASTING_CLASSES = {
 export const getFooterConditionLabel = (count) => {
   const numericCount = Number(count) || 0;
   if (numericCount <= 0) return 'No conditions';
-  return `${numericCount} ${numericCount === 1 ? 'condition' : 'conditions'}`;
+  return `${numericCount} ${numericCount === 1 ? 'Condition' : 'Conditions'}`;
 };
 
 export const getFooterConditionSummary = (conditions) => {
   const activeConditions = Array.isArray(conditions) ? conditions.filter(Boolean) : [];
-  if (activeConditions.length === 0) {
-    return { empty: true, label: 'No conditions', conditions: [] };
-  }
-
-  const [firstCondition, ...remainingConditions] = activeConditions;
-  const name = firstCondition?.name || firstCondition?.label || firstCondition?.id || 'Condition';
-  const overflowCount = remainingConditions.length;
+  const activeStatusCount = activeConditions.length;
 
   return {
-    empty: false,
-    label: overflowCount > 0 ? `${name} +${overflowCount}` : name,
+    empty: activeStatusCount === 0,
+    label: getFooterConditionLabel(activeStatusCount),
     conditions: activeConditions,
-    primaryCondition: firstCondition,
-    overflowCount,
+    activeStatusCount,
   };
 };
 
@@ -5910,14 +5903,7 @@ export default function ZombiesCharacterSheet() {
                       ) : (
                         <Sparkles size={16} aria-hidden="true" />
                       )}
-                      {footerConditionSummary.empty ? (
-                        footerConditionSummary.label
-                      ) : (
-                        <span className="combat-hud-condition" style={{ '--hud-condition-accent': footerConditionSummary.primaryCondition?.color }} title={footerConditionSummary.conditions.map((condition) => condition?.name || condition?.label || condition?.id || 'Condition').join(', ')}>
-                          <span className="combat-hud-condition__icon" aria-hidden="true">{footerConditionSummary.primaryCondition?.icon || '✦'}</span>
-                          <span className="combat-hud-condition__label">{footerConditionSummary.label}</span>
-                        </span>
-                      )}
+                      <span className="combat-hud-condition__label">{footerConditionSummary.label}</span>
                     </span>
                   </div>
                 </Panel>

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -162,20 +162,20 @@ describe('footer condition helpers', () => {
 
   test('formats empty, singular, and plural condition labels', () => {
     expect(getFooterConditionLabel(0)).toBe('No conditions');
-    expect(getFooterConditionLabel(1)).toBe('1 condition');
-    expect(getFooterConditionLabel(2)).toBe('2 conditions');
+    expect(getFooterConditionLabel(1)).toBe('1 Condition');
+    expect(getFooterConditionLabel(2)).toBe('2 Conditions');
+    expect(getFooterConditionLabel(3)).toBe('3 Conditions');
   });
 
-  test('summarizes active conditions for rendering inside the existing pill', () => {
-    expect(getFooterConditionSummary([])).toMatchObject({ empty: true, label: 'No conditions' });
-    expect(getFooterConditionSummary([{ id: 'rage', icon: '🔥', name: 'Rage' }])).toMatchObject({
-      empty: false,
-      label: 'Rage',
-      primaryCondition: { id: 'rage', icon: '🔥', name: 'Rage' },
-      overflowCount: 0,
-    });
-    expect(getFooterConditionSummary([{ id: 'rage', icon: '🔥', name: 'Rage' }, { id: 'poisoned', name: 'Poisoned' }])).toMatchObject({ label: 'Rage +1', overflowCount: 1 });
-    expect(getFooterConditionSummary([{ id: 'rage', icon: '🔥', name: 'Rage' }, { id: 'poisoned', name: 'Poisoned' }, { id: 'frightened', name: 'Frightened' }])).toMatchObject({ label: 'Rage +2', overflowCount: 2 });
+  test('summarizes active conditions as a count from the shared collection', () => {
+    expect(getFooterConditionSummary([])).toMatchObject({ empty: true, label: 'No conditions', activeStatusCount: 0, conditions: [] });
+    const one = [{ id: 'rage', icon: '🔥', name: 'Rage' }];
+    const two = [...one, { id: 'poisoned', name: 'Poisoned' }];
+    const three = [...two, { id: 'frightened', name: 'Frightened' }];
+
+    expect(getFooterConditionSummary(one)).toMatchObject({ empty: false, label: '1 Condition', activeStatusCount: 1, conditions: one });
+    expect(getFooterConditionSummary(two)).toMatchObject({ label: '2 Conditions', activeStatusCount: 2, conditions: two });
+    expect(getFooterConditionSummary(three)).toMatchObject({ label: '3 Conditions', activeStatusCount: 3, conditions: three });
   });
 });
 
@@ -212,7 +212,14 @@ test('active conditions sparkle opens modal with shared active entries and close
 
   render(<ZombiesCharacterSheet />);
 
-  expect(await screen.findByText('Rage +2')).toBeInTheDocument();
+  const statPills = await screen.findByLabelText('Defenses and conditions');
+  const activeConditionsBadge = within(statPills).getByLabelText('Active conditions');
+  expect(activeConditionsBadge).toHaveTextContent('3 Conditions');
+  expect(activeConditionsBadge).not.toHaveTextContent('Rage');
+  expect(activeConditionsBadge).not.toHaveTextContent('Reckless Attack');
+  expect(activeConditionsBadge).not.toHaveTextContent('Poisoned');
+  expect(activeConditionsBadge).not.toHaveTextContent(/\+1|\+2/);
+  expect(activeConditionsBadge.querySelector('.combat-hud-condition__icon')).toBeNull();
 
   const trigger = await screen.findByRole('button', { name: /view active conditions/i });
   expect(trigger.querySelector('svg')).not.toBeNull();
@@ -401,7 +408,8 @@ test('combat HUD proficiency badge uses centralized proficiency calculation and 
 
   const statPills = await screen.findByLabelText('Defenses and conditions');
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Pro +4');
-  expect(statPills).toHaveTextContent(/AC 11\s*Pro \+4.*Rage/);
+  expect(statPills).toHaveTextContent(/AC 11\s*Pro \+4.*1 Condition/);
+  expect(within(statPills).getByLabelText('Active conditions')).not.toHaveTextContent('Rage');
 });
 
 beforeEach(() => {


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the combat HUD by replacing inline condition names/icons/overflow with a single, centralized count badge. 
- Reuse the existing centralized active-status collection used by the Active Conditions modal so HUD remains a presentation-only change. 
- Preserve existing modal behavior and accessibility (click/keyboard/tooltip) so the detailed view is unchanged.

### Description
- Updated label/count helpers by changing `getFooterConditionLabel` to return `No conditions`, `1 Condition`, or `N Conditions` and by making `getFooterConditionSummary` return a count (`activeStatusCount = activeConditions.length`) and the corresponding label via `getFooterConditionLabel` (file: `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Simplified the HUD rendering to display only the single count label (`<span className="combat-hud-condition__label">{footerConditionSummary.label}</span>`) and removed inline icons, first-condition name, and overflow indicators from the HUD (file: `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Preserved the existing sparkle trigger and its handler (`IconButton` with `onClick={handleOpenActiveConditionsModal}`) and left the `ActiveConditionsModal` unchanged, which still receives the full `footerConditions` collection (`conditions={footerConditions}`) and lists every active condition/effect (file: `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Files changed: `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` and `client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`.

### Testing
- Updated tests in `client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` to assert the new count-only HUD behavior and labels, including zero/one/two/three displays and absence of inline names/icons/overflow, and to verify the sparkle trigger still opens the `Active Conditions` modal which continues to list all active entries.
- Ran the modified component tests with `npm test -- --runInBand src/components/Zombies/pages/ZombiesCharacterSheet.test.js` and the suite passed (all tests in that file passed).
- Ran the full test suite with `CI=true npm test -- --runInBand`; the run failed due to unrelated pre-existing test failures in other suites (not caused by this change), while the targeted `ZombiesCharacterSheet` tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a519bcb27d48323bccbd16cfccb9d04)