### PR TITLE
Make footer death panel responsive and dynamically position dock on mobile HUD

### DIFF
--- a/client/src/components/Zombies/death/DyingStatePanel.css
+++ b/client/src/components/Zombies/death/DyingStatePanel.css
@@ -274,7 +274,7 @@
   white-space: nowrap;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 900px) {
   .dying-state-panel,
   .dying-state-panel--compact {
     border-radius: 18px 18px 0 0;
@@ -304,30 +304,9 @@
   }
 
   .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 132px);
-    width: min(94vw, 360px);
-  }
-
-  .footer-character-slot__death-toggle {
-    min-width: 0;
-    width: 100%;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    width: min(94vw, 360px);
-  }
-
-  .footer-character-slot__death-toggle {
-    min-width: 0;
-    width: 100%;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    width: min(94vw, 360px);
+    bottom: var(--footer-death-dock-bottom, calc(env(safe-area-inset-bottom, 0px) + 214px));
+    width: min(94vw, 540px);
+    transition: bottom 180ms ease;
   }
 
   .footer-character-slot__death-toggle {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5818,6 +5818,7 @@ export default function ZombiesCharacterSheet() {
         isActiveTurn={isPlayersTurn}
         onRollDeathSave={handleRollDeathSave}
         collapseDeathPanelSignal={mobileHudPanel}
+        isCombatHudPanelOpen={isMobileCombatHudLayout && Boolean(mobileHudPanel)}
       />
       <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
         <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -39,6 +39,7 @@ const FooterCharacterSlot = ({
   onRollDeathSave,
   isActiveTurn,
   collapseDeathPanelSignal,
+  isCombatHudPanelOpen,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
@@ -47,6 +48,7 @@ const FooterCharacterSlot = ({
   const [damageHighlightClass, setDamageHighlightClass] = useState('');
   const [isResourcesOpen, setIsResourcesOpen] = useState(false);
   const [isDeathPanelOpen, setIsDeathPanelOpen] = useState(false);
+  const [deathDockBottomOffset, setDeathDockBottomOffset] = useState(null);
   const normalizedDeathState = useMemo(() => normalizeDeathState(deathState), [deathState]);
   const isDeathStateVisible = normalizedDeathState.isDying || normalizedDeathState.isDead;
 
@@ -370,8 +372,74 @@ const FooterCharacterSlot = ({
     setIsDeathPanelOpen(false);
   }, [collapseDeathPanelSignal]);
 
+  useEffect(() => {
+    if (!isDeathStateVisible || typeof window === 'undefined' || typeof document === 'undefined') {
+      setDeathDockBottomOffset(null);
+      return undefined;
+    }
+
+    const mobileQuery = window.matchMedia('(max-width: 900px)');
+    let animationFrameId = null;
+    let followUpTimeoutId = null;
+    let resizeObserver = null;
+
+    const updateDeathDockOffset = () => {
+      if (!mobileQuery.matches) {
+        setDeathDockBottomOffset(null);
+        return;
+      }
+
+      const combatDock = document.querySelector('.combat-hud-dock');
+      if (!combatDock) {
+        setDeathDockBottomOffset(null);
+        return;
+      }
+
+      const dockTop = combatDock.getBoundingClientRect().top;
+      setDeathDockBottomOffset(Math.max(0, Math.round(window.innerHeight - dockTop)));
+    };
+
+    const scheduleUpdate = () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      animationFrameId = window.requestAnimationFrame(updateDeathDockOffset);
+    };
+
+    const combatDock = document.querySelector('.combat-hud-dock');
+    if (combatDock && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(scheduleUpdate);
+      resizeObserver.observe(combatDock);
+    }
+
+    scheduleUpdate();
+    followUpTimeoutId = window.setTimeout(scheduleUpdate, 220);
+    window.addEventListener('resize', scheduleUpdate);
+    mobileQuery.addEventListener?.('change', scheduleUpdate);
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      if (followUpTimeoutId !== null) {
+        window.clearTimeout(followUpTimeoutId);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', scheduleUpdate);
+      mobileQuery.removeEventListener?.('change', scheduleUpdate);
+    };
+  }, [isCombatHudPanelOpen, isDeathStateVisible]);
+
+  const deathDockStyle = deathDockBottomOffset === null
+    ? undefined
+    : { '--footer-death-dock-bottom': `${deathDockBottomOffset}px` };
+
   const deathDock = isDeathStateVisible ? (
-    <div className="footer-character-slot__death-dock" data-allow-pointer-events="true">
+    <div
+      className="footer-character-slot__death-dock"
+      style={deathDockStyle}
+      data-allow-pointer-events="true"
+    >
       <button
         type="button"
         className={`footer-character-slot__death-toggle ${isDeathPanelOpen ? 'is-open' : ''}`}
@@ -635,6 +703,7 @@ FooterCharacterSlot.propTypes = {
   onRollDeathSave: PropTypes.func,
   isActiveTurn: PropTypes.bool,
   collapseDeathPanelSignal: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  isCombatHudPanelOpen: PropTypes.bool,
 };
 
 FooterCharacterSlot.defaultProps = {
@@ -656,6 +725,7 @@ FooterCharacterSlot.defaultProps = {
   onRollDeathSave: null,
   isActiveTurn: false,
   collapseDeathPanelSignal: null,
+  isCombatHudPanelOpen: false,
 };
 
 export default FooterCharacterSlot;


### PR DESCRIPTION
### Motivation

- Prevent the footer death toggle/panel from colliding with the mobile combat HUD and improve responsive behavior on larger small-screen breakpoints.  

### Description

- Update CSS breakpoint from `@media (max-width: 640px)` to `@media (max-width: 900px)` and replace duplicated bottom rules with `--footer-death-dock-bottom` fallback, increase dock `width` to `min(94vw, 540px)` and add `transition: bottom 180ms ease`.  
- Add an `isCombatHudPanelOpen` prop to `FooterCharacterSlot` and pass it from `ZombiesCharacterSheet`.  
- Compute a dynamic `deathDockBottomOffset` inside `FooterCharacterSlot` using `window.matchMedia('(max-width: 900px)')`, `ResizeObserver`, `requestAnimationFrame` and resize listeners, then inject it as an inline CSS variable style on the dock element.  
- Add PropTypes and default for the new prop and collapse duplicated/obsolete CSS blocks related to the death dock positioning.  

### Testing

- Ran unit tests with `yarn test` and they passed.  
- Ran the linter with `yarn lint` and it passed.  
- Performed a production build with `yarn build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55163ac93c832ea96f3fcbf5977c73)