### PR TITLE
Close Primal Knowledge modifier prompt before rolling

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -522,19 +522,20 @@ export default function Skills({
 
   const confirmModifierPrompt = async () => {
     if (!modifierPrompt || isRollingSkill) return;
-    const ability = selectedModifierAbility || modifierPrompt.ability;
-    const suffix = ability === 'str' && ability !== modifierPrompt.ability ? '— Primal Knowledge' : '';
+    const prompt = modifierPrompt;
+    const ability = selectedModifierAbility || prompt.ability;
+    const suffix = ability === 'str' && ability !== prompt.ability ? '— Primal Knowledge' : '';
+
+    closeModifierPrompt();
     setIsRollingSkill(true);
     try {
       await executeSkillRoll(
-        modifierPrompt.skillKey,
+        prompt.skillKey,
         ability,
-        modifierPrompt.proficient,
-        modifierPrompt.expertise,
+        prompt.proficient,
+        prompt.expertise,
         suffix
       );
-      setModifierPrompt(null);
-      setSelectedModifierAbility('');
       if (!isDocked) {
         handleCloseSkill?.();
       }


### PR DESCRIPTION
### Motivation
- Ensure the Primal Knowledge "Choose Modifier" modal closes immediately when the player clicks Roll while preserving the selected modifier and continuing the existing skill-roll flow unchanged.

### Description
- Capture the current `modifierPrompt` and `selectedModifierAbility` into local variables and call the existing `closeModifierPrompt()` before starting `executeSkillRoll(...)`, passing the captured values into the roll so the modal is hidden immediately but the roll uses the preserved choice.

### Testing
- Ran `git diff --check` which reported no new issues and the change was committed successfully. 
- Ran `npm --prefix client test -- --watchAll=false --runInBand Skills.test.js` where the skill-rolling behavior tests passed but two unrelated docking-prop assertions failed (existing test failures in repo). 
- Ran `npm --prefix client run build` which failed due to an unrelated syntax error in `src/components/Zombies/attributes/LevelUp.js` present in the repository prior to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53cd6e217483239c3427de60a64750)