### PR TITLE
Adjust mobile dying dock positioning to follow HUD panels

### DIFF
--- a/client/src/components/Zombies/death/DyingStatePanel.css
+++ b/client/src/components/Zombies/death/DyingStatePanel.css
@@ -274,7 +274,7 @@
   white-space: nowrap;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 900px) {
   .dying-state-panel,
   .dying-state-panel--compact {
     border-radius: 18px 18px 0 0;
@@ -304,30 +304,13 @@
   }
 
   .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 132px);
-    width: min(94vw, 360px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 214px);
+    width: min(94vw, 540px);
+    transition: bottom 180ms ease;
   }
 
-  .footer-character-slot__death-toggle {
-    min-width: 0;
-    width: 100%;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    width: min(94vw, 360px);
-  }
-
-  .footer-character-slot__death-toggle {
-    min-width: 0;
-    width: 100%;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    width: min(94vw, 360px);
+  .footer-character-slot__death-dock--hud-panel-open {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + min(62vh, 500px));
   }
 
   .footer-character-slot__death-toggle {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5818,6 +5818,7 @@ export default function ZombiesCharacterSheet() {
         isActiveTurn={isPlayersTurn}
         onRollDeathSave={handleRollDeathSave}
         collapseDeathPanelSignal={mobileHudPanel}
+        isCombatHudPanelOpen={isMobileCombatHudLayout && Boolean(mobileHudPanel)}
       />
       <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
         <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -39,6 +39,7 @@ const FooterCharacterSlot = ({
   onRollDeathSave,
   isActiveTurn,
   collapseDeathPanelSignal,
+  isCombatHudPanelOpen,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
@@ -370,8 +371,13 @@ const FooterCharacterSlot = ({
     setIsDeathPanelOpen(false);
   }, [collapseDeathPanelSignal]);
 
+  const deathDockClassName = [
+    'footer-character-slot__death-dock',
+    isCombatHudPanelOpen ? 'footer-character-slot__death-dock--hud-panel-open' : null,
+  ].filter(Boolean).join(' ');
+
   const deathDock = isDeathStateVisible ? (
-    <div className="footer-character-slot__death-dock" data-allow-pointer-events="true">
+    <div className={deathDockClassName} data-allow-pointer-events="true">
       <button
         type="button"
         className={`footer-character-slot__death-toggle ${isDeathPanelOpen ? 'is-open' : ''}`}
@@ -635,6 +641,7 @@ FooterCharacterSlot.propTypes = {
   onRollDeathSave: PropTypes.func,
   isActiveTurn: PropTypes.bool,
   collapseDeathPanelSignal: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  isCombatHudPanelOpen: PropTypes.bool,
 };
 
 FooterCharacterSlot.defaultProps = {
@@ -656,6 +663,7 @@ FooterCharacterSlot.defaultProps = {
   onRollDeathSave: null,
   isActiveTurn: false,
   collapseDeathPanelSignal: null,
+  isCombatHudPanelOpen: false,
 };
 
 export default FooterCharacterSlot;


### PR DESCRIPTION
### Motivation
- The dying-state compact bar on mobile floated too high above the combat HUD and could be obscured by the Resources/Menu panels, so it should sit just above the panel below and remain positioned above when those mobile HUD panels open.
- Ensure the dying dock animates its vertical position when the HUD panels open/close for a smoother UX on small screens.

### Description
- Broadened the mobile CSS breakpoint and repositioned the dying dock by updating `client/src/components/Zombies/death/DyingStatePanel.css` to set a lower default `bottom` (closer to the HUD), increase its width, and add a `transition: bottom 180ms ease` for smooth movement.
- Added a modifier class `.footer-character-slot__death-dock--hud-panel-open` in the CSS that moves the dying dock upward to sit above an open mobile Resources/Menu panel.
- Passed a new prop `isCombatHudPanelOpen` from `ZombiesCharacterSheet` into `FooterCharacterSlot`, and updated `FooterCharacterSlot` to accept the prop, compute a `deathDock` class string, and toggle the HUD-open modifier class via that prop; also added propTypes/defaultProps for the new flag.

### Testing
- Ran `git diff --check` to ensure no whitespace errors and it passed.
- Ran the client production build with `npm --prefix client run build`, which completed successfully (build emits unrelated lint/autoprefixer warnings but no build errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55163ac93c832ea96f3fcbf5977c73)