### PR TITLE
Improve active combat row readability

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9240,6 +9240,14 @@ h1 {
   color: var(--realm-muted) !important;
 }
 
+.modal .combat-tracker__active-row,
+.modal .combat-tracker__active-row > th,
+.modal .combat-tracker__active-row > td,
+.modal .combat-tracker__active-row > th :not(.btn):not(.btn *),
+.modal .combat-tracker__active-row > td :not(.btn):not(.btn *) {
+  color: var(--bs-dark) !important;
+}
+
 .modal .dropdown-menu,
 .modal .list-group-item,
 .modal table,

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -7016,7 +7016,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                               return (
                                 <tr
                                   key={resolvedRowId || playerName}
-                                  className={isActive ? 'table-success text-dark' : undefined}
+                                  className={isActive ? 'table-success text-dark combat-tracker__active-row' : undefined}
                                   {...rowDataAttributes}
                                 >
                                   <td className="fw-semibold">{displayName}</td>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1914,6 +1914,10 @@ describe('ZombiesDM AI generation', () => {
         screen.getByRole('status', { name: /Current Turn: Hero/i })
       ).toBeInTheDocument(),
     );
+    await waitFor(() =>
+      expect(heroRow).toHaveClass('combat-tracker__active-row')
+    );
+    expect(heroSetTurnButton).toHaveClass('btn-success');
 
     const nextTurnButton = screen.getByRole('button', { name: /Next Turn/i });
     await userEvent.click(nextTurnButton);


### PR DESCRIPTION
### Motivation
- The active combatant row uses a light green `table-success` background but its white text lacked contrast, reducing readability.
- Text inside the active row (character, player, passive perception, initiative, icons/values) should use a darker foreground while keeping the existing green background and the `Set Turn` button visuals unchanged.

### Description
- Add a scoped class `combat-tracker__active-row` to the active `<tr>` in the combat tracker rendering so the row can be targeted without changing the green background (`table-success`).
- Add CSS rules in `client/src/App.scss` that set non-button descendants of `.combat-tracker__active-row` to use the existing theme token `var(--bs-dark)` for high-contrast text, while explicitly excluding `.btn` descendants so the `Set Turn` button remains visually identical.
- Add regression assertions in `client/src/components/Zombies/pages/ZombiesDM.test.js` to verify the active row receives the new class and the active `Set Turn` button keeps its `btn-success` styling.

### Testing
- Ran a production build with `npm --prefix client run build`, which completed successfully (build output produced expected warnings but finished).
- Ran the DM combat-tracker unit tests via `npm --prefix client test -- --watchAll=false ZombiesDM.test.js -t "allows the DM to manage combat participants"`, which failed in the test environment because the targeted test could not find the `Combat Tracker` heading in the rendered output (the failure is unrelated to styling changes and indicates a render/test setup mismatch).
- Committed the style/JSX/test changes and validated the new CSS/JSX compiles and the added test assertions are present; the visual change is isolated to the active-row text color and does not alter the `Set Turn` button appearance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5278e4658883239701aea598630001)