### PR TITLE
Add Barbarian Fast Movement speed bonus

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js
@@ -422,6 +422,39 @@ test('combat HUD movement badge uses centralized derived speed and preserves com
   expect(within(statPills).queryByLabelText('Passive Perception')).not.toBeInTheDocument();
 });
 
+test('combat HUD movement badge reflects Barbarian Fast Movement and heavy armor suppression', async () => {
+  const baseCharacter = {
+    _id: '1', characterId: '1', characterName: 'Sprinter', campaign: 'test-campaign',
+    health: 20, currentHp: 20, speed: 30, str: 10, dex: 12, con: 10, int: 10, wis: 10, cha: 10,
+    occupation: [{ Name: 'Barbarian', Level: 5 }], conditions: [], classState: {},
+    feat: [], equipment: {},
+  };
+  const heavyArmorCharacter = {
+    ...baseCharacter,
+    equipment: { chest: { name: 'Plate', category: 'Heavy Armor', source: 'armor', acBonus: 8, maxDex: 0 } },
+  };
+  let currentCharacter = baseCharacter;
+
+  apiFetch.mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('/characters/1')) {
+      return Promise.resolve({ ok: true, json: async () => currentCharacter });
+    }
+    return defaultApiFetchImplementation(url);
+  });
+
+  const { unmount } = render(<ZombiesCharacterSheet />);
+
+  let statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 40 ft');
+
+  unmount();
+  currentCharacter = heavyArmorCharacter;
+  render(<ZombiesCharacterSheet />);
+
+  statPills = await screen.findByLabelText('Defenses and conditions');
+  expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
+});
+
 test('combat HUD displays initiative from derived stats without passive perception', async () => {
   const character = {
     _id: '1', characterId: '1', characterName: 'Scout', campaign: 'test-campaign',
@@ -486,8 +519,8 @@ test('combat HUD proficiency badge uses centralized proficiency calculation and 
 
   const statPills = await screen.findByLabelText('Defenses and conditions');
   expect(within(statPills).getByLabelText('Proficiency bonus')).toHaveTextContent('Proficiency +4');
-  expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 30 ft');
-  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 30 ft\s*Initiative: \+1.*1 Condition/);
+  expect(within(statPills).getByLabelText('Movement speed')).toHaveTextContent('Move: 40 ft');
+  expect(statPills).toHaveTextContent(/AC 11\s*Proficiency \+4\s*Move: 40 ft\s*Initiative: \+1.*1 Condition/);
   expect(within(statPills).getByLabelText('Active conditions')).not.toHaveTextContent('Rage');
 });
 

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -115,6 +115,37 @@ const collectMovementSpeedBonus = (value) => {
   );
 };
 
+const isHeavyArmorItem = (item) => {
+  if (!item || isExplicitlyUnowned(item)) {
+    return false;
+  }
+
+  if (Array.isArray(item)) {
+    const category = String(item[3] ?? '').toLowerCase();
+    return category === 'heavy' || category.includes('heavy armor');
+  }
+
+  if (typeof item !== 'object') {
+    return false;
+  }
+
+  const armorClassification = String(
+    item.category ?? item.type ?? item.armorType ?? ''
+  ).toLowerCase();
+
+  return armorClassification === 'heavy' || armorClassification.includes('heavy armor');
+};
+
+const calculateClassMovementSpeedBonus = (character, equipmentEntries) => {
+  const barbarianLevel = getBarbarianLevel(character);
+  if (barbarianLevel < 5) {
+    return 0;
+  }
+
+  const hasHeavyArmorEquipped = equipmentEntries.some((item) => isHeavyArmorItem(item));
+  return hasHeavyArmorEquipped ? 0 : 10;
+};
+
 export const calculateCharacterMovementSpeed = (character, overrides = {}) => {
   if (!character || typeof character !== 'object') {
     return 0;
@@ -130,10 +161,12 @@ export const calculateCharacterMovementSpeed = (character, overrides = {}) => {
   const normalizedEquipment = normalizeEquipmentMap(character?.equipment);
   const equipmentEntries = Object.values(normalizedEquipment || {}).filter(Boolean);
   const accessoryEntries = normalizeAccessoryCollection(character);
+  const classMovementSpeedBonus = calculateClassMovementSpeedBonus(character, equipmentEntries);
 
   const total =
     baseSpeed +
     featBonuses +
+    classMovementSpeedBonus +
     collectMovementSpeedBonus(character?.race) +
     collectMovementSpeedBonus(character?.classState) +
     collectMovementSpeedBonus(character?.features) +

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -217,4 +217,80 @@ describe('calculateCharacterMovementSpeed', () => {
   it('clamps reduced movement at zero feet', () => {
     expect(calculateCharacterMovementSpeed({ speed: 25, conditions: [{ speedBonus: -40 }] })).toBe(0);
   });
+
+  it('applies Barbarian Fast Movement starting at Barbarian level 5', () => {
+    const base = { speed: 30, equipment: {} };
+
+    expect(calculateCharacterMovementSpeed({ ...base, occupation: [{ Name: 'Barbarian', Level: 4 }] })).toBe(30);
+    expect(calculateCharacterMovementSpeed({ ...base, occupation: [{ Name: 'Barbarian', Level: 5 }] })).toBe(40);
+    expect(calculateCharacterMovementSpeed({ ...base, occupation: [{ Name: 'Barbarian', Level: 10 }] })).toBe(40);
+  });
+
+  it('suppresses Barbarian Fast Movement only while heavy armor is equipped', () => {
+    const base = { speed: 30, occupation: [{ Name: 'Barbarian', Level: 5 }] };
+    const lightArmor = { name: 'Leather', category: 'Light Armor', source: 'armor' };
+    const mediumArmor = { name: 'Hide', category: 'Medium Armor', source: 'armor' };
+    const heavyArmor = { name: 'Plate', category: 'Heavy Armor', source: 'armor' };
+
+    expect(calculateCharacterMovementSpeed({ ...base, equipment: {} })).toBe(40);
+    expect(calculateCharacterMovementSpeed({ ...base, equipment: { chest: lightArmor } })).toBe(40);
+    expect(calculateCharacterMovementSpeed({ ...base, equipment: { chest: mediumArmor } })).toBe(40);
+    expect(calculateCharacterMovementSpeed({ ...base, equipment: { chest: heavyArmor } })).toBe(30);
+    expect(calculateCharacterMovementSpeed({ ...base, equipment: { chest: null }, armor: [heavyArmor] })).toBe(40);
+  });
+
+  it('uses armor classification rather than item name for Fast Movement heavy armor checks', () => {
+    const character = { speed: 30, occupation: [{ Name: 'Barbarian', Level: 5 }] };
+
+    expect(calculateCharacterMovementSpeed({
+      ...character,
+      equipment: { chest: { name: 'Ceremonial Plate', category: 'Light Armor', source: 'armor' } },
+    })).toBe(40);
+    expect(calculateCharacterMovementSpeed({
+      ...character,
+      equipment: { chest: { name: 'Silken Robe', armorType: 'Heavy Armor', source: 'armor' } },
+    })).toBe(30);
+  });
+
+  it('applies Barbarian Fast Movement based only on Barbarian levels when multiclassed', () => {
+    const base = { speed: 30, equipment: {} };
+
+    expect(calculateCharacterMovementSpeed({
+      ...base,
+      occupation: [{ Name: 'Barbarian', Level: 5 }, { Name: 'Fighter', Level: 5 }],
+    })).toBe(40);
+    expect(calculateCharacterMovementSpeed({
+      ...base,
+      occupation: [{ Name: 'Barbarian', Level: 4 }, { Name: 'Fighter', Level: 10 }],
+    })).toBe(30);
+    expect(calculateCharacterMovementSpeed({
+      ...base,
+      occupation: [{ Name: 'Barbarian', Level: 8 }, { Name: 'Rogue', Level: 5 }],
+    })).toBe(40);
+  });
+
+  it('stacks Barbarian Fast Movement with existing centralized movement bonuses', () => {
+    const character = {
+      speed: 30,
+      occupation: [{ Name: 'Barbarian', Level: 5 }],
+      feat: [{ speed: 5 }],
+      equipment: { feet: { name: 'Boots of Pace', speedBonus: 5 } },
+      conditions: [{ name: 'Slowed', movementSpeedBonus: -10 }],
+    };
+
+    expect(calculateCharacterMovementSpeed(character)).toBe(40);
+  });
+
+  it('recalculates Fast Movement after save/load, armor changes, and Barbarian level changes', () => {
+    const heavyArmor = { name: 'Plate', category: 'Heavy Armor', source: 'armor' };
+    const levelFour = { speed: 30, occupation: [{ Name: 'Barbarian', Level: 4 }], equipment: {} };
+    const levelFive = { ...levelFour, occupation: [{ Name: 'Barbarian', Level: 5 }] };
+    const savedAndLoaded = JSON.parse(JSON.stringify(levelFive));
+
+    expect(calculateCharacterMovementSpeed(levelFour)).toBe(30);
+    expect(calculateCharacterMovementSpeed(levelFive)).toBe(40);
+    expect(calculateCharacterMovementSpeed(savedAndLoaded)).toBe(40);
+    expect(calculateCharacterMovementSpeed({ ...levelFive, equipment: { chest: heavyArmor } })).toBe(30);
+    expect(calculateCharacterMovementSpeed({ ...levelFive, equipment: { chest: null } })).toBe(40);
+  });
 });


### PR DESCRIPTION
### Motivation
- Implement Barbarian Level 5 "Fast Movement": grant +10 ft movement when Barbarian level is 5 or higher and the character is not wearing Heavy Armor.

### Description
- Add centralized class movement bonus logic to `calculateCharacterMovementSpeed` by introducing `isHeavyArmorItem` and `calculateClassMovementSpeedBonus`, which uses `getBarbarianLevel(character)` and equipment classification (`category|type|armorType`) to decide the +10 ft bonus or suppression.
- Preserve existing movement pipeline and stacking: base speed still comes from `overrides.baseSpeed` → `character.speed` → `character.race.speed`, then existing bonus collectors (feats, race, classState, items, armor, equipment, accessories, conditions, misc) remain unchanged and continue to stack with Fast Movement.
- Rely on armor classification rather than item name to detect Heavy Armor, and only check equipped normalized `equipment` entries so unequipping immediately restores the bonus via normal reactive `form` updates.
- Files modified: `client/src/components/Zombies/utils/characterMetrics.js`, `client/src/components/Zombies/utils/characterMetrics.test.js`, `client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js`.

### Testing
- Added unit tests covering: Barbarian level thresholds (4/5/10), light/medium/heavy armor behavior, unequipping heavy armor, classification-over-name checks, multiclass scenarios, stacking with existing movement bonuses, and persistence/recalculation cases; and a combat HUD test asserting `Move: 40 ft` for Barbarian 5 and `Move: 30 ft` while wearing Heavy Armor.
- Ran: `npm --prefix client test -- --watchAll=false client/src/components/Zombies/utils/characterMetrics.test.js client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` and observed: Test Suites: 2 passed, Tests: 80 passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53d6c808bc832384bcc8b76b50dd0c)