### PR TITLE
Add Movespeed column to Combat Tracker

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -23,7 +23,7 @@ import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative, calculatePassivePerception } from '../utils/derivedStats';
 import { resolveInitiativeRollMode } from '../utils/barbarian';
-import { calculateCharacterHitPoints } from '../utils/characterMetrics';
+import { calculateCharacterHitPoints, calculateCharacterMovementSpeed } from '../utils/characterMetrics';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import DamageDiceCanvas from '../attributes/DamageDiceCanvas';
@@ -296,6 +296,52 @@ const formatSensesDisplay = (senses) => {
   });
 
   return entries.length > 0 ? entries.join(', ') : '—';
+};
+
+
+const hasMovementSpeedSource = (entity) => {
+  if (!entity || typeof entity !== 'object') {
+    return false;
+  }
+
+  return [
+    entity.speed,
+    entity?.race?.speed,
+    entity?.movementSpeed,
+    entity?.walkingSpeed,
+  ].some((value) => toFiniteNumberOrNull(value) !== null);
+};
+
+const getEntityMovementSpeed = (entity) => {
+  if (!entity || typeof entity !== 'object') {
+    return null;
+  }
+
+  if (entity.entityType !== 'enemy') {
+    if (!hasMovementSpeedSource(entity)) {
+      return null;
+    }
+
+    const movementSpeed = calculateCharacterMovementSpeed(entity);
+    return Number.isFinite(movementSpeed) ? movementSpeed : null;
+  }
+
+  const directCandidates = [
+    entity.speed,
+    entity.movementSpeed,
+    entity.walkingSpeed,
+    entity.speed?.walk,
+    entity.speed?.walking,
+  ];
+
+  for (const candidate of directCandidates) {
+    const value = toFiniteNumberOrNull(candidate);
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  return null;
 };
 
 const getEntityPassivePerception = (entity) => {
@@ -4073,6 +4119,7 @@ export default function ZombiesDM() {
             rowId,
             participantInfo,
             passivePerception: getEntityPassivePerception(entity),
+            movementSpeed: getEntityMovementSpeed(entity),
             initiativeValue,
             sortInitiative: numericInitiative,
             recordIndex,
@@ -6970,6 +7017,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           <th scope="col">Character</th>
                           <th scope="col">Player</th>
                           <th scope="col" className="text-center">In Combat</th>
+                          <th scope="col" className="text-center">Movespeed</th>
                           <th scope="col" className="text-center">Passive Perception</th>
                           <th scope="col" className="text-center">Initiative</th>
                           <th scope="col" className="text-center">Actions</th>
@@ -6983,6 +7031,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                               rowId,
                               participantInfo,
                               passivePerception,
+                              movementSpeed,
                               initiativeValue,
                               recordIndex,
                             }) => {
@@ -6995,6 +7044,10 @@ const resolveIcon = (category, iconMap, fallback) => {
                               const displayPassivePerception =
                                 passivePerception !== undefined && passivePerception !== null
                                   ? passivePerception
+                                  : '—';
+                              const displayMovementSpeed =
+                                movementSpeed !== undefined && movementSpeed !== null
+                                  ? `${movementSpeed} ft`
                                   : '—';
                               const isActive =
                                 isParticipant &&
@@ -7066,6 +7119,9 @@ const resolveIcon = (category, iconMap, fallback) => {
                                       aria-label={`Toggle ${checkboxLabel} in combat`}
                                     />
                                   </td>
+                                  <td className="text-center" style={{ width: '110px' }}>
+                                    {displayMovementSpeed}
+                                  </td>
                                   <td className="text-center" style={{ width: '150px' }}>
                                     {displayPassivePerception}
                                   </td>
@@ -7092,7 +7148,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           )
                         ) : (
                           <tr>
-                            <td colSpan={6} className="text-center text-muted py-3">
+                            <td colSpan={7} className="text-center text-muted py-3">
                               No characters available.
                             </td>
                           </tr>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -1819,9 +1819,27 @@ describe('ZombiesDM AI generation', () => {
         characterName: 'Hero',
         token: 'Player1',
         dex: 14,
+        speed: 30,
         feat: [{ initiative: 1 }],
       },
-      { _id: 'char2', characterName: 'Rogue', token: 'Player2', dex: 12 },
+      {
+        _id: 'char2',
+        characterName: 'Rogue',
+        token: 'Player2',
+        dex: 12,
+        speed: 30,
+        occupation: [{ Occupation: 'Barbarian', Level: 5 }],
+      },
+      {
+        _id: 'char3',
+        characterName: 'Armored Barbarian',
+        token: 'Player3',
+        dex: 10,
+        speed: 30,
+        occupation: [{ Occupation: 'Barbarian', Level: 5 }],
+        equipment: { chest: { name: 'Plate', category: 'Heavy Armor' } },
+      },
+      { _id: 'char4', characterName: 'Mystery', token: 'Player4', dex: 10 },
     ];
     let combatState = { participants: [], activeTurn: null };
     const combatUpdates = [];
@@ -1863,6 +1881,7 @@ describe('ZombiesDM AI generation', () => {
     expect(socketInstance).toBeDefined();
     expect(socketInstance.emit).toHaveBeenCalledWith('campaign:join', 'Camp1');
 
+    await openResourceCard('Characters', 'resource-characters-card');
     await screen.findByRole('heading', { name: /Combat Tracker/i });
 
     const combatTurnOrder = await screen.findByRole('group', {
@@ -1875,14 +1894,33 @@ describe('ZombiesDM AI generation', () => {
       throw new Error('Combat tracker table not found');
     }
 
+    const headers = within(combatTable).getAllByRole('columnheader').map((header) => header.textContent);
+    expect(headers).toEqual([
+      'Character',
+      'Player',
+      'In Combat',
+      'Movespeed',
+      'Passive Perception',
+      'Initiative',
+      'Actions',
+    ]);
+
     const heroRow = (await within(combatTable).findByText('Hero')).closest('tr');
     if (!heroRow) {
       throw new Error('Hero row not found in combat table');
     }
 
+    const rogueRow = (await within(combatTable).findByText('Rogue')).closest('tr');
+    const armoredBarbarianRow = (await within(combatTable).findByText('Armored Barbarian')).closest('tr');
+    const mysteryRow = (await within(combatTable).findByText('Mystery')).closest('tr');
+
     const cells = within(heroRow).getAllByRole('cell');
-    const initiativeCell = cells[3];
-    expect(initiativeCell).toHaveTextContent('3');
+    expect(cells).toHaveLength(headers.length);
+    expect(cells[3]).toHaveTextContent('30 ft');
+    expect(cells[5]).toHaveTextContent('3');
+    expect(within(rogueRow).getAllByRole('cell')[3]).toHaveTextContent('40 ft');
+    expect(within(armoredBarbarianRow).getAllByRole('cell')[3]).toHaveTextContent('30 ft');
+    expect(within(mysteryRow).getAllByRole('cell')[3]).toHaveTextContent('—');
 
     const heroCheckbox = within(heroRow).getByRole('checkbox', {
       name: /Toggle Hero in combat/i,
@@ -1910,9 +1948,7 @@ describe('ZombiesDM AI generation', () => {
     expect(combatUpdates[1].activeTurn).toBe(0);
 
     await waitFor(() =>
-      expect(
-        screen.getByRole('status', { name: /Current Turn: Hero/i })
-      ).toBeInTheDocument(),
+      expect(screen.getByText(/Current Turn:/i).closest('[role="status"]')).toHaveTextContent('Hero'),
     );
     await waitFor(() =>
       expect(heroRow).toHaveClass('combat-tracker__active-row')


### PR DESCRIPTION
### Motivation
- Surface each combatant’s resolved current movement speed in the Combat Tracker so it matches other HUD displays and makes Fast Movement / armor effects visible at a glance. 
- Reuse the existing centralized movement calculation rather than introducing a tracker-only implementation.

### Description
- Added a `Movespeed` header between `In Combat` and `Passive Perception` and expanded the empty-state `colSpan` for the new 7-column layout in `ZombiesDM` table. 
- Plumbed `movementSpeed` into each combat row by adding `getEntityMovementSpeed` which delegates player characters to the centralized `calculateCharacterMovementSpeed` helper and reads direct speed fields for enemies. 
- Rendered movement values as `<number> ft` (e.g. `30 ft`, `40 ft`) and display a safe fallback of `—` when no movement source is available. 
- Updated tests in `ZombiesDM.test.js` to check header order, per-row movespeed values (normal `30 ft`, Level 5 Barbarian `40 ft`, Barbarian in Heavy Armor `30 ft`), missing data fallback, and that existing initiative/turn controls still function.

### Testing
- Ran the focused unit test: `CI=true npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js --testNamePattern="allows the DM to manage combat participants" --watch=false` and the targeted test passed. 
- Ran `git diff --check` with no issues.

Files changed: `client/src/components/Zombies/pages/ZombiesDM.js`, `client/src/components/Zombies/pages/ZombiesDM.test.js`.

Where the movement value comes from: the Combat Tracker uses the centralized `calculateCharacterMovementSpeed` helper (imported from `../utils/characterMetrics`) for player characters and falls back to direct entity speed fields for enemies. 

How the Combat Tracker stays consistent with the HUD movement value: both the HUD and the Combat Tracker now rely on the same `calculateCharacterMovementSpeed` code path, so Barbarian Fast Movement, heavy armor suppression, species/base speed, and item/temporary modifiers are included consistently. 

Fallback behavior: if no movement source is resolvable the tracker displays `—` rather than `undefined ft` or `NaN ft`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53efcc3c3c83238edea6da9bd545ab)