### PR TITLE
Wait for dice box host/layout before initializing and add roll readiness handling

### DIFF
--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -44,9 +44,12 @@ let warmupPromise = null;
 let retryTimeoutId = null;
 let diceBoxGeneration = 0;
 let pendingResolutionFrame = null;
+let hostAvailabilityWaiters = new Set();
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const DICEBOX_ROLL_READY_TIMEOUT_MS = 10000;
+const DICEBOX_LAYOUT_TIMEOUT_MS = 3000;
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -102,6 +105,131 @@ const notifyAvailability = (ready) => {
 const setAvailability = (ready) => {
   diceBoxReady = ready;
   notifyAvailability(ready);
+};
+
+const hasDiceBoxTarget = () => {
+  const { element } = resolveDiceBoxTarget();
+  return Boolean(element);
+};
+
+const getDiceBoxTargetElement = () => {
+  const { element } = resolveDiceBoxTarget();
+  return element || null;
+};
+
+const notifyHostAvailable = () => {
+  if (hostAvailabilityWaiters.size === 0) {
+    return;
+  }
+
+  const waiters = Array.from(hostAvailabilityWaiters);
+  hostAvailabilityWaiters.clear();
+  waiters.forEach((resolve) => resolve());
+};
+
+const waitForHostAvailable = () => {
+  if (hasDiceBoxTarget()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    hostAvailabilityWaiters.add(resolve);
+  });
+};
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+  const width = Number(rect?.width) || Number(element.clientWidth) || 0;
+  const height = Number(rect?.height) || Number(element.clientHeight) || 0;
+
+  return { width, height };
+};
+
+const isElementReadyForDiceBox = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if ('isConnected' in element && !element.isConnected) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForElementReadyForDiceBox = (element) => {
+  if (isElementReadyForDiceBox(element)) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let frameId = null;
+    let observer = null;
+
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+
+    const finish = (callback) => (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+
+    const resolveReady = finish(resolve);
+
+    const check = () => {
+      frameId = null;
+      if (isElementReadyForDiceBox(element)) {
+        resolveReady(true);
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      resolveReady(false);
+    }, DICEBOX_LAYOUT_TIMEOUT_MS);
+
+    if (typeof ResizeObserver === 'function') {
+      observer = new ResizeObserver(() => {
+        if (isElementReadyForDiceBox(element)) {
+          resolveReady(true);
+        }
+      });
+      observer.observe(element);
+    }
+
+    if (typeof requestAnimationFrame === 'function') {
+      frameId = requestAnimationFrame(check);
+    } else {
+      check();
+    }
+
+    if (isElementReadyForDiceBox(element)) {
+      resolveReady(true);
+    }
+  });
 };
 
 const withTimeout = (promise, timeoutMs, errorFactory) =>
@@ -592,7 +720,11 @@ async function ensureDiceBox() {
     return null;
   }
   const { element: targetElement, selector } = resolveDiceBoxTarget();
-  if (!targetElement && !selector) {
+  if (!targetElement) {
+    scheduleRetry();
+    return null;
+  }
+  if (!isElementReadyForDiceBox(targetElement)) {
     scheduleRetry();
     return null;
   }
@@ -616,8 +748,13 @@ async function ensureDiceBox() {
           return null;
         }
         const target = targetElement || selector;
-        if (!target) {
+        if (!target || !targetElement) {
           throw new Error('Dice box target was not available');
+        }
+        const targetReady = await waitForElementReadyForDiceBox(targetElement);
+        if (!targetReady) {
+          scheduleRetry();
+          return null;
         }
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
@@ -668,9 +805,15 @@ async function ensureDiceBox() {
         setAvailability(true);
         return instance;
       } catch (error) {
-        // eslint-disable-next-line no-console
         if (diceBoxGeneration === initGeneration) {
-          console.error('Dice box initialization failed', error);
+          // eslint-disable-next-line no-console
+          console.error('Dice box initialization failed', {
+            error,
+            hasHost: hasDiceBoxTarget(),
+            workerSupportState,
+            diceBoxGeneration,
+            initGeneration,
+          });
           const fatal =
             isSecurityPolicyViolation(error) ||
             (workerSupportState === 'blocked' &&
@@ -684,13 +827,68 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (diceBoxPromise === pending && !diceBoxInstance) {
         diceBoxPromise = null;
       }
     });
   }
   return diceBoxPromise;
 }
+
+const ensureDiceBoxForRoll = async () => {
+  const startedAt = Date.now();
+
+  while (true) {
+    const instance = await ensureDiceBox();
+    if (instance) {
+      return instance;
+    }
+
+    if (diceBoxFailed || diceBoxDisabled) {
+      return null;
+    }
+
+    const remaining = DICEBOX_ROLL_READY_TIMEOUT_MS - (Date.now() - startedAt);
+    if (remaining <= 0) {
+      // eslint-disable-next-line no-console
+      console.error('Dice box unavailable for roll after waiting for initialization', {
+        hasHost: hasDiceBoxTarget(),
+        hasInstance: Boolean(diceBoxInstance),
+        hasInitializationPromise: Boolean(diceBoxPromise),
+        failed: diceBoxFailed,
+        disabled: diceBoxDisabled,
+        workerSupportState,
+      });
+      return null;
+    }
+
+    const targetElement = getDiceBoxTargetElement();
+    if (!targetElement) {
+      await withTimeout(
+        waitForHostAvailable(),
+        remaining,
+        () => new Error('Timed out waiting for dice box host')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host was not available for roll', error);
+      });
+    } else if (!isElementReadyForDiceBox(targetElement)) {
+      const targetReady = await withTimeout(
+        waitForElementReadyForDiceBox(targetElement),
+        remaining,
+        () => new Error('Timed out waiting for dice box host layout')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host layout was not available for roll', error);
+        return false;
+      });
+
+      if (!targetReady) {
+        return null;
+      }
+    }
+  }
+};
 
 const collectNumericLeaves = (node, target) => {
   if (!node) return;
@@ -888,8 +1086,11 @@ export const registerDiceBoxContainer = (element) => {
   resetInstance();
   diceBoxFailed = false;
   diceBoxDisabled = false;
-  const { element: resolvedElement, selector } = resolveDiceBoxTarget();
-  if (!resolvedElement && !selector) {
+  const { element: resolvedElement } = resolveDiceBoxTarget();
+  if (resolvedElement) {
+    notifyHostAvailable();
+  }
+  if (!resolvedElement) {
     setAvailability(false);
     return () => {};
   }
@@ -973,7 +1174,7 @@ export const rollDiceWithBox = (requests) => {
   }
 
   const executeRoll = async () => {
-    const instance = await ensureDiceBox();
+    const instance = await ensureDiceBoxForRoll();
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {


### PR DESCRIPTION
### Motivation
- Ensure the dice box is only initialized when a host element is present and has non-zero layout, and make rolls wait for the host if necessary to avoid silent failures and improve reliability.
- Provide clearer diagnostics and timeouts for initialization and roll readiness so failures are easier to detect and recover from.

### Description
- Added host availability waiters and notification (`hostAvailabilityWaiters`, `waitForHostAvailable`, `notifyHostAvailable`) so callers can await a registered container before proceeding. 
- Added layout detection and readiness helpers (`getElementLayoutSize`, `isElementReadyForDiceBox`, `waitForElementReadyForDiceBox`) that use `getBoundingClientRect`, `clientWidth/clientHeight`, `ResizeObserver`, and `requestAnimationFrame` with a layout timeout (`DICEBOX_LAYOUT_TIMEOUT_MS`).
- Modified `ensureDiceBox` to require a ready host element before attempting initialization, improved retry logic, and added richer error diagnostics on init failures.
- Introduced `ensureDiceBoxForRoll` which waits (with `DICEBOX_ROLL_READY_TIMEOUT_MS`) for the host/instance to become available before performing a roll and logs detailed state if the roll cannot proceed.
- Notify waiting callers when a container is registered in `registerDiceBoxContainer` and clear availability state on unregister.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563fb0ca3c832eadf794a4295acba5)