### PR TITLE
Show Initiative and Passive Perception in Combat HUD

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8280,8 +8280,8 @@ h1 {
 }
 
 .combat-hud-dock__status {
-  width: 320px;
-  min-width: 320px;
+  width: 520px;
+  min-width: 520px;
   padding: 8px;
   gap: 8px;
 }
@@ -8359,7 +8359,7 @@ h1 {
 
 @media (min-width: 901px) {
   .combat-hud-dock {
-    grid-template-columns: 320px auto 360px;
+    grid-template-columns: 520px auto 360px;
   }
 }
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -31,6 +31,8 @@ import {
   aggregateStatEffects,
   collectFeatAbilityBonuses,
   collectFeatNumericBonuses,
+  calculateCharacterInitiative,
+  calculatePassivePerception,
 } from "../utils/derivedStats";
 import {
   calculateCharacterArmorClass,
@@ -5033,6 +5035,14 @@ export default function ZombiesCharacterSheet() {
     () => calculateCharacterMovementSpeed(form),
     [form]
   );
+  const footerInitiativeModifier = useMemo(
+    () => calculateCharacterInitiative(form),
+    [form]
+  );
+  const footerPassivePerception = useMemo(
+    () => calculatePassivePerception(form, totalLevel),
+    [form, totalLevel]
+  );
 
   const SPELLCASTING_ABILITIES = {
     cleric: 'wis',
@@ -5897,6 +5907,7 @@ export default function ZombiesCharacterSheet() {
                     <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
                     <span className="combat-hud-pill" aria-label="Proficiency bonus">Proficiency {formatSignedBonus(footerProficiencyBonus)}</span>
                     <span className="combat-hud-pill" aria-label="Movement speed">Move: {footerMovementSpeed} ft</span>
+                    <span className="combat-hud-pill" aria-label="Initiative modifier">Int: {formatSignedBonus(footerInitiativeModifier)}</span>
                     <span className="combat-hud-pill" aria-label="Active conditions">
                       {hasActiveFooterConditions ? (
                         <IconButton
@@ -5911,6 +5922,7 @@ export default function ZombiesCharacterSheet() {
                       )}
                       <span className="combat-hud-condition__label">{footerConditionSummary.label}</span>
                     </span>
+                    <span className="combat-hud-pill" aria-label="Passive Perception">Passive Perception: {footerPassivePerception}</span>
                   </div>
                 </Panel>
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -387,7 +387,9 @@ test('combat HUD restores proficiency badge between AC and conditions using deri
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +4');
   expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
   expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
-  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*No conditions/);
+  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Int: +1');
+  expect(within(statPills).getByLabelText('Passive Perception')).toHaveTextContent('Passive Perception: 10');
+  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Int: \+1\s*No conditions\s*Passive Perception: 10/);
 });
 
 
@@ -416,6 +418,32 @@ test('combat HUD movement badge uses centralized derived speed and preserves com
   expect(within(statPills).getByText(/AC 11/)).toBeInTheDocument();
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +2');
   expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
+  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Int: +1');
+  expect(within(statPills).getByLabelText('Passive Perception')).toHaveTextContent('Passive Perception: 10');
+});
+
+test('combat HUD displays initiative and passive perception from derived stats', async () => {
+  const character = {
+    _id: '1', characterId: '1', characterName: 'Scout', campaign: 'test-campaign',
+    health: 20, currentHp: 20, speed: 30, str: 10, dex: 16, con: 10, int: 10, wis: 14, cha: 10,
+    occupation: [{ Name: 'Rogue', Level: 5 }], conditions: [], classState: {},
+    feat: [{ initiative: 1 }], equipment: {}, skills: { perception: { proficient: true, expertise: true } },
+  };
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({ ok: true, json: async () => character });
+    }
+    return defaultApiFetchImplementation(url);
+  });
+
+  render(<ZombiesCharacterSheet />);
+
+  const statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
+  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Int: +4');
+  expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
+  expect(within(statPills).getByLabelText('Passive Perception')).toHaveTextContent('Passive Perception: 18');
 });
 
 test('combat HUD movement badge displays zero feet from centralized derived speed', async () => {
@@ -459,7 +487,7 @@ test('combat HUD proficiency badge uses centralized proficiency calculation and 
   const statPills = await screen.findByLabelText('Defenses and conditions');
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +4');
   expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
-  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft.*1 Condition/);
+  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Int: \+1.*1 Condition.*Passive Perception: 10/);
   expect(within(statPills).getByLabelText('Active conditions')).not.toHaveTextContent('Rage');
 });
 

--- a/client/src/components/Zombies/utils/derivedStats.js
+++ b/client/src/components/Zombies/utils/derivedStats.js
@@ -1,3 +1,4 @@
+import proficiencyBonus from '../../../utils/proficiencyBonus';
 import { SKILLS } from '../skillSchema';
 
 export const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
@@ -162,19 +163,13 @@ const getHighestOverride = (candidates) => {
   }, null);
 };
 
-export const calculateCharacterInitiative = (character) => {
-  if (!character || typeof character !== 'object') {
+export const calculateAbilityModifier = (character, abilityKey) => {
+  if (!character || typeof character !== 'object' || !STAT_KEYS.includes(abilityKey)) {
     return 0;
   }
 
-  const baseStats = STAT_KEYS.reduce((acc, key) => {
-    acc[key] = toNumber(character[key]);
-    return acc;
-  }, {});
-
-  const { bonuses: itemBonuses, overrides: itemOverrides } = aggregateStatEffects(
-    character?.item
-  );
+  const base = toNumber(character[abilityKey]);
+  const { bonuses: itemBonuses, overrides: itemOverrides } = aggregateStatEffects(character?.item);
   const accessorySource = Array.isArray(character?.accessories)
     ? character.accessories
     : Array.isArray(character?.accessory)
@@ -184,21 +179,87 @@ export const calculateCharacterInitiative = (character) => {
     accessorySource
   );
   const featAbilityBonuses = collectFeatAbilityBonuses(character?.feat);
-  const raceAbilityBonuses = STAT_KEYS.reduce((acc, key) => {
-    acc[key] = toNumber(character?.race?.abilities?.[key]);
-    return acc;
-  }, createEmptyStatMap());
+  const raceAbilityBonus = toNumber(character?.race?.abilities?.[abilityKey]);
 
-  const totalDex =
-    baseStats.dex +
-    itemBonuses.dex +
-    accessoryBonuses.dex +
-    featAbilityBonuses.dex +
-    raceAbilityBonuses.dex;
+  const total =
+    base +
+    itemBonuses[abilityKey] +
+    accessoryBonuses[abilityKey] +
+    featAbilityBonuses[abilityKey] +
+    raceAbilityBonus;
+  const override = getHighestOverride([itemOverrides?.[abilityKey], accessoryOverrides?.[abilityKey]]);
+  const effective = override !== null && override > total ? override : total;
 
-  const dexOverride = getHighestOverride([itemOverrides?.dex, accessoryOverrides?.dex]);
-  const effectiveDex = dexOverride !== null && dexOverride > totalDex ? dexOverride : totalDex;
-  const dexMod = Math.floor((effectiveDex - 10) / 2);
+  return Math.floor((effective - 10) / 2);
+};
+
+const getCharacterTotalLevel = (character) =>
+  (character?.occupation || []).reduce((sum, occupation) => sum + (Number(occupation?.Level) || 0), 0);
+
+const getSkillState = (character, skillKey) => {
+  const characterSkill = character?.skills?.[skillKey] || {};
+  const raceSkill = character?.race?.skills?.[skillKey] || {};
+  const backgroundSkill = character?.background?.skills?.[skillKey] || {};
+
+  const proficient = Boolean(
+    characterSkill.proficient || raceSkill.proficient || backgroundSkill.proficient
+  );
+  const expertise = Boolean(
+    characterSkill.expertise || raceSkill.expertise || backgroundSkill.expertise
+  );
+
+  return { proficient, expertise };
+};
+
+export const calculateCharacterSkillModifier = (character, skillKey, totalLevel) => {
+  const skill = SKILLS.find((entry) => entry.key === skillKey);
+  if (!skill) {
+    return 0;
+  }
+
+  const resolvedTotalLevel = Number.isFinite(Number(totalLevel))
+    ? Number(totalLevel)
+    : getCharacterTotalLevel(character);
+  const providedProficiency = Number(character?.proficiencyBonus);
+  const profBonus = Number.isFinite(providedProficiency)
+    ? providedProficiency
+    : proficiencyBonus(resolvedTotalLevel);
+  const { proficient, expertise } = getSkillState(character, skillKey);
+  const proficiencyMultiplier = expertise ? 2 : proficient ? 1 : 0;
+
+  const equippedItems = character?.equipment && typeof character.equipment === 'object'
+    ? Object.values(character.equipment).filter(Boolean)
+    : Array.isArray(character?.item)
+      ? character.item.filter(Boolean)
+      : [];
+  const itemBonus = equippedItems.reduce(
+    (sum, item) => sum + toNumber(item?.skillBonuses?.[skillKey]),
+    0
+  );
+  const featBonus = (Array.isArray(character?.feat) ? character.feat : []).reduce(
+    (sum, feat) => sum + toNumber(feat?.[skillKey]),
+    0
+  );
+  const raceBonus = toNumber(character?.race?.[skillKey]);
+
+  return (
+    calculateAbilityModifier(character, skill.ability) +
+    profBonus * proficiencyMultiplier +
+    itemBonus +
+    featBonus +
+    raceBonus
+  );
+};
+
+export const calculatePassivePerception = (character, totalLevel) =>
+  10 + calculateCharacterSkillModifier(character, 'perception', totalLevel);
+
+export const calculateCharacterInitiative = (character) => {
+  if (!character || typeof character !== 'object') {
+    return 0;
+  }
+
+  const dexMod = calculateAbilityModifier(character, 'dex');
 
   const featNumericBonuses = collectFeatNumericBonuses(character?.feat);
 

--- a/client/src/components/Zombies/utils/derivedStats.test.js
+++ b/client/src/components/Zombies/utils/derivedStats.test.js
@@ -1,4 +1,4 @@
-import { calculateCharacterInitiative } from './derivedStats';
+import { calculateCharacterInitiative, calculatePassivePerception } from './derivedStats';
 
 describe('calculateCharacterInitiative', () => {
   it('combines dexterity modifier with feat initiative bonuses', () => {
@@ -40,5 +40,31 @@ describe('calculateCharacterInitiative', () => {
 
     // Only the owned accessory should contribute, resulting in dex 12 -> modifier +1
     expect(calculateCharacterInitiative(character)).toBe(1);
+  });
+});
+
+
+describe('calculatePassivePerception', () => {
+  it('uses wisdom modifier and perception proficiency from the shared skill modifier system', () => {
+    const character = {
+      wis: 16,
+      occupation: [{ Level: 5 }],
+      skills: { perception: { proficient: true } },
+    };
+
+    expect(calculatePassivePerception(character)).toBe(16);
+  });
+
+  it('respects perception expertise and skill bonuses automatically', () => {
+    const character = {
+      wis: 14,
+      proficiencyBonus: 3,
+      skills: { perception: { proficient: true, expertise: true } },
+      equipment: { amulet: { skillBonuses: { perception: 1 } } },
+      feat: [{ perception: 2 }],
+      race: { perception: 1 },
+    };
+
+    expect(calculatePassivePerception(character)).toBe(22);
   });
 });


### PR DESCRIPTION
### Motivation
- Surface two additional combat stats (initiative modifier and passive perception) in the existing HUD so the player can see them at-a-glance without changing current visual design. 
- Reuse centralized derived-stat logic (initiative, skill/proficiency) rather than duplicating calculations in the UI. 
- Keep the pill layout and styling intact while adjusting HUD width so the pills wrap into exactly two rows on desktop.

### Description
- Added shared derived-stat helpers to `client/src/components/Zombies/utils/derivedStats.js`: `calculateAbilityModifier`, `calculateCharacterSkillModifier`, and `calculatePassivePerception`, and reused `calculateCharacterInitiative` so ability/skill/proficiency logic is centralized and not duplicated. 
- Rendered two new stat pills in the existing pill row in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`: an `Int: <signed>` pill immediately after the `Move` pill and a `Passive Perception: <value>` pill immediately after the `No conditions` pill. 
- Kept business logic out of UI by computing derived values via `useMemo` (`footerInitiativeModifier`, `footerPassivePerception`) and passing formatted values into the existing pill components; initiative display reuses `calculateCharacterInitiative`. 
- Slightly widened the desktop HUD column in `client/src/App.scss` (desktop status column and grid template columns) so the expanded set of pills wraps cleanly into two rows without changing pill styling or responsive behavior. 
- Added/updated tests: `client/src/components/Zombies/utils/derivedStats.test.js` to cover `calculatePassivePerception` and `client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` to assert the new pill rendering and values.

### Testing
- Ran the focused unit tests with `npm --prefix client test -- --runTestsByPath src/components/Zombies/utils/derivedStats.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js --watchAll=false`, and all tests passed (`2 test suites, 64 tests` passed). 
- Built the client with `npm --prefix client run build`; the build completed successfully (compiled with existing lint/autoprefixer warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a524fabc9a88323b54eba29eb41a27c)