### PR TITLE
Move Passive Perception to DM views; update Combat HUD and Combat Tracker

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -32,7 +32,6 @@ import {
   collectFeatAbilityBonuses,
   collectFeatNumericBonuses,
   calculateCharacterInitiative,
-  calculatePassivePerception,
 } from "../utils/derivedStats";
 import {
   calculateCharacterArmorClass,
@@ -5039,10 +5038,6 @@ export default function ZombiesCharacterSheet() {
     () => calculateCharacterInitiative(form),
     [form]
   );
-  const footerPassivePerception = useMemo(
-    () => calculatePassivePerception(form, totalLevel),
-    [form, totalLevel]
-  );
 
   const SPELLCASTING_ABILITIES = {
     cleric: 'wis',
@@ -5907,7 +5902,7 @@ export default function ZombiesCharacterSheet() {
                     <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
                     <span className="combat-hud-pill" aria-label="Proficiency bonus">Proficiency {formatSignedBonus(footerProficiencyBonus)}</span>
                     <span className="combat-hud-pill" aria-label="Movement speed">Move: {footerMovementSpeed} ft</span>
-                    <span className="combat-hud-pill" aria-label="Initiative modifier">Int: {formatSignedBonus(footerInitiativeModifier)}</span>
+                    <span className="combat-hud-pill" aria-label="Initiative modifier">Initiative: {formatSignedBonus(footerInitiativeModifier)}</span>
                     <span className="combat-hud-pill" aria-label="Active conditions">
                       {hasActiveFooterConditions ? (
                         <IconButton
@@ -5922,7 +5917,6 @@ export default function ZombiesCharacterSheet() {
                       )}
                       <span className="combat-hud-condition__label">{footerConditionSummary.label}</span>
                     </span>
-                    <span className="combat-hud-pill" aria-label="Passive Perception">Passive Perception: {footerPassivePerception}</span>
                   </div>
                 </Panel>
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -387,9 +387,9 @@ test('combat HUD restores proficiency badge between AC and conditions using deri
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +4');
   expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
   expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
-  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Int: +1');
-  expect(within(statPills).getByLabelText('Passive Perception')).toHaveTextContent('Passive Perception: 10');
-  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Int: \+1\s*No conditions\s*Passive Perception: 10/);
+  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Initiative: +1');
+  expect(within(statPills).queryByLabelText('Passive Perception')).not.toBeInTheDocument();
+  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Initiative: \+1\s*No conditions/);
 });
 
 
@@ -418,11 +418,11 @@ test('combat HUD movement badge uses centralized derived speed and preserves com
   expect(within(statPills).getByText(/AC 11/)).toBeInTheDocument();
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +2');
   expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
-  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Int: +1');
-  expect(within(statPills).getByLabelText('Passive Perception')).toHaveTextContent('Passive Perception: 10');
+  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Initiative: +1');
+  expect(within(statPills).queryByLabelText('Passive Perception')).not.toBeInTheDocument();
 });
 
-test('combat HUD displays initiative and passive perception from derived stats', async () => {
+test('combat HUD displays initiative from derived stats without passive perception', async () => {
   const character = {
     _id: '1', characterId: '1', characterName: 'Scout', campaign: 'test-campaign',
     health: 20, currentHp: 20, speed: 30, str: 10, dex: 16, con: 10, int: 10, wis: 14, cha: 10,
@@ -441,9 +441,9 @@ test('combat HUD displays initiative and passive perception from derived stats',
 
   const statPills = await screen.findByLabelText('Defenses and conditions');
   expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
-  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Int: +4');
+  expect(within(statPills).getByLabelText('Initiative modifier')).toHaveTextContent('Initiative: +4');
   expect(within(statPills).getByLabelText('Active conditions')).toHaveTextContent('No conditions');
-  expect(within(statPills).getByLabelText('Passive Perception')).toHaveTextContent('Passive Perception: 18');
+  expect(within(statPills).queryByLabelText('Passive Perception')).not.toBeInTheDocument();
 });
 
 test('combat HUD movement badge displays zero feet from centralized derived speed', async () => {
@@ -487,7 +487,7 @@ test('combat HUD proficiency badge uses centralized proficiency calculation and 
   const statPills = await screen.findByLabelText('Defenses and conditions');
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +4');
   expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
-  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Int: \+1.*1 Condition.*Passive Perception: 10/);
+  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Initiative: \+1.*1 Condition/);
   expect(within(statPills).getByLabelText('Active conditions')).not.toHaveTextContent('Rage');
 });
 

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -21,7 +21,7 @@ import loginbg from "../../../images/loginbg.png";
 import useUser from '../../../hooks/useUser';
 import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
-import { calculateCharacterInitiative } from '../utils/derivedStats';
+import { calculateCharacterInitiative, calculatePassivePerception } from '../utils/derivedStats';
 import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
@@ -284,6 +284,51 @@ const formatSensesDisplay = (senses) => {
   });
 
   return entries.length > 0 ? entries.join(', ') : '—';
+};
+
+const getEntityPassivePerception = (entity) => {
+  if (!entity || typeof entity !== 'object') {
+    return null;
+  }
+
+  if (entity.entityType !== 'enemy') {
+    const totalLevel = Array.isArray(entity.occupation)
+      ? entity.occupation.reduce((total, role) => total + (Number(role?.Level) || 0), 0)
+      : undefined;
+    const passivePerception = calculatePassivePerception(entity, totalLevel);
+    return Number.isFinite(passivePerception) ? passivePerception : null;
+  }
+
+  const directCandidates = [
+    entity.passivePerception,
+    entity.passive_perception,
+    entity.passive_perception_value,
+    entity.passivePerceptionValue,
+    entity.senses?.passive_perception,
+    entity.senses?.passivePerception,
+  ];
+
+  for (const candidate of directCandidates) {
+    const value = toFiniteNumberOrNull(candidate);
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  const sensesText = typeof entity.senses === 'string'
+    ? entity.senses
+    : typeof entity.senses?.summary === 'string'
+      ? entity.senses.summary
+      : '';
+  const match = sensesText.match(/passive\s+perception\s*(\d+)/i);
+  if (match) {
+    const value = toFiniteNumberOrNull(match[1]);
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  return null;
 };
 
 const formatDamageTraitsDisplay = (traits) => {
@@ -3993,6 +4038,7 @@ export default function ZombiesDM() {
             character: entity,
             rowId,
             participantInfo,
+            passivePerception: getEntityPassivePerception(entity),
             initiativeValue,
             sortInitiative: numericInitiative,
             recordIndex,
@@ -6890,6 +6936,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           <th scope="col">Character</th>
                           <th scope="col">Player</th>
                           <th scope="col" className="text-center">In Combat</th>
+                          <th scope="col" className="text-center">Passive Perception</th>
                           <th scope="col" className="text-center">Initiative</th>
                           <th scope="col" className="text-center">Actions</th>
                         </tr>
@@ -6901,6 +6948,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                               character,
                               rowId,
                               participantInfo,
+                              passivePerception,
                               initiativeValue,
                               recordIndex,
                             }) => {
@@ -6909,6 +6957,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                               const displayInitiative =
                                 initiativeValue !== undefined && initiativeValue !== null
                                   ? initiativeValue
+                                  : '—';
+                              const displayPassivePerception =
+                                passivePerception !== undefined && passivePerception !== null
+                                  ? passivePerception
                                   : '—';
                               const isActive =
                                 isParticipant &&
@@ -6980,7 +7032,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                                       aria-label={`Toggle ${checkboxLabel} in combat`}
                                     />
                                   </td>
-                                  <td className="text-center" style={{ width: '120px' }}>
+                                  <td className="text-center" style={{ width: '150px' }}>
+                                    {displayPassivePerception}
+                                  </td>
+                                  <td className="text-center" style={{ width: '110px' }}>
                                     {displayInitiative}
                                   </td>
                                   <td className="text-center">
@@ -7003,7 +7058,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           )
                         ) : (
                           <tr>
-                            <td colSpan={5} className="text-center text-muted py-3">
+                            <td colSpan={6} className="text-center text-muted py-3">
                               No characters available.
                             </td>
                           </tr>
@@ -7123,6 +7178,7 @@ const resolveIcon = (category, iconMap, fallback) => {
 
                   const detailRows = [
                     { label: 'Level', value: totalLevel },
+                    { label: 'Passive Perception', value: getEntityPassivePerception(character) },
                     { label: 'Classes', value: classSummary },
                   ];
 


### PR DESCRIPTION
### Motivation
- Passive Perception is DM-facing information and should not be shown in the player combat HUD, while Initiative labeling should be clearer for players. 
- DM character cards and the Combat Tracker need to surface each player character’s derived Passive Perception so the DM can reference it without duplicating calculation logic. 
- Preserve the centralized calculation and existing component/data-flow while only moving presentation into DM views.

### Description
- Removed the Passive Perception pill from the player combat HUD and renamed the HUD initiative pill from `Int: +X` to `Initiative: +X` in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`. 
- Added a `getEntityPassivePerception` resolver in `client/src/components/Zombies/pages/ZombiesDM.js` that reuses the existing `calculatePassivePerception` for player characters and probes common monster/NPC fields and `senses` text before falling back to `—`. 
- Included `passivePerception` in the `orderedCombatRecords` entries and added a centered `Passive Perception` column between `In Combat` and `Initiative` in the DM Combat Tracker table, with a neutral fallback for entities that don’t expose a value. 
- Added `Passive Perception` to the DM player cards detail rows (inserted between `Level` and `Classes`), and updated tests to expect the new HUD label and that the HUD no longer shows Passive Perception.

### Testing
- Ran `npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js --watchAll=false` which passed. 
- Ran `npm --prefix client test -- --runTestsByPath src/components/Zombies/utils/derivedStats.test.js --watchAll=false` which passed and verifies `calculatePassivePerception` behavior. 
- Ran `npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js --watchAll=false` where some DM tests (notably the isolated "allows the DM to manage combat participants" check) failed in the CI-like test harness because the resource panel / tracker heading was not present in that test setup; failures appear related to test render setup rather than the passive perception logic. 
- Built the client with `npm --prefix client run build`, which completed successfully (project build warnings unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a525ef1cfec832396daa69a5cb0fcb6)