### PR TITLE
Fix dying state UI, enable animated death-save rolls, and reset per-turn roll gate

### DIFF
--- a/client/src/components/Zombies/death/DyingStatePanel.css
+++ b/client/src/components/Zombies/death/DyingStatePanel.css
@@ -1,8 +1,10 @@
 .dying-state-panel {
-  background: linear-gradient(135deg, rgba(13, 22, 38, 0.96), rgba(69, 8, 22, 0.9));
-  border: 1px solid rgba(255, 92, 122, 0.45);
-  border-radius: 18px;
-  box-shadow: 0 0 24px rgba(220, 35, 70, 0.28), inset 0 0 28px rgba(255, 255, 255, 0.04);
+  background:
+    radial-gradient(circle at 14% 18%, rgba(255, 120, 148, 0.24), transparent 28%),
+    linear-gradient(145deg, rgba(12, 16, 32, 0.97), rgba(53, 7, 28, 0.94) 58%, rgba(20, 11, 28, 0.97));
+  border: 1px solid rgba(255, 120, 150, 0.5);
+  border-radius: 22px;
+  box-shadow: 0 18px 44px rgba(4, 7, 18, 0.48), 0 0 28px rgba(220, 35, 70, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.08);
   color: #f7eef2;
   padding: 1rem;
   min-width: 280px;
@@ -11,11 +13,11 @@
 }
 
 .dying-state-panel--compact {
-  width: min(100%, 360px);
+  width: min(100%, 330px);
   min-width: 0;
-  max-width: 360px;
-  padding: 0.75rem;
-  border-radius: 16px;
+  max-width: 330px;
+  padding: 0.8rem;
+  border-radius: 18px;
 }
 
 .dying-state-panel--dead {
@@ -138,6 +140,7 @@
   width: 100%;
   min-height: 46px;
   border: 0 !important;
+  border-radius: 12px !important;
   font-weight: 900 !important;
   background: linear-gradient(90deg, #b91c3c, #f59e0b) !important;
   box-shadow: 0 0 18px rgba(245, 158, 11, 0.25);
@@ -192,28 +195,11 @@
   50% { box-shadow: 0 0 30px rgba(220, 35, 70, 0.42); }
 }
 
-.footer-character-slot--dying {
-  justify-content: center;
-  align-items: center;
-  width: min(100%, 380px);
-}
-
-.footer-character-slot--dying .footer-character-slot__profile-card {
-  display: none;
-}
-
-.footer-character-slot--dying .footer-character-slot__health-inline {
-  box-shadow: 0 0 18px rgba(220, 38, 70, 0.65) !important;
-  background: linear-gradient(90deg, #48111c, #7f1d1d) !important;
-}
-
-.footer-character-slot--dying .footer-character-slot__health-current {
-  color: #fecdd3;
-}
 
 .footer-character-slot__death-panel {
-  width: min(100%, 360px);
-  margin: 0 auto;
+  width: min(32vw, 330px);
+  min-width: 290px;
+  margin: 0 0 0 0.75rem;
   position: relative;
   z-index: 2;
 }
@@ -241,9 +227,10 @@
     font-size: 0.78rem;
   }
 
-  .footer-character-slot--dying,
   .footer-character-slot__death-panel {
     width: 100%;
+    min-width: 0;
+    margin: 0;
   }
 }
 

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1574,13 +1574,30 @@ export default function ZombiesCharacterSheet() {
     combatState.participants.length > 0;
 
 
+  useEffect(() => {
+    if (!characterId || activeTurnParticipantId !== characterId) return;
+    setForm((prev) => {
+      if (!prev?.deathState?.isDying || prev.deathState.isDead || !prev.deathState.rolledThisTurn) {
+        return prev;
+      }
+      return { ...prev, deathState: { ...prev.deathState, rolledThisTurn: false } };
+    });
+  }, [activeTurnParticipantId, characterId]);
+
   const handleRollDeathSave = useCallback(async () => {
     if (!characterId) return;
     try {
+      let animatedRoll = null;
+      try {
+        const { rolls } = await rollDiceWithBox([{ count: 1, sides: 20 }]);
+        animatedRoll = collectRollValues(rolls)[0] ?? null;
+      } catch (diceError) {
+        console.error('Failed to animate death save roll', diceError);
+      }
       const response = await apiFetch(`/characters/death-state/${characterId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'roll' }),
+        body: JSON.stringify({ action: 'roll', ...(animatedRoll ? { roll: animatedRoll } : {}) }),
       });
       if (!response.ok) throw new Error(response.statusText || 'Failed to roll death save.');
       const payload = await response.json();

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -72,7 +72,7 @@ import { resolveFigurineImageData } from '../utils/figurineAssets';
 import TokenPickerModal from '../components/TokenPickerModal';
 import ActiveEnemyQuickList from '../components/ActiveEnemyQuickList';
 import CombatTurnHeader from '../components/CombatTurnHeader';
-import DyingStatePanel, { DeathStateBadge, DeathSaveTracker } from '../death/DyingStatePanel';
+import { DeathStateBadge } from '../death/DyingStatePanel';
 import { buildEnemyTokenFilterScopeValues } from '../utils/enemyTokenFilters';
 import { sanitizeIdentifierForTestId } from '../utils/sanitizeIdentifierForTestId';
 
@@ -7197,7 +7197,6 @@ const resolveIcon = (category, iconMap, fallback) => {
                                     {displayName}
                                     <div className="mt-1">
                                       <DeathStateBadge deathState={character?.deathState} />
-                                      {(character?.deathState?.isDying || character?.deathState?.isDead) ? <DeathSaveTracker deathState={character.deathState} /> : null}
                                     </div>
                                   </td>
                                   <td>{playerName}</td>
@@ -7233,17 +7232,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                                       >
                                         Set Turn
                                       </Button>
-                                      {(character?.deathState?.isDying || character?.deathState?.isDead) ? (
-                                        <DyingStatePanel
-                                          compact
-                                          characterName={displayName}
-                                          currentHp={rowCurrentHp ?? 0}
-                                          deathState={character.deathState}
-                                          onRollDeathSave={() => handleDeathStateAction(character, 'roll')}
-                                          onDmAction={(action) => handleDeathStateAction(character, action)}
-                                          isActiveTurn={isActive}
-                                        />
-                                      ) : null}
+
                                     </div>
                                   </td>
                                 </tr>

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -358,7 +358,7 @@ const FooterCharacterSlot = ({
 
   return (
     <div
-      className={`footer-character-slot ${isResourcesOpen ? 'footer-character-slot--resources-open' : ''} ${isDeathStateVisible ? 'footer-character-slot--dying' : ''}`}
+      className={`footer-character-slot ${isResourcesOpen ? 'footer-character-slot--resources-open' : ''}`}
       data-allow-pointer-events="true"
     >
       {hasResourcesDrawer ? (
@@ -480,7 +480,7 @@ const FooterCharacterSlot = ({
           />
         </div>
       ) : null}
-      {hasHudContent && !normalizedDeathState.isDying && !normalizedDeathState.isDead ? (
+      {hasHudContent ? (
         <div className="footer-character-slot__hud" data-allow-pointer-events="true">
           {hasSpellSlots ? (
             <div className="footer-character-slot__slots-wrapper">

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -25,6 +25,21 @@ const {
   suggestEnemyFigurine,
 } = require('../utils/cloudinary');
 
+
+const resetActiveDeathSaveRoll = async (db, combatState) => {
+  const activeTurn = Number.isInteger(combatState?.activeTurn) ? combatState.activeTurn : null;
+  const participants = Array.isArray(combatState?.participants) ? combatState.participants : [];
+  if (activeTurn === null || activeTurn < 0 || activeTurn >= participants.length) return;
+  const characterId = typeof participants[activeTurn]?.characterId === 'string' ? participants[activeTurn].characterId.trim() : '';
+  if (!characterId) return;
+  const filters = [{ characterId }];
+  if (ObjectId.isValid(characterId)) filters.push({ _id: new ObjectId(characterId) });
+  await db.collection('Characters').updateOne(
+    { $or: filters, 'deathState.isDying': true, 'deathState.isDead': { $ne: true } },
+    { $set: { 'deathState.rolledThisTurn': false, 'deathState.updatedAt': new Date().toISOString() } }
+  );
+};
+
 const deriveCloudinaryPublicIdFromUrl = (url) => {
   if (typeof url !== 'string' || url.trim() === '') {
     return null;
@@ -2067,6 +2082,8 @@ module.exports = (router) => {
               { campaignName: req.params.campaign },
               { $set: { combat: combatState } }
             );
+
+          await resetActiveDeathSaveRoll(db_connect, combatState);
 
           emitCombatUpdate(req.params.campaign, combatState);
 


### PR DESCRIPTION
### Motivation
- Prevent the full dying-state popup/tracker from appearing in the DM combat table while keeping a compact badge, so the DM list stays uncluttered and the combat table remains usable.
- Allow players to still interact with character health controls (and the combat HUD) while a dying popup is shown so a character can be healed without UI blocking.
- Permit an animated d20 roll to be used for death saves and ensure the one-roll-per-turn gate is reset so a dying character can roll again each turn.
- Improve the dying popup styling and constrain its desktop width so it no longer enlarges the combat bar.

### Description
- Removed the inline `DyingStatePanel` from the DM combat table and kept only the compact `DeathStateBadge` for DM listing (updated `ZombiesDM.js`).
- Restored the footer HUD/health controls visibility when a character is dying and removed the class that forced a large combat bar, keeping the per-character `DyingStatePanel` only in the footer (updated `FooterCharacterSlot.js` and related CSS adjustments).
- Switched the character-sheet death save flow to attempt an animated roll via `rollDiceWithBox` and, if successful, submit that roll as `roll` to the death-state API before falling back to server RNG (updated `ZombiesCharacterSheet.js`).
- Added a client `useEffect` to clear `deathState.rolledThisTurn` when the character becomes the active turn so the UI allows a new roll on that turn (updated `ZombiesCharacterSheet.js`).
- Added server-side logic `resetActiveDeathSaveRoll` to `server/routes/campaigns.js` and invoked it after combat `activeTurn` updates to clear `deathState.rolledThisTurn` for the active dying character, enabling per-turn rolls from the server side.
- Restyled `DyingStatePanel.css` to a more compact/polished card, constrained desktop width (`min-width`/`max-width` changes) and removed the styles that hid/restyled the footer in a way that enlarged the combat bar.

Files changed: `client/src/components/Zombies/death/DyingStatePanel.css`, `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`, `client/src/components/Zombies/pages/ZombiesDM.js`, `client/src/components/Zombies/pages/components/FooterCharacterSlot.js`, `server/routes/campaigns.js`.

### Testing
- Ran server unit tests `npm --prefix server test -- --runInBand __tests__/deathState.test.js` and they passed (`7 tests, 1 suite`).
- Ran client unit tests `npm --prefix client test -- --watchAll=false --runInBand ZombiesCharacterSheet.test.js` and the `ZombiesCharacterSheet` suite passed (59 tests passed); running `ZombiesDM.test.js` produced pre-existing unrelated failures/timeouts in map/currency tests.
- Built the client with `npm --prefix client run build` which completed successfully (build succeeded with existing lint/autoprefixer warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f2eb6f30832ebd4d1b878bd4b8d8)