### PR TITLE
Attach Dying State UI to Footer HUD and refactor layout/styles

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11621,3 +11621,58 @@ body.character-creation-modal-open {
     padding-bottom: calc(0.85rem + env(safe-area-inset-bottom, 0px));
   }
 }
+
+/* Shared footer HUD dock tokens keep the Dying drawer and character bar aligned as one component. */
+.footer-character-slot__hud {
+  --hud-max-width: clamp(320px, 62vw, 780px);
+  --hud-radius: 22px;
+  --hud-inline-gap: 0px;
+  width: min(100%, var(--hud-max-width));
+  max-width: var(--hud-max-width);
+  gap: var(--hud-inline-gap);
+  align-items: stretch;
+}
+
+.footer-character-slot__hud > .footer-character-slot__footer-rail,
+.footer-character-slot__hud > .footer-character-slot__slots-wrapper,
+.footer-character-slot__hud > .footer-character-slot__death-dock {
+  width: 100%;
+}
+
+.footer-character-slot__hud > .footer-character-slot__footer-rail {
+  align-self: stretch;
+  width: 100%;
+}
+
+.footer-character-slot__death-dock + .footer-character-slot__slots-wrapper .footer-character-slot__slots {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+@media (max-width: 600px) {
+  .footer-character-slot {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .footer-character-slot__hud {
+    --hud-max-width: 100%;
+  }
+}
+
+.footer-character-slot__hud:has(.footer-character-slot__death-dock) {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+@media (max-width: 600px) {
+  .footer-character-slot__hud:has(.footer-character-slot__death-dock) .footer-character-slot__footer-rail,
+  .footer-character-slot__hud:has(.footer-character-slot__death-dock) .footer-character-slot__footer-rail-body {
+    display: flex;
+  }
+
+  .footer-character-slot__hud:has(.footer-character-slot__death-dock) .footer-character-slot__footer-rail-body {
+    flex-wrap: wrap;
+  }
+}

--- a/client/src/components/Zombies/death/DyingStatePanel.css
+++ b/client/src/components/Zombies/death/DyingStatePanel.css
@@ -356,3 +356,192 @@
     animation: none;
   }
 }
+
+/* HUD-attached death-save drawer: lives in the footer character HUD flow, not a viewport portal. */
+.footer-character-slot__death-dock {
+  --hud-radius: 22px;
+  --hud-border: rgba(255, 120, 150, 0.48);
+  --hud-backdrop: blur(16px) saturate(1.12);
+  --hud-shadow: 0 18px 46px rgba(2, 6, 18, 0.54), 0 0 22px rgba(185, 28, 62, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  position: relative;
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  max-width: inherit;
+  pointer-events: auto;
+  filter: none;
+  isolation: isolate;
+}
+
+.footer-character-slot__death-panel {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  transform-origin: bottom center;
+  animation: dyingHudDrawerIn 180ms ease-out;
+}
+
+.footer-character-slot__death-toggle {
+  width: 100%;
+  min-width: 0;
+  min-height: 50px;
+  border: 1px solid var(--hud-border);
+  border-bottom-color: rgba(255, 150, 170, 0.28);
+  border-radius: var(--hud-radius) var(--hud-radius) 0 0;
+  color: #fff1f4;
+  background:
+    radial-gradient(circle at 18% 15%, rgba(255, 168, 188, 0.18), transparent 32%),
+    linear-gradient(135deg, rgba(22, 18, 34, 0.97), rgba(81, 13, 36, 0.94));
+  box-shadow: var(--hud-shadow);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.56rem 0.9rem;
+  text-align: left;
+  backdrop-filter: var(--hud-backdrop);
+}
+
+.footer-character-slot__death-toggle.is-open {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  box-shadow: none;
+}
+
+.footer-character-slot__death-toggle:hover,
+.footer-character-slot__death-toggle:focus-visible {
+  border-color: rgba(255, 188, 202, 0.82);
+}
+
+.footer-character-slot__death-toggle:focus-visible {
+  outline: 3px solid #7dd3fc;
+  outline-offset: -3px;
+}
+
+.footer-character-slot__death-toggle-eyebrow {
+  border-radius: 999px;
+  padding: 0.26rem 0.52rem;
+  background: rgba(255, 104, 132, 0.18);
+  color: #ffb8c6;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.footer-character-slot__death-toggle-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 900;
+}
+
+.footer-character-slot__death-toggle-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #ffe4ea;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.footer-character-slot__death-dock + .footer-character-slot__slots-wrapper,
+.footer-character-slot__death-dock + .footer-character-slot__footer-rail {
+  margin-top: 0;
+}
+
+.footer-character-slot__death-dock + .footer-character-slot__footer-rail,
+.footer-character-slot__death-dock + .footer-character-slot__slots-wrapper + .footer-character-slot__footer-rail {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-top-color: rgba(255, 150, 170, 0.22);
+}
+
+.footer-character-slot__death-dock .dying-state-panel {
+  width: 100%;
+  max-width: none;
+  min-width: 0;
+  border-radius: var(--hud-radius) var(--hud-radius) 0 0;
+  border-bottom: 0;
+  box-shadow: var(--hud-shadow);
+  animation: none;
+}
+
+.footer-character-slot__death-dock .dying-state-panel--compact {
+  padding: 0.85rem 1rem;
+}
+
+.dying-state-panel--compact {
+  max-width: none;
+}
+
+.footer-character-slot__death-dock .dying-state-panel--compact {
+  display: grid;
+  grid-template-columns: minmax(210px, 0.8fr) minmax(260px, 1fr) minmax(190px, 0.75fr);
+  grid-template-areas:
+    'header tracker action'
+    'turn tracker result';
+  align-items: center;
+  gap: 0.75rem 1rem;
+}
+
+.footer-character-slot__death-dock .dying-state-panel__header { grid-area: header; min-width: 0; }
+.footer-character-slot__death-dock .dying-state-panel__turn { grid-area: turn; margin: 0; }
+.footer-character-slot__death-dock .death-save-tracker { grid-area: tracker; margin: 0; }
+.footer-character-slot__death-dock .death-save-roll-button { grid-area: action; justify-self: end; width: min(100%, 190px); }
+.footer-character-slot__death-dock .dying-state-panel__result { grid-area: result; text-align: right; min-height: 0; }
+
+@keyframes dyingHudDrawerIn {
+  from { opacity: 0; clip-path: inset(100% 0 0 0); transform: translateY(6px); }
+  to { opacity: 1; clip-path: inset(0 0 0 0); transform: translateY(0); }
+}
+
+@media (max-width: 900px) {
+  .footer-character-slot__death-dock .dying-state-panel--compact {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      'header action'
+      'tracker tracker'
+      'turn turn'
+      'result result';
+  }
+}
+
+@media (max-width: 640px) {
+  .footer-character-slot__death-toggle {
+    min-height: 48px;
+    padding: 0.55rem 0.75rem;
+    gap: 0.5rem;
+  }
+
+  .footer-character-slot__death-toggle-eyebrow { font-size: 0.66rem; letter-spacing: 0.12em; }
+
+  .footer-character-slot__death-dock .dying-state-panel,
+  .footer-character-slot__death-dock .dying-state-panel--compact {
+    border-radius: 20px 20px 0 0;
+    padding: 0.75rem;
+  }
+
+  .footer-character-slot__death-dock .dying-state-panel--compact {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'header'
+      'tracker'
+      'action'
+      'turn'
+      'result';
+    gap: 0.65rem;
+    max-height: min(52vh, 360px);
+    overflow-y: auto;
+  }
+
+  .footer-character-slot__death-dock .death-save-roll-button { width: 100%; }
+  .footer-character-slot__death-dock .dying-state-panel__result { text-align: center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footer-character-slot__death-panel { animation: none; }
+}

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { Button, Spinner } from 'react-bootstrap';
 
@@ -372,20 +371,6 @@ const FooterCharacterSlot = ({
 
   const deathDock = isDeathStateVisible ? (
     <div className="footer-character-slot__death-dock" data-allow-pointer-events="true">
-      <button
-        type="button"
-        className={`footer-character-slot__death-toggle ${isDeathPanelOpen ? 'is-open' : ''}`}
-        aria-expanded={isDeathPanelOpen}
-        aria-controls="footer-character-death-panel"
-        onClick={() => setIsDeathPanelOpen((current) => !current)}
-      >
-        <span className="footer-character-slot__death-toggle-eyebrow">{deathPanelLabel}</span>
-        <span className="footer-character-slot__death-toggle-name">{characterName}</span>
-        <span className="footer-character-slot__death-toggle-meta">
-          HP {displayCurrent}
-          <i className={`fas fa-chevron-${isDeathPanelOpen ? 'down' : 'up'}`} aria-hidden="true" />
-        </span>
-      </button>
       {isDeathPanelOpen ? (
         <div
           id="footer-character-death-panel"
@@ -403,6 +388,20 @@ const FooterCharacterSlot = ({
           />
         </div>
       ) : null}
+      <button
+        type="button"
+        className={`footer-character-slot__death-toggle ${isDeathPanelOpen ? 'is-open' : ''}`}
+        aria-expanded={isDeathPanelOpen}
+        aria-controls="footer-character-death-panel"
+        onClick={() => setIsDeathPanelOpen((current) => !current)}
+      >
+        <span className="footer-character-slot__death-toggle-eyebrow">{deathPanelLabel}</span>
+        <span className="footer-character-slot__death-toggle-name">{characterName}</span>
+        <span className="footer-character-slot__death-toggle-meta">
+          HP {displayCurrent}
+          <i className={`fas fa-chevron-${isDeathPanelOpen ? 'down' : 'up'}`} aria-hidden="true" />
+        </span>
+      </button>
     </div>
   ) : null;
 
@@ -411,7 +410,6 @@ const FooterCharacterSlot = ({
       className={`footer-character-slot ${isResourcesOpen ? 'footer-character-slot--resources-open' : ''}`}
       data-allow-pointer-events="true"
     >
-      {deathDock && typeof document !== 'undefined' ? createPortal(deathDock, document.body) : null}
       {hasResourcesDrawer ? (
         <div
           id="footer-resources-drawer"
@@ -517,8 +515,9 @@ const FooterCharacterSlot = ({
           </div>
         </div>
       </div>
-      {hasHudContent ? (
+      {(hasHudContent || deathDock) ? (
         <div className="footer-character-slot__hud" data-allow-pointer-events="true">
+          {deathDock}
           {hasSpellSlots ? (
             <div className="footer-character-slot__slots-wrapper">
               <div className="footer-character-slot__slots">{spellSlots}</div>


### PR DESCRIPTION
### Motivation

- Stop treating the Dying bar/panel as a floating viewport portal and make it a first‑class part of the footer character HUD so the collapsed bar and expanded panel visually and structurally read as one component.
- Eliminate magic offsets and independent centering by anchoring the Dying UI to the HUD layout, improve responsiveness across desktop/tablet/mobile, and keep death-save rules intact.

### Description

- Render the Dying dock inline inside the footer HUD and remove the `createPortal` portal so the panel participates in normal document flow (changed `client/src/components/Zombies/pages/components/FooterCharacterSlot.js`).
- Add shared HUD layout tokens and width/alignment rules to `client/src/App.scss` so the death dock, spell slots, and footer rail share the same horizontal anchor, max width, and edge radii.
- Replace the fixed/viewport CSS with an attached drawer style in `client/src/components/Zombies/death/DyingStatePanel.css`, including a compact collapsed bar, coordinated border/border‑radius/shadow treatment, HUD‑origin animation, and a desktop horizontal grid plus mobile stacked layout for the expanded panel.
- Improve mobile handling with safe‑area consideration, full‑width CTA on mobile, bounded expanded height with internal scrolling when necessary, and responsive grid breakpoints at ~900/640px.

### Testing

- Ran the Zombies character sheet unit tests with `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js`, and the suite passed (59 tests passed).
- Performed a production build with `npm --prefix client run build`, which completed successfully but reported existing project warnings from Browserslist/autoprefixer/ESLint (no build failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551394223c832eb740339011801159)