### PR TITLE
Add turn-based combat effect expiration

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -75,6 +75,12 @@ import CombatTurnHeader from '../components/CombatTurnHeader';
 import { DeathStateBadge } from '../death/DyingStatePanel';
 import { buildEnemyTokenFilterScopeValues } from '../utils/enemyTokenFilters';
 import { sanitizeIdentifierForTestId } from '../utils/sanitizeIdentifierForTestId';
+import {
+  advanceCombatTurn,
+  createEmptyCombatState,
+  normalizeCombatTimelineState,
+  removeCombatantEffects,
+} from '../utils/combatEffects';
 
 const STAT_LOOKUP = STATS.reduce((acc, { key, label }) => {
   acc[label.toLowerCase()] = key;
@@ -431,8 +437,6 @@ const formatXpDisplay = (xp) => {
 
   return numeric.toLocaleString();
 };
-
-const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
 
 
 const trimTrailingPunctuation = (value) => {
@@ -1165,7 +1169,11 @@ const normalizeCombatState = (state) => {
     }
   }
 
-  return { participants: sortedParticipants, activeTurn };
+  return normalizeCombatTimelineState({
+    ...state,
+    participants: sortedParticipants,
+    activeTurn,
+  });
 };
 
 export const createActiveMapEnemySummaries = ({
@@ -3977,6 +3985,7 @@ export default function ZombiesDM() {
           };
           const stateWithDerived = applyDerivedInitiativesToState(
             {
+              ...combatState,
               participants: [...participants, participant],
               activeTurn: combatState.activeTurn,
             },
@@ -3998,10 +4007,13 @@ export default function ZombiesDM() {
             }
           }
 
-          nextState = normalizeCombatState({
+          nextState = removeCombatantEffects(normalizeCombatState({
             participants: updatedParticipants,
             activeTurn: nextActiveTurn,
-          });
+            activeEffects: combatState.activeEffects,
+            round: combatState.round,
+            turnSequence: combatState.turnSequence,
+          }), characterId);
         }
 
         setCombatState(nextState);
@@ -4168,10 +4180,10 @@ export default function ZombiesDM() {
           nextIndex = direction > 0 ? 0 : total - 1;
         }
 
-        const nextState = normalizeCombatState({
+        const nextState = normalizeCombatState(advanceCombatTurn({
+          ...combatState,
           participants,
-          activeTurn: nextIndex,
-        });
+        }, direction));
 
         setCombatState(nextState);
         persistCombatState(nextState);

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -102,10 +102,21 @@ const collectMovementSpeedBonus = (value) => {
     return 0;
   }
 
+  const modifierBonus = Array.isArray(value.modifiers)
+    ? value.modifiers.reduce((sum, modifier) => {
+        const type = String(modifier?.type || modifier?.stat || modifier?.attribute || '').toLowerCase();
+        if (type !== 'speed' && type !== 'movement' && type !== 'movementspeed') {
+          return sum;
+        }
+        return sum + toFiniteNumberOrZero(modifier.value ?? modifier.amount ?? modifier.bonus);
+      }, 0)
+    : 0;
+
   const directBonus =
     toFiniteNumberOrZero(value.speedBonus) +
     toFiniteNumberOrZero(value.movementSpeedBonus) +
-    toFiniteNumberOrZero(value.walkingSpeedBonus);
+    toFiniteNumberOrZero(value.walkingSpeedBonus) +
+    modifierBonus;
 
   return (
     directBonus +
@@ -177,6 +188,7 @@ export const calculateCharacterMovementSpeed = (character, overrides = {}) => {
     collectMovementSpeedBonus(accessoryEntries) +
     collectMovementSpeedBonus(character?.conditions) +
     collectMovementSpeedBonus(character?.statusConditions) +
+    collectMovementSpeedBonus(character?.activeEffects) +
     collectMovementSpeedBonus(character?.miscBonuses) +
     collectMovementSpeedBonus(character?.bonuses);
 

--- a/client/src/components/Zombies/utils/combatEffects.js
+++ b/client/src/components/Zombies/utils/combatEffects.js
@@ -1,0 +1,212 @@
+const VALID_BOUNDARIES = new Set(['start', 'end']);
+const VALID_STACK_POLICIES = new Set(['replace', 'refresh', 'stack', 'ignore']);
+
+export const createEmptyCombatState = () => ({
+  participants: [],
+  activeTurn: null,
+  round: 1,
+  turnSequence: 0,
+  activeEffects: [],
+  lastEvents: [],
+});
+
+const toNumber = (value, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const normalizeBoundary = (boundary, fallback = 'start') =>
+  VALID_BOUNDARIES.has(boundary) ? boundary : fallback;
+
+export const normalizeEffectExpiration = (expiration) => {
+  if (!expiration || typeof expiration !== 'object') {
+    return { type: 'manual' };
+  }
+  switch (expiration.type) {
+    case 'sourceTurn':
+      return {
+        type: 'sourceTurn',
+        sourceCombatantId: expiration.sourceCombatantId || expiration.combatantId || null,
+        boundary: normalizeBoundary(expiration.boundary),
+        remainingOccurrences: Math.max(1, Math.trunc(toNumber(expiration.remainingOccurrences, 1))),
+      };
+    case 'targetTurn':
+      return {
+        type: 'targetTurn',
+        targetCombatantId: expiration.targetCombatantId || expiration.combatantId || null,
+        boundary: normalizeBoundary(expiration.boundary),
+        remainingOccurrences: Math.max(1, Math.trunc(toNumber(expiration.remainingOccurrences, 1))),
+      };
+    case 'rounds':
+      return {
+        type: 'rounds',
+        expiresAtRound: Math.max(1, Math.trunc(toNumber(expiration.expiresAtRound, 1))),
+        boundary: normalizeBoundary(expiration.boundary, 'end'),
+      };
+    case 'combatEnd':
+    case 'concentration':
+    case 'manual':
+      return { ...expiration, type: expiration.type };
+    default:
+      return { type: 'manual' };
+  }
+};
+
+export const buildExpirationFromDuration = (duration, { sourceCombatantId, targetCombatantId, currentRound = 1 } = {}) => {
+  if (!duration || typeof duration !== 'object') return { type: 'manual' };
+  switch (duration.type) {
+    case 'untilSourceTurn':
+      return { type: 'sourceTurn', sourceCombatantId, boundary: normalizeBoundary(duration.boundary), remainingOccurrences: 1 };
+    case 'untilTargetTurn':
+      return { type: 'targetTurn', targetCombatantId, boundary: normalizeBoundary(duration.boundary), remainingOccurrences: 1 };
+    case 'sourceTurns':
+      return { type: 'sourceTurn', sourceCombatantId, boundary: normalizeBoundary(duration.boundary), remainingOccurrences: Math.max(1, Math.trunc(toNumber(duration.count, 1))) };
+    case 'targetTurns':
+      return { type: 'targetTurn', targetCombatantId, boundary: normalizeBoundary(duration.boundary), remainingOccurrences: Math.max(1, Math.trunc(toNumber(duration.count, 1))) };
+    case 'rounds':
+      return { type: 'rounds', expiresAtRound: Math.max(1, Math.trunc(toNumber(currentRound, 1) + toNumber(duration.count, 1))), boundary: normalizeBoundary(duration.boundary, 'end') };
+    case 'combat':
+      return { type: 'combatEnd' };
+    case 'permanent':
+      return { type: 'manual' };
+    case 'concentration':
+      return { type: 'concentration', concentrationId: duration.concentrationId };
+    default:
+      return { type: 'manual' };
+  }
+};
+
+export const normalizeActiveEffect = (effect, combatState = {}) => {
+  if (!effect || typeof effect !== 'object') return null;
+  const id = effect.id || `${effect.definitionId || 'effect'}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  const sourceCombatantId = effect.sourceCombatantId || effect.sourceCharacterId || undefined;
+  const targetCombatantId = effect.targetCombatantId || effect.targetCharacterId || effect.characterId;
+  return {
+    ...effect,
+    id,
+    definitionId: effect.definitionId || effect.name || id,
+    ...(sourceCombatantId ? { sourceCombatantId } : {}),
+    targetCombatantId,
+    appliedAtTurnSequence: Math.max(0, Math.trunc(toNumber(effect.appliedAtTurnSequence, combatState.turnSequence || 0))),
+    expiration: normalizeEffectExpiration(effect.expiration),
+    modifiers: Array.isArray(effect.modifiers) ? effect.modifiers : [],
+    stackPolicy: VALID_STACK_POLICIES.has(effect.stackPolicy) ? effect.stackPolicy : (effect.stackKey ? 'refresh' : 'stack'),
+  };
+};
+
+export const normalizeCombatTimelineState = (state = {}) => ({
+  ...createEmptyCombatState(),
+  ...state,
+  participants: Array.isArray(state.participants) ? state.participants : [],
+  activeTurn: Number.isInteger(state.activeTurn) ? state.activeTurn : null,
+  round: Math.max(1, Math.trunc(toNumber(state.round, 1))),
+  turnSequence: Math.max(0, Math.trunc(toNumber(state.turnSequence, 0))),
+  activeEffects: Array.isArray(state.activeEffects)
+    ? state.activeEffects.map((effect) => normalizeActiveEffect(effect, state)).filter(Boolean)
+    : [],
+  lastEvents: Array.isArray(state.lastEvents) ? state.lastEvents : [],
+});
+
+const eventIsAfterApplication = (event, effect) =>
+  event.turnSequence === undefined || toNumber(event.turnSequence, 0) > toNumber(effect.appliedAtTurnSequence, 0);
+
+const resolveEffectForEvent = (effect, event) => {
+  const expiration = normalizeEffectExpiration(effect.expiration);
+  if (expiration.type === 'manual' || expiration.type === 'concentration') return { effect, expired: false };
+  if (expiration.type === 'combatEnd') return { effect, expired: event.type === 'combatEnded' };
+  if (expiration.type === 'rounds') {
+    const eventBoundary = event.type === 'roundStarted' ? 'start' : event.type === 'roundEnded' ? 'end' : null;
+    return { effect, expired: eventBoundary === expiration.boundary && toNumber(event.round, 0) >= expiration.expiresAtRound };
+  }
+  const expectedEvent = expiration.boundary === 'start' ? 'turnStarted' : 'turnEnded';
+  if (event.type !== expectedEvent || !eventIsAfterApplication(event, effect)) return { effect, expired: false };
+  const expectedCombatantId = expiration.type === 'sourceTurn' ? expiration.sourceCombatantId : expiration.targetCombatantId;
+  if (!expectedCombatantId || event.combatantId !== expectedCombatantId) return { effect, expired: false };
+  const remaining = Math.max(1, Math.trunc(toNumber(expiration.remainingOccurrences, 1))) - 1;
+  if (remaining <= 0) return { effect, expired: true };
+  return { effect: { ...effect, expiration: { ...expiration, remainingOccurrences: remaining } }, expired: false };
+};
+
+export const resolveCombatEvent = (combatState, event) => {
+  const state = normalizeCombatTimelineState(combatState);
+  const resolved = state.activeEffects.map((effect) => resolveEffectForEvent(effect, event));
+  const activeEffects = resolved.filter((entry) => !entry.expired).map((entry) => entry.effect);
+  const expiredEffects = resolved.filter((entry) => entry.expired).map((entry) => entry.effect).sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  return { ...state, activeEffects, expiredEffects, lastEvents: [...(state.lastEvents || []), event] };
+};
+
+export const applyCombatEvents = (combatState, events) =>
+  (Array.isArray(events) ? events : []).reduce((state, event) => resolveCombatEvent(state, event), combatState);
+
+export const addActiveEffect = (combatState, effect) => {
+  const state = normalizeCombatTimelineState(combatState);
+  const nextEffect = normalizeActiveEffect({ ...effect, appliedAtTurnSequence: effect?.appliedAtTurnSequence ?? state.turnSequence }, state);
+  if (!nextEffect) return state;
+  const stackKey = nextEffect.stackKey;
+  const policy = nextEffect.stackPolicy;
+  if (!stackKey || policy === 'stack') return { ...state, activeEffects: [...state.activeEffects, nextEffect] };
+  const existingIndex = state.activeEffects.findIndex((entry) => entry.stackKey === stackKey);
+  if (existingIndex === -1) return { ...state, activeEffects: [...state.activeEffects, nextEffect] };
+  if (policy === 'ignore') return state;
+  const activeEffects = [...state.activeEffects];
+  activeEffects[existingIndex] = policy === 'refresh' ? { ...activeEffects[existingIndex], ...nextEffect, id: activeEffects[existingIndex].id } : nextEffect;
+  return { ...state, activeEffects };
+};
+
+export const removeCombatantEffects = (combatState, combatantId) => {
+  const state = normalizeCombatTimelineState(combatState);
+  return {
+    ...state,
+    activeEffects: state.activeEffects.filter(
+      (effect) => effect.targetCombatantId !== combatantId && effect.sourceCombatantId !== combatantId
+    ),
+  };
+};
+
+export const getEffectiveSpeed = (baseSpeed, effects = [], targetCombatantId) => {
+  const total = (Array.isArray(effects) ? effects : []).reduce((sum, effect) => {
+    if (targetCombatantId && effect?.targetCombatantId !== targetCombatantId) return sum;
+    return sum + (Array.isArray(effect?.modifiers) ? effect.modifiers : []).reduce((modSum, modifier) => {
+      const type = String(modifier?.type || modifier?.stat || modifier?.attribute || '').toLowerCase();
+      if (type !== 'speed' && type !== 'movement' && type !== 'movementSpeed') return modSum;
+      const value = toNumber(modifier.value ?? modifier.amount ?? modifier.bonus, 0);
+      return modifier.operation === 'set' ? value - toNumber(baseSpeed, 0) : modSum + value;
+    }, 0);
+  }, toNumber(baseSpeed, 0));
+  return Math.max(0, Math.trunc(total));
+};
+
+export const advanceCombatTurn = (combatState, direction = 1, { extraTurnCombatantId = null } = {}) => {
+  const state = normalizeCombatTimelineState(combatState);
+  const total = state.participants.length;
+  if (total === 0) return { ...state, activeTurn: null };
+  let nextState = state;
+  const events = [];
+  const active = Number.isInteger(state.activeTurn) && state.activeTurn >= 0 && state.activeTurn < total ? state.activeTurn : null;
+  if (active !== null) {
+    events.push({ type: 'turnEnded', combatantId: state.participants[active].characterId, round: state.round, turnSequence: state.turnSequence });
+  }
+  let nextIndex;
+  let wrapped = false;
+  if (extraTurnCombatantId) {
+    nextIndex = state.participants.findIndex((p) => p.characterId === extraTurnCombatantId);
+    if (nextIndex === -1) nextIndex = active ?? 0;
+  } else if (active === null) {
+    nextIndex = direction > 0 ? 0 : total - 1;
+  } else {
+    nextIndex = (active + direction + total) % total;
+    wrapped = direction > 0 ? nextIndex <= active : nextIndex >= active;
+  }
+  let round = state.round;
+  if (wrapped && direction > 0) {
+    events.push({ type: 'roundEnded', round });
+    round += 1;
+    events.push({ type: 'roundStarted', round });
+  }
+  const turnSequence = state.turnSequence + 1;
+  events.push({ type: 'turnStarted', combatantId: state.participants[nextIndex].characterId, round, turnSequence });
+  nextState = { ...nextState, activeTurn: nextIndex, round, turnSequence };
+  return applyCombatEvents(nextState, events);
+};
+
+export const endCombat = (combatState) => resolveCombatEvent(combatState, { type: 'combatEnded' });

--- a/client/src/components/Zombies/utils/combatEffects.test.js
+++ b/client/src/components/Zombies/utils/combatEffects.test.js
@@ -1,0 +1,151 @@
+import {
+  addActiveEffect,
+  advanceCombatTurn,
+  buildExpirationFromDuration,
+  endCombat,
+  getEffectiveSpeed,
+  normalizeCombatTimelineState,
+  removeCombatantEffects,
+  resolveCombatEvent,
+} from './combatEffects';
+import { calculateCharacterMovementSpeed } from './characterMetrics';
+
+const participants = ['barb', 'rogue', 'goblin'].map((characterId, index) => ({ characterId, initiative: 20 - index }));
+const baseState = (extra = {}) => normalizeCombatTimelineState({ participants, activeTurn: 0, round: 1, turnSequence: 1, ...extra });
+const speedEffect = (overrides = {}) => ({
+  id: overrides.id || 'slow-1',
+  definitionId: 'barbarian-speed-reduction',
+  sourceCombatantId: 'barb',
+  targetCombatantId: 'goblin',
+  expiration: { type: 'sourceTurn', sourceCombatantId: 'barb', boundary: 'start', remainingOccurrences: 1 },
+  modifiers: [{ type: 'speed', operation: 'add', value: -15, minimum: 0 }],
+  stackKey: 'barbarian-speed-reduction:barb:goblin',
+  stackPolicy: 'refresh',
+  ...overrides,
+});
+
+describe('turn-based combat effects', () => {
+  test('source-start effect applied during source turn waits through other turns and expires next source start', () => {
+    let state = addActiveEffect(baseState(), speedEffect());
+    state = resolveCombatEvent(state, { type: 'turnStarted', combatantId: 'barb', round: 1, turnSequence: 1 });
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(state, 1);
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(state, 1);
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(state, 1);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('end-of-turn source effect expires at end boundary, not start boundary', () => {
+    let state = addActiveEffect(baseState(), speedEffect({ expiration: { type: 'sourceTurn', sourceCombatantId: 'barb', boundary: 'end', remainingOccurrences: 1 } }));
+    state = resolveCombatEvent(state, { type: 'turnStarted', combatantId: 'barb', round: 2, turnSequence: 4 });
+    expect(state.activeEffects).toHaveLength(1);
+    state = resolveCombatEvent(state, { type: 'turnEnded', combatantId: 'barb', round: 2, turnSequence: 4 });
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('target-turn duration tracks target, not source', () => {
+    let state = addActiveEffect(baseState(), speedEffect({ expiration: { type: 'targetTurn', targetCombatantId: 'goblin', boundary: 'start', remainingOccurrences: 1 } }));
+    state = advanceCombatTurn(state, 1);
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(state, 1);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('effect applied before source acts can expire later in same round', () => {
+    let state = addActiveEffect(baseState({ activeTurn: 1, turnSequence: 2 }), speedEffect({ appliedAtTurnSequence: 2 }));
+    state = advanceCombatTurn(state, 1); // goblin
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(state, 1); // barb, same cycle wrap
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('initiative order changes do not break id-based expiration', () => {
+    let state = addActiveEffect(baseState({ participants: [{ characterId: 'barb', initiative: 1 }, { characterId: 'goblin', initiative: 30 }] }), speedEffect());
+    state = normalizeCombatTimelineState({ ...state, participants: [{ characterId: 'goblin', initiative: 30 }, { characterId: 'barb', initiative: 1 }], activeTurn: 0 });
+    state = advanceCombatTurn(state, 1);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('adding/removing unrelated combatants does not break expiration', () => {
+    let state = addActiveEffect(baseState({ participants: [...participants, { characterId: 'owl', initiative: 9 }] }), speedEffect());
+    state = { ...removeCombatantEffects(state, 'owl'), participants };
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(advanceCombatTurn(advanceCombatTurn(state, 1), 1), 1);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('removing source or target cleans up effects', () => {
+    let state = addActiveEffect(baseState(), speedEffect());
+    expect(removeCombatantEffects(state, 'barb').activeEffects).toHaveLength(0);
+    state = addActiveEffect(baseState(), speedEffect());
+    expect(removeCombatantEffects(state, 'goblin').activeEffects).toHaveLength(0);
+  });
+
+  test('refresh reapplication refreshes without stacking, while stack policy stacks', () => {
+    let state = addActiveEffect(baseState(), speedEffect({ id: 'first' }));
+    state = addActiveEffect(state, speedEffect({ id: 'second', appliedAtTurnSequence: 3 }));
+    expect(state.activeEffects).toHaveLength(1);
+    expect(state.activeEffects[0].id).toBe('first');
+    expect(state.activeEffects[0].appliedAtTurnSequence).toBe(3);
+    state = addActiveEffect(state, speedEffect({ id: 'stacked', stackPolicy: 'stack' }));
+    expect(state.activeEffects).toHaveLength(2);
+  });
+
+  test('speed modifiers affect effective speed, preserve base speed, combine, clamp to zero, and restore on expiration', () => {
+    let state = addActiveEffect(baseState(), speedEffect());
+    state = addActiveEffect(state, speedEffect({ id: 'mud', stackKey: 'mud', stackPolicy: 'stack', modifiers: [{ type: 'speed', value: -20 }] }));
+    expect(getEffectiveSpeed(30, state.activeEffects, 'goblin')).toBe(0);
+    const character = { speed: 30, activeEffects: state.activeEffects.filter((e) => e.targetCombatantId === 'goblin') };
+    expect(character.speed).toBe(30);
+    expect(calculateCharacterMovementSpeed(character)).toBe(0);
+    state = resolveCombatEvent(state, { type: 'turnStarted', combatantId: 'barb', round: 2, turnSequence: 4 });
+    expect(calculateCharacterMovementSpeed({ speed: 30, activeEffects: state.activeEffects })).toBe(30);
+  });
+
+  test('skipped-action turns still process boundaries', () => {
+    const state = resolveCombatEvent(addActiveEffect(baseState(), speedEffect()), { type: 'turnStarted', combatantId: 'barb', round: 2, turnSequence: 2, skippedActions: true });
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('true extra turn counts; extra action does not', () => {
+    let state = addActiveEffect(baseState({ activeTurn: 1 }), speedEffect());
+    state = resolveCombatEvent(state, { type: 'extraAction', combatantId: 'barb', round: 1, turnSequence: 2 });
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceCombatTurn(state, 1, { extraTurnCombatantId: 'barb' });
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('undo and saved state preserve duration behavior', () => {
+    const before = addActiveEffect(baseState(), speedEffect());
+    const after = advanceCombatTurn(before, 1);
+    expect(after.turnSequence).toBe(2);
+    const undo = before;
+    expect(undo.activeEffects).toHaveLength(1);
+    const restored = normalizeCombatTimelineState(JSON.parse(JSON.stringify(undo)));
+    expect(advanceCombatTurn(advanceCombatTurn(advanceCombatTurn(restored, 1), 1), 1).activeEffects).toHaveLength(0);
+  });
+
+  test('multiple simultaneous expirations are deterministic', () => {
+    const state = addActiveEffect(addActiveEffect(baseState(), speedEffect({ id: 'b' })), speedEffect({ id: 'a', stackKey: 'a' }));
+    const resolved = resolveCombatEvent(state, { type: 'turnStarted', combatantId: 'barb', round: 2, turnSequence: 3 });
+    expect(resolved.expiredEffects.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  test('combat-end and round-based effects expire on their documented events', () => {
+    let state = addActiveEffect(baseState(), speedEffect({ id: 'combat', stackKey: 'combat', expiration: { type: 'combatEnd' } }));
+    expect(endCombat(state).activeEffects).toHaveLength(0);
+    state = addActiveEffect(baseState(), speedEffect({ id: 'round', expiration: buildExpirationFromDuration({ type: 'rounds', count: 1, boundary: 'end' }, { currentRound: 1 }) }));
+    state = resolveCombatEvent(state, { type: 'roundStarted', round: 2 });
+    expect(state.activeEffects).toHaveLength(1);
+    state = resolveCombatEvent(state, { type: 'roundEnded', round: 2 });
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('duration definitions support source and target turn counts/manual', () => {
+    expect(buildExpirationFromDuration({ type: 'sourceTurns', count: 2, boundary: 'end' }, { sourceCombatantId: 'barb' })).toMatchObject({ type: 'sourceTurn', remainingOccurrences: 2 });
+    expect(buildExpirationFromDuration({ type: 'targetTurns', count: 2, boundary: 'start' }, { targetCombatantId: 'goblin' })).toMatchObject({ type: 'targetTurn', remainingOccurrences: 2 });
+    expect(buildExpirationFromDuration({ type: 'permanent' })).toEqual({ type: 'manual' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Combat effects with durations tied to turn/round boundaries (for example "until the start of the source’s next turn") needed reliable lifecycle handling and a monotonic turn sequence so temporary modifiers expire correctly; the current initiative flow could not deterministically resolve these expirations.
- The change provides a generic timeline and expiration model so features (e.g. a future Barbarian speed-reduction) can apply modifiers and rely on the engine to remove them at the correct turn/round boundary.

### Description
- Add a centralized combat timeline / active-effect utility (`client/src/components/Zombies/utils/combatEffects.js`) that normalizes timeline state, tracks `round` and a monotonically increasing `turnSequence`, emits lifecycle events (`turnEnded`, `roundEnded`, `roundStarted`, `turnStarted`, `combatEnded`), and resolves declarative expirations (source/target turn boundaries, turn counts, rounds, combat end, concentration/manual).
- Implement declarative duration conversion and expiration resolution, stack policies (`refresh`, `replace`, `stack`, `ignore`), deterministic simultaneous-expiration ordering, and removal of effects when a source/target is removed.
- Wire the DM combat flow to use the timeline resolver by integrating `advanceCombatTurn`, preserving timeline fields on normalization, cleaning up effects when participants are removed, and emitting lifecycle events in a single state transition (`client/src/components/Zombies/pages/ZombiesDM.js`).
- Extend movement-speed derivation to include active-effect speed modifiers (without changing base speed) and clamp effective speed to zero (`client/src/components/Zombies/utils/characterMetrics.js`).
- Add focused unit tests covering the required timing scenarios, stacking/refresh behavior, combatant removal, initiative changes, extra turns vs extra actions, persistence/undo behavior, deterministic expirations, and speed modifier effects (`client/src/components/Zombies/utils/combatEffects.test.js`).

### Testing
- Ran the new focused tests: `cd client && CI=true npm test -- --runInBand src/components/Zombies/utils/combatEffects.test.js` and they passed locally (all tests in that file green).
- Ran related movement and initiative tests: `cd client && CI=true npm test -- --runInBand src/components/Zombies/utils/characterMetrics.test.js src/components/Zombies/pages/ZombiesDM.initiative.test.js` and both suites passed locally.
- All automated tests mentioned above succeeded (no failures observed during the rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a554178c3108323b9ee87b47e78f5a8)