### PR TITLE
Fix dice-box first-roll initialization race

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -580,6 +580,10 @@ async function ensureDiceBox() {
     return diceBoxInstance;
   }
 
+  if (diceBoxPromise) {
+    return diceBoxPromise;
+  }
+
   if (diceBoxDisabled) {
     return null;
   }
@@ -607,88 +611,90 @@ async function ensureDiceBox() {
     markDiceBoxFailure({ fatal: true });
     return null;
   }
-  if (!diceBoxPromise) {
-    const initGeneration = diceBoxGeneration;
-    const pending = (async () => {
-      try {
-        const DiceBox = await getDiceBoxConstructor();
-        if (diceBoxGeneration !== initGeneration) {
-          return null;
-        }
-        const target = targetElement || selector;
-        if (!target) {
-          throw new Error('Dice box target was not available');
-        }
-
-        const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
-        const normalizedActiveTheme = normalizeThemeName(activeThemeName);
-        const resolvedThemeName = normalizedPendingTheme || normalizedActiveTheme || DEFAULT_DICE_THEME;
-
-        const overrides = {};
-        if (pendingThemeColor) {
-          overrides.themeColor = pendingThemeColor;
-        }
-        if (resolvedThemeName) {
-          overrides.theme = resolvedThemeName;
-        }
-
-        const options = createDiceBoxConfig(
-          Object.keys(overrides).length > 0 ? overrides : null,
-        );
-
-        let instance = null;
-
-        try {
-          instance = new DiceBox(target, options);
-        } catch (error) {
-          if (selector && target !== selector) {
-            instance = new DiceBox(selector, options);
-          } else {
-            throw error;
-          }
-        }
-
-        await withTimeout(
-          instance.init(),
-          DICEBOX_INIT_TIMEOUT_MS,
-          () => new Error('Dice box initialization timed out'),
-        );
-        if (diceBoxGeneration !== initGeneration) {
-          destroyInstance(instance);
-          return null;
-        }
-        diceBoxInstance = instance;
-        diceBoxFailed = false;
-        diceBoxDisabled = false;
-        activeThemeName = resolvedThemeName || DEFAULT_DICE_THEME;
-        applyPendingThemeName(instance);
-        applyPendingThemeColor(instance);
-        refreshDiceBoxResolution(instance);
-        clearScheduledRetry();
-        setAvailability(true);
-        return instance;
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        if (diceBoxGeneration === initGeneration) {
-          console.error('Dice box initialization failed', error);
-          const fatal =
-            isSecurityPolicyViolation(error) ||
-            (workerSupportState === 'blocked' &&
-              typeof error?.message === 'string' &&
-              error.message.toLowerCase().includes('timed out')) ||
-            workerSupportState === 'unsupported';
-          markDiceBoxFailure({ fatal });
-        }
+  const initGeneration = diceBoxGeneration;
+  const pending = (async () => {
+    try {
+      const DiceBox = await getDiceBoxConstructor();
+      if (diceBoxGeneration !== initGeneration) {
         return null;
       }
-    })();
-    diceBoxPromise = pending;
-    pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
-        diceBoxPromise = null;
+      const target = targetElement || selector;
+      if (!target) {
+        throw new Error('Dice box target was not available');
       }
-    });
-  }
+
+      const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
+      const normalizedActiveTheme = normalizeThemeName(activeThemeName);
+      const resolvedThemeName = normalizedPendingTheme || normalizedActiveTheme || DEFAULT_DICE_THEME;
+
+      const overrides = {};
+      if (pendingThemeColor) {
+        overrides.themeColor = pendingThemeColor;
+      }
+      if (resolvedThemeName) {
+        overrides.theme = resolvedThemeName;
+      }
+
+      const options = createDiceBoxConfig(
+        Object.keys(overrides).length > 0 ? overrides : null,
+      );
+
+      let instance = null;
+
+      try {
+        instance = new DiceBox(target, options);
+      } catch (error) {
+        if (selector && target !== selector) {
+          instance = new DiceBox(selector, options);
+        } else {
+          throw error;
+        }
+      }
+
+      await withTimeout(
+        instance.init(),
+        DICEBOX_INIT_TIMEOUT_MS,
+        () => new Error('Dice box initialization timed out'),
+      );
+      if (diceBoxGeneration !== initGeneration) {
+        destroyInstance(instance);
+        return null;
+      }
+      diceBoxInstance = instance;
+      diceBoxFailed = false;
+      diceBoxDisabled = false;
+      activeThemeName = resolvedThemeName || DEFAULT_DICE_THEME;
+      applyPendingThemeName(instance);
+      applyPendingThemeColor(instance);
+      refreshDiceBoxResolution(instance);
+      clearScheduledRetry();
+      setAvailability(true);
+      return instance;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      if (diceBoxGeneration === initGeneration) {
+        console.error('Dice box initialization failed', error);
+        const fatal =
+          isSecurityPolicyViolation(error) ||
+          (workerSupportState === 'blocked' &&
+            typeof error?.message === 'string' &&
+            error.message.toLowerCase().includes('timed out')) ||
+          workerSupportState === 'unsupported';
+        markDiceBoxFailure({ fatal });
+      }
+      return null;
+    }
+  })();
+  diceBoxPromise = pending;
+  pending.then((instance) => {
+    if (diceBoxPromise === pending && (!instance || diceBoxGeneration !== initGeneration)) {
+      diceBoxPromise = null;
+    }
+  }, () => {
+    if (diceBoxPromise === pending) {
+      diceBoxPromise = null;
+    }
+  });
   return diceBoxPromise;
 }
 
@@ -977,6 +983,17 @@ export const rollDiceWithBox = (requests) => {
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {
+      if (typeof console !== 'undefined' && typeof console.error === 'function') {
+        const { element, selector } = resolveDiceBoxTarget();
+        console.error('Dice box unavailable; using fallback roll.', {
+          hasHost: Boolean(element || selector),
+          ready: diceBoxReady,
+          failed: diceBoxFailed,
+          disabled: diceBoxDisabled,
+          initializationInProgress: Boolean(diceBoxPromise),
+          workerSupportState,
+        });
+      }
       return {
         rolls: fallback,
         rawResults: null,


### PR DESCRIPTION
### Motivation
- The first roll after a hard reload sometimes used the fallback because concurrent callers missed an in-progress dice-box initialization and observed a `null` instance instead of awaiting the same promise.
- The aim is to make the dice engine initialization a single source-of-truth and ensure the first user roll waits for the engine rather than falling back prematurely.

### Description
- Return any in-progress `diceBoxPromise` immediately from `ensureDiceBox()` so concurrent callers reuse the same initialization promise and wait rather than triggering the fallback.
- Create and cache a single `pending` initialization promise for `ensureDiceBox()` and clear the cached promise when the initialization resolves to `null` or fails so retries are possible.
- Keep the existing lifecycle (host/selector checks, worker support assessment, dynamic import, `instance.init()` with timeout, apply theme/color, resolution refresh, fallback path) unchanged and only synchronize the initialization path.
- Add targeted contextual error logging when a fallback roll is used to record host availability, readiness/failure/disabled flags, whether initialization is in progress, and worker support state.

### Testing
- Ran unit tests for affected components: `npm test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/Skills.test.js`, and the suite passed (all tests green).
- Built a production bundle: `npm run build` (completed successfully; unrelated lint/warning messages remain but the build finished).
- Verified the changes keep the same fallback behavior on genuine failures while ensuring the first roll will await initialization when it is in progress.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55472acc00832e911294aeb624c72c)