### PR TITLE
Add dice-box initializing state and wait-for-host layout logic

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -18,6 +18,7 @@ import {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady as checkDiceBoxReady,
   hasDiceBoxFailed as checkDiceBoxFailed,
+  isDiceBoxInitializing as checkDiceBoxInitializing,
 } from '../../../utils/diceBoxManager';
 import {
   collectRollValues,
@@ -710,6 +711,7 @@ export default function ZombiesCharacterSheet() {
   const [diceBoxStatus, setDiceBoxStatus] = useState(() => ({
     ready: isTestEnvironment ? true : checkDiceBoxReady(),
     failed: isTestEnvironment ? false : checkDiceBoxFailed(),
+    loading: isTestEnvironment ? false : checkDiceBoxInitializing(),
   }));
 
   useEffect(() => {
@@ -721,6 +723,7 @@ export default function ZombiesCharacterSheet() {
       setDiceBoxStatus({
         ready: Boolean(ready),
         failed: !ready && checkDiceBoxFailed(),
+        loading: !ready && checkDiceBoxInitializing(),
       });
     });
 
@@ -730,6 +733,7 @@ export default function ZombiesCharacterSheet() {
   }, [
     setDiceBoxStatus,
     checkDiceBoxFailed,
+    checkDiceBoxInitializing,
     subscribeToDiceBoxAvailability,
     isTestEnvironment,
   ]);
@@ -5228,8 +5232,9 @@ export default function ZombiesCharacterSheet() {
   const isFormReady = Boolean(form);
   const diceBoxReady = diceBoxStatus.ready;
   const diceBoxFailed = diceBoxStatus.failed;
+  const diceBoxLoading = diceBoxStatus.loading;
   const shouldShowDiceLoadingOverlay =
-    isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed;
+    isFormReady && !isTestEnvironment && !diceBoxReady && !diceBoxFailed && diceBoxLoading;
 
   const handleFooterQuickAction = useCallback(
     (action) => {

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -47,6 +47,10 @@ let pendingResolutionFrame = null;
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const HOST_LAYOUT_TIMEOUT_MS = 2000;
+const HOST_LAYOUT_POLL_MS = 50;
+const HOST_REGISTRATION_TIMEOUT_MS = 750;
+const POST_INIT_RENDER_SETTLE_MS = 250;
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -287,6 +291,169 @@ const resolveDiceBoxTarget = () => {
   const selector = ensureElementSelector(reference);
   return { element: reference, selector };
 };
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+
+  const width =
+    Number(rect?.width) || Number(element.clientWidth) || Number(element.offsetWidth) || 0;
+  const height =
+    Number(rect?.height) ||
+    Number(element.clientHeight) ||
+    Number(element.offsetHeight) ||
+    0;
+
+  return { width, height };
+};
+
+const isElementConnected = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if (typeof element.isConnected === 'boolean') {
+    return element.isConnected;
+  }
+
+  return typeof document === 'undefined' || !document.body
+    ? true
+    : document.body.contains(element);
+};
+
+const hasUsableHostLayout = (element) => {
+  if (!isElementConnected(element)) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForUsableHostLayout = (element, timeoutMs = HOST_LAYOUT_TIMEOUT_MS) => {
+  if (!element) {
+    return Promise.resolve(false);
+  }
+
+  if (hasUsableHostLayout(element)) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let frameId = null;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const finish = (value) => {
+      cleanup();
+      resolve(value);
+    };
+
+    const check = () => {
+      frameId = null;
+      timeoutId = null;
+
+      if (hasUsableHostLayout(element)) {
+        finish(true);
+        return;
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        finish(false);
+        return;
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+        frameId = requestAnimationFrame(check);
+      } else {
+        timeoutId = setTimeout(check, HOST_LAYOUT_POLL_MS);
+      }
+    };
+
+    check();
+  });
+};
+
+const waitForDiceBoxTarget = (timeoutMs = HOST_REGISTRATION_TIMEOUT_MS) => {
+  const initialTarget = resolveDiceBoxTarget();
+  if (initialTarget.element || initialTarget.selector) {
+    return Promise.resolve(initialTarget);
+  }
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let frameId = null;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const finish = (target) => {
+      cleanup();
+      resolve(target);
+    };
+
+    const check = () => {
+      frameId = null;
+      timeoutId = null;
+      const target = resolveDiceBoxTarget();
+
+      if (target.element || target.selector || Date.now() - startedAt >= timeoutMs) {
+        finish(target);
+        return;
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+        frameId = requestAnimationFrame(check);
+      } else {
+        timeoutId = setTimeout(check, HOST_LAYOUT_POLL_MS);
+      }
+    };
+
+    check();
+  });
+};
+
+const waitForRenderSettle = (timeoutMs = POST_INIT_RENDER_SETTLE_MS) =>
+  new Promise((resolve) => {
+    if (typeof window === 'undefined') {
+      resolve();
+      return;
+    }
+
+    const settle = () => {
+      window.setTimeout(resolve, timeoutMs);
+    };
+
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(settle);
+      });
+    } else {
+      settle();
+    }
+  });
 
 const getDiceBoxConstructor = () => {
   if (modulePromise) {
@@ -575,7 +742,7 @@ const refreshDiceBoxResolution = (instance) => {
   }
 };
 
-async function ensureDiceBox() {
+async function ensureDiceBox({ waitForTarget = false } = {}) {
   if (diceBoxInstance) {
     return diceBoxInstance;
   }
@@ -591,7 +758,9 @@ async function ensureDiceBox() {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return null;
   }
-  const { element: targetElement, selector } = resolveDiceBoxTarget();
+  const { element: targetElement, selector } = waitForTarget
+    ? await waitForDiceBoxTarget()
+    : resolveDiceBoxTarget();
   if (!targetElement && !selector) {
     scheduleRetry();
     return null;
@@ -615,9 +784,22 @@ async function ensureDiceBox() {
         if (diceBoxGeneration !== initGeneration) {
           return null;
         }
-        const target = targetElement || selector;
+        let target = targetElement || selector;
         if (!target) {
           throw new Error('Dice box target was not available');
+        }
+
+        if (targetElement) {
+          const hostReady = await waitForUsableHostLayout(targetElement);
+          if (diceBoxGeneration !== initGeneration) {
+            return null;
+          }
+          if (!hostReady && selector && typeof document !== 'undefined') {
+            const resolvedTarget = document.querySelector(selector);
+            if (resolvedTarget && resolvedTarget !== targetElement) {
+              target = resolvedTarget;
+            }
+          }
         }
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
@@ -664,6 +846,11 @@ async function ensureDiceBox() {
         applyPendingThemeName(instance);
         applyPendingThemeColor(instance);
         refreshDiceBoxResolution(instance);
+        await waitForRenderSettle();
+        if (diceBoxGeneration !== initGeneration) {
+          destroyInstance(instance);
+          return null;
+        }
         clearScheduledRetry();
         setAvailability(true);
         return instance;
@@ -684,7 +871,10 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (
+        diceBoxPromise === pending &&
+        (!diceBoxInstance || diceBoxGeneration !== initGeneration)
+      ) {
         diceBoxPromise = null;
       }
     });
@@ -920,6 +1110,8 @@ export const isDiceBoxReady = () => diceBoxReady;
 
 export const hasDiceBoxFailed = () => diceBoxFailed;
 
+export const isDiceBoxInitializing = () => Boolean(diceBoxPromise) && !diceBoxReady;
+
 export const warmupDiceBox = () => {
   if (diceBoxInstance) {
     return Promise.resolve(diceBoxInstance);
@@ -973,7 +1165,7 @@ export const rollDiceWithBox = (requests) => {
   }
 
   const executeRoll = async () => {
-    const instance = await ensureDiceBox();
+    const instance = await ensureDiceBox({ waitForTarget: true });
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {
@@ -1086,6 +1278,7 @@ export default {
   subscribeToDiceBoxAvailability,
   isDiceBoxReady,
   hasDiceBoxFailed,
+  isDiceBoxInitializing,
   clearDiceBoxResults,
   rollDiceWithBox,
   setDiceBoxThemeColor,


### PR DESCRIPTION
### Motivation
- Improve robustness of the 3D dice-box initialization by detecting and exposing an "initializing" state and by waiting for a usable host element/layout before creating the dice box instance. 
- Prevent spurious loading overlays and initialization failures when the target DOM host is not yet available or has zero size. 

### Description
- Added host/layout detection utilities (`getElementLayoutSize`, `isElementConnected`, `hasUsableHostLayout`, `waitForUsableHostLayout`, `waitForDiceBoxTarget`, and `waitForRenderSettle`) and timeout constants in `client/src/utils/diceBoxManager.js` to wait for a usable container before instantiating the dice box. 
- Modified `ensureDiceBox` to accept an options object with `waitForTarget` and to use `waitForDiceBoxTarget`/`waitForUsableHostLayout` and a render settle pause before finalizing initialization, plus improved promise/instance cleanup logic. 
- Exposed `isDiceBoxInitializing` from `diceBoxManager` and updated `rollDiceWithBox` to call `ensureDiceBox({ waitForTarget: true })`. 
- Updated `ZombiesCharacterSheet` to import and track the new initialization/loading state (`diceBoxStatus.loading`) and to only show the dice-loading overlay when initialization is actually in progress. 

### Testing
- Ran the frontend unit test suite with `npm test` and all tests passed. 
- Built the client bundle with `npm run build` to verify bundling and dynamic import of the dice-box module, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552cbb75d8832ead5900ad164ea229)