### PR TITLE
Expose dice-box initializing state and wait for host layout before initialization

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -18,6 +18,7 @@ import {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady as checkDiceBoxReady,
   hasDiceBoxFailed as checkDiceBoxFailed,
+  isDiceBoxInitializing as checkDiceBoxInitializing,
 } from '../../../utils/diceBoxManager';
 import {
   collectRollValues,
@@ -710,6 +711,7 @@ export default function ZombiesCharacterSheet() {
   const [diceBoxStatus, setDiceBoxStatus] = useState(() => ({
     ready: isTestEnvironment ? true : checkDiceBoxReady(),
     failed: isTestEnvironment ? false : checkDiceBoxFailed(),
+    loading: isTestEnvironment ? false : checkDiceBoxInitializing(),
   }));
 
   useEffect(() => {
@@ -721,6 +723,7 @@ export default function ZombiesCharacterSheet() {
       setDiceBoxStatus({
         ready: Boolean(ready),
         failed: !ready && checkDiceBoxFailed(),
+        loading: !ready && checkDiceBoxInitializing(),
       });
     });
 
@@ -730,6 +733,7 @@ export default function ZombiesCharacterSheet() {
   }, [
     setDiceBoxStatus,
     checkDiceBoxFailed,
+    checkDiceBoxInitializing,
     subscribeToDiceBoxAvailability,
     isTestEnvironment,
   ]);
@@ -5228,8 +5232,9 @@ export default function ZombiesCharacterSheet() {
   const isFormReady = Boolean(form);
   const diceBoxReady = diceBoxStatus.ready;
   const diceBoxFailed = diceBoxStatus.failed;
+  const diceBoxLoading = diceBoxStatus.loading;
   const shouldShowDiceLoadingOverlay =
-    isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed;
+    isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed && diceBoxLoading;
 
   const handleFooterQuickAction = useCallback(
     (action) => {

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -47,6 +47,8 @@ let pendingResolutionFrame = null;
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const HOST_LAYOUT_TIMEOUT_MS = 2000;
+const HOST_LAYOUT_POLL_MS = 50;
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -286,6 +288,103 @@ const resolveDiceBoxTarget = () => {
 
   const selector = ensureElementSelector(reference);
   return { element: reference, selector };
+};
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+
+  const width =
+    Number(rect?.width) || Number(element.clientWidth) || Number(element.offsetWidth) || 0;
+  const height =
+    Number(rect?.height) ||
+    Number(element.clientHeight) ||
+    Number(element.offsetHeight) ||
+    0;
+
+  return { width, height };
+};
+
+const isElementConnected = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if (typeof element.isConnected === 'boolean') {
+    return element.isConnected;
+  }
+
+  return typeof document === 'undefined' || !document.body
+    ? true
+    : document.body.contains(element);
+};
+
+const hasUsableHostLayout = (element) => {
+  if (!isElementConnected(element)) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForUsableHostLayout = (element, timeoutMs = HOST_LAYOUT_TIMEOUT_MS) => {
+  if (!element) {
+    return Promise.resolve(false);
+  }
+
+  if (hasUsableHostLayout(element)) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let frameId = null;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const finish = (value) => {
+      cleanup();
+      resolve(value);
+    };
+
+    const check = () => {
+      frameId = null;
+      timeoutId = null;
+
+      if (hasUsableHostLayout(element)) {
+        finish(true);
+        return;
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        finish(false);
+        return;
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+        frameId = requestAnimationFrame(check);
+      } else {
+        timeoutId = setTimeout(check, HOST_LAYOUT_POLL_MS);
+      }
+    };
+
+    check();
+  });
 };
 
 const getDiceBoxConstructor = () => {
@@ -615,9 +714,29 @@ async function ensureDiceBox() {
         if (diceBoxGeneration !== initGeneration) {
           return null;
         }
-        const target = targetElement || selector;
+        let target = targetElement || selector;
         if (!target) {
           throw new Error('Dice box target was not available');
+        }
+
+        if (targetElement) {
+          const hostReady = await waitForUsableHostLayout(targetElement);
+          if (diceBoxGeneration !== initGeneration) {
+            return null;
+          }
+          if (!hostReady) {
+            if (selector && typeof document !== 'undefined') {
+              const resolvedTarget = document.querySelector(selector);
+              if (resolvedTarget && resolvedTarget !== targetElement) {
+                target = resolvedTarget;
+              }
+            }
+
+            if (target === targetElement) {
+              scheduleRetry();
+              return null;
+            }
+          }
         }
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
@@ -684,7 +803,10 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (
+        diceBoxPromise === pending &&
+        (!diceBoxInstance || diceBoxGeneration !== initGeneration)
+      ) {
         diceBoxPromise = null;
       }
     });
@@ -920,6 +1042,8 @@ export const isDiceBoxReady = () => diceBoxReady;
 
 export const hasDiceBoxFailed = () => diceBoxFailed;
 
+export const isDiceBoxInitializing = () => Boolean(diceBoxPromise) && !diceBoxReady;
+
 export const warmupDiceBox = () => {
   if (diceBoxInstance) {
     return Promise.resolve(diceBoxInstance);
@@ -1086,6 +1210,7 @@ export default {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady,
   hasDiceBoxFailed,
+  isDiceBoxInitializing,
   clearDiceBoxResults,
   rollDiceWithBox,
   setDiceBoxThemeColor,


### PR DESCRIPTION
### Motivation
- Improve reliability of the 3D dice widget by waiting for the host container to have a usable layout before constructing the dice box. 
- Surface an explicit "initializing/loading" state so the UI can show a loading overlay while the dice box is being prepared.

### Description
- Added host layout helpers `getElementLayoutSize`, `isElementConnected`, `hasUsableHostLayout`, and async `waitForUsableHostLayout` with timeouts to `utils/diceBoxManager.js` so initialization defers until the target element has non-zero layout.
- Added constants `HOST_LAYOUT_TIMEOUT_MS` and `HOST_LAYOUT_POLL_MS` and logic in `ensureDiceBox` to wait for a usable host, attempt selector fallback, and schedule retries when layout is not ready.
- Exposed a new helper `isDiceBoxInitializing` that returns whether a dice box promise is pending and not yet ready, and added it to the module's default export.
- Tightened dice box promise lifecycle handling to avoid leaking stale promises when the generation or instance changes.
- Updated `ZombiesCharacterSheet` to import `isDiceBoxInitializing`, store a `loading` flag in `diceBoxStatus`, subscribe to loading updates, and only show the dice loading overlay when `diceBoxLoading` is true.

### Testing
- Ran the application test suite with `npm test` and the unit tests completed successfully. 
- Ran linting with `npm run lint` and no new lint errors were reported. 
- Verified in a development build that the dice box defers initialization until the host has a visible layout and that the character sheet shows the loading overlay while initialization is pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552cbb75d8832ead5900ad164ea229)