### PR TITLE
Make footer death dock position adaptive and add dynamic offset calculation

### DIFF
--- a/client/src/components/Zombies/death/DyingStatePanel.css
+++ b/client/src/components/Zombies/death/DyingStatePanel.css
@@ -203,7 +203,7 @@
 .footer-character-slot__death-dock {
   position: fixed;
   left: 50%;
-  bottom: clamp(156px, 20vh, 230px);
+  bottom: var(--footer-death-dock-bottom, clamp(156px, 20vh, 230px));
   transform: translateX(-50%);
   z-index: 80;
   display: grid;
@@ -274,7 +274,7 @@
   white-space: nowrap;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 900px) {
   .dying-state-panel,
   .dying-state-panel--compact {
     border-radius: 18px 18px 0 0;
@@ -304,30 +304,9 @@
   }
 
   .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 132px);
-    width: min(94vw, 360px);
-  }
-
-  .footer-character-slot__death-toggle {
-    min-width: 0;
-    width: 100%;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    width: min(94vw, 360px);
-  }
-
-  .footer-character-slot__death-toggle {
-    min-width: 0;
-    width: 100%;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-
-  .footer-character-slot__death-dock {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    width: min(94vw, 360px);
+    bottom: var(--footer-death-dock-bottom, calc(env(safe-area-inset-bottom, 0px) + 214px));
+    width: min(94vw, 540px);
+    transition: bottom 180ms ease;
   }
 
   .footer-character-slot__death-toggle {

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -5818,6 +5818,7 @@ export default function ZombiesCharacterSheet() {
         isActiveTurn={isPlayersTurn}
         onRollDeathSave={handleRollDeathSave}
         collapseDeathPanelSignal={mobileHudPanel}
+        isCombatHudPanelOpen={isMobileCombatHudLayout && Boolean(mobileHudPanel)}
       />
       <div className="combat-hud-dock__stat-pills" aria-label="Defenses and conditions">
         <span className="combat-hud-pill"><HeartPulse size={16} /> {footerHealth.current}/{footerHealth.max}</span>

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -39,6 +39,7 @@ const FooterCharacterSlot = ({
   onRollDeathSave,
   isActiveTurn,
   collapseDeathPanelSignal,
+  isCombatHudPanelOpen,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState(null);
@@ -47,6 +48,7 @@ const FooterCharacterSlot = ({
   const [damageHighlightClass, setDamageHighlightClass] = useState('');
   const [isResourcesOpen, setIsResourcesOpen] = useState(false);
   const [isDeathPanelOpen, setIsDeathPanelOpen] = useState(false);
+  const [deathDockBottomOffset, setDeathDockBottomOffset] = useState(null);
   const normalizedDeathState = useMemo(() => normalizeDeathState(deathState), [deathState]);
   const isDeathStateVisible = normalizedDeathState.isDying || normalizedDeathState.isDead;
 
@@ -370,8 +372,66 @@ const FooterCharacterSlot = ({
     setIsDeathPanelOpen(false);
   }, [collapseDeathPanelSignal]);
 
+  useEffect(() => {
+    if (!isDeathStateVisible || typeof window === 'undefined' || typeof document === 'undefined') {
+      setDeathDockBottomOffset(null);
+      return undefined;
+    }
+
+    let animationFrameId = null;
+    let followUpTimeoutId = null;
+    let resizeObserver = null;
+
+    const updateDeathDockOffset = () => {
+      const combatDock = document.querySelector('.combat-hud-dock');
+      if (!combatDock) {
+        setDeathDockBottomOffset(null);
+        return;
+      }
+
+      const dockTop = combatDock.getBoundingClientRect().top;
+      setDeathDockBottomOffset(Math.max(0, Math.round(window.innerHeight - dockTop)));
+    };
+
+    const scheduleUpdate = () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      animationFrameId = window.requestAnimationFrame(updateDeathDockOffset);
+    };
+
+    const combatDock = document.querySelector('.combat-hud-dock');
+    if (combatDock && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(scheduleUpdate);
+      resizeObserver.observe(combatDock);
+    }
+
+    scheduleUpdate();
+    followUpTimeoutId = window.setTimeout(scheduleUpdate, 220);
+    window.addEventListener('resize', scheduleUpdate);
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      if (followUpTimeoutId !== null) {
+        window.clearTimeout(followUpTimeoutId);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', scheduleUpdate);
+    };
+  }, [isCombatHudPanelOpen, isDeathStateVisible]);
+
+  const deathDockStyle = deathDockBottomOffset === null
+    ? undefined
+    : { '--footer-death-dock-bottom': `${deathDockBottomOffset}px` };
+
   const deathDock = isDeathStateVisible ? (
-    <div className="footer-character-slot__death-dock" data-allow-pointer-events="true">
+    <div
+      className="footer-character-slot__death-dock"
+      style={deathDockStyle}
+      data-allow-pointer-events="true"
+    >
       <button
         type="button"
         className={`footer-character-slot__death-toggle ${isDeathPanelOpen ? 'is-open' : ''}`}
@@ -635,6 +695,7 @@ FooterCharacterSlot.propTypes = {
   onRollDeathSave: PropTypes.func,
   isActiveTurn: PropTypes.bool,
   collapseDeathPanelSignal: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  isCombatHudPanelOpen: PropTypes.bool,
 };
 
 FooterCharacterSlot.defaultProps = {
@@ -656,6 +717,7 @@ FooterCharacterSlot.defaultProps = {
   onRollDeathSave: null,
   isActiveTurn: false,
   collapseDeathPanelSignal: null,
+  isCombatHudPanelOpen: false,
 };
 
 export default FooterCharacterSlot;


### PR DESCRIPTION
### Motivation

- Prevent the footer death dock from overlapping or being obscured by the combat HUD and improve its positioning on varying viewports and layouts. 
- Make the small/mobile death panel layout more responsive by broadening the breakpoint and allowing a calculable bottom offset. 

### Description

- Expose the death dock bottom via a CSS variable `--footer-death-dock-bottom`, change the mobile breakpoint from `640px` to `900px`, increase the dock width, and add a `bottom` transition for smoother adjustments in `DyingStatePanel.css`. 
- Pass a new `isCombatHudPanelOpen` boolean from `ZombiesCharacterSheet` into `FooterCharacterSlot` to indicate the combat HUD layout state. 
- Add `deathDockBottomOffset` state and an effect in `FooterCharacterSlot` that computes the dock offset by measuring `.combat-hud-dock` using `getBoundingClientRect`, `ResizeObserver`, `requestAnimationFrame`, and `resize` events, and apply the computed value via inline `style` using the CSS variable. 
- Update `FooterCharacterSlot` propTypes and defaultProps to include `isCombatHudPanelOpen` and wire the inline `style` into the death dock element. 

### Testing

- Ran the frontend test suite with `yarn test` and the tests passed. 
- Ran linting with `yarn lint` and there were no new linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55163ac93c832ea96f3fcbf5977c73)