### PR TITLE
Add Barbarian L7: Feral Instinct & Instinctive Pounce (initiative advantage integration)

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.initiative.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.initiative.test.js
@@ -1,0 +1,46 @@
+import { rollInitiativeD20 } from './ZombiesDM';
+
+describe('DM initiative rolling', () => {
+  it('rolls normally with one d20', () => {
+    const rollD20 = jest.fn(() => 4);
+
+    expect(rollInitiativeD20({ rollD20 })).toEqual({
+      mode: 'normal',
+      rolls: [4],
+      kept: 4,
+    });
+    expect(rollD20).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls initiative with Advantage and keeps the higher d20', () => {
+    const rolls = [4, 17];
+    const rollD20 = jest.fn(() => rolls.shift());
+
+    const result = rollInitiativeD20({ rollD20, mode: 'advantage' });
+
+    expect(result).toEqual({ mode: 'advantage', rolls: [4, 17], kept: 17 });
+    expect(result.kept + 3).toBe(20);
+    expect(rollD20).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not roll more than two d20s for Advantage', () => {
+    const rollD20 = jest.fn()
+      .mockReturnValueOnce(12)
+      .mockReturnValueOnce(15)
+      .mockReturnValueOnce(20);
+
+    expect(rollInitiativeD20({ rollD20, mode: 'advantage' }).kept).toBe(15);
+    expect(rollD20).toHaveBeenCalledTimes(2);
+  });
+
+  it('rolls initiative with Disadvantage and keeps the lower d20', () => {
+    const rolls = [17, 4];
+    const rollD20 = jest.fn(() => rolls.shift());
+
+    expect(rollInitiativeD20({ rollD20, mode: 'disadvantage' })).toEqual({
+      mode: 'disadvantage',
+      rolls: [17, 4],
+      kept: 4,
+    });
+  });
+});

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -22,6 +22,7 @@ import useUser from '../../../hooks/useUser';
 import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative, calculatePassivePerception } from '../utils/derivedStats';
+import { resolveInitiativeRollMode } from '../utils/barbarian';
 import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
@@ -109,6 +110,17 @@ const toTitleCase = (value) => {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+};
+
+export const rollInitiativeD20 = ({ rollD20 = () => Math.floor(Math.random() * 20) + 1, mode = 'normal' } = {}) => {
+  const first = rollD20();
+  if (mode !== 'advantage' && mode !== 'disadvantage') {
+    return { rolls: [first], kept: first, mode: 'normal' };
+  }
+
+  const second = rollD20();
+  const kept = mode === 'advantage' ? Math.max(first, second) : Math.min(first, second);
+  return { rolls: [first, second], kept, mode };
 };
 
 const formatSignedModifier = (value) => {
@@ -3751,6 +3763,20 @@ export default function ZombiesDM() {
       [calculateCharacterInitiative]
     );
 
+    const characterInitiativeRollModeMap = useMemo(() => {
+      const map = new Map();
+      if (Array.isArray(combinedRecords)) {
+        combinedRecords.forEach((entity) => {
+          const id = getEntityId(entity);
+          if (!id || entity?.entityType === 'enemy') {
+            return;
+          }
+          map.set(id, resolveInitiativeRollMode(entity));
+        });
+      }
+      return map;
+    }, [combinedRecords, getEntityId]);
+
     const characterInitiativeMap = useMemo(() => {
       const map = new Map();
       if (Array.isArray(combinedRecords)) {
@@ -3902,11 +3928,19 @@ export default function ZombiesDM() {
             : Number.isFinite(Number(baseInitiative))
               ? Number(baseInitiative)
               : 0;
-          const roll = Math.floor(Math.random() * 20) + 1;
+          const rollMode = characterInitiativeRollModeMap.get(participant.characterId);
+          const initiativeRoll = rollInitiativeD20({ mode: rollMode?.mode || 'normal' });
 
           return {
             ...participant,
-            initiative: numericBase + roll,
+            initiative: numericBase + initiativeRoll.kept,
+            initiativeRoll: {
+              ...initiativeRoll,
+              modifier: numericBase,
+              total: numericBase + initiativeRoll.kept,
+              sources: rollMode?.advantageSources || [],
+              disadvantageSources: rollMode?.disadvantageSources || [],
+            },
           };
         })
         .filter(Boolean);
@@ -3942,7 +3976,7 @@ export default function ZombiesDM() {
 
       setCombatState(nextState);
       persistCombatState(nextState);
-    }, [combatState, characterInitiativeMap, persistCombatState]);
+    }, [combatState, characterInitiativeMap, characterInitiativeRollModeMap, persistCombatState]);
 
     const handleAdvanceTurn = useCallback(
       (direction) => {

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -226,6 +226,27 @@ export const getActiveBarbarianSubclassFeatures = (character) => {
 };
 
 export const hasPrimalKnowledge = (character) => getBarbarianLevel(character) >= 3;
+export const hasFeralInstinct = (character) => getBarbarianLevel(character) >= 7;
+
+export const getFeralInstinctInitiativeSources = (character) =>
+  hasFeralInstinct(character) ? ["Feral Instinct"] : [];
+
+export const resolveInitiativeRollMode = (character, options = {}) => {
+  const advantageSources = Array.isArray(options.advantageSources)
+    ? [...options.advantageSources]
+    : [];
+  const disadvantageSources = Array.isArray(options.disadvantageSources)
+    ? [...options.disadvantageSources]
+    : [];
+
+  advantageSources.push(...getFeralInstinctInitiativeSources(character));
+
+  return {
+    mode: resolveD20RollMode({ advantageSources, disadvantageSources }),
+    advantageSources,
+    disadvantageSources,
+  };
+};
 export const isPrimalKnowledgeSkill = (skillKey) =>
   PRIMAL_KNOWLEDGE_SKILLS.includes(normalize(skillKey));
 export const canUsePrimalKnowledgeForSkill = (character, skillKey) =>
@@ -279,6 +300,26 @@ export const BARBARIAN_FEATURES = [
     level: 3,
     type: "configuration",
     description: "Choose a Barbarian subclass. Path of the Berserker is currently available.",
+  },
+  {
+    id: "feral-instinct",
+    name: "Feral Instinct",
+    class: "Barbarian",
+    classId: "barbarian",
+    level: 7,
+    type: "passive",
+    description:
+      "Your instincts are so honed that you have Advantage on Initiative rolls.",
+  },
+  {
+    id: "instinctive-pounce",
+    name: "Instinctive Pounce",
+    class: "Barbarian",
+    classId: "barbarian",
+    level: 7,
+    type: "passive",
+    description:
+      "As part of the Bonus Action you take to enter your Rage, you can move up to half your Speed.",
   },
   {
     id: "reckless-attack",

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -23,6 +23,8 @@ import {
   canUsePrimalKnowledgeForSkill,
   getFrenzyDamageDice,
   markFrenzyUsed,
+  hasFeralInstinct,
+  resolveInitiativeRollMode,
 } from "./barbarian";
 
 const barbarian = (extra = {}) => ({
@@ -308,5 +310,58 @@ describe("barbarian level 3 features", () => {
     expect(getFrenzyDamageDice(nonBerserker, { ability: "str", type: "weapon attack", dealsDamage: true })).toBeNull();
     const lowLevel = declareRecklessAttack(activateRage(barbarian({ occupation: [{ Name: "Barbarian", Level: 2 }], classState: { barbarian: { subclass: { id: "path-of-the-berserker" } } } })));
     expect(getFrenzyDamageDice(lowLevel, { ability: "str", type: "weapon attack", dealsDamage: true })).toBeNull();
+  });
+});
+
+
+describe("barbarian level 7 features", () => {
+  it("gates Feral Instinct and Instinctive Pounce at Barbarian level 7", () => {
+    const level6 = barbarian({ occupation: [{ Name: "Barbarian", Level: 6 }] });
+    const level7 = barbarian({ occupation: [{ Name: "Barbarian", Level: 7 }] });
+    const level10 = barbarian({ occupation: [{ Name: "Barbarian", Level: 10 }] });
+
+    expect(hasFeralInstinct(level6)).toBe(false);
+    expect(hasFeralInstinct(level7)).toBe(true);
+    expect(hasFeralInstinct(level10)).toBe(true);
+    expect(getAvailableBarbarianFeatures(level6).map((f) => f.name)).not.toEqual(
+      expect.arrayContaining(["Feral Instinct", "Instinctive Pounce"])
+    );
+    expect(getAvailableBarbarianFeatures(level7)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Feral Instinct",
+          level: 7,
+          description: "Your instincts are so honed that you have Advantage on Initiative rolls.",
+        }),
+        expect.objectContaining({
+          name: "Instinctive Pounce",
+          level: 7,
+          description: "As part of the Bonus Action you take to enter your Rage, you can move up to half your Speed.",
+        }),
+      ])
+    );
+  });
+
+  it("uses only Barbarian levels for Feral Instinct in multiclass builds", () => {
+    expect(resolveInitiativeRollMode({ occupation: [{ Name: "Barbarian", Level: 6 }, { Name: "Rogue", Level: 10 }] }).mode).toBe("normal");
+    expect(resolveInitiativeRollMode({ occupation: [{ Name: "Barbarian", Level: 7 }, { Name: "Fighter", Level: 3 }] })).toMatchObject({
+      mode: "advantage",
+      advantageSources: ["Feral Instinct"],
+    });
+    expect(resolveInitiativeRollMode({ occupation: [{ Name: "Barbarian", Level: 12 }, { Name: "Wizard", Level: 2 }] }).mode).toBe("advantage");
+  });
+
+  it("centralizes initiative advantage stacking and cancellation", () => {
+    const level7 = barbarian({ occupation: [{ Name: "Barbarian", Level: 7 }] });
+
+    expect(resolveInitiativeRollMode(level7, { advantageSources: ["Other source"] })).toMatchObject({
+      mode: "advantage",
+      advantageSources: ["Other source", "Feral Instinct"],
+    });
+    expect(resolveInitiativeRollMode(level7, { disadvantageSources: ["Hampered"] })).toMatchObject({
+      mode: "normal",
+      advantageSources: ["Feral Instinct"],
+      disadvantageSources: ["Hampered"],
+    });
   });
 });

--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -219,7 +219,11 @@ A Rage can last for up to 10 minutes.`
   7: [
     {
       name: 'Feral Instinct',
-      description: 'You have advantage on initiative rolls.'
+      description: 'Your instincts are so honed that you have Advantage on Initiative rolls.'
+    },
+    {
+      name: 'Instinctive Pounce',
+      description: 'As part of the Bonus Action you take to enter your Rage, you can move up to half your Speed.'
     }
   ],
   8: [ASI],


### PR DESCRIPTION
### Motivation
- Implement Barbarian level 7 class features so characters gain Advantage on initiative at Barbarian 7 and display the Instinctive Pounce feature without changing movement flows. 
- Reuse the existing initiative, class-feature, and info-eye systems and respect existing advantage/disadvantage cancellation and multiclass gating.

### Description
- Added server and client feature data for `Feral Instinct` and `Instinctive Pounce` at Barbarian level 7 with the exact provided descriptions (`server/data/classFeatures.js` and `client/src/components/Zombies/utils/barbarian.js`).
- Exposed `hasFeralInstinct`, `getFeralInstinctInitiativeSources`, and `resolveInitiativeRollMode` in `client/src/components/Zombies/utils/barbarian.js` to centralize initiative advantage sources and delegate cancellation to the existing `resolveD20RollMode` helper. 
- Integrated into the DM initiative flow in `client/src/components/Zombies/pages/ZombiesDM.js` by adding `rollInitiativeD20` (rolls one or two d20s depending on mode), building a per-character `characterInitiativeRollModeMap`, using the kept d20 via `initiativeRoll.kept`, and assigning `participant.initiative = numericBase + initiativeRoll.kept` so the kept result is passed into the existing initiative tracker without altering tie handling or initiative UI formats. 
- Preserved `Instinctive Pounce` as display-only (no movement, no new buttons, and no changes to Rage/Bonus Action flows) and kept all class feature cards and info-eye presentation consistent with existing conventions. 
- Files changed: `server/data/classFeatures.js`, `client/src/components/Zombies/utils/barbarian.js`, `client/src/components/Zombies/pages/ZombiesDM.js`, `client/src/components/Zombies/utils/barbarian.test.js`, and added `client/src/components/Zombies/pages/ZombiesDM.initiative.test.js`.

### Testing
- Ran unit tests with `npm --prefix client test -- --runTestsByPath src/components/Zombies/utils/barbarian.test.js src/components/Zombies/pages/ZombiesDM.initiative.test.js --watchAll=false` and both test suites passed (all tests green). 
- Added tests include Barbarian level-gating and multiclass eligibility for Feral Instinct, exact info-eye descriptions, centralized roll-mode stacking/cancellation checks, and deterministic initiative d20 behavior (two d20s kept behavior for Advantage/Disadvantage). 
- Verified `participant.initiative` receives `numericBase + initiativeRoll.kept` and that only up to two d20s are rolled for Advantage, with Advantage+Disadvantage resolved by the shared roll-mode logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53e8ec89ac8323a5458b7cd4d3e436)