### PR TITLE
Mobile: move combat HUD into Resources and place Pass Turn on action row

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8600,12 +8600,12 @@ h1 {
   }
 
   .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__resource-rail {
-    grid-row: 1;
+    grid-row: 3;
     width: 100%;
   }
 
   .combat-hud-dock__resources.is-mobile-open .spell-slot-container {
-    grid-row: 2;
+    grid-row: 4;
     width: 100% !important;
     min-width: 0 !important;
     max-width: none;
@@ -8672,13 +8672,25 @@ h1 {
     padding: 12px;
   }
 
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__status {
+    order: 0;
+    width: 100%;
+    padding: 8px;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__turn-slots {
+    order: 1;
+  }
+
   .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__resource-rail {
+    order: 2;
     padding: 10px;
     gap: 8px;
     grid-template-columns: repeat(4, minmax(96px, 1fr));
   }
 
   .combat-hud-dock__resources.is-mobile-open .spell-slot-container {
+    order: 3;
     padding: 12px 14px;
     scroll-padding-inline: 14px;
   }
@@ -8688,7 +8700,13 @@ h1 {
   }
 
   .combat-hud-dock__primary {
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 56px 56px 64px minmax(0, 1fr);
+    align-items: center;
+    justify-content: stretch;
+    gap: 8px;
+    min-width: 0;
+    flex-wrap: nowrap;
   }
 
   .combat-hud-damage-chip {
@@ -8698,7 +8716,12 @@ h1 {
   }
 
   .hud-pass-turn-button.btn {
-    flex: 1 1 168px;
+    width: 100%;
+    min-width: 0;
+    min-height: 56px;
+    padding-inline: 8px;
+    border-radius: 18px;
+    white-space: nowrap;
   }
 }
 
@@ -10950,4 +10973,67 @@ body.character-select-scroll-enabled {
 
 .active-conditions-modal__content small {
   color: var(--hud-muted, rgba(255, 255, 255, 0.72));
+}
+
+/* Mobile combat HUD: keep the character HUD inside the Resources drawer and keep end-turn on the bottom action row. */
+@media (max-width: 900px) {
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__status {
+    grid-row: 1;
+    min-height: 0;
+    margin-bottom: 2px;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__turn-slots {
+    grid-row: 2;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open .combat-hud-dock__resource-rail {
+    grid-row: 3;
+  }
+
+  .combat-hud-dock__resources.is-mobile-open > .spell-slot-container {
+    grid-row: 4;
+  }
+
+  .combat-hud-dock__primary {
+    display: grid;
+    grid-template-columns: 56px 56px 64px minmax(0, 1fr);
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    justify-content: stretch;
+  }
+
+  .combat-hud-dock__primary .hud-action-button.btn,
+  .combat-hud-dock__primary .hud-action-button--attack.btn {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .combat-hud-dock__primary .hud-pass-turn-button.btn {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+}
+
+@media (max-width: 380px) {
+  .combat-hud-dock__primary {
+    grid-template-columns: 50px 50px 56px minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .combat-hud-dock__primary .hud-action-button.btn,
+  .combat-hud-dock__primary .hud-action-button--attack.btn {
+    min-height: 50px;
+  }
+
+  .combat-hud-dock__primary .hud-pass-turn-button.btn {
+    min-height: 50px;
+    font-size: 0.78rem;
+  }
+
+  .hud-pass-turn-button__optional {
+    display: none;
+  }
 }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -75,6 +75,39 @@ import CombatTurnHeader, { HEADER_PADDING } from "../components/CombatTurnHeader
 
 const MIN_DOCKED_MODAL_WIDTH = 320;
 const DOCKED_MODAL_VIEWPORT_PADDING = 32;
+
+function useMediaQuery(query) {
+  const getMatches = useCallback(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  }, [query]);
+
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = () => setMatches(mediaQueryList.matches);
+
+    handleChange();
+
+    if (typeof mediaQueryList.addEventListener === 'function') {
+      mediaQueryList.addEventListener('change', handleChange);
+      return () => mediaQueryList.removeEventListener('change', handleChange);
+    }
+
+    mediaQueryList.addListener(handleChange);
+    return () => mediaQueryList.removeListener(handleChange);
+  }, [getMatches, query]);
+
+  return matches;
+}
+
 const DOCKABLE_MODAL_DEFINITIONS = {
   characterInfo: { label: 'Character Info', component: CharacterInfo },
   stats: { label: 'Stats', component: Stats },
@@ -3623,6 +3656,7 @@ export default function ZombiesCharacterSheet() {
     return null;
   }, [form]);
 
+  const isMobileCombatHudLayout = useMediaQuery('(max-width: 900px)');
   const [mobileHudPanel, setMobileHudPanel] = useState(null);
   const [isDamagePopupDismissed, setIsDamagePopupDismissed] = useState(false);
   const [footerDamageSummary, setFooterDamageSummary] = useState({
@@ -5712,6 +5746,48 @@ export default function ZombiesCharacterSheet() {
     return classes.join(' ');
   }, [isMapInteractionActive]);
 
+  const renderCombatHudStatusPanel = () => (
+    <Panel className="combat-hud-dock__status" aria-label="Character status">
+      <FooterCharacterSlot
+        characterFigurine={characterFigurine}
+        characterId={characterId}
+        characterName={footerCharacterName}
+        currentHealth={footerHealth.current}
+        maxHealth={footerHealth.max}
+        armorClass={footerArmorClass}
+        onHealthChange={handleHealthChange}
+        damageSummary={footerDamageSummary}
+        onOpenDamageLog={() => handleFooterQuickAction(openDamageLog)}
+        spellSlots={null}
+        resourcesDrawer={null}
+        hiddenResourceCount={footerHiddenResourceCount}
+        actions={null}
+        onToggleCritical={toggleCriticalFromFooter}
+      />
+      <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
+        <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>
+        <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
+        <span className="combat-hud-pill" aria-label="Proficiency bonus">Proficiency {formatSignedBonus(footerProficiencyBonus)}</span>
+        <span className="combat-hud-pill" aria-label="Movement speed">Move: {footerMovementSpeed} ft</span>
+        <span className="combat-hud-pill" aria-label="Initiative modifier">Initiative: {formatSignedBonus(footerInitiativeModifier)}</span>
+        <span className="combat-hud-pill" aria-label="Active conditions">
+          {hasActiveFooterConditions ? (
+            <IconButton
+              className="combat-hud-conditions-trigger"
+              label="View active conditions"
+              onClick={handleOpenActiveConditionsModal}
+            >
+              <Sparkles size={16} />
+            </IconButton>
+          ) : (
+            <Sparkles size={16} aria-hidden="true" />
+          )}
+          <span className="combat-hud-condition__label">{footerConditionSummary.label}</span>
+        </span>
+      </div>
+    </Panel>
+  );
+
   return (
     <div className={layoutClassName}>
       <div className={mapContainerClassName}>
@@ -5880,47 +5956,10 @@ export default function ZombiesCharacterSheet() {
                     Menu
                   </button>
                 </div>
-                <Panel className="combat-hud-dock__status" aria-label="Character status">
-                  <FooterCharacterSlot
-                    characterFigurine={characterFigurine}
-                    characterId={characterId}
-                    characterName={footerCharacterName}
-                    currentHealth={footerHealth.current}
-                    maxHealth={footerHealth.max}
-                    armorClass={footerArmorClass}
-                    onHealthChange={handleHealthChange}
-                    damageSummary={footerDamageSummary}
-                    onOpenDamageLog={() => handleFooterQuickAction(openDamageLog)}
-                    spellSlots={null}
-                    resourcesDrawer={null}
-                    hiddenResourceCount={footerHiddenResourceCount}
-                    actions={null}
-                    onToggleCritical={toggleCriticalFromFooter}
-                  />
-                  <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
-                    <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>
-                    <span className="combat-hud-pill"><Shield size={16} /> AC {footerArmorClass || '—'}</span>
-                    <span className="combat-hud-pill" aria-label="Proficiency bonus">Proficiency {formatSignedBonus(footerProficiencyBonus)}</span>
-                    <span className="combat-hud-pill" aria-label="Movement speed">Move: {footerMovementSpeed} ft</span>
-                    <span className="combat-hud-pill" aria-label="Initiative modifier">Initiative: {formatSignedBonus(footerInitiativeModifier)}</span>
-                    <span className="combat-hud-pill" aria-label="Active conditions">
-                      {hasActiveFooterConditions ? (
-                        <IconButton
-                          className="combat-hud-conditions-trigger"
-                          label="View active conditions"
-                          onClick={handleOpenActiveConditionsModal}
-                        >
-                          <Sparkles size={16} />
-                        </IconButton>
-                      ) : (
-                        <Sparkles size={16} aria-hidden="true" />
-                      )}
-                      <span className="combat-hud-condition__label">{footerConditionSummary.label}</span>
-                    </span>
-                  </div>
-                </Panel>
+                {!isMobileCombatHudLayout && renderCombatHudStatusPanel()}
 
                 <Panel className={`combat-hud-dock__resources ${mobileHudPanel === 'resources' ? 'is-mobile-open' : ''}`} aria-label="Combat resources">
+                  {isMobileCombatHudLayout && renderCombatHudStatusPanel()}
                   {form && (
                     <div className="combat-hud-dock__turn-slots" aria-label="Turn action tracking">
                       <SpellSlots
@@ -6023,7 +6062,7 @@ export default function ZombiesCharacterSheet() {
                     aria-label="Pass turn"
                     title="Pass turn"
                   >
-                    Pass Turn
+                    Pass<span className="hud-pass-turn-button__optional"> Turn</span>
                   </HudButton>
                 </Toolbar>
 


### PR DESCRIPTION
### Motivation
- On mobile, the full combat HUD should live inside the expanded Resources panel and appear above the action/resource pills, while desktop/tablet behavior must be preserved.
- The Pass Turn control should sit on the same horizontal row as the three primary icon buttons on supported mobile widths without duplicating logic or HUD state.

### Description
- Added a small `useMediaQuery` hook and `isMobileCombatHudLayout` flag to detect the project mobile breakpoint (`(max-width: 900px)`).
- Refactored the status portion of the HUD into a single `renderCombatHudStatusPanel` helper and conditionally render it in the original dock for non-mobile and at the top of the Resources panel for mobile, keeping one shared instance so state/logic is not duplicated.
- Updated the Pass Turn label to be compact on narrow screens by rendering `Pass<span class="hud-pass-turn-button__optional"> Turn</span>` and added responsive CSS to hide the optional text at very small widths.
- Adjusted mobile CSS in `App.scss` to reorder Resources content when open (`status` -> `turn-slots` -> `resource-rail` -> spell slots), and changed the mobile `.combat-hud-dock__primary` layout to a responsive grid (`auto auto auto minmax(0,1fr)`-equivalent) so the three icon buttons remain square/near-square and Pass Turn occupies remaining space without overflow.

### Testing
- Ran the Zombies character HUD unit tests with `npm test -- --watchAll=false ZombiesCharacterSheet.test.js` and the suite passed: `1` test suite, `58` tests all passing.
- Ran `git diff --check` as a lint-style verification with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5280cdc9f08323bf6ec31a6aad2748)