### PR TITLE
Wait for dice box host/layout readiness, add roll-time wait and improved diagnostics

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -44,9 +44,12 @@ let warmupPromise = null;
 let retryTimeoutId = null;
 let diceBoxGeneration = 0;
 let pendingResolutionFrame = null;
+let hostAvailabilityWaiters = new Set();
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const DICEBOX_ROLL_READY_TIMEOUT_MS = 10000;
+const DICEBOX_LAYOUT_TIMEOUT_MS = 3000;
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -102,6 +105,132 @@ const notifyAvailability = (ready) => {
 const setAvailability = (ready) => {
   diceBoxReady = ready;
   notifyAvailability(ready);
+};
+
+const hasDiceBoxTarget = () => {
+  const { element } = resolveDiceBoxTarget();
+  return Boolean(element);
+};
+
+const notifyHostAvailable = () => {
+  if (hostAvailabilityWaiters.size === 0) {
+    return;
+  }
+
+  const waiters = Array.from(hostAvailabilityWaiters);
+  hostAvailabilityWaiters.clear();
+  waiters.forEach((resolve) => resolve());
+};
+
+const waitForHostAvailable = () => {
+  if (hasDiceBoxTarget()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    hostAvailabilityWaiters.add(resolve);
+  });
+};
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+  const width = Number(rect?.width) || Number(element.clientWidth) || 0;
+  const height = Number(rect?.height) || Number(element.clientHeight) || 0;
+
+  return { width, height };
+};
+
+const isElementReadyForDiceBox = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if ('isConnected' in element && !element.isConnected) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForElementReadyForDiceBox = (element) => {
+  if (isElementReadyForDiceBox(element)) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let frameId = null;
+    let observer = null;
+
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+
+    const finish = (callback) => (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+
+    const resolveReady = finish(resolve);
+    const rejectReady = finish(reject);
+
+    const check = () => {
+      frameId = null;
+      if (isElementReadyForDiceBox(element)) {
+        resolveReady();
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      const { width, height } = getElementLayoutSize(element);
+      rejectReady(
+        new Error(
+          `Dice box target was not measurable before initialization (width: ${width}, height: ${height})`
+        )
+      );
+    }, DICEBOX_LAYOUT_TIMEOUT_MS);
+
+    if (typeof ResizeObserver === 'function') {
+      observer = new ResizeObserver(() => {
+        if (isElementReadyForDiceBox(element)) {
+          resolveReady();
+        }
+      });
+      observer.observe(element);
+    }
+
+    if (typeof requestAnimationFrame === 'function') {
+      frameId = requestAnimationFrame(check);
+    } else {
+      check();
+    }
+
+    if (isElementReadyForDiceBox(element)) {
+      resolveReady();
+    }
+  });
 };
 
 const withTimeout = (promise, timeoutMs, errorFactory) =>
@@ -592,7 +721,7 @@ async function ensureDiceBox() {
     return null;
   }
   const { element: targetElement, selector } = resolveDiceBoxTarget();
-  if (!targetElement && !selector) {
+  if (!targetElement) {
     scheduleRetry();
     return null;
   }
@@ -616,9 +745,10 @@ async function ensureDiceBox() {
           return null;
         }
         const target = targetElement || selector;
-        if (!target) {
+        if (!target || !targetElement) {
           throw new Error('Dice box target was not available');
         }
+        await waitForElementReadyForDiceBox(targetElement);
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
         const normalizedActiveTheme = normalizeThemeName(activeThemeName);
@@ -668,9 +798,15 @@ async function ensureDiceBox() {
         setAvailability(true);
         return instance;
       } catch (error) {
-        // eslint-disable-next-line no-console
         if (diceBoxGeneration === initGeneration) {
-          console.error('Dice box initialization failed', error);
+          // eslint-disable-next-line no-console
+          console.error('Dice box initialization failed', {
+            error,
+            hasHost: hasDiceBoxTarget(),
+            workerSupportState,
+            diceBoxGeneration,
+            initGeneration,
+          });
           const fatal =
             isSecurityPolicyViolation(error) ||
             (workerSupportState === 'blocked' &&
@@ -684,13 +820,53 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (diceBoxPromise === pending && !diceBoxInstance) {
         diceBoxPromise = null;
       }
     });
   }
   return diceBoxPromise;
 }
+
+const ensureDiceBoxForRoll = async () => {
+  const startedAt = Date.now();
+
+  while (true) {
+    const instance = await ensureDiceBox();
+    if (instance) {
+      return instance;
+    }
+
+    if (diceBoxFailed || diceBoxDisabled) {
+      return null;
+    }
+
+    const remaining = DICEBOX_ROLL_READY_TIMEOUT_MS - (Date.now() - startedAt);
+    if (remaining <= 0) {
+      // eslint-disable-next-line no-console
+      console.error('Dice box unavailable for roll after waiting for initialization', {
+        hasHost: hasDiceBoxTarget(),
+        hasInstance: Boolean(diceBoxInstance),
+        hasInitializationPromise: Boolean(diceBoxPromise),
+        failed: diceBoxFailed,
+        disabled: diceBoxDisabled,
+        workerSupportState,
+      });
+      return null;
+    }
+
+    if (!hasDiceBoxTarget()) {
+      await withTimeout(
+        waitForHostAvailable(),
+        remaining,
+        () => new Error('Timed out waiting for dice box host')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host was not available for roll', error);
+      });
+    }
+  }
+};
 
 const collectNumericLeaves = (node, target) => {
   if (!node) return;
@@ -888,8 +1064,11 @@ export const registerDiceBoxContainer = (element) => {
   resetInstance();
   diceBoxFailed = false;
   diceBoxDisabled = false;
-  const { element: resolvedElement, selector } = resolveDiceBoxTarget();
-  if (!resolvedElement && !selector) {
+  const { element: resolvedElement } = resolveDiceBoxTarget();
+  if (resolvedElement) {
+    notifyHostAvailable();
+  }
+  if (!resolvedElement) {
     setAvailability(false);
     return () => {};
   }
@@ -973,7 +1152,7 @@ export const rollDiceWithBox = (requests) => {
   }
 
   const executeRoll = async () => {
-    const instance = await ensureDiceBox();
+    const instance = await ensureDiceBoxForRoll();
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {


### PR DESCRIPTION
### Motivation
- Ensure the dice box is not initialized or used until its host element is present and measurable to avoid failed inits or invisible layouts.
- Allow roll requests to wait briefly for the dice box host/instance to become available instead of immediately falling back to random results.
- Improve diagnostics to aid debugging when initialization fails due to host, worker, or timing issues.

### Description
- Added host presence and layout checks with `hasDiceBoxTarget`, `getElementLayoutSize`, `isElementReadyForDiceBox`, and `waitForElementReadyForDiceBox` to delay initialization until the container is measurable.
- Introduced host availability waiters via `hostAvailabilityWaiters`, `notifyHostAvailable`, and `waitForHostAvailable` to allow roll logic to await a registered host.
- Added `ensureDiceBoxForRoll` which retries `ensureDiceBox` up to `DICEBOX_ROLL_READY_TIMEOUT_MS` and waits for host availability before falling back.
- Updated `ensureDiceBox` to require a real target element, await element readiness before constructing `DiceBox`, improve failure logging with contextual info, and adjust promise cleanup logic.
- `rollDiceWithBox` now uses `ensureDiceBoxForRoll`, and `registerDiceBoxContainer` notifies waiters when a host element is registered.

### Testing
- Ran the existing automated unit test suite (`npm test`) and the linter (`npm run lint`) against the changes and they completed without failures.
- Verified that initialization waits for a measurable host element and that `rollDiceWithBox` will wait briefly for the host/instance before returning fallback results under test scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563fb0ca3c832eadf794a4295acba5)