### PR TITLE
Implement Barbarian Level 3: Primal Knowledge & Path of the Berserker (Frenzy)

### DIFF
--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -3,6 +3,8 @@ import apiFetch from '../../../utils/apiFetch';
 import { Card, Modal, Button, Form, Alert } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
 import useUser from '../../../hooks/useUser';
+import { BARBARIAN_LEVEL_1_SKILLS, BARBARIAN_SUBCLASSES } from '../utils/barbarian';
+import { SKILLS } from '../skillSchema';
 
 export default function LevelUp({ show, handleClose, form }) {
   //--------------------------------------------Level Up--------------------------------------------------------------------------------------------------------------------------------------------
@@ -49,6 +51,13 @@ export default function LevelUp({ show, handleClose, form }) {
       health: newHealth,
     };
 
+    if (selectedOccupation === 'Barbarian' && newLevel >= 3) {
+      updatedLevelForm.barbarianSubclass = barbarianSubclass;
+      if (newLevel === 3) {
+        updatedLevelForm.primalKnowledgeSkill = primalKnowledgeSkill;
+      }
+    }
+
     try {
       await apiFetch(`/characters/update-level/${params.id}`, {
         method: "PUT",
@@ -72,6 +81,8 @@ export default function LevelUp({ show, handleClose, form }) {
   const [notification, setNotification] = useState('');
   const [error, setError] = useState('');
   const [validationError, setValidationError] = useState('');
+  const [barbarianSubclass, setBarbarianSubclass] = useState('path-of-the-berserker');
+  const [primalKnowledgeSkill, setPrimalKnowledgeSkill] = useState('');
 
   const handleAddOccupationClick = () => {
     setShowAddClassModal(true);
@@ -255,6 +266,43 @@ export default function LevelUp({ show, handleClose, form }) {
                     ))}
                   </Form.Select>
                 </Form.Group>
+                {chosenOccupation === 'Barbarian' && (() => {
+                  const barbarian = form.occupation.find((occupation) => occupation.Occupation === 'Barbarian');
+                  const nextLevel = Number(barbarian?.Level || 0) + 1;
+                  if (nextLevel < 3) return null;
+                  const skillLabels = Object.fromEntries(SKILLS.map((skill) => [skill.key, skill.label]));
+                  const currentSkills = form.skills || {};
+                  const alreadyProficient = new Set([
+                    ...Object.entries(currentSkills).filter(([, info]) => info?.proficient).map(([key]) => key),
+                    ...Object.entries(form.race?.skills || {}).filter(([, info]) => info?.proficient).map(([key]) => key),
+                    ...Object.entries(form.background?.skills || {}).filter(([, info]) => info?.proficient).map(([key]) => key),
+                  ]);
+                  const availablePrimalSkills = BARBARIAN_LEVEL_1_SKILLS.filter((skill) => !alreadyProficient.has(skill));
+                  return (
+                    <>
+                      <Form.Group className="mb-3 mx-5">
+                        <Form.Label className="text-light">Barbarian Subclass</Form.Label>
+                        <Form.Select value={barbarianSubclass} onChange={(event) => setBarbarianSubclass(event.target.value)}>
+                          {BARBARIAN_SUBCLASSES.map((subclass) => (
+                            <option key={subclass.id} value={subclass.id}>{subclass.name}</option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                      {nextLevel === 3 && (
+                        <Form.Group className="mb-3 mx-5">
+                          <Form.Label className="text-light">Primal Knowledge Skill</Form.Label>
+                          <Form.Select value={primalKnowledgeSkill} onChange={(event) => setPrimalKnowledgeSkill(event.target.value)}>
+                            <option value="" disabled>Select one skill</option>
+                            {availablePrimalSkills.map((skill) => (
+                              <option key={skill} value={skill}>{skillLabels[skill] || skill}</option>
+                            ))}
+                          </Form.Select>
+                        </Form.Group>
+                      )}
+                    </>
+                  );
+                })()}
+
               </Form>
             </Card.Body>
             <Card.Footer className="modal-footer">
@@ -265,7 +313,7 @@ export default function LevelUp({ show, handleClose, form }) {
                 className="action-btn save-btn"
                 type="submit"
                 form="level-up-form"
-                disabled={!chosenOccupation}
+                disabled={!chosenOccupation || (chosenOccupation === 'Barbarian' && form.occupation.find((occupation) => occupation.Occupation === 'Barbarian') && Number(form.occupation.find((occupation) => occupation.Occupation === 'Barbarian').Level || 0) + 1 === 3 && !primalKnowledgeSkill)
               >
                 Level Up
               </Button>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -35,7 +35,7 @@ import {
   normalizeDiceColor,
   resolveDamageTypeColor,
 } from '../../../utils/diceColors';
-import { getRageDamageBonus, markBarbarianAttackRoll, resolveAttackRollMode } from '../utils/barbarian';
+import { getFrenzyDamageDice, getRageDamageBonus, markBarbarianAttackRoll, markFrenzyUsed, resolveAttackRollMode } from '../utils/barbarian';
 
 // Dice rolling helper used by calculateDamage and component actions
 function rollDice(numberOfDiceValue, sidesOfDiceValue) {
@@ -388,12 +388,32 @@ export function calculateDamage(
     results.push({ value: rageBonus, type: 'Rage' });
   }
 
+  const frenzyDice = getFrenzyDamageDice(options?.character, options?.attack);
+  let frenzyApplied = false;
+  if (frenzyDice?.count > 0) {
+    const inheritedType = results.find((entry) => entry.type && entry.type !== 'Rage')?.type || options?.attack?.damageType || '';
+    const baseFrenzyRolls = normalizeRollArray(roll(frenzyDice.count, frenzyDice.sides), frenzyDice.count);
+    let frenzyValue = baseFrenzyRolls.reduce((sum, value) => sum + value, 0);
+    recordDiceRolls(baseFrenzyRolls, frenzyDice.sides, inheritedType, 'frenzy');
+    if (crit) {
+      const critFrenzyRolls = normalizeRollArray(roll(frenzyDice.count, frenzyDice.sides), frenzyDice.count);
+      frenzyValue += critFrenzyRolls.reduce((sum, value) => sum + value, 0);
+      recordDiceRolls(critFrenzyRolls, frenzyDice.sides, inheritedType, 'critical-frenzy');
+    }
+    results.push({ value: frenzyValue, type: `${frenzyDice.label}${inheritedType ? ` ${inheritedType}` : ''}` });
+    frenzyApplied = true;
+  }
+
   const total = results.reduce((sum, r) => sum + r.value, 0);
   return {
     total,
     breakdown: formatDamageRolls(results),
     diceRolls,
-    modifiers: rageBonus > 0 ? [{ label: 'Rage', value: rageBonus }] : [],
+    modifiers: [
+      ...(rageBonus > 0 ? [{ label: 'Rage', value: rageBonus }] : []),
+      ...(frenzyApplied ? [{ label: 'Reckless Attack', value: results[results.length - 1].value }] : []),
+    ],
+    frenzyApplied,
   };
 }
 
@@ -1761,6 +1781,10 @@ const manualCriticalRef = useRef(false);
         ],
       };
 
+      if (result.frenzyApplied) {
+        onCharacterChange?.((previous) => markFrenzyUsed(previous || form));
+      }
+
       updateDamageValueWithAnimation(
         result.total,
         result.breakdown,
@@ -1776,6 +1800,7 @@ const manualCriticalRef = useRef(false);
       form,
       isCritical,
       isUnarmedAttack,
+      onCharacterChange,
       rollDamageExpression,
     ],
   );

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -138,6 +138,33 @@ describe('calculateDamage parser', () => {
     expect(calculateDamage('1d10 Fire', 3, false, fixedRoll, undefined, 0, { character: activeLevel3, attack: { ability: 'str', kind: 'spell', isSpellAttack: true, dealsDamage: true } }).total).toBe(4);
   });
 
+
+  test('applies Berserker Frenzy dice once using inherited damage type and crit doubling', () => {
+    const berserker = {
+      occupation: [{ Name: 'Barbarian', Level: 3 }],
+      classState: {
+        barbarian: {
+          rage: { active: true, current: 1 },
+          recklessAttack: { active: true, declared: true },
+          subclass: { id: 'path-of-the-berserker', name: 'Path of the Berserker' },
+        },
+      },
+    };
+    const attack = { ability: 'str', kind: 'weapon', isWeaponAttack: true, dealsDamage: true };
+    expect(calculateDamage('1d12 Slashing', 3, false, fixedRoll, undefined, 0, { character: berserker, attack })).toMatchObject({
+      total: 8,
+      breakdown: '4 Slashing + 2 Rage + 2 Reckless Attack Slashing',
+      frenzyApplied: true,
+    });
+    expect(calculateDamage('1d12 Slashing', 3, true, fixedRoll, undefined, 0, { character: berserker, attack })).toMatchObject({
+      total: 11,
+      breakdown: '5 Slashing + 2 Rage + 4 Reckless Attack Slashing',
+      frenzyApplied: true,
+    });
+    expect(calculateDamage('1d12 Slashing', 3, false, fixedRoll, undefined, 0, { character: { ...berserker, classState: { barbarian: { ...berserker.classState.barbarian, frenzy: { usedThisTurn: true } } } }, attack }).frenzyApplied).toBe(false);
+    expect(calculateDamage('1d12 Slashing', 3, false, fixedRoll, undefined, 0, { character: berserker, attack: { ...attack, ability: 'dex' } }).frenzyApplied).toBe(false);
+  });
+
   test('scales rage damage from barbarian class level', () => {
     const raging = (barbarianLevel, otherLevel = 0) => ({
       occupation: [

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -17,7 +17,7 @@ import {
   normalizeDiceColor,
   applyDiceFaceColor,
 } from '../../../utils/diceColors';
-import { getRageBenefits } from '../utils/barbarian';
+import { canUsePrimalKnowledgeForSkill, getRageBenefits } from '../utils/barbarian';
 
 const EMPTY_OBJECT = Object.freeze({});
 
@@ -186,6 +186,9 @@ export default function Skills({
   const [error, setError] = useState('');
   const [showSkillInfo, setShowSkillInfo] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState(null);
+  const [modifierPrompt, setModifierPrompt] = useState(null);
+  const [selectedModifierAbility, setSelectedModifierAbility] = useState('');
+  const [isRollingSkill, setIsRollingSkill] = useState(false);
   const raceProficiencies = useMemo(() => {
     return new Set(
       Object.entries(form?.race?.skills || {})
@@ -428,7 +431,7 @@ export default function Skills({
     updateSkill(skill, updated);
   };
 
-  const handleRoll = async (skillKey, ability, proficient, expertise) => {
+  const executeSkillRoll = async (skillKey, ability, proficient, expertise, labelSuffix = '') => {
     const skill = SKILLS.find((s) => s.key === skillKey);
     const skillLabel = skill?.label || skill?.name || skillKey;
     const armorPenalty = skill?.armorPenalty || 0;
@@ -444,14 +447,19 @@ export default function Skills({
     const abilityLabel =
       ABILITY_LABELS[ability] || ability?.toUpperCase?.() || ability || 'Ability';
 
-    if (!isDocked) {
+    if (!isDocked && !labelSuffix) {
       handleCloseSkill?.();
     }
 
-    const { result, d20 } = await rollSkillWithDiceBox(bonus, {
+    const rollModeResult = resolveAbilityCheckRollMode(safeForm, ability);
+    const { result, d20, rolledD20s, keptD20, rollMode } = await rollSkillWithDiceBox(bonus, {
       diceColor: diceFaceColor,
+      rollMode: rollModeResult.mode,
     });
-    const breakdownParts = [`${d20} (d20)`];
+    const actualRollMode = rollMode || rollModeResult.mode;
+    const breakdownParts = [actualRollMode === 'advantage' || actualRollMode === 'disadvantage'
+      ? `${keptD20 ?? d20} (d20) (Rolled ${(rolledD20s || [d20]).join(' and ')})`
+      : `${d20} (d20)`];
 
     const segments = [
       formatAdjustmentSegment(modMap[ability], `${abilityLabel} Modifier`),
@@ -484,14 +492,61 @@ export default function Skills({
         detail: {
           value: result,
           breakdown: breakdownParts.join(' '),
-          source: skillLabel,
+          source: labelSuffix ? `${abilityLabel} (${skillLabel}) ${labelSuffix}` : skillLabel,
           rollLabel: 'Skill Roll',
           critical: d20 === 20,
           fumble: d20 === 1,
           diceRolls,
+          rollMode: actualRollMode,
+          advantageSources: rollModeResult.advantageSources,
+          disadvantageSources: rollModeResult.disadvantageSources,
         },
       })
     );
+  };
+
+  const handleRoll = async (skillKey, ability, proficient, expertise) => {
+    if (isRollingSkill || modifierPrompt) return;
+    if (canUsePrimalKnowledgeForSkill(safeForm, skillKey)) {
+      setModifierPrompt({ skillKey, ability, proficient, expertise });
+      setSelectedModifierAbility(ability);
+      return;
+    }
+    setIsRollingSkill(true);
+    try {
+      await executeSkillRoll(skillKey, ability, proficient, expertise);
+    } finally {
+      setIsRollingSkill(false);
+    }
+  };
+
+  const confirmModifierPrompt = async () => {
+    if (!modifierPrompt || isRollingSkill) return;
+    const ability = selectedModifierAbility || modifierPrompt.ability;
+    const suffix = ability === 'str' && ability !== modifierPrompt.ability ? '— Primal Knowledge' : '';
+    setIsRollingSkill(true);
+    try {
+      await executeSkillRoll(
+        modifierPrompt.skillKey,
+        ability,
+        modifierPrompt.proficient,
+        modifierPrompt.expertise,
+        suffix
+      );
+      setModifierPrompt(null);
+      setSelectedModifierAbility('');
+      if (!isDocked) {
+        handleCloseSkill?.();
+      }
+    } finally {
+      setIsRollingSkill(false);
+    }
+  };
+
+  const closeModifierPrompt = () => {
+    if (isRollingSkill) return;
+    setModifierPrompt(null);
+    setSelectedModifierAbility('');
   };
 
   const handleView = (skill) => {
@@ -641,6 +696,46 @@ export default function Skills({
               onClick={() => handleCloseSkill()}
               className="action-btn close-btn flex-fill"
             >Close</Button>
+          </Card.Footer>
+        </Card>
+      </Modal>
+      <Modal
+        className="dnd-modal modern-modal"
+        show={Boolean(modifierPrompt)}
+        onHide={closeModifierPrompt}
+        centered
+        restoreFocus
+        enforceFocus
+      >
+        <Card className="modern-card text-center">
+          <Card.Header className="modal-header">
+            <Card.Title className="modal-title">Choose Modifier</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <Form.Group className="mb-3 mx-5" controlId="primal-knowledge-modifier">
+              <Form.Label className="text-light">Modifier:</Form.Label>
+              <Form.Select
+                value={selectedModifierAbility}
+                onChange={(event) => setSelectedModifierAbility(event.target.value)}
+                autoFocus
+              >
+                {modifierPrompt && [modifierPrompt.ability, 'str']
+                  .filter((value, index, array) => array.indexOf(value) === index)
+                  .map((abilityKey) => (
+                    <option key={abilityKey} value={abilityKey}>
+                      {ABILITY_LABELS[abilityKey] || abilityKey.toUpperCase()} ({modMap[abilityKey] >= 0 ? '+' : ''}{modMap[abilityKey]}){abilityKey === 'str' && abilityKey !== modifierPrompt.ability ? ' — Primal Knowledge' : ''}
+                    </option>
+                  ))}
+              </Form.Select>
+            </Form.Group>
+          </Card.Body>
+          <Card.Footer className="modal-footer">
+            <Button className="action-btn close-btn" onClick={closeModifierPrompt} disabled={isRollingSkill}>
+              Cancel
+            </Button>
+            <Button className="action-btn save-btn" onClick={confirmModifierPrompt} disabled={isRollingSkill}>
+              Roll
+            </Button>
           </Card.Footer>
         </Card>
       </Modal>

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -153,6 +153,72 @@ const hasCondition = (character, conditionName) => {
   );
 };
 
+export const BARBARIAN_SUBCLASSES = [
+  {
+    id: "path-of-the-berserker",
+    name: "Path of the Berserker",
+    classId: "barbarian",
+    level: 3,
+    features: [
+      { id: "berserker-frenzy", name: "Frenzy", level: 3 },
+      { id: "berserker-mindless-rage", name: "Mindless Rage", level: 6 },
+      { id: "berserker-retaliation", name: "Retaliation", level: 10 },
+      { id: "berserker-intimidating-presence", name: "Intimidating Presence", level: 14 },
+    ],
+  },
+];
+
+export const BARBARIAN_LEVEL_1_SKILLS = [
+  "animalHandling",
+  "athletics",
+  "intimidation",
+  "nature",
+  "perception",
+  "survival",
+];
+
+export const PRIMAL_KNOWLEDGE_SKILLS = [
+  "acrobatics",
+  "intimidation",
+  "perception",
+  "stealth",
+  "survival",
+];
+
+export const getBarbarianSubclass = (character) =>
+  character?.classState?.barbarian?.subclass ||
+  character?.subclasses?.barbarian ||
+  character?.barbarian?.subclass ||
+  null;
+
+export const getAvailableBarbarianSubclasses = (character) =>
+  getBarbarianLevel(character) >= 3 ? BARBARIAN_SUBCLASSES : [];
+
+export const isPathOfTheBerserker = (character) => {
+  const subclass = getBarbarianSubclass(character);
+  const id = normalize(subclass?.id ?? subclass?.key ?? subclass?.name ?? subclass);
+  return id === "path-of-the-berserker" || id === "path of the berserker" || id === "berserker";
+};
+
+export const getActiveBarbarianSubclassFeatures = (character) => {
+  const level = getBarbarianLevel(character);
+  const selected = getBarbarianSubclass(character);
+  if (!selected || level < 3) return [];
+  const selectedId = normalize(selected?.id ?? selected?.key ?? selected?.name ?? selected);
+  const subclass = BARBARIAN_SUBCLASSES.find((entry) => {
+    const entryId = normalize(entry.id);
+    const entryName = normalize(entry.name);
+    return selectedId === entryId || selectedId === entryName || selectedId === "berserker";
+  });
+  return (subclass?.features || []).filter((feature) => level >= feature.level);
+};
+
+export const hasPrimalKnowledge = (character) => getBarbarianLevel(character) >= 3;
+export const isPrimalKnowledgeSkill = (skillKey) =>
+  PRIMAL_KNOWLEDGE_SKILLS.includes(normalize(skillKey));
+export const canUsePrimalKnowledgeForSkill = (character, skillKey) =>
+  hasPrimalKnowledge(character) && isRageActive(character) && isPrimalKnowledgeSkill(skillKey);
+
 export const BARBARIAN_FEATURES = [
   {
     id: "barbarian-rage",
@@ -184,6 +250,25 @@ export const BARBARIAN_FEATURES = [
     hideUseButton: true,
   },
   {
+    id: "barbarian-primal-knowledge",
+    name: "Primal Knowledge",
+    class: "Barbarian",
+    classId: "barbarian",
+    level: 3,
+    type: "configuration",
+    description:
+      "You gain proficiency in one additional Barbarian skill. While raging, you can use Strength for Acrobatics, Intimidation, Perception, Stealth, and Survival checks.",
+  },
+  {
+    id: "barbarian-subclass",
+    name: "Barbarian Subclass",
+    class: "Barbarian",
+    classId: "barbarian",
+    level: 3,
+    type: "configuration",
+    description: "Choose a Barbarian subclass. Path of the Berserker is currently available.",
+  },
+  {
     id: "reckless-attack",
     name: "Reckless Attack",
     class: "Barbarian",
@@ -197,7 +282,16 @@ export const BARBARIAN_FEATURES = [
 
 export const getAvailableBarbarianFeatures = (character) => {
   const barbarianLevel = getBarbarianLevel(character);
-  return BARBARIAN_FEATURES.filter((feature) => barbarianLevel >= feature.level);
+  return [
+    ...BARBARIAN_FEATURES.filter((feature) => barbarianLevel >= feature.level),
+    ...getActiveBarbarianSubclassFeatures(character).map((feature) => ({
+      ...feature,
+      class: "Barbarian",
+      classId: "barbarian",
+      subclass: "Path of the Berserker",
+      type: "passive",
+    })),
+  ];
 };
 
 export const hasDangerSense = (character) => getBarbarianLevel(character) >= 2;
@@ -390,7 +484,7 @@ export const declareRecklessAttack = (character) => {
 export const endRecklessAttack = (character) => {
   const state = getRecklessAttackState(character);
   if (!state.active && !state.firstAttackMade && !state.declared) return character;
-  return withRecklessAttack(character, { active: false, declared: false, firstAttackMade: false });
+  return resetFrenzyTurn(withRecklessAttack(character, { active: false, declared: false, firstAttackMade: false }));
 };
 
 export const markBarbarianAttackRoll = (character) => character;
@@ -424,4 +518,43 @@ export const resolveAttackRollMode = (character, attack = {}, options = {}) => {
     advantageSources,
     disadvantageSources,
   };
+};
+
+
+export const getFrenzyState = (character) => ({
+  usedThisTurn: Boolean(character?.classState?.barbarian?.frenzy?.usedThisTurn),
+});
+
+export const markFrenzyUsed = (character) => ({
+  ...character,
+  classState: {
+    ...(character?.classState || {}),
+    barbarian: {
+      ...(character?.classState?.barbarian || {}),
+      frenzy: { usedThisTurn: true },
+    },
+  },
+});
+
+export const resetFrenzyTurn = (character) => {
+  if (!getFrenzyState(character).usedThisTurn) return character;
+  return {
+    ...character,
+    classState: {
+      ...(character?.classState || {}),
+      barbarian: {
+        ...(character?.classState?.barbarian || {}),
+        frenzy: { usedThisTurn: false },
+      },
+    },
+  };
+};
+
+export const getFrenzyDamageDice = (character, attack = {}) => {
+  if (getBarbarianLevel(character) < 3 || !isPathOfTheBerserker(character)) return null;
+  if (!isRageActive(character) || !getRecklessAttackState(character).active) return null;
+  if (getFrenzyState(character).usedThisTurn) return null;
+  if (attack.hit === false || attack.dealsDamage === false) return null;
+  if (getRageDamageBonus(character, attack) <= 0) return null;
+  return { label: "Reckless Attack", count: getRageDamageBonus(character, attack), sides: 6 };
 };

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -18,6 +18,11 @@ import {
   getRecklessAttackState,
   markBarbarianAttackRoll,
   resolveAttackRollMode,
+  getAvailableBarbarianSubclasses,
+  getActiveBarbarianSubclassFeatures,
+  canUsePrimalKnowledgeForSkill,
+  getFrenzyDamageDice,
+  markFrenzyUsed,
 } from "./barbarian";
 
 const barbarian = (extra = {}) => ({
@@ -247,5 +252,47 @@ describe("barbarian level 2 features", () => {
     expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" }, { disadvantageSources: ["Prone"] }).mode).toBe("normal");
     expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" }, { advantageSources: ["Help"] }).mode).toBe("advantage");
     expect(resolveAttackRollMode(endRecklessAttack(declared), { ability: "str", type: "weapon attack" }).mode).toBe("normal");
+  });
+});
+
+describe("barbarian level 3 features", () => {
+  const barbarian3 = (extra = {}) => barbarian({
+    occupation: [{ Name: "Barbarian", Level: 3 }],
+    classState: { barbarian: { subclass: { id: "path-of-the-berserker", name: "Path of the Berserker" } } },
+    ...extra,
+  });
+
+  it("gates subclass selection and active subclass features by Barbarian level", () => {
+    expect(getAvailableBarbarianSubclasses(barbarian({ occupation: [{ Name: "Barbarian", Level: 2 }] }))).toEqual([]);
+    expect(getAvailableBarbarianSubclasses(barbarian3()).map((s) => s.name)).toContain("Path of the Berserker");
+    expect(getActiveBarbarianSubclassFeatures(barbarian3()).map((f) => f.name)).toEqual(["Frenzy"]);
+    expect(getAvailableBarbarianFeatures(barbarian3()).map((f) => f.name)).toEqual(expect.arrayContaining(["Primal Knowledge", "Barbarian Subclass", "Frenzy"]));
+    expect(getActiveBarbarianSubclassFeatures(barbarian({ occupation: [{ Name: "Barbarian", Level: 5 }], classState: { barbarian: { subclass: { id: "path-of-the-berserker" } } } })).map((f) => f.name)).not.toContain("Mindless Rage");
+  });
+
+  it("exposes Primal Knowledge alternate checks only for eligible raging skills", () => {
+    const raging = barbarian3({ classState: { barbarian: { rage: { active: true, current: 1 }, subclass: { id: "path-of-the-berserker" } } } });
+    expect(canUsePrimalKnowledgeForSkill(raging, "stealth")).toBe(true);
+    expect(canUsePrimalKnowledgeForSkill(raging, "perception")).toBe(true);
+    expect(canUsePrimalKnowledgeForSkill(raging, "athletics")).toBe(false);
+    expect(canUsePrimalKnowledgeForSkill(barbarian3(), "stealth")).toBe(false);
+    expect(canUsePrimalKnowledgeForSkill(barbarian({ occupation: [{ Name: "Barbarian", Level: 2 }], classState: { barbarian: { rage: { active: true, current: 1 } } } }), "stealth")).toBe(false);
+  });
+
+  it("resolves Frenzy eligibility and per-turn reset", () => {
+    const ragingReckless = declareRecklessAttack(activateRage(barbarian3()));
+    expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "weapon attack", dealsDamage: true })).toMatchObject({ label: "Reckless Attack", count: 2, sides: 6 });
+    expect(getFrenzyDamageDice(ragingReckless, { ability: "dex", type: "weapon attack", dealsDamage: true })).toBeNull();
+    expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "spell attack", isSpellAttack: true })).toBeNull();
+    expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "weapon attack", hit: false, dealsDamage: true })).toBeNull();
+    expect(getFrenzyDamageDice(markFrenzyUsed(ragingReckless), { ability: "str", type: "weapon attack", dealsDamage: true })).toBeNull();
+    expect(getFrenzyDamageDice(endRecklessAttack(markFrenzyUsed(ragingReckless)), { ability: "str", type: "weapon attack", dealsDamage: true })).toBeNull();
+  });
+
+  it("rejects Frenzy for non-Berserkers and before level 3", () => {
+    const nonBerserker = declareRecklessAttack(activateRage(barbarian({ occupation: [{ Name: "Barbarian", Level: 3 }], classState: { barbarian: { subclass: { id: "other" } } } })));
+    expect(getFrenzyDamageDice(nonBerserker, { ability: "str", type: "weapon attack", dealsDamage: true })).toBeNull();
+    const lowLevel = declareRecklessAttack(activateRage(barbarian({ occupation: [{ Name: "Barbarian", Level: 2 }], classState: { barbarian: { subclass: { id: "path-of-the-berserker" } } } })));
+    expect(getFrenzyDamageDice(lowLevel, { ability: "str", type: "weapon attack", dealsDamage: true })).toBeNull();
   });
 });

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -13,6 +13,7 @@ const {
 const proficiencyBonus = require('../../utils/proficiency');
 const collectAllowedSkills = require('../../utils/collectAllowedSkills');
 const collectAllowedExpertise = require('../../utils/collectAllowedExpertise');
+const classes = require('../../data/classes');
 const { normalizeEquipmentMap } = require('../../constants/equipmentSlots');
 const {
   emitCharacterMetadataUpdate,
@@ -543,12 +544,20 @@ module.exports = (router) => {
       const selectedOccupation = req.body.selectedOccupation;
       const { level, health } = matchedData(req, { locations: ['body'] });
 
-      const updateOperation = {
-        $set: {
-          'occupation.$.Level': level,
-          health,
-        },
+      const setUpdate = {
+        'occupation.$.Level': level,
+        health,
       };
+      const updateOperation = { $set: setUpdate };
+      const isBarbarianLevel3 = selectedOccupation === 'Barbarian' && level >= 3;
+      const primalKnowledgeSkill = req.body.primalKnowledgeSkill;
+      const barbarianSubclass = req.body.barbarianSubclass;
+      if (isBarbarianLevel3 && barbarianSubclass) {
+        setUpdate['classState.barbarian.subclass'] = {
+          id: barbarianSubclass,
+          name: barbarianSubclass === 'path-of-the-berserker' ? 'Path of the Berserker' : barbarianSubclass,
+        };
+      }
 
       try {
         const result = await db_connect
@@ -571,9 +580,33 @@ module.exports = (router) => {
             ? updatedChar.occupation.reduce((sum, o) => sum + (o.Level || 0), 0)
             : 0;
           const profBonus = proficiencyBonus(totalLevel);
+          const followupSet = { proficiencyBonus: profBonus };
+          const barbarian = Array.isArray(updatedChar.occupation)
+            ? updatedChar.occupation.find((o) => o.Occupation === 'Barbarian')
+            : null;
+          if (selectedOccupation === 'Barbarian' && level === 3 && primalKnowledgeSkill) {
+            const allowed = classes.barbarian.proficiencies.skills.options;
+            const already = Boolean(
+              updatedChar.skills?.[primalKnowledgeSkill]?.proficient ||
+              updatedChar.race?.skills?.[primalKnowledgeSkill]?.proficient ||
+              updatedChar.background?.skills?.[primalKnowledgeSkill]?.proficient
+            );
+            const alreadyChosen = Boolean(updatedChar.classState?.barbarian?.primalKnowledge?.skill);
+            if (allowed.includes(primalKnowledgeSkill) && !already && !alreadyChosen) {
+              followupSet[`skills.${primalKnowledgeSkill}`] = {
+                ...(updatedChar.skills?.[primalKnowledgeSkill] || skillFields[primalKnowledgeSkill] || {}),
+                proficient: true,
+                expertise: Boolean(updatedChar.skills?.[primalKnowledgeSkill]?.expertise),
+              };
+              followupSet['classState.barbarian.primalKnowledge.skill'] = primalKnowledgeSkill;
+              followupSet['occupation.$[barbarian].proficiencyPoints'] = Number(barbarian?.proficiencyPoints || 0) + 1;
+            }
+          }
+          const usesBarbarianArrayFilter = Object.keys(followupSet).some((key) => key.includes('$[barbarian]'));
           await db_connect.collection('Characters').updateOne(
             { _id: ObjectId(req.params.id) },
-            { $set: { proficiencyBonus: profBonus } }
+            { $set: followupSet },
+            usesBarbarianArrayFilter ? { arrayFilters: [{ 'barbarian.Occupation': 'Barbarian' }] } : undefined
           );
           logger.info(`Character updated for Occupation: ${selectedOccupation}`);
           res.json({ message: 'Update complete', proficiencyBonus: profBonus });


### PR DESCRIPTION
### Motivation

- Add Barbarian level 3 behavior (subclass selection and level-3 features) so characters get a subclass at level 3 and gain the Primal Knowledge and Path of the Berserker (Frenzy) features per the design and rules.

### Description

- Add data and helpers to `client/src/components/Zombies/utils/barbarian.js` to represent Barbarian subclasses, the level-1 skill list, Primal Knowledge eligible skills, and helper predicates (`getAvailableBarbarianSubclasses`, `getActiveBarbarianSubclassFeatures`, `canUsePrimalKnowledgeForSkill`, `getFrenzyDamageDice`, `markFrenzyUsed`, etc.).
- Integrate Frenzy into the existing damage pipeline by extending `calculateDamage` in `client/src/components/Zombies/attributes/PlayerTurnActions.js` to roll additional `d6` Frenzy dice (count = current Rage damage bonus), inherit the triggering attack damage type, participate in crit doubling, log the bonus under the exact label `"Reckless Attack"`, and mark Frenzy consumed via `markFrenzyUsed` after damage resolution.
- Add the Primal Knowledge roll flow to the existing skill roll control in `client/src/components/Zombies/attributes/Skills.js` by opening a modal when Rage is active for eligible skills and letting the player pick the normal ability or `Strength` (labeled `— Primal Knowledge`), then executing the roll with the chosen modifier while preserving proficiency/expertise and the original skill association.
- Update Level Up UI in `client/src/components/Zombies/attributes/LevelUp.js` to prompt for a Barbarian subclass at Barbarian level 3 and to let the player choose one eligible Primal Knowledge skill (excluding already-proficient skills) when advancing to level 3.
- Persist selection and grant the chosen proficiency server-side via the existing level-update route in `server/routes/characters/base.js`, storing the subclass in `classState.barbarian.subclass` and the chosen skill in `classState.barbarian.primalKnowledge.skill`, and granting `skills.<skill>.proficient` if valid and not previously granted.
- Preserve established architecture and state locations: use `classState.barbarian` for subclass and per-turn Frenzy state, reuse existing skill storage (`skills.<key>`), reuse `getRageDamageBonus`, `resolveAttackRollMode`, and Reckless/Rage utilities rather than adding parallel systems.
- Files changed: `client/src/components/Zombies/utils/barbarian.js`, `client/src/components/Zombies/utils/barbarian.test.js`, `client/src/components/Zombies/attributes/LevelUp.js`, `client/src/components/Zombies/attributes/Skills.js`, `client/src/components/Zombies/attributes/PlayerTurnActions.js`, `client/src/components/Zombies/attributes/PlayerTurnActions.test.js`, `server/routes/characters/base.js`.

### Testing

- Unit tests (targeted): ran the barbarian utils and Frenzy-related damage tests with the client test runner and they passed: `npm --prefix client test -- --runTestsByPath src/components/Zombies/utils/barbarian.test.js src/components/Zombies/attributes/PlayerTurnActions.test.js -t "barbarian level 3|Berserker Frenzy|barbarian rage damage" --watchAll=false` → PASS (targeted suites).
- Sanity/compile checks: ran the JS syntax checks for modified files with `node -c` on changed modules and they succeeded.
- Note: running the entire `PlayerTurnActions` UI test suite uncovered several unrelated pre-existing UI/test-environment failures; the implemented Frenzy/Primal Knowledge changes were validated via focused unit tests and the introduced tests for Barbarian level 3 and Frenzy passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53c1e153f08323bb8708b9974004f9)