### PR TITLE
Fix manual character modal scrolling on mobile

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11052,3 +11052,63 @@ body.character-select-scroll-enabled {
     display: none;
   }
 }
+
+.manual-character-modal__dialog {
+  max-height: calc(100dvh - 1rem);
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.manual-character-modal .modal-content {
+  max-height: calc(100dvh - 1rem);
+  overflow: hidden;
+}
+
+.manual-character-modal__card {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100dvh - 1rem);
+  overflow: hidden;
+}
+
+.manual-character-modal__card .card-title {
+  flex: 0 0 auto;
+  margin-bottom: 0;
+  padding: 0.75rem 1rem 0.25rem;
+}
+
+.manual-character-modal__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+}
+
+.manual-character-modal__actions {
+  position: sticky;
+  bottom: calc(-1 * var(--bs-card-spacer-y, 1rem));
+  z-index: 2;
+  margin: 0 calc(-1 * var(--bs-card-spacer-x, 1rem));
+  padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(180deg, rgba(3, 7, 16, 0.2), rgba(3, 7, 16, 0.96) 32%);
+  backdrop-filter: blur(10px);
+}
+
+@media (max-width: 640px) {
+  .manual-character-modal__dialog {
+    max-height: 100dvh;
+    margin: 0.5rem;
+  }
+
+  .manual-character-modal .modal-content,
+  .manual-character-modal__card {
+    max-height: calc(100dvh - 1rem);
+  }
+
+  .manual-character-modal__form {
+    padding-left: 1rem !important;
+    padding-right: 1rem !important;
+  }
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -2087,15 +2087,15 @@ const getAvailableSkillOptions = (index) => {
      </div>      
       </Modal>
        {/* ---------------------------Create Character (Manual)------------------------------------------------------- */}
-    <Modal className="dnd-modal" centered show={show5} onHide={handleClose5}>
+    <Modal className="dnd-modal manual-character-modal" dialogClassName="manual-character-modal__dialog" centered show={show5} onHide={handleClose5}>
        <div className="text-center">
-        <Card className="dnd-background">
+        <Card className="dnd-background manual-character-modal__card">
           <Card.Title>Create Manual</Card.Title>
-        <Card.Body>   
+        <Card.Body className="manual-character-modal__body">   
         <div className="text-center">
       <Form 
       onSubmit={onSubmitManual} 
-      className="px-5">
+      className="px-5 manual-character-modal__form">
       <Form.Group className="mb-3 pt-3">
        <Form.Label className="text-light">Character Name</Form.Label>
        <Form.Control className="mb-2" onChange={(e) => updateForm({ characterName: e.target.value })}
@@ -2286,7 +2286,7 @@ const getAvailableSkillOptions = (index) => {
           </React.Fragment>
         ))}
      </Form.Group>
-     <div className="text-center">
+     <div className="text-center manual-character-modal__actions">
      <Button variant="primary" type="submit">
             Create
           </Button>


### PR DESCRIPTION
### Motivation
- The manual character creation modal on small screens was not scrollable, causing form fields and controls to be cut off and preventing completion.
- The intent is to constrain the modal height on mobile and make the form body scrollable while keeping the action buttons reachable.

### Description
- Added a distinct `manual-character-modal` variant and dialog/card/form/action class names to the manual modal markup in `client/src/components/Zombies/pages/ZombiesCharacterSelect.js` so the manual modal can be targeted independently.
- Implemented CSS rules in `client/src/App.scss` to constrain dialog/card height with `calc(100dvh - 1rem)`, make the card a column flex container, and enable `overflow-y: auto` with `-webkit-overflow-scrolling: touch` for the modal body so the form becomes scrollable on mobile.
- Made the Create/Close controls sticky at the bottom of the modal with safe-area padding and reduced horizontal form padding for narrow screens to improve accessibility and usability.

### Testing
- Ran the component-scoped test command `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSelect.js`, which reported no matching tests for that path.
- Built the client with `npm run build`, which completed successfully and produced the production bundle while reporting pre-existing lint/autoprefixer/browserslist warnings.
- Verified the modal markup/CSS changes are present and that the site builds without introducing new build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54144f7a10832e8dff467288dbc5ac)