### PR TITLE
Fix Primal Knowledge modal closure

### DIFF
--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -431,7 +431,8 @@ export default function Skills({
     updateSkill(skill, updated);
   };
 
-  const executeSkillRoll = async (skillKey, ability, proficient, expertise, labelSuffix = '') => {
+  const executeSkillRoll = async (skillKey, ability, proficient, expertise, labelSuffix = '', options = {}) => {
+    const { closeParentBeforeRoll = true } = options;
     const skill = SKILLS.find((s) => s.key === skillKey);
     const skillLabel = skill?.label || skill?.name || skillKey;
     const armorPenalty = skill?.armorPenalty || 0;
@@ -447,7 +448,7 @@ export default function Skills({
     const abilityLabel =
       ABILITY_LABELS[ability] || ability?.toUpperCase?.() || ability || 'Ability';
 
-    if (!isDocked && !labelSuffix) {
+    if (closeParentBeforeRoll && !isDocked) {
       handleCloseSkill?.();
     }
 
@@ -522,11 +523,15 @@ export default function Skills({
 
   const confirmModifierPrompt = async () => {
     if (!modifierPrompt || isRollingSkill) return;
-    const prompt = modifierPrompt;
+    const prompt = { ...modifierPrompt };
     const ability = selectedModifierAbility || prompt.ability;
     const suffix = ability === 'str' && ability !== prompt.ability ? '— Primal Knowledge' : '';
 
     closeModifierPrompt();
+    if (!isDocked) {
+      handleCloseSkill?.();
+    }
+
     setIsRollingSkill(true);
     try {
       await executeSkillRoll(
@@ -534,11 +539,9 @@ export default function Skills({
         ability,
         prompt.proficient,
         prompt.expertise,
-        suffix
+        suffix,
+        { closeParentBeforeRoll: false }
       );
-      if (!isDocked) {
-        handleCloseSkill?.();
-      }
     } finally {
       setIsRollingSkill(false);
     }

--- a/client/src/components/Zombies/attributes/Skills.test.js
+++ b/client/src/components/Zombies/attributes/Skills.test.js
@@ -10,6 +10,7 @@ jest.mock('react-bootstrap', () => {
   return {
     ...actual,
     Modal: ({ children, ...props }) => {
+      if (!props.show) return null;
       capturedModalProps = props;
       return <div data-testid="mock-modal">{children}</div>;
     },
@@ -57,6 +58,34 @@ const createProps = (overrides = {}) => ({
   onRollResult: jest.fn(),
   ...overrides,
 });
+
+const createPrimalKnowledgeProps = (overrides = {}) =>
+  createProps({
+    totalLevel: 5,
+    strMod: 4,
+    dexMod: 2,
+    form: {
+      ...createProps().form,
+      skills: {
+        stealth: { proficient: true, expertise: true },
+      },
+      occupation: [{ Name: 'Barbarian', Level: 5 }],
+      classState: {
+        barbarian: {
+          rage: { active: true, current: 1 },
+        },
+      },
+    },
+    ...overrides,
+  });
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
 
 describe('Skills modal docking props', () => {
   beforeEach(() => {
@@ -144,6 +173,88 @@ describe('skill rolling behavior', () => {
       dispatchSpy.mockRestore();
     }
   });
+
+  it('closes both modals immediately before resolving a normal Primal Knowledge ability roll', async () => {
+    const handleCloseSkill = jest.fn();
+    const pendingRoll = deferred();
+    rollDiceWithBox.mockReturnValueOnce(pendingRoll.promise);
+
+    render(<Skills {...createPrimalKnowledgeProps({ handleCloseSkill })} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /roll stealth/i }));
+    expect(screen.getByText(/choose modifier/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^roll$/i }));
+
+    expect(screen.queryByText(/choose modifier/i)).not.toBeInTheDocument();
+    expect(handleCloseSkill).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(rollDiceWithBox).toHaveBeenCalledTimes(1));
+
+    pendingRoll.resolve({ rolls: [[12, 12]] });
+    await waitFor(() => expect(rollDiceWithBox).toHaveBeenCalledTimes(1));
+  });
+
+  it('closes both modals immediately before resolving a Strength Primal Knowledge roll and preserves roll context', async () => {
+    const handleCloseSkill = jest.fn();
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    const pendingRoll = deferred();
+    rollDiceWithBox.mockReturnValueOnce(pendingRoll.promise);
+
+    render(<Skills {...createPrimalKnowledgeProps({ handleCloseSkill })} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /roll stealth/i }));
+    await userEvent.selectOptions(screen.getByLabelText(/modifier/i), 'str');
+    await userEvent.click(screen.getByRole('button', { name: /^roll$/i }));
+
+    expect(screen.queryByText(/choose modifier/i)).not.toBeInTheDocument();
+    expect(handleCloseSkill).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(rollDiceWithBox).toHaveBeenCalledTimes(1));
+
+    pendingRoll.resolve({ rolls: [[12, 12]] });
+
+    await waitFor(() => {
+      const rollEventCall = dispatchSpy.mock.calls.find(
+        ([event]) => event?.type === 'damage-roll'
+      );
+      expect(rollEventCall?.[0].detail).toEqual(
+        expect.objectContaining({
+          value: 22,
+          source: 'Strength (Stealth) — Primal Knowledge',
+        })
+      );
+      expect(rollEventCall?.[0].detail.breakdown).toContain('+ 4 Strength Modifier');
+      expect(rollEventCall?.[0].detail.breakdown).toContain('+ 6 Expertise Bonus');
+    });
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('does not roll or close the parent Skills modal when cancelling the modifier prompt', async () => {
+    const handleCloseSkill = jest.fn();
+
+    render(<Skills {...createPrimalKnowledgeProps({ handleCloseSkill })} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /roll stealth/i }));
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.queryByText(/choose modifier/i)).not.toBeInTheDocument();
+    expect(handleCloseSkill).not.toHaveBeenCalled();
+    expect(rollDiceWithBox).not.toHaveBeenCalled();
+  });
+
+  it('keeps existing eligible-skill checks by rolling ineligible Rage skills without the modifier prompt', async () => {
+    const handleCloseSkill = jest.fn();
+    rollDiceWithBox.mockResolvedValueOnce({ rolls: [[11, 11]] });
+
+    render(<Skills {...createPrimalKnowledgeProps({ handleCloseSkill })} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /roll athletics/i }));
+
+    expect(screen.queryByText(/choose modifier/i)).not.toBeInTheDocument();
+    expect(handleCloseSkill).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(rollDiceWithBox).toHaveBeenCalledTimes(1));
+  });
+
   it('applies the player dice color before rolling', async () => {
     rollDiceWithBox.mockResolvedValueOnce({ rolls: [[8]] });
 


### PR DESCRIPTION
### Motivation
- Primal Knowledge Strength rolls left the parent Skills modal open because the Strength path diverged from the normal path and the parent close happened after awaiting the async roll flow.  
- The change aims to make the Strength — Primal Knowledge path close both the Choose Modifier and Skills modals immediately (like the normal ability path) while preserving the roll context and not changing existing roll behavior.

### Description
- Closed the divergence by adding an `options` parameter to `executeSkillRoll` with `closeParentBeforeRoll` (default `true`) so callers can opt out of a second parent-close when the prompt handler already closed it, and by conditionally calling `handleCloseSkill?.()` inside `executeSkillRoll` only when appropriate. (modified `client/src/components/Zombies/attributes/Skills.js`)  
- Updated the modifier-confirmation flow to snapshot the prompt data (`const prompt = { ...modifierPrompt }`) before calling `closeModifierPrompt()` and to call the parent `handleCloseSkill?.()` immediately when undocked, then invoke `executeSkillRoll` with `{ closeParentBeforeRoll: false }`. (modified `client/src/components/Zombies/attributes/Skills.js`)  
- Preserved roll context by explicitly passing `skillKey`, `ability`, `proficient`, `expertise`, and the Primal Knowledge suffix to `executeSkillRoll` so the roll still uses Strength, applies proficiency/expertise correctly, and emits the same combat-log `source` (e.g. `Strength (Stealth) — Primal Knowledge`). (modified `client/src/components/Zombies/attributes/Skills.js`)  
- Added regression tests and small test-support helpers for the Primal Knowledge flows and updated the modal mock to only capture open modals, so tests can assert that both the Choose Modifier and Skills modals close immediately; changes are in `client/src/components/Zombies/attributes/Skills.test.js`.

### Testing
- Ran the updated test file with `cd client && npm test -- --watchAll=false src/components/Zombies/attributes/Skills.test.js`, which executed the full test suite for `Skills.test.js`.  
- Result: all tests in that file passed (`9 passed, 0 failed`); the run produced React `act(...)` warnings from existing async state updates but the assertions passed.  
- New/updated tests cover: immediate closing of both modals for normal modifier and Strength — Primal Knowledge modifier, ensuring both modals close before the dice promise resolves, preserving Strength/proficiency/expertise and the Primal Knowledge label, preventing duplicate rolls, and preserving cancel behavior (no roll and no parent close).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53d094f5148323b6901d2d5079d9d8)