### PR TITLE
Revive dead characters when healed

### DIFF
--- a/server/__tests__/deathState.test.js
+++ b/server/__tests__/deathState.test.js
@@ -34,9 +34,17 @@ describe('death save rules', () => {
   test('healing clears Dying state and repeated zero-HP resets counters', () => {
     const dying = { ...applyHealthChange(pc(), 0, 5).character, deathState: { isDying: true, successes: 2, failures: 1 } };
     const healed = applyHealthChange(dying, 3, 0).character;
-    expect(healed.deathState).toMatchObject({ isDying: false, successes: 0, failures: 0 });
+    expect(healed.deathState).toMatchObject({ isDying: false, isDead: false, successes: 0, failures: 0 });
     const dyingAgain = applyHealthChange(healed, 0, 3).character;
     expect(dyingAgain.deathState).toMatchObject({ isDying: true, successes: 0, failures: 0 });
+  });
+
+  test('healing a dead character revives and clears the death state', () => {
+    const dead = { ...pc({ tempHealth: 0 }), deathState: { isDying: false, isDead: true, failures: 3 } };
+    const healed = applyHealthChange(dead, 7, 0);
+    expect(healed.event).toBe('revived');
+    expect(healed.character.tempHealth).toBe(7);
+    expect(healed.character.deathState).toMatchObject({ isDying: false, isDead: false, successes: 0, failures: 0 });
   });
   test('duplicate roll requests are ignored and state normalizes after reload', () => {
     const rolled = applyDeathSaveResult(applyHealthChange(pc(), 0, 5).character, 12).character;

--- a/server/utils/deathState.js
+++ b/server/utils/deathState.js
@@ -78,9 +78,9 @@ const applyHealthChange = (character, nextHp, previousHp = character.tempHealth)
   const prev = Number(previousHp);
   const state = normalizeDeathState(character.deathState);
   const updated = { ...character, tempHealth: hp };
+  if (hp > 0 && (state.isDying || state.isDead)) return reviveCharacter(updated, hp, 'healed');
   if (state.isDead) return result({ ...updated, deathState: state }, 'none', null);
   if (hp <= 0 && canUseDeathSaves(character) && (!Number.isFinite(prev) || prev > 0 || !state.isDying)) return enterDyingState(updated);
-  if (hp > 0 && state.isDying) return reviveCharacter(updated, hp, 'healed');
   return result({ ...updated, deathState: state }, 'none', null);
 };
 


### PR DESCRIPTION
### Motivation

- Ensure that adding positive HP to a character who is marked as dying or dead clears the death state so the dying status bar is removed and the character behaves as revived.

### Description

- Change `applyHealthChange` in `server/utils/deathState.js` to call `reviveCharacter` when `hp > 0` and the normalized death state is either `isDying` or `isDead`.
- Preserve the existing behavior that prevents death-save logic for already-dead characters by normalizing state and returning early when appropriate.
- Add a regression test in `server/__tests__/deathState.test.js` that asserts healing a dead character produces the `revived` event, restores the provided HP, and clears `isDying`/`isDead` flags, and tighten an existing expectation to include `isDead: false` after healing.

### Testing

- Ran `npm test -- --runTestsByPath server/__tests__/deathState.test.js --runInBand` from the `server/` directory and the test suite passed (`1` suite, `8` tests all passed).
- Running `npm test -- --runTestsByPath server/__tests__/deathState.test.js` from the repo root initially routed to the client test runner and found no matching client tests (no server tests run), so the server-local test run was used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552968fda8832eac5385e0f555c1f7)