### PR TITLE
Add Mindless Rage (Path of the Berserker L6) feature card and subclass metadata

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1739,6 +1739,10 @@ body.docked-modal--resizing {
   color: rgba(255, 255, 255, 0.7);
 }
 
+.feature-card-subclass {
+  flex-basis: 100%;
+}
+
 .feature-card-actions {
   display: flex;
   align-items: center;

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1317,6 +1317,7 @@ export default function Features({
         `${String(feature?.class || '').toLowerCase()}:${String(feature?.name || '').toLowerCase()}`
       )
     );
+    const hiddenBarbarianFeatureNames = new Set(['primal path', 'primal path feature']);
     const generatedBarbarianFeatures = getAvailableBarbarianFeatures(form)
       .filter((feature) => !existingKeys.has('barbarian:' + String(feature.name || '').toLowerCase()))
       .map((feature) => ({
@@ -1325,7 +1326,11 @@ export default function Features({
         isWeaponMasteryConfig: feature.id === 'barbarian-weapon-mastery',
         isRecklessAttackToggle: feature.id === 'reckless-attack',
       }));
-    return [...features, ...generatedBarbarianFeatures].sort(
+    const visibleFeatures = features.filter((feature) => {
+      if (String(feature?.class || '').toLowerCase() !== 'barbarian') return true;
+      return !hiddenBarbarianFeatureNames.has(String(feature?.name || '').toLowerCase());
+    });
+    return [...visibleFeatures, ...generatedBarbarianFeatures].sort(
       (a, b) =>
         (a.class || '').localeCompare(b.class || '') ||
         (a.level || 0) - (b.level || 0)
@@ -1714,6 +1719,9 @@ export default function Features({
                                   {feat.class && <span>{feat.class}</span>}
                                   {feat.level != null && (
                                     <span>Level {feat.level}</span>
+                                  )}
+                                  {feat.subclass && (
+                                    <span className="feature-card-subclass">{feat.subclass}</span>
                                   )}
                                 </>
                               )}

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -1994,6 +1994,86 @@ test('features are sorted by class then level', async () => {
   expect(order).toEqual(['Second Wind', 'Action Surge', 'Arcane Recovery']);
 });
 
+
+test('barbarian Berserker subclass features render subclass metadata and Mindless Rage details', async () => {
+  apiFetch.mockImplementation((url) => {
+    const levelMatch = url.match(/features\/(\d+)/);
+    const level = levelMatch ? parseInt(levelMatch[1], 10) : 0;
+    const features = [];
+    if (level === 3) {
+      features.push({ name: 'Primal Path', description: 'Placeholder path.' });
+    }
+    if (level === 5) {
+      features.push({ name: 'Extra Attack', description: 'Attack twice.' });
+    }
+    if (level === 6) {
+      features.push({ name: 'Primal Path Feature', description: 'Placeholder feature.' });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({ features }) });
+  });
+
+  const renderBerserker = (level) => render(
+    <Features
+      form={{
+        occupation: [{ Name: 'Barbarian', Level: level }],
+        classState: {
+          barbarian: {
+            subclass: { id: 'path-of-the-berserker', name: 'Path of the Berserker' },
+          },
+        },
+      }}
+      showFeatures={true}
+      handleCloseFeatures={() => {}}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const levelFive = renderBerserker(5);
+  expect(await screen.findByText('Frenzy')).toBeInTheDocument();
+  expect(screen.queryByText('Mindless Rage')).not.toBeInTheDocument();
+  levelFive.unmount();
+
+  renderBerserker(6);
+
+  const subclassTitle = await screen.findByText('Barbarian Subclass');
+  const subclassCard = subclassTitle.closest('.feature-card');
+  expect(subclassCard).not.toBeNull();
+  expect(within(subclassCard).getByText('Barbarian')).toBeInTheDocument();
+  expect(within(subclassCard).getByText('Level 3')).toBeInTheDocument();
+  expect(within(subclassCard).getByText('Path of the Berserker')).toBeInTheDocument();
+
+  for (const featureName of ['Frenzy', 'Mindless Rage']) {
+    const title = await screen.findByText(featureName);
+    const card = title.closest('.feature-card');
+    expect(card).not.toBeNull();
+    expect(within(card).getByText('Path of the Berserker')).toBeInTheDocument();
+  }
+
+  const extraAttackCard = (await screen.findByText('Extra Attack')).closest('.feature-card');
+  expect(extraAttackCard).not.toBeNull();
+  expect(within(extraAttackCard).getByText('Barbarian')).toBeInTheDocument();
+  expect(within(extraAttackCard).getByText('Level 5')).toBeInTheDocument();
+  expect(within(extraAttackCard).queryByText('Path of the Berserker')).not.toBeInTheDocument();
+
+  expect(screen.queryByText('Primal Path')).not.toBeInTheDocument();
+  expect(screen.queryByText('Primal Path Feature')).not.toBeInTheDocument();
+
+  const mindlessRageCard = screen.getByText('Mindless Rage').closest('.feature-card');
+  await act(async () => {
+    await userEvent.click(within(mindlessRageCard).getByRole('button', { name: /view feature/i }));
+  });
+
+  await screen.findByText(
+    'You have Immunity to the Charmed and Frightened conditions while your Rage is active. If you’re Charmed or Frightened when you enter your Rage, the condition ends on you.'
+  );
+  expect(Array.from(document.querySelectorAll('.modern-modal .modal-title')).some((node) => node.textContent === 'Mindless Rage')).toBe(true);
+  expect(
+    screen.getByText(
+      'You have Immunity to the Charmed and Frightened conditions while your Rage is active. If you’re Charmed or Frightened when you enter your Rage, the condition ends on you.'
+    )
+  ).toBeInTheDocument();
+});
+
 describe('barbarian weapon mastery feature UI', () => {
   const weapons = {
     club: { name: 'Club', type: 'club', category: 'simple melee', mastery: 'slow' },

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -160,8 +160,20 @@ export const BARBARIAN_SUBCLASSES = [
     classId: "barbarian",
     level: 3,
     features: [
-      { id: "berserker-frenzy", name: "Frenzy", level: 3 },
-      { id: "berserker-mindless-rage", name: "Mindless Rage", level: 6 },
+      {
+        id: "berserker-frenzy",
+        name: "Frenzy",
+        level: 3,
+        description:
+          "If you use Reckless Attack while your Rage is active, you deal extra damage to the first target you hit on your turn with a Strength-based attack.",
+      },
+      {
+        id: "berserker-mindless-rage",
+        name: "Mindless Rage",
+        level: 6,
+        description:
+          "You have Immunity to the Charmed and Frightened conditions while your Rage is active. If you’re Charmed or Frightened when you enter your Rage, the condition ends on you.",
+      },
       { id: "berserker-retaliation", name: "Retaliation", level: 10 },
       { id: "berserker-intimidating-presence", name: "Intimidating Presence", level: 14 },
     ],
@@ -282,8 +294,17 @@ export const BARBARIAN_FEATURES = [
 
 export const getAvailableBarbarianFeatures = (character) => {
   const barbarianLevel = getBarbarianLevel(character);
+  const selectedSubclass = getBarbarianSubclass(character);
+  const selectedSubclassName =
+    typeof selectedSubclass === "object" && selectedSubclass !== null
+      ? selectedSubclass.name || selectedSubclass.label || selectedSubclass.id
+      : selectedSubclass;
   return [
-    ...BARBARIAN_FEATURES.filter((feature) => barbarianLevel >= feature.level),
+    ...BARBARIAN_FEATURES.filter((feature) => barbarianLevel >= feature.level).map((feature) =>
+      feature.id === "barbarian-subclass" && selectedSubclassName
+        ? { ...feature, subclass: selectedSubclassName }
+        : feature
+    ),
     ...getActiveBarbarianSubclassFeatures(character).map((feature) => ({
       ...feature,
       class: "Barbarian",

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -266,8 +266,22 @@ describe("barbarian level 3 features", () => {
     expect(getAvailableBarbarianSubclasses(barbarian({ occupation: [{ Name: "Barbarian", Level: 2 }] }))).toEqual([]);
     expect(getAvailableBarbarianSubclasses(barbarian3()).map((s) => s.name)).toContain("Path of the Berserker");
     expect(getActiveBarbarianSubclassFeatures(barbarian3()).map((f) => f.name)).toEqual(["Frenzy"]);
-    expect(getAvailableBarbarianFeatures(barbarian3()).map((f) => f.name)).toEqual(expect.arrayContaining(["Primal Knowledge", "Barbarian Subclass", "Frenzy"]));
-    expect(getActiveBarbarianSubclassFeatures(barbarian({ occupation: [{ Name: "Barbarian", Level: 5 }], classState: { barbarian: { subclass: { id: "path-of-the-berserker" } } } })).map((f) => f.name)).not.toContain("Mindless Rage");
+    const level3Features = getAvailableBarbarianFeatures(barbarian3());
+    expect(level3Features.map((f) => f.name)).toEqual(expect.arrayContaining(["Primal Knowledge", "Barbarian Subclass", "Frenzy"]));
+    expect(level3Features.find((f) => f.name === "Barbarian Subclass")?.subclass).toBe("Path of the Berserker");
+    expect(level3Features.find((f) => f.name === "Frenzy")?.subclass).toBe("Path of the Berserker");
+
+    const level5Features = getActiveBarbarianSubclassFeatures(barbarian({ occupation: [{ Name: "Barbarian", Level: 5 }], classState: { barbarian: { subclass: { id: "path-of-the-berserker" } } } }));
+    expect(level5Features.map((f) => f.name)).not.toContain("Mindless Rage");
+
+    const level6Features = getAvailableBarbarianFeatures(barbarian({ occupation: [{ Name: "Barbarian", Level: 6 }], classState: { barbarian: { subclass: { id: "path-of-the-berserker", name: "Path of the Berserker" } } } }));
+    const mindlessRage = level6Features.find((f) => f.name === "Mindless Rage");
+    expect(mindlessRage).toMatchObject({
+      level: 6,
+      subclass: "Path of the Berserker",
+      description:
+        "You have Immunity to the Charmed and Frightened conditions while your Rage is active. If you’re Charmed or Frightened when you enter your Rage, the condition ends on you.",
+    });
   });
 
   it("exposes Primal Knowledge alternate checks only for eligible raging skills", () => {


### PR DESCRIPTION
### Motivation
- Surface the Path of the Berserker Level 6 feature as player-facing feature card data and ensure subclass-granted features clearly show which subclass granted them without implementing any mechanics yet.
- Remove internal placeholder cards (`Primal Path` / `Primal Path Feature`) from the rendered class feature list because they are implementation artifacts rather than player-visible features.

### Description
- Added the Mindless Rage display data to the Berserker subclass feature list in `client/src/components/Zombies/utils/barbarian.js` with the exact requested description text and level gating (Level 6, Path of the Berserker). (see `BARBARIAN_SUBCLASSES` features). 
- Included the selected subclass name on the generated Barbarian features and the `Barbarian Subclass` feature by augmenting `getAvailableBarbarianFeatures` to attach `subclass` metadata when a subclass is selected in `client/src/components/Zombies/utils/barbarian.js`.
- Updated the feature card renderer in `client/src/components/Zombies/attributes/Features.js` to render the subclass name as a third meta line on subclass-granted features and added filtering to hide the `Primal Path` and `Primal Path Feature` placeholder cards while preserving generated subclass features.
- Added a small style in `client/src/App.scss` (`.feature-card-subclass`) so the subclass name appears on its own line in the existing feature card layout.

### Testing
- Ran the component/unit tests with `CI=true npm test -- --runInBand src/components/Zombies/utils/barbarian.test.js src/components/Zombies/attributes/Features.test.js` and both suites passed (2 suites, 40 tests, all passing).
- Tests added/updated include assertions in `client/src/components/Zombies/utils/barbarian.test.js` that `Mindless Rage` is gated to Barbarian level >= 6 and carries the `subclass` and exact description, and additions in `client/src/components/Zombies/attributes/Features.test.js` that confirm the `Barbarian Subclass` card and all subclass feature cards display the selected subclass name, `Mindless Rage` is not visible at level 5 but is visible at level 6, the info-eye modal shows the exact description, and `Primal Path` / `Primal Path Feature` placeholders are not rendered.

Files changed: `client/src/components/Zombies/utils/barbarian.js`, `client/src/components/Zombies/attributes/Features.js`, `client/src/components/Zombies/attributes/Features.test.js`, `client/src/components/Zombies/utils/barbarian.test.js`, `client/src/App.scss`.

Notes: the actual condition immunity/removal mechanics were intentionally not implemented as requested; this change only provides display data and UI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53e4487bd88323a04bf745d1650c6c)