### PR TITLE
Align Resources spell-slot panel

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -9013,6 +9013,7 @@ h1 {
     grid-column: 2;
     grid-row: 1;
     align-self: center;
+    margin-top: 8px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Nudge the spell-slot section in the Resources panel down a small amount so its top edge visually aligns with the large resource container on the left, improving two-column balance while preserving spacing, sizes, and behavior.

### Description
- Added `margin-top: 8px` to `.combat-hud-dock__resources > .spell-slot-container` in `client/src/App.scss` to lower the spell-slot container within the existing grid placement, keeping the change localized to the Resources panel and using the existing layout system.

### Testing
- Ran `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/SpellSlots.test.js` and the test suite passed (10 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5284af8d88832397ea6b0d928a0199)