### PR TITLE
Improve dice box initialization robustness and expose initializing/loading state

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -18,6 +18,7 @@ import {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady as checkDiceBoxReady,
   hasDiceBoxFailed as checkDiceBoxFailed,
+  isDiceBoxInitializing as checkDiceBoxInitializing,
 } from '../../../utils/diceBoxManager';
 import {
   collectRollValues,
@@ -710,6 +711,7 @@ export default function ZombiesCharacterSheet() {
   const [diceBoxStatus, setDiceBoxStatus] = useState(() => ({
     ready: isTestEnvironment ? true : checkDiceBoxReady(),
     failed: isTestEnvironment ? false : checkDiceBoxFailed(),
+    loading: isTestEnvironment ? false : checkDiceBoxInitializing(),
   }));
 
   useEffect(() => {
@@ -721,6 +723,7 @@ export default function ZombiesCharacterSheet() {
       setDiceBoxStatus({
         ready: Boolean(ready),
         failed: !ready && checkDiceBoxFailed(),
+        loading: !ready && checkDiceBoxInitializing(),
       });
     });
 
@@ -730,6 +733,7 @@ export default function ZombiesCharacterSheet() {
   }, [
     setDiceBoxStatus,
     checkDiceBoxFailed,
+    checkDiceBoxInitializing,
     subscribeToDiceBoxAvailability,
     isTestEnvironment,
   ]);
@@ -5228,8 +5232,9 @@ export default function ZombiesCharacterSheet() {
   const isFormReady = Boolean(form);
   const diceBoxReady = diceBoxStatus.ready;
   const diceBoxFailed = diceBoxStatus.failed;
+  const diceBoxLoading = diceBoxStatus.loading;
   const shouldShowDiceLoadingOverlay =
-    isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed;
+    isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed && diceBoxLoading;
 
   const handleFooterQuickAction = useCallback(
     (action) => {

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -47,6 +47,9 @@ let pendingResolutionFrame = null;
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const HOST_LAYOUT_TIMEOUT_MS = 2000;
+const HOST_LAYOUT_POLL_MS = 50;
+const HOST_REGISTRATION_TIMEOUT_MS = 750;
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -286,6 +289,149 @@ const resolveDiceBoxTarget = () => {
 
   const selector = ensureElementSelector(reference);
   return { element: reference, selector };
+};
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+
+  const width =
+    Number(rect?.width) || Number(element.clientWidth) || Number(element.offsetWidth) || 0;
+  const height =
+    Number(rect?.height) ||
+    Number(element.clientHeight) ||
+    Number(element.offsetHeight) ||
+    0;
+
+  return { width, height };
+};
+
+const isElementConnected = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if (typeof element.isConnected === 'boolean') {
+    return element.isConnected;
+  }
+
+  return typeof document === 'undefined' || !document.body
+    ? true
+    : document.body.contains(element);
+};
+
+const hasUsableHostLayout = (element) => {
+  if (!isElementConnected(element)) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForUsableHostLayout = (element, timeoutMs = HOST_LAYOUT_TIMEOUT_MS) => {
+  if (!element) {
+    return Promise.resolve(false);
+  }
+
+  if (hasUsableHostLayout(element)) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let frameId = null;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const finish = (value) => {
+      cleanup();
+      resolve(value);
+    };
+
+    const check = () => {
+      frameId = null;
+      timeoutId = null;
+
+      if (hasUsableHostLayout(element)) {
+        finish(true);
+        return;
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        finish(false);
+        return;
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+        frameId = requestAnimationFrame(check);
+      } else {
+        timeoutId = setTimeout(check, HOST_LAYOUT_POLL_MS);
+      }
+    };
+
+    check();
+  });
+};
+
+const waitForDiceBoxTarget = (timeoutMs = HOST_REGISTRATION_TIMEOUT_MS) => {
+  const initialTarget = resolveDiceBoxTarget();
+  if (initialTarget.element || initialTarget.selector) {
+    return Promise.resolve(initialTarget);
+  }
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let frameId = null;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const finish = (target) => {
+      cleanup();
+      resolve(target);
+    };
+
+    const check = () => {
+      frameId = null;
+      timeoutId = null;
+      const target = resolveDiceBoxTarget();
+
+      if (target.element || target.selector || Date.now() - startedAt >= timeoutMs) {
+        finish(target);
+        return;
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+        frameId = requestAnimationFrame(check);
+      } else {
+        timeoutId = setTimeout(check, HOST_LAYOUT_POLL_MS);
+      }
+    };
+
+    check();
+  });
 };
 
 const getDiceBoxConstructor = () => {
@@ -575,7 +721,7 @@ const refreshDiceBoxResolution = (instance) => {
   }
 };
 
-async function ensureDiceBox() {
+async function ensureDiceBox({ waitForTarget = false } = {}) {
   if (diceBoxInstance) {
     return diceBoxInstance;
   }
@@ -591,7 +737,9 @@ async function ensureDiceBox() {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return null;
   }
-  const { element: targetElement, selector } = resolveDiceBoxTarget();
+  const { element: targetElement, selector } = waitForTarget
+    ? await waitForDiceBoxTarget()
+    : resolveDiceBoxTarget();
   if (!targetElement && !selector) {
     scheduleRetry();
     return null;
@@ -615,9 +763,22 @@ async function ensureDiceBox() {
         if (diceBoxGeneration !== initGeneration) {
           return null;
         }
-        const target = targetElement || selector;
+        let target = targetElement || selector;
         if (!target) {
           throw new Error('Dice box target was not available');
+        }
+
+        if (targetElement) {
+          const hostReady = await waitForUsableHostLayout(targetElement);
+          if (diceBoxGeneration !== initGeneration) {
+            return null;
+          }
+          if (!hostReady && selector && typeof document !== 'undefined') {
+            const resolvedTarget = document.querySelector(selector);
+            if (resolvedTarget && resolvedTarget !== targetElement) {
+              target = resolvedTarget;
+            }
+          }
         }
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
@@ -684,7 +845,10 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (
+        diceBoxPromise === pending &&
+        (!diceBoxInstance || diceBoxGeneration !== initGeneration)
+      ) {
         diceBoxPromise = null;
       }
     });
@@ -920,6 +1084,8 @@ export const isDiceBoxReady = () => diceBoxReady;
 
 export const hasDiceBoxFailed = () => diceBoxFailed;
 
+export const isDiceBoxInitializing = () => Boolean(diceBoxPromise) && !diceBoxReady;
+
 export const warmupDiceBox = () => {
   if (diceBoxInstance) {
     return Promise.resolve(diceBoxInstance);
@@ -973,7 +1139,7 @@ export const rollDiceWithBox = (requests) => {
   }
 
   const executeRoll = async () => {
-    const instance = await ensureDiceBox();
+    const instance = await ensureDiceBox({ waitForTarget: true });
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {
@@ -1086,6 +1252,7 @@ export default {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady,
   hasDiceBoxFailed,
+  isDiceBoxInitializing,
   clearDiceBoxResults,
   rollDiceWithBox,
   setDiceBoxThemeColor,


### PR DESCRIPTION
### Motivation

- Improve reliability when the dice box host element is not yet present or has no layout, and provide a UI-visible "initializing" state to avoid false error overlays.
- Reduce spurious dice-box failures caused by timing/layout races during app boot or route changes.

### Description

- Add host/layout detection and wait helpers: `getElementLayoutSize`, `isElementConnected`, `hasUsableHostLayout`, `waitForUsableHostLayout`, and `waitForDiceBoxTarget` with related timeouts (`HOST_LAYOUT_TIMEOUT_MS`, `HOST_REGISTRATION_TIMEOUT_MS`, `HOST_LAYOUT_POLL_MS`).
- Change `ensureDiceBox` signature to accept `{ waitForTarget = false }` and wait for a usable host target when requested; attempt to recover by resolving selector if layout becomes available later.
- Make the dice-box warmup/registration flow more resilient by adjusting promise cleanup logic and retry scheduling to avoid leaving stale promises.
- Expose a public `isDiceBoxInitializing` helper that returns whether initialization is in progress, and wire it into the character sheet to track `diceBoxStatus.loading` and to control `shouldShowDiceLoadingOverlay`.
- Ensure `rollDiceWithBox` waits for the target registration by calling `ensureDiceBox({ waitForTarget: true })` before rolling.

### Testing

- Ran unit tests via `yarn test`, and the test suite completed successfully.
- Built the application via `yarn build`, and the production build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552cbb75d8832ead5900ad164ea229)