### PR TITLE
Display enemy movement modes in Combat Tracker

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -430,6 +430,13 @@
   line-height: 1.2;
 }
 
+
+.combat-tracker-movespeed {
+  min-width: 9rem;
+  max-width: 14rem;
+  white-space: normal;
+}
+
 .zombies-dm-page__combat-header {
   position: absolute;
   top: calc(env(safe-area-inset-top, 0px) + clamp(3.5rem, 1vh, 6.75rem));

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -312,7 +312,7 @@ const hasMovementSpeedSource = (entity) => {
   ].some((value) => toFiniteNumberOrNull(value) !== null);
 };
 
-const getEntityMovementSpeed = (entity) => {
+export const getEntityMovementSpeed = (entity) => {
   if (!entity || typeof entity !== 'object') {
     return null;
   }
@@ -342,6 +342,19 @@ const getEntityMovementSpeed = (entity) => {
   }
 
   return null;
+};
+
+export const getEntityMovementSpeedDisplay = (entity) => {
+  if (!entity || typeof entity !== 'object') {
+    return '—';
+  }
+
+  if (entity.entityType === 'enemy') {
+    return formatMovementSpeed(entity.speed);
+  }
+
+  const movementSpeed = getEntityMovementSpeed(entity);
+  return movementSpeed !== null ? `${movementSpeed} ft` : '—';
 };
 
 const getEntityPassivePerception = (entity) => {
@@ -419,6 +432,96 @@ const formatXpDisplay = (xp) => {
 };
 
 const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
+
+
+const trimTrailingPunctuation = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().replace(/[.\s]+$/g, '');
+};
+
+const formatSpeedValue = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? `${value} ft` : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = trimTrailingPunctuation(value);
+    if (!trimmed) {
+      return null;
+    }
+
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) {
+      return `${numeric} ft`;
+    }
+
+    return trimmed.replace(/\bfeet\b/gi, 'ft');
+  }
+
+  return null;
+};
+
+export const formatMovementSpeed = (speedData) => {
+  if (speedData === undefined || speedData === null || speedData === '') {
+    return '—';
+  }
+
+  if (typeof speedData === 'number') {
+    return Number.isFinite(speedData) ? `${speedData} ft` : '—';
+  }
+
+  if (typeof speedData === 'string') {
+    const trimmed = trimTrailingPunctuation(speedData);
+    if (!trimmed) {
+      return '—';
+    }
+
+    const modeMatch = trimmed.match(/^([a-z][a-z\s_-]*):\s*(.+)$/i);
+    if (modeMatch) {
+      const value = formatSpeedValue(modeMatch[2]);
+      return value ? `${toTitleCase(modeMatch[1])}: ${value}` : '—';
+    }
+
+    const value = formatSpeedValue(trimmed);
+    return value || '—';
+  }
+
+  if (Array.isArray(speedData)) {
+    const entries = speedData
+      .map((entry) => {
+        if (!entry || typeof entry !== 'object') {
+          return null;
+        }
+
+        const mode = entry.type || entry.mode || entry.name;
+        const value = formatSpeedValue(entry.value ?? entry.speed ?? entry.distance);
+        return mode && value ? `${toTitleCase(String(mode))}: ${value}` : null;
+      })
+      .filter(Boolean);
+
+    return entries.length > 0 ? entries.join(', ') : '—';
+  }
+
+  if (typeof speedData === 'object') {
+    const entries = Object.entries(speedData)
+      .map(([mode, value]) => {
+        const formattedValue = formatSpeedValue(value);
+        return formattedValue ? `${toTitleCase(mode)}: ${formattedValue}` : null;
+      })
+      .filter(Boolean);
+
+    return entries.length > 0 ? entries.join(', ') : '—';
+  }
+
+  return '—';
+};
 
 const toFiniteNumberOrNull = (value) => {
   if (value === null || value === undefined || value === '') {
@@ -4119,7 +4222,7 @@ export default function ZombiesDM() {
             rowId,
             participantInfo,
             passivePerception: getEntityPassivePerception(entity),
-            movementSpeed: getEntityMovementSpeed(entity),
+            movementSpeedDisplay: getEntityMovementSpeedDisplay(entity),
             initiativeValue,
             sortInitiative: numericInitiative,
             recordIndex,
@@ -4170,29 +4273,7 @@ export default function ZombiesDM() {
       return parts.length > 0 ? parts.join(', ') : '—';
     }, []);
 
-    const formatSpeed = useCallback((speed) => {
-      if (!speed) {
-        return '—';
-      }
-
-      if (typeof speed === 'string') {
-        return speed;
-      }
-
-      if (typeof speed === 'object') {
-        const entries = Object.entries(speed)
-          .map(([mode, value]) => {
-            if (value === undefined || value === null || value === '') {
-              return null;
-            }
-            return `${mode}: ${value}`;
-          })
-          .filter(Boolean);
-        return entries.length > 0 ? entries.join(', ') : '—';
-      }
-
-      return '—';
-    }, []);
+    const formatSpeed = useCallback(formatMovementSpeed, []);
 
     const formatAbilityScore = useCallback((key, value) => {
       const label = STAT_LABELS[key] || key.toUpperCase();
@@ -7017,7 +7098,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                           <th scope="col">Character</th>
                           <th scope="col">Player</th>
                           <th scope="col" className="text-center">In Combat</th>
-                          <th scope="col" className="text-center">Movespeed</th>
+                          <th scope="col" className="text-center combat-tracker-movespeed">Movespeed</th>
                           <th scope="col" className="text-center">Passive Perception</th>
                           <th scope="col" className="text-center">Initiative</th>
                           <th scope="col" className="text-center">Actions</th>
@@ -7031,7 +7112,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                               rowId,
                               participantInfo,
                               passivePerception,
-                              movementSpeed,
+                              movementSpeedDisplay,
                               initiativeValue,
                               recordIndex,
                             }) => {
@@ -7045,10 +7126,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                                 passivePerception !== undefined && passivePerception !== null
                                   ? passivePerception
                                   : '—';
-                              const displayMovementSpeed =
-                                movementSpeed !== undefined && movementSpeed !== null
-                                  ? `${movementSpeed} ft`
-                                  : '—';
+                              const displayMovementSpeed = movementSpeedDisplay || '—';
                               const isActive =
                                 isParticipant &&
                                 Number.isInteger(combatState.activeTurn) &&
@@ -7119,7 +7197,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                                       aria-label={`Toggle ${checkboxLabel} in combat`}
                                     />
                                   </td>
-                                  <td className="text-center" style={{ width: '110px' }}>
+                                  <td className="text-center combat-tracker-movespeed">
                                     {displayMovementSpeed}
                                   </td>
                                   <td className="text-center" style={{ width: '150px' }}>

--- a/client/src/components/Zombies/pages/ZombiesDM.test.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.test.js
@@ -43,6 +43,8 @@ const {
   applyCharacterHealthUpdateToRecords,
   getCharacterCardMeta,
   getCombatRowMeta,
+  formatMovementSpeed,
+  getEntityMovementSpeedDisplay,
 } = require('./ZombiesDM');
 
 const armorSlotOptions = [
@@ -95,6 +97,42 @@ describe('ZombiesDM metadata helpers', () => {
     });
     expect(combatMeta.testId).toBe('combat-row-hero-1');
     expect(combatMeta.dataAttributes['data-current-hp']).toBe(12);
+  });
+
+  test('formats monster movement speed modes from normalized speed data', () => {
+    expect(formatMovementSpeed({ walk: '30 ft.' })).toBe('Walk: 30 ft');
+    expect(formatMovementSpeed({ walk: '50 ft.', burrow: '50 ft.' })).toBe(
+      'Walk: 50 ft, Burrow: 50 ft'
+    );
+    expect(
+      formatMovementSpeed({ walk: '40 ft.', fly: '80 ft.', swim: '40 ft.', climb: '30 ft.' })
+    ).toBe('Walk: 40 ft, Fly: 80 ft, Swim: 40 ft, Climb: 30 ft');
+    expect(formatMovementSpeed({ climb: '30 ft.' })).toBe('Climb: 30 ft');
+    expect(formatMovementSpeed('walk: 30 ft.')).toBe('Walk: 30 ft');
+    expect(formatMovementSpeed({ walk: undefined, fly: Number.NaN })).toBe('—');
+  });
+
+  test('combat tracker movement display preserves player speed and barbarian fast movement', () => {
+    expect(getEntityMovementSpeedDisplay({ speed: 30 })).toBe('30 ft');
+    expect(
+      getEntityMovementSpeedDisplay({
+        speed: 30,
+        occupation: [{ Name: 'Barbarian', Level: 5 }],
+        equipment: {},
+      })
+    ).toBe('40 ft');
+  });
+
+  test('combat tracker movement display uses enemy movement modes without monster-specific names', () => {
+    expect(getEntityMovementSpeedDisplay({ entityType: 'enemy', speed: { walk: '30 ft.' } })).toBe(
+      'Walk: 30 ft'
+    );
+    expect(
+      getEntityMovementSpeedDisplay({
+        entityType: 'enemy',
+        speed: { walk: '50 ft.', burrow: '50 ft.' },
+      })
+    ).toBe('Walk: 50 ft, Burrow: 50 ft');
   });
 
   test('combat row metadata prefers participant max hp over character health when no explicit current hp is present', () => {


### PR DESCRIPTION
### Motivation
- Enemy combatants were showing `—` in the Movespeed column even when monster stat blocks included movement data, so the Combat Tracker needed to parse and surface monster movement modes (walk, fly, swim, climb, burrow, etc.).
- Movement data in the monster dataset appears in multiple shapes (keyed objects like `{ walk: "30 ft." }`, strings, arrays, or numbers) and requires a single, robust formatter to present consistent UI output.
- Player-character movement behavior (including Barbarian Fast Movement) must be preserved while only enhancing enemy display.

### Description
- Added a shared formatter `formatMovementSpeed(speedData)` in `client/src/components/Zombies/pages/ZombiesDM.js` that accepts numbers, strings, arrays, and objects and returns human-friendly strings such as `Walk: 30 ft` or `Walk: 50 ft, Burrow: 50 ft`, capitalizes modes, normalizes `ft`, strips trailing punctuation, and falls back to `—` for invalid data.
- Exported `getEntityMovementSpeed` and added `getEntityMovementSpeedDisplay` in `ZombiesDM.js` so player entities still use the existing numeric derived speed while enemy entities display the formatted movement-mode string.
- Replaced the ad-hoc `formatSpeed` logic with the reusable `formatMovementSpeed` and wired `orderedCombatRecords` to include `movementSpeedDisplay` which is rendered in the Movespeed column of the Combat Tracker.
- Slightly widened and allowed wrapping of the Movespeed column by adding the `.combat-tracker-movespeed` CSS rule in `client/src/App.scss` so multi-mode strings remain readable.
- Added/updated tests in `client/src/components/Zombies/pages/ZombiesDM.test.js` to assert formatting and Combat Tracker behavior (examples and expectations for Troll and Purple Worm are included in tests).
- Files changed: `client/src/components/Zombies/pages/ZombiesDM.js`, `client/src/components/Zombies/pages/ZombiesDM.test.js`, and `client/src/App.scss`.
- Monster speed data shape found: server stores `speed` as an object mapping modes to strings (e.g. `{ "walk": "30 ft." }` and `{ "walk": "50 ft.", "burrow": "50 ft." }` in `server/data/monsters.json`), and the formatter is written to handle that shape plus alternative shapes.

### Testing
- Ran the focused metadata tests with `npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js --watchAll=false -t "ZombiesDM metadata helpers"` and the metadata helper tests passed (all movement-formatting related tests passed).
- Ran the narrow movement test filter with `npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js --watchAll=false -t "movement speed"` and it passed (movement formatting and Combat Tracker display assertions succeeded).
- A full run of the entire `ZombiesDM` test file (`npm --prefix client test -- --runTestsByPath src/components/Zombies/pages/ZombiesDM.test.js --watchAll=false`) initially surfaced unrelated timeouts in large AI/map tests in that file; the movement/metadata tests themselves are green when run in isolation or with the metadata helpers filter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53fc7a83208323802a5295628210e2)