### PR TITLE
Add manual character-creation wizard with UI, validation, unsaved-changes flow, and improved API error handling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11112,3 +11112,479 @@ body.character-select-scroll-enabled {
     padding-right: 1rem !important;
   }
 }
+
+.manual-character-modal__dialog {
+  width: min(1180px, calc(100vw - 32px));
+  max-width: 1180px;
+}
+
+.manual-character-modal .modal-content {
+  border: 1px solid rgba(147, 197, 253, 0.18);
+  border-radius: 28px;
+  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.18), transparent 34%), linear-gradient(145deg, rgba(7, 13, 27, 0.98), rgba(14, 18, 35, 0.98));
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  color: #eef6ff;
+}
+
+.character-wizard {
+  display: flex;
+  flex-direction: column;
+  height: min(860px, calc(100dvh - 24px));
+  overflow: hidden;
+}
+
+.character-wizard__header,
+.character-wizard__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(3, 8, 20, 0.72);
+  backdrop-filter: blur(18px);
+}
+
+.character-wizard__header {
+  position: relative;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.character-wizard__header h2,
+.character-wizard-step h3,
+.character-review h4 {
+  margin: 0;
+  color: #f8fbff;
+  font-family: Georgia, 'Times New Roman', serif;
+  letter-spacing: 0.02em;
+}
+
+.character-wizard__header span,
+.character-wizard-step h3 {
+  color: #b7c8de;
+}
+
+.character-wizard__header > button {
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 1.6rem;
+}
+
+.character-wizard__mobile-progress {
+  position: absolute;
+  inset-inline: 1.25rem;
+  bottom: 0;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 99px;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.character-wizard__mobile-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #60a5fa, #a78bfa, #facc15);
+}
+
+.character-wizard__shell {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+}
+
+.character-wizard__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.14);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(8, 13, 26, 0.92));
+}
+
+.character-wizard__portrait {
+  display: grid;
+  place-items: center;
+  height: 150px;
+  border-radius: 24px;
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.22), rgba(30, 41, 59, 0.72));
+  color: #facc15;
+  font-size: 2.4rem;
+  font-weight: 800;
+  box-shadow: inset 0 0 36px rgba(96, 165, 250, 0.12);
+}
+
+.character-wizard__sidebar nav {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.character-wizard__sidebar nav button {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 0.1rem 0.75rem;
+  min-height: 58px;
+  padding: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.56);
+  color: #dbeafe;
+  text-align: left;
+}
+
+.character-wizard__sidebar nav button span {
+  grid-row: span 2;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.12);
+  color: #93c5fd;
+}
+
+.character-wizard__sidebar nav button small,
+.character-wizard__summary span,
+.character-option-card small,
+.character-option-card span,
+.ability-score-card small,
+.character-wizard-field p {
+  color: #9fb2c8;
+}
+
+.character-wizard__sidebar nav button.is-current {
+  border-color: rgba(250, 204, 21, 0.56);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(167, 139, 250, 0.12));
+}
+
+.character-wizard__sidebar nav button.is-complete span {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+}
+
+.character-wizard__sidebar nav button.has-error {
+  border-color: rgba(248, 113, 113, 0.65);
+}
+
+.character-wizard__summary {
+  margin-top: auto;
+  display: grid;
+  gap: 0.2rem;
+  padding: 1rem;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.46);
+}
+
+.character-wizard__content {
+  min-width: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 1.5rem;
+}
+
+.character-wizard-step {
+  width: min(100%, 820px);
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.character-wizard-field {
+  display: grid;
+  gap: 0.4rem;
+  text-align: left;
+}
+
+.character-wizard-field label {
+  color: #f8fbff;
+  font-weight: 750;
+}
+
+.character-wizard input,
+.character-wizard select {
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid rgba(147, 197, 253, 0.2);
+  border-radius: 14px;
+  background: rgba(8, 15, 30, 0.84);
+  color: #f8fbff;
+  padding: 0.72rem 0.9rem;
+  outline: none;
+}
+
+.character-wizard input:focus,
+.character-wizard select:focus,
+.character-option-card:focus-visible,
+.character-wizard__sidebar button:focus-visible,
+.character-wizard__header > button:focus-visible,
+.ability-score-card button:focus-visible {
+  border-color: rgba(250, 204, 21, 0.82);
+  box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.18);
+}
+
+.character-wizard-error,
+.character-wizard-error-summary {
+  color: #fecaca;
+}
+
+.character-wizard-error-summary {
+  padding: 0.8rem 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 16px;
+  background: rgba(127, 29, 29, 0.28);
+}
+
+.character-option-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+}
+
+.character-option-grid--classes {
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.character-option-card {
+  min-height: 122px;
+  display: grid;
+  gap: 0.25rem;
+  align-content: start;
+  padding: 1rem;
+  border: 1px solid rgba(147, 197, 253, 0.16);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.86), rgba(17, 24, 39, 0.66));
+  color: #f8fbff;
+  text-align: left;
+}
+
+.character-option-card:hover,
+.character-option-card--selected {
+  border-color: rgba(250, 204, 21, 0.58);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255,255,255,0.08);
+}
+
+.character-option-card__sigil {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: rgba(96, 165, 250, 0.14);
+  color: #facc15 !important;
+}
+
+.conditional-lineage,
+.character-wizard-fields-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.identity-preview,
+.character-review {
+  padding: 1rem;
+  border: 1px solid rgba(147, 197, 253, 0.15);
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.ability-score-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ability-score-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border: 1px solid rgba(147, 197, 253, 0.16);
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.64);
+}
+
+.ability-score-card > div:first-child {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.ability-score-card > div:first-child strong {
+  color: #facc15;
+  font-size: 1.35rem;
+}
+
+.ability-score-card__stepper {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  gap: 0.45rem;
+}
+
+.ability-score-card__stepper button {
+  min-height: 44px;
+  border: 1px solid rgba(147, 197, 253, 0.18);
+  border-radius: 12px;
+  background: rgba(96, 165, 250, 0.14);
+  color: #fff;
+}
+
+.character-review {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.character-review > div:not(.character-review__abilities) {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.55rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.character-review__abilities {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.5rem;
+}
+
+.character-review__abilities span {
+  padding: 0.55rem;
+  border-radius: 12px;
+  background: rgba(96, 165, 250, 0.1);
+  text-align: center;
+}
+
+.character-wizard__actions {
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+}
+
+.character-wizard__actions .btn {
+  min-height: 46px;
+  min-width: 150px;
+  border-radius: 999px;
+  font-weight: 800;
+}
+
+.unsaved-character-modal__card {
+  padding: 1rem;
+  color: #f8fbff;
+}
+
+.unsaved-character-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .character-option-card,
+  .conditional-lineage {
+    transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease, opacity 180ms ease;
+  }
+}
+
+@media (max-width: 900px) {
+  .manual-character-modal__dialog {
+    width: 100%;
+    max-width: none;
+    height: 100dvh;
+    margin: 0;
+  }
+
+  .manual-character-modal .modal-content,
+  .character-wizard {
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .character-wizard__shell {
+    display: block;
+    overflow-y: auto;
+  }
+
+  .character-wizard__sidebar {
+    display: none;
+  }
+
+  .character-wizard__content {
+    overflow: visible;
+    padding: 1rem 1rem 6rem;
+  }
+
+  .character-wizard__actions {
+    position: sticky;
+    bottom: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .character-wizard__actions .btn {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .ability-score-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .character-option-grid,
+  .conditional-lineage,
+  .character-wizard-fields-grid,
+  .ability-score-grid,
+  .character-review__abilities {
+    grid-template-columns: 1fr;
+  }
+
+  .character-wizard__header,
+  .character-wizard__actions {
+    padding-inline: 0.85rem;
+  }
+}
+
+/* Desktop wizard sizing refinements: keep long sidebars and card grids reachable. */
+@media (min-width: 901px) {
+  .manual-character-modal__dialog {
+    width: min(1280px, calc(100vw - 24px));
+    max-width: 1280px;
+  }
+
+  .character-wizard {
+    height: min(940px, calc(100dvh - 16px));
+  }
+
+  .character-wizard__sidebar {
+    min-height: 0;
+    overflow-y: auto;
+    padding-bottom: 1.5rem;
+  }
+
+  .character-wizard__content {
+    padding: 2rem 2rem 3rem;
+  }
+
+  .character-option-grid--classes {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -172,6 +172,115 @@ const CharacterGrid = ({ records, onContinue }) => (
   </div>
 );
 
+const abilityModifier = (score) => {
+  const value = Number(score);
+  if (!Number.isFinite(value)) return "—";
+  const modifier = Math.floor((value - 10) / 2);
+  return modifier >= 0 ? `+${modifier}` : `${modifier}`;
+};
+
+const MANUAL_STEPS = [
+  { id: "identity", title: "Identity", helper: "Name the hero who will enter this realm." },
+  { id: "ancestry", title: "Ancestry", helper: "Choose lineage traits and conditional heritage options." },
+  { id: "class", title: "Class", helper: "Select the first adventuring path and starting hit die." },
+  { id: "background", title: "Background", helper: "Anchor the character in the world." },
+  { id: "physical", title: "Physical Details", helper: "Capture concise table-facing details." },
+  { id: "abilities", title: "Ability Scores", helper: "Set the six core scores used by the existing character model." },
+  { id: "review", title: "Review & Create", helper: "Confirm the sheet before creating the character." },
+];
+
+const getManualErrors = (form, selectedOccupation) => {
+  const errors = {};
+  if (!form.characterName?.trim()) errors.characterName = "Enter a character name before continuing.";
+  if ((form.characterName || "").length > 12) errors.characterName = "Use 12 characters or fewer.";
+  if (/\d/.test(form.characterName || "")) errors.characterName = "Names cannot include numbers.";
+  if (!form.race) errors.race = "Choose a race.";
+  if (form.race?.dragonAncestries && !form.dragonAncestryKey) errors.dragonAncestryKey = "Choose a dragon ancestry.";
+  if (form.race?.giantAncestries && !form.giantAncestryKey) errors.giantAncestryKey = "Choose a giant ancestry.";
+  if (form.race?.elvenLineages && !form.elvenLineageKey) errors.elvenLineageKey = "Choose an elven lineage.";
+  if (form.elvenLineage?.spellcastingAbilities?.length && !form.elvenLineageAbility) errors.elvenLineageAbility = "Choose a spellcasting ability.";
+  if (form.race?.gnomeLineages && !form.gnomeLineageKey) errors.gnomeLineageKey = "Choose a gnome lineage.";
+  if (form.gnomeLineage?.spellcastingAbilities?.length && !form.gnomeLineageAbility) errors.gnomeLineageAbility = "Choose a spellcasting ability.";
+  if (form.race?.fiendishLegacies && !form.tieflingLegacyKey) errors.tieflingLegacyKey = "Choose a fiendish legacy.";
+  if (form.tieflingLegacy?.spellcastingAbilities?.length && !form.tieflingLegacyAbility) errors.tieflingLegacyAbility = "Choose a spellcasting ability.";
+  if (!selectedOccupation) errors.occupation = "Choose a class.";
+  if (!form.background) errors.background = "Choose a background.";
+  if (!form.size) errors.size = "Choose a size.";
+  if (form.age && Number(form.age) < 0) errors.age = "Age must be zero or higher.";
+  if (form.weight && Number(form.weight) < 0) errors.weight = "Weight must be zero or higher.";
+  STATS.forEach(({ key, label }) => {
+    if (form[key] === "" || form[key] == null) errors[key] = `Enter ${label}.`;
+    else if (Number(form[key]) < 1 || Number(form[key]) > 30) errors[key] = `${label} must be between 1 and 30.`;
+  });
+  return errors;
+};
+
+const CharacterFormField = ({ id, label, helper, error, children }) => (
+  <div className={`character-wizard-field${error ? " character-wizard-field--error" : ""}`}>
+    <label htmlFor={id}>{label}</label>
+    {helper && <p>{helper}</p>}
+    {children}
+    {error && <span className="character-wizard-error" id={`${id}-error`}>{error}</span>}
+  </div>
+);
+
+const CharacterSelectCard = ({ selected, title, meta, detail, onClick, name }) => (
+  <button type="button" className={`character-option-card${selected ? " character-option-card--selected" : ""}`} onClick={onClick} aria-pressed={selected} name={name}>
+    <span className="character-option-card__sigil">✦</span><strong>{title}</strong>{meta && <small>{meta}</small>}{detail && <span>{detail}</span>}
+  </button>
+);
+
+const AbilityScoreCard = ({ stat, value, onChange, error }) => {
+  const numberValue = Number(value || 0);
+  const setScore = (next) => onChange(String(Math.min(30, Math.max(1, next))));
+  return <div className={`ability-score-card${error ? " ability-score-card--error" : ""}`}>
+    <div><strong>{stat.key.toUpperCase()}</strong><span>{stat.label}</span></div>
+    <div className="ability-score-card__stepper">
+      <button type="button" onClick={() => setScore(numberValue - 1)} aria-label={`Decrease ${stat.label}`}>−</button>
+      <input id={`manual-${stat.key}`} type="number" min="1" max="30" value={value} onChange={(e) => onChange(e.target.value)} aria-describedby={error ? `manual-${stat.key}-error` : undefined} />
+      <button type="button" onClick={() => setScore(numberValue + 1)} aria-label={`Increase ${stat.label}`}>+</button>
+    </div>
+    <small>Modifier: {abilityModifier(value)} • Range 1–30</small>
+    {error && <span className="character-wizard-error" id={`manual-${stat.key}-error`}>{error}</span>}
+  </div>;
+};
+
+const CharacterCreationWizard = ({ form, updateForm, races, backgrounds, occupations, selectedOccupation, selectedAddOccupationRef, sizeOptions, step, setStep, touched, setTouched, onClose, onSubmit, onRaceChange, onClassChange, onSelectClass, onBackgroundChange, onDragonAncestryChange, onGiantAncestryChange, onElvenLineageChange, onElvenLineageAbilityChange, onGnomeLineageChange, onGnomeLineageAbilityChange, onTieflingLegacyChange, onTieflingLegacyAbilityChange }) => {
+  const errors = getManualErrors(form, selectedOccupation);
+  const stepFields = {
+    identity: ["characterName"], ancestry: ["race", "dragonAncestryKey", "giantAncestryKey", "elvenLineageKey", "elvenLineageAbility", "gnomeLineageKey", "gnomeLineageAbility", "tieflingLegacyKey", "tieflingLegacyAbility"], class: ["occupation"], background: ["background"], physical: ["age", "sex", "size", "weight"], abilities: STATS.map((s) => s.key), review: Object.keys(errors),
+  };
+  const current = MANUAL_STEPS[step];
+  const stepHasError = (id) => stepFields[id].some((field) => errors[field] && touched[field]);
+  const validateStep = () => {
+    const fields = stepFields[current.id];
+    setTouched((prev) => ({ ...prev, ...Object.fromEntries(fields.map((field) => [field, true])) }));
+    const firstInvalid = fields.find((field) => errors[field]);
+    if (firstInvalid) {
+      setTimeout(() => document.querySelector(`[name="${firstInvalid}"], #manual-${firstInvalid}`)?.focus(), 0);
+      return false;
+    }
+    return true;
+  };
+  const goNext = () => { if (validateStep()) setStep(Math.min(step + 1, MANUAL_STEPS.length - 1)); };
+  const submit = (e) => { e.preventDefault(); if (validateStep() && !Object.keys(errors).length) onSubmit(e); else setTouched((p) => ({...p, ...Object.fromEntries(Object.keys(errors).map((k) => [k, true]))})); };
+  const selectRaceKey = Object.keys(races).find((key) => races[key]?.name === form.race?.name) || "";
+  const selectBackgroundKey = Object.keys(backgrounds).find((key) => backgrounds[key]?.name === form.background?.name) || "";
+
+  return <form className="character-wizard" onSubmit={submit} noValidate>
+    <header className="character-wizard__header"><div><p className="character-select-kicker">Hero Forge</p><h2>Create Character</h2><span>Step {step + 1} of {MANUAL_STEPS.length} · {current.title}</span></div><button type="button" onClick={onClose} aria-label="Close character creator">×</button><div className="character-wizard__mobile-progress"><span style={{ width: `${((step + 1) / MANUAL_STEPS.length) * 100}%` }} /></div></header>
+    <div className="character-wizard__shell"><aside className="character-wizard__sidebar"><div className="character-wizard__portrait">{(form.characterName || "RT").slice(0,2).toUpperCase()}</div><nav aria-label="Character creation steps">{MANUAL_STEPS.map((s, i) => <button type="button" key={s.id} className={`${i===step ? "is-current" : ""} ${i<step ? "is-complete" : ""} ${stepHasError(s.id) ? "has-error" : ""}`} onClick={() => i <= step ? setStep(i) : null}><span>{i < step ? "✓" : i + 1}</span><strong>{s.title}</strong><small>{s.helper}</small></button>)}</nav><div className="character-wizard__summary"><strong>{form.characterName || "Unnamed Hero"}</strong><span>{form.race?.name || "Ancestry pending"}</span><span>{selectedOccupation?.name || "Class pending"}</span></div></aside>
+    <main className="character-wizard__content"><section className="character-wizard-step"><p className="character-select-kicker">{current.title}</p><h3>{current.helper}</h3>{Object.keys(errors).some((k) => stepFields[current.id].includes(k) && touched[k]) && <div className="character-wizard-error-summary">Review the highlighted fields before continuing.</div>}
+      {current.id === "identity" && <><CharacterFormField id="manual-characterName" label="Character Name" helper={`Choose a name up to 12 characters. ${(form.characterName || "").length}/12`} error={touched.characterName && errors.characterName}><input id="manual-characterName" name="characterName" value={form.characterName || ""} maxLength="12" onBlur={() => setTouched((p)=>({...p, characterName:true}))} onChange={(e)=>updateForm({characterName:e.target.value})} aria-describedby={errors.characterName ? "manual-characterName-error" : undefined} /></CharacterFormField><div className="identity-preview"><span>✦</span><strong>{form.characterName || "Your hero's name"}</strong><small>This preview updates as you build the character.</small></div></>}
+      {current.id === "ancestry" && <><div className="character-option-grid">{Object.entries(races).map(([key, race]) => <CharacterSelectCard key={key} name="race" selected={selectRaceKey===key} title={race.name} meta={getRaceSizeOptions(race).join(" / ") || "Size varies"} onClick={()=>{onRaceChange({target:{value:key}}); setTouched((p)=>({...p,race:true}));}} />)}</div>{touched.race && errors.race && <span className="character-wizard-error">{errors.race}</span>}<div className="conditional-lineage">{form.race?.dragonAncestries && <CharacterFormField id="manual-dragonAncestryKey" label="Dragon Ancestry" error={touched.dragonAncestryKey && errors.dragonAncestryKey}><select id="manual-dragonAncestryKey" name="dragonAncestryKey" value={form.dragonAncestryKey || ""} onChange={onDragonAncestryChange} onBlur={()=>setTouched((p)=>({...p,dragonAncestryKey:true}))}><option value="" disabled>Select ancestry</option>{Object.entries(form.race.dragonAncestries).map(([key,a])=><option key={key} value={key}>{a.label}</option>)}</select></CharacterFormField>}{form.race?.giantAncestries && <CharacterFormField id="manual-giantAncestryKey" label="Giant Ancestry" error={touched.giantAncestryKey && errors.giantAncestryKey}><select id="manual-giantAncestryKey" name="giantAncestryKey" value={form.giantAncestryKey || ""} onChange={onGiantAncestryChange}><option value="" disabled>Select ancestry</option>{Object.entries(form.race.giantAncestries).map(([key,a])=><option key={key} value={key}>{a.ancestryName || a.label || a.name}</option>)}</select></CharacterFormField>}{form.race?.elvenLineages && <CharacterFormField id="manual-elvenLineageKey" label="Elven Lineage" error={touched.elvenLineageKey && errors.elvenLineageKey}><select id="manual-elvenLineageKey" name="elvenLineageKey" value={form.elvenLineageKey || ""} onChange={onElvenLineageChange}><option value="" disabled>Select lineage</option>{Object.entries(form.race.elvenLineages).map(([key,a])=><option key={key} value={key}>{a.label || a.name}</option>)}</select></CharacterFormField>}{form.elvenLineage?.spellcastingAbilities?.length ? <CharacterFormField id="manual-elvenLineageAbility" label="Spellcasting Ability" error={touched.elvenLineageAbility && errors.elvenLineageAbility}><select id="manual-elvenLineageAbility" name="elvenLineageAbility" value={form.elvenLineageAbility || ""} onChange={onElvenLineageAbilityChange}><option value="" disabled>Select ability</option>{form.elvenLineage.spellcastingAbilities.map((a)=><option key={a} value={a}>{a}</option>)}</select></CharacterFormField> : null}{form.race?.gnomeLineages && <CharacterFormField id="manual-gnomeLineageKey" label="Gnome Lineage" error={touched.gnomeLineageKey && errors.gnomeLineageKey}><select id="manual-gnomeLineageKey" name="gnomeLineageKey" value={form.gnomeLineageKey || ""} onChange={onGnomeLineageChange}><option value="" disabled>Select lineage</option>{Object.entries(form.race.gnomeLineages).map(([key,a])=><option key={key} value={key}>{a.label || a.name}</option>)}</select></CharacterFormField>}{form.gnomeLineage?.spellcastingAbilities?.length ? <CharacterFormField id="manual-gnomeLineageAbility" label="Spellcasting Ability" error={touched.gnomeLineageAbility && errors.gnomeLineageAbility}><select id="manual-gnomeLineageAbility" name="gnomeLineageAbility" value={form.gnomeLineageAbility || ""} onChange={onGnomeLineageAbilityChange}><option value="" disabled>Select ability</option>{form.gnomeLineage.spellcastingAbilities.map((a)=><option key={a} value={a}>{a}</option>)}</select></CharacterFormField> : null}{form.race?.fiendishLegacies && <CharacterFormField id="manual-tieflingLegacyKey" label="Fiendish Legacy" error={touched.tieflingLegacyKey && errors.tieflingLegacyKey}><select id="manual-tieflingLegacyKey" name="tieflingLegacyKey" value={form.tieflingLegacyKey || ""} onChange={onTieflingLegacyChange}><option value="" disabled>Select legacy</option>{Object.entries(form.race.fiendishLegacies).map(([key,a])=><option key={key} value={key}>{a.label || a.name}</option>)}</select></CharacterFormField>}{form.tieflingLegacy?.spellcastingAbilities?.length ? <CharacterFormField id="manual-tieflingLegacyAbility" label="Spellcasting Ability" error={touched.tieflingLegacyAbility && errors.tieflingLegacyAbility}><select id="manual-tieflingLegacyAbility" name="tieflingLegacyAbility" value={form.tieflingLegacyAbility || ""} onChange={onTieflingLegacyAbilityChange}><option value="" disabled>Select ability</option>{form.tieflingLegacy.spellcastingAbilities.map((a)=><option key={a} value={a}>{a}</option>)}</select></CharacterFormField> : null}</div></>}
+      {current.id === "class" && <><select className="visually-hidden" ref={selectedAddOccupationRef} onChange={onClassChange} value={selectedOccupation?.name || ""}><option value="">Select class</option>{occupations.map((o)=><option key={o.name} value={o.name}>{o.name}</option>)}</select><div className="character-option-grid character-option-grid--classes">{occupations.map((o) => <CharacterSelectCard key={o.name} name="occupation" selected={selectedOccupation?.name===o.name} title={o.name} meta={o.hitDie ? `Hit Die d${o.hitDie}` : "Starting class"} detail={o.proficiencies?.savingThrows?.length ? `Saves: ${o.proficiencies.savingThrows.join(", ")}` : "Choose this path"} onClick={()=>{onSelectClass(o); setTouched((p)=>({...p,occupation:true}));}} />)}</div>{touched.occupation && errors.occupation && <span className="character-wizard-error">{errors.occupation}</span>}</>}
+      {current.id === "background" && <><div className="character-option-grid">{Object.entries(backgrounds).map(([key,bg]) => <CharacterSelectCard key={key} name="background" selected={selectBackgroundKey===key} title={bg.name} meta={bg.skills ? `Skills: ${Object.keys(bg.skills).join(", ")}` : "Background"} onClick={()=>{onBackgroundChange({target:{value:key}}); setTouched((p)=>({...p,background:true}));}} />)}</div>{touched.background && errors.background && <span className="character-wizard-error">{errors.background}</span>}</>}
+      {current.id === "physical" && <div className="character-wizard-fields-grid"><CharacterFormField id="manual-age" label="Age" error={touched.age && errors.age}><input id="manual-age" name="age" type="number" min="0" value={form.age || ""} onChange={(e)=>updateForm({age:e.target.value})} onBlur={()=>setTouched((p)=>({...p,age:true}))} /></CharacterFormField><CharacterFormField id="manual-sex" label="Sex / Gender" helper="Free text to match your table." ><input id="manual-sex" name="sex" value={form.sex || ""} onChange={(e)=>updateForm({sex:e.target.value})} /></CharacterFormField><CharacterFormField id="manual-size" label="Size" error={touched.size && errors.size}><select id="manual-size" name="size" value={form.size || ""} onChange={(e)=>updateForm({size:e.target.value})} onBlur={()=>setTouched((p)=>({...p,size:true}))}><option value="" disabled>Select size</option>{sizeOptions.map((o)=><option key={o} value={o}>{o}</option>)}</select></CharacterFormField><CharacterFormField id="manual-weight" label="Weight" error={touched.weight && errors.weight}><input id="manual-weight" name="weight" type="number" min="0" value={form.weight || ""} onChange={(e)=>updateForm({weight:e.target.value})} onBlur={()=>setTouched((p)=>({...p,weight:true}))} /></CharacterFormField></div>}
+      {current.id === "abilities" && <div className="ability-score-grid">{STATS.map((stat)=><AbilityScoreCard key={stat.key} stat={stat} value={form[stat.key] || ""} error={touched[stat.key] && errors[stat.key]} onChange={(value)=>updateForm({[stat.key]:value})} />)}</div>}
+      {current.id === "review" && <div className="character-review"><h4>{form.characterName || "Unnamed Hero"}</h4>{[["Ancestry", form.race?.name], ["Class", selectedOccupation?.name], ["Background", form.background?.name], ["Size", form.size], ["Age", form.age || "—"], ["Sex / Gender", form.sex || "—"], ["Weight", form.weight || "—"]].map(([label,value])=><div key={label}><span>{label}</span><strong>{value || "Missing"}</strong></div>)}<div className="character-review__abilities">{STATS.map((s)=><span key={s.key}>{s.key.toUpperCase()} <strong>{form[s.key] || "—"}</strong></span>)}</div>{Object.keys(errors).length > 0 && <div className="character-wizard-error-summary">Complete missing sections before creating this character.</div>}</div>}
+    </section></main></div><footer className="character-wizard__actions"><Button type="button" variant="secondary" onClick={() => step ? setStep(step - 1) : onClose()}>{step ? "Back" : "Cancel"}</Button>{step < MANUAL_STEPS.length - 1 ? <Button type="button" onClick={goNext}>Continue</Button> : <Button type="submit" disabled={Object.keys(errors).length > 0}>Create Character</Button>}</footer></form>;
+};
+
 export default function RecordList() {
   const params = useParams();
   const [records, setRecords] = useState([]);
@@ -950,22 +1059,60 @@ useEffect(() => {
         body: JSON.stringify(newCharacter),
       });
       if (!response.ok) {
-        notify(`An error occurred: ${response.statusText}`);
-        return;
+        let message = response.statusText;
+        try {
+          const errorBody = await response.json();
+          const validationMessages = errorBody?.errors?.map((error) => error.msg || error.path).filter(Boolean).join(", ");
+          message = validationMessages || errorBody?.message || message;
+        } catch (_) {
+          // Keep the HTTP status text when the response body is not JSON.
+        }
+        notify(`An error occurred: ${message}`);
+        return false;
       }
       const { insertedId } = await response.json();
       handleClose();
       setRecords((prev) => [...prev, { ...newCharacter, _id: insertedId }]);
-      setForm(createDefaultForm(params.campaign));
+      setForm((prev) => ({ ...createDefaultForm(params.campaign), token: user?.username || prev.token || "" }));
+      return true;
     } catch (error) {
       notify(error.toString());
+      return false;
     }
-}, [form, params.campaign, handleClose, setRecords, setForm, createDefaultForm, attachSelectedAncestryToRace]);
+}, [form, params.campaign, handleClose, setRecords, setForm, createDefaultForm, attachSelectedAncestryToRace, user]);
 
 //--------------------------------------------Create Character (Manual)---------------------
 const [show5, setShow5] = useState(false);
+const [manualStep, setManualStep] = useState(0);
+const [manualTouched, setManualTouched] = useState({});
+const [showUnsavedManualDialog, setShowUnsavedManualDialog] = useState(false);
+const initialManualSnapshot = useRef(null);
 const handleClose5 = useCallback(() => setShow5(false), []);
-const handleShow5 = () => setShow5(true);
+const handleShow5 = () => {
+  const freshForm = { ...createDefaultForm(params.campaign), token: user?.username || form.token || "" };
+  setForm(freshForm);
+  setSelectedOccupation(null);
+  setIsOccupationConfirmed(false);
+  initialManualSnapshot.current = JSON.stringify(freshForm);
+  setManualStep(0);
+  setManualTouched({});
+  setShow5(true);
+};
+const hasManualChanges = useCallback(() => show5 && initialManualSnapshot.current && JSON.stringify(form) !== initialManualSnapshot.current, [form, show5]);
+const requestCloseManual = useCallback(() => {
+  if (hasManualChanges()) {
+    setShowUnsavedManualDialog(true);
+    return;
+  }
+  handleClose5();
+}, [handleClose5, hasManualChanges]);
+const discardManualChanges = () => {
+  setShowUnsavedManualDialog(false);
+  handleClose5();
+  setForm((prev) => ({ ...createDefaultForm(params.campaign), token: user?.username || prev.token || "" }));
+  setSelectedOccupation(null);
+  setIsOccupationConfirmed(false);
+};
 
 const [selectedOccupation, setSelectedOccupation] = useState(null);
 const selectedAddOccupationRef = useRef();
@@ -975,6 +1122,12 @@ const [getOccupation, setGetOccupation] = useState([]);
 const handleOccupationChange = (event) => {
   const selectedIndex = event.target.selectedIndex;
   setSelectedOccupation(getOccupation[selectedIndex - 1]); // Subtract 1 because the first option is empty
+  setIsOccupationConfirmed(false);
+};
+
+const selectOccupation = (occupation) => {
+  setSelectedOccupation(occupation);
+  setIsOccupationConfirmed(false);
 };
 
 const handleRaceChange = (e) => {
@@ -1795,11 +1948,11 @@ const [isOccupationConfirmed, setIsOccupationConfirmed] = useState(false);
 
 const handleConfirmOccupation = useCallback(() => {
   if (selectedOccupation && !isOccupationConfirmed) {
-    const selectedAddOccupation = selectedAddOccupationRef.current.value;
+    const selectedAddOccupation = selectedOccupation.name;
     const occupationExists = form.occupation.some(
       (occupation) => occupation.Occupation === selectedOccupation.name
     );
-    const selectedAddOccupationObject = getOccupation.find(
+    const selectedAddOccupationObject = selectedOccupation || getOccupation.find(
       (occupation) => occupation.name === selectedAddOccupation
     );
 
@@ -1872,7 +2025,7 @@ const handleConfirmOccupation = useCallback(() => {
     }
   }
   return form;
-}, [selectedOccupation, isOccupationConfirmed, form, getOccupation, selectedAddOccupationRef, setForm]);
+}, [selectedOccupation, isOccupationConfirmed, form, getOccupation, setForm]);
 
 const sendManualToDb = useCallback(async (characterData) => {
   const baseCharacter = characterData ?? form;
@@ -1927,17 +2080,27 @@ const sendManualToDb = useCallback(async (characterData) => {
       body: JSON.stringify(newCharacter),
     });
     if (!response.ok) {
-      notify(`An error occurred: ${response.statusText}`);
-      return;
+      let message = response.statusText;
+      try {
+        const errorBody = await response.json();
+        const validationMessages = errorBody?.errors?.map((error) => error.msg || error.path).filter(Boolean).join(", ");
+        message = validationMessages || errorBody?.message || message;
+      } catch (_) {
+        // Keep the HTTP status text when the response body is not JSON.
+      }
+      notify(`An error occurred: ${message}`);
+      return false;
     }
     const { insertedId } = await response.json();
     handleClose5();
     setRecords((prev) => [...prev, { ...newCharacter, _id: insertedId }]);
-    setForm(createDefaultForm(params.campaign));
+    setForm((prev) => ({ ...createDefaultForm(params.campaign), token: user?.username || prev.token || "" }));
+    return true;
   } catch (error) {
     notify(error.toString());
+    return false;
   }
-}, [form, params.campaign, handleClose5, setRecords, setForm, createDefaultForm, attachSelectedAncestryToRace]);
+}, [form, params.campaign, handleClose5, setRecords, setForm, createDefaultForm, attachSelectedAncestryToRace, user]);
 
 // Function to handle submission for manual character creation.
 const onSubmitManual = async (e) => {
@@ -1953,8 +2116,8 @@ const onSubmitManual = async (e) => {
   await sendManualToDb(updatedForm);
 };
 
-const handleAbilitySkillConfirm = () => {
-  const raceObj = { ...form.race };
+const handleAbilitySkillConfirm = async () => {
+  const raceObj = { ...form.race, abilities: { ...(form.race?.abilities || {}) } };
   let updatedSkills = { ...(form.skills || {}) };
 
   if (raceObj.abilityChoices) {
@@ -2006,14 +2169,20 @@ const handleAbilitySkillConfirm = () => {
   }
 
   setForm(updatedForm);
+  if (show5) {
+    const saved = await sendManualToDb(updatedForm);
+    if (!saved) {
+      return;
+    }
+  } else {
+    const saved = await sendToDb(updatedForm);
+    if (!saved) {
+      return;
+    }
+  }
   setShowAbilitySkillModal(false);
   setAbilitySelections([]);
   setSkillSelections([]);
-  if (show5) {
-    sendManualToDb(updatedForm);
-  } else {
-    sendToDb(updatedForm);
-  }
 };
 
 const getAvailableAbilityOptions = (index) => {
@@ -2087,219 +2256,49 @@ const getAvailableSkillOptions = (index) => {
      </div>      
       </Modal>
        {/* ---------------------------Create Character (Manual)------------------------------------------------------- */}
-    <Modal className="dnd-modal manual-character-modal" dialogClassName="manual-character-modal__dialog" centered show={show5} onHide={handleClose5}>
-       <div className="text-center">
-        <Card className="dnd-background manual-character-modal__card">
-          <Card.Title>Create Manual</Card.Title>
-        <Card.Body className="manual-character-modal__body">   
-        <div className="text-center">
-      <Form 
-      onSubmit={onSubmitManual} 
-      className="px-5 manual-character-modal__form">
-      <Form.Group className="mb-3 pt-3">
-       <Form.Label className="text-light">Character Name</Form.Label>
-       <Form.Control className="mb-2" onChange={(e) => updateForm({ characterName: e.target.value })}
-        type="text" placeholder="Enter character name max 12 characters" pattern="^([^0-9]{0,12})$"/>        
-        <Form.Label className="text-light">Class</Form.Label>
-        <Form.Select
-              ref={selectedAddOccupationRef}
-              onChange={handleOccupationChange}
-              defaultValue=""
-            >
-              <option value="" disabled>Select your class</option>
-              {getOccupation.map((occupation, i) => (
-                <option key={i}>{occupation.name}</option>
-              ))}
-            </Form.Select>
-        <Form.Label className="text-light">Race</Form.Label>
-        <Form.Select onChange={handleRaceChange} defaultValue="">
-          <option value="" disabled>Select your race</option>
-          {Object.keys(races).map((key) => (
-            <option key={key} value={key}>{races[key].name}</option>
-          ))}
-        </Form.Select>
-        {form.race?.name === "Dragonborn" && (
-          <>
-            <Form.Label className="text-light">Dragon Ancestry</Form.Label>
-            <Form.Select
-              value={form.dragonAncestryKey || ""}
-              onChange={handleDragonAncestryChange}
-            >
-              <option value="" disabled>Select your dragon ancestry</option>
-              {Object.entries(form.race.dragonAncestries || {}).map(([key, ancestry]) => (
-                <option key={key} value={key}>{ancestry.label}</option>
-              ))}
-            </Form.Select>
-          </>
-        )}
-        {form.race?.name === "Goliath" && (
-          <>
-            <Form.Label className="text-light">Giant Ancestry</Form.Label>
-            <Form.Select
-              value={form.giantAncestryKey || ""}
-              onChange={handleGiantAncestryChange}
-            >
-              <option value="" disabled>Select your giant ancestry</option>
-              {Object.entries(form.race.giantAncestries || {}).map(([key, ancestry]) => (
-                <option key={key} value={key}>
-                  {ancestry.ancestryName || ancestry.label || ancestry.name || "Giant Ancestry"}
-                </option>
-              ))}
-            </Form.Select>
-          </>
-        )}
-        {form.race?.name === "Elf" && (
-          <>
-            <Form.Label className="text-light">Elven Lineage</Form.Label>
-            <Form.Select
-              value={form.elvenLineageKey || ""}
-              onChange={handleElvenLineageChange}
-            >
-              <option value="" disabled>Select your elven lineage</option>
-              {Object.entries(form.race.elvenLineages || {}).map(([key, lineage]) => (
-                <option key={key} value={key}>
-                  {lineage.label || lineage.name || "Elven Lineage"}
-                </option>
-              ))}
-            </Form.Select>
-            {form.elvenLineage?.spellcastingAbilities?.length ? (
-              <>
-                <Form.Label className="text-light">Spellcasting Ability</Form.Label>
-                <Form.Select
-                  value={form.elvenLineageAbility || ""}
-                  onChange={handleElvenLineageAbilityChange}
-                >
-                  <option value="" disabled>Select your spellcasting ability</option>
-                  {(form.elvenLineage?.spellcastingAbilities || []).map((ability) => (
-                    <option key={ability} value={ability}>
-                      {ability}
-                    </option>
-                  ))}
-                </Form.Select>
-              </>
-            ) : null}
-          </>
-        )}
-        {form.race?.name === "Gnome" && (
-          <>
-            <Form.Label className="text-light">Gnome Lineage</Form.Label>
-            <Form.Select
-              value={form.gnomeLineageKey || ""}
-              onChange={handleGnomeLineageChange}
-            >
-              <option value="" disabled>Select your gnome lineage</option>
-              {Object.entries(form.race.gnomeLineages || {}).map(([key, lineage]) => (
-                <option key={key} value={key}>
-                  {lineage.label || lineage.name || "Gnome Lineage"}
-                </option>
-              ))}
-            </Form.Select>
-            {form.gnomeLineage?.spellcastingAbilities?.length ? (
-              <>
-                <Form.Label className="text-light">Spellcasting Ability</Form.Label>
-                <Form.Select
-                  value={form.gnomeLineageAbility || ""}
-                  onChange={handleGnomeLineageAbilityChange}
-                >
-                  <option value="" disabled>Select your spellcasting ability</option>
-                  {(form.gnomeLineage?.spellcastingAbilities || []).map((ability) => (
-                    <option key={ability} value={ability}>
-                      {ability}
-                    </option>
-                  ))}
-                </Form.Select>
-              </>
-            ) : null}
-          </>
-        )}
-        {form.race?.name === "Tiefling" && (
-          <>
-            <Form.Label className="text-light">Fiendish Legacy</Form.Label>
-            <Form.Select
-              value={form.tieflingLegacyKey || ""}
-              onChange={handleTieflingLegacyChange}
-            >
-              <option value="" disabled>Select your fiendish legacy</option>
-              {Object.entries(form.race.fiendishLegacies || {}).map(([key, legacy]) => (
-                <option key={key} value={key}>
-                  {legacy.label || legacy.name || "Fiendish Legacy"}
-                </option>
-              ))}
-            </Form.Select>
-            {form.tieflingLegacy?.spellcastingAbilities?.length ? (
-              <>
-                <Form.Label className="text-light">Spellcasting Ability</Form.Label>
-                <Form.Select
-                  value={form.tieflingLegacyAbility || ""}
-                  onChange={handleTieflingLegacyAbilityChange}
-                >
-                  <option value="" disabled>Select your spellcasting ability</option>
-                  {(form.tieflingLegacy?.spellcastingAbilities || []).map((ability) => (
-                    <option key={ability} value={ability}>
-                      {ability}
-                    </option>
-                  ))}
-                </Form.Select>
-              </>
-            ) : null}
-          </>
-        )}
-        <Form.Label className="text-light">Background</Form.Label>
-        <Form.Select onChange={handleBackgroundChange} defaultValue="">
-          <option value="" disabled>Select your background</option>
-          {Object.keys(backgrounds).map((key) => (
-            <option key={key} value={key}>{backgrounds[key].name}</option>
-          ))}
-        </Form.Select>
-         <Form.Label className="text-light">Age</Form.Label>
-       <Form.Control className="mb-2" onChange={(e) => updateForm({ age: e.target.value })}
-        type="number" placeholder="Enter age" pattern="[0-9]*" />
-         <Form.Label className="text-light">Sex</Form.Label>
-       <Form.Control className="mb-2" onChange={(e) => updateForm({ sex: e.target.value })}
-        type="text"  placeholder="Enter sex" pattern="[^0-9]+" />
-        <Form.Label className="text-light">Size</Form.Label>
-        <Form.Select
-          className="mb-2"
-          value={form.size || ""}
-          onChange={(e) => updateForm({ size: e.target.value })}
-        >
-          <option value="" disabled>Select your size</option>
-          {sizeOptionsForManual.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </Form.Select>
-        <Form.Label className="text-light">Weight</Form.Label>
-       <Form.Control className="mb-2" onChange={(e) => updateForm({ weight: e.target.value })}
-        type="number" placeholder="Enter weight" pattern="[0-9]*" />
-        {STATS.map(({ key, label }) => (
-          <React.Fragment key={key}>
-            <Form.Label className="text-light">{label}</Form.Label>
-            <Form.Control
-              className="mb-2"
-              onChange={(e) => updateForm({ [key]: e.target.value })}
-              type="number"
-              placeholder={`Enter ${label.toLowerCase()}`}
-              pattern="[0-9]*"
-            />
-          </React.Fragment>
-        ))}
-     </Form.Group>
-     <div className="text-center manual-character-modal__actions">
-     <Button variant="primary" type="submit">
-            Create
-          </Button>
-          <Button className="ms-4" variant="secondary" onClick={handleClose5}>
-            Close
-          </Button>
+    <Modal className="dnd-modal manual-character-modal" dialogClassName="manual-character-modal__dialog" centered show={show5} onHide={requestCloseManual} backdrop="static" keyboard={false}>
+      <CharacterCreationWizard
+        form={form}
+        updateForm={updateForm}
+        races={races}
+        backgrounds={backgrounds}
+        occupations={getOccupation}
+        selectedOccupation={selectedOccupation}
+        selectedAddOccupationRef={selectedAddOccupationRef}
+        sizeOptions={sizeOptionsForManual}
+        step={manualStep}
+        setStep={setManualStep}
+        touched={manualTouched}
+        setTouched={setManualTouched}
+        onClose={requestCloseManual}
+        onSubmit={onSubmitManual}
+        onRaceChange={handleRaceChange}
+        onClassChange={handleOccupationChange}
+        onSelectClass={selectOccupation}
+        onBackgroundChange={handleBackgroundChange}
+        onDragonAncestryChange={handleDragonAncestryChange}
+        onGiantAncestryChange={handleGiantAncestryChange}
+        onElvenLineageChange={handleElvenLineageChange}
+        onElvenLineageAbilityChange={handleElvenLineageAbilityChange}
+        onGnomeLineageChange={handleGnomeLineageChange}
+        onGnomeLineageAbilityChange={handleGnomeLineageAbilityChange}
+        onTieflingLegacyChange={handleTieflingLegacyChange}
+        onTieflingLegacyAbilityChange={handleTieflingLegacyAbilityChange}
+      />
+    </Modal>
+    <Modal className="dnd-modal unsaved-character-modal" centered show={showUnsavedManualDialog} onHide={() => setShowUnsavedManualDialog(false)}>
+      <Card className="dnd-background unsaved-character-modal__card">
+        <Card.Body>
+          <p className="character-select-kicker">Unsaved hero</p>
+          <h2>Discard this character?</h2>
+          <p>Your current character creation progress will be lost if you leave now.</p>
+          <div className="unsaved-character-modal__actions">
+            <Button variant="secondary" onClick={discardManualChanges}>Discard</Button>
+            <Button variant="primary" onClick={() => setShowUnsavedManualDialog(false)}>Continue Editing</Button>
           </div>
-     </Form>
-     </div>
-      </Card.Body>
+        </Card.Body>
       </Card>
-      </div>
-      </Modal>
+    </Modal>
        <Modal className="dnd-modal" centered show={showAbilitySkillModal} onHide={() => setShowAbilitySkillModal(false)}>
        <div className="text-center">
         <Card className="dnd-background">


### PR DESCRIPTION
### Motivation
- Replace the one-page manual character form with a polished multi-step wizard to improve UX for creating characters and to better guide users through required fields.
- Surface and aggregate server-side validation messages when save requests fail so users get clearer feedback.
- Prevent accidental data loss by detecting unsaved manual creation changes and prompting the user before closing.

### Description
- Introduces a full-featured character creation UI: `CharacterCreationWizard`, `CharacterFormField`, `CharacterSelectCard`, and `AbilityScoreCard` components and supporting helpers (e.g. `abilityModifier`, `MANUAL_STEPS`, `getManualErrors`) embedded in `ZombiesCharacterSelect.js` to manage multi-step state, per-field validation, and navigation.
- Replaces the old manual modal form with the new wizard modal, adds `manualStep`, `manualTouched`, `showUnsavedManualDialog`, `initialManualSnapshot` and related logic to detect unsaved changes and offer a discard confirmation dialog.
- Improves occupation selection flow by tracking `selectedOccupation` and simplifying confirm logic, and updates `handleConfirmOccupation` to use the selected object directly.
- Enhances save routines (`sendManualToDb` and the existing save path) to parse JSON error bodies and aggregate validation messages into the UI `notify` message; these save functions now return booleans to allow caller logic to react to failure.
- Reworks ability/skill bonus confirmation (`handleAbilitySkillConfirm`) to await saves and abort further actions when a save fails, and ensures cleanup (closing dialogs and clearing temporary selections) only after successful saves.
- Adds extensive styling for the character wizard and responsive behavior in `client/src/App.scss` to support the new wizard UI (layout, sidebar, steps, cards, ability steppers, mobile adaptations, reduced-motion transitions, etc.).
- Adds `user` to several hook dependency arrays and ensures new forms preserve or assign the `token` field from the current user when creating/resetting forms.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a541712ec28832e9a8ef561aaae4c25)