### PR TITLE
Wait for dice box host/layout before initializing rolls and preserve HUD layout for damage amount visibility

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8811,11 +8811,18 @@ h1 {
 
 /* User-requested HUD fit fixes: keep spell labels visible, make resources four-wide, and tuck pact magic under level IX. */
 #damageAmount.damage-roller--hidden {
-  display: none;
+  position: absolute;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
 }
 
 #damageAmount.damage-roller--visible {
-  display: block;
+  display: flex;
+  position: relative;
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .combat-hud-dock__resource-rail {

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -44,9 +44,12 @@ let warmupPromise = null;
 let retryTimeoutId = null;
 let diceBoxGeneration = 0;
 let pendingResolutionFrame = null;
+let hostAvailabilityWaiters = new Set();
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const DICEBOX_ROLL_READY_TIMEOUT_MS = 10000;
+const DICEBOX_LAYOUT_TIMEOUT_MS = 3000;
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -102,6 +105,131 @@ const notifyAvailability = (ready) => {
 const setAvailability = (ready) => {
   diceBoxReady = ready;
   notifyAvailability(ready);
+};
+
+const hasDiceBoxTarget = () => {
+  const { element } = resolveDiceBoxTarget();
+  return Boolean(element);
+};
+
+const getDiceBoxTargetElement = () => {
+  const { element } = resolveDiceBoxTarget();
+  return element || null;
+};
+
+const notifyHostAvailable = () => {
+  if (hostAvailabilityWaiters.size === 0) {
+    return;
+  }
+
+  const waiters = Array.from(hostAvailabilityWaiters);
+  hostAvailabilityWaiters.clear();
+  waiters.forEach((resolve) => resolve());
+};
+
+const waitForHostAvailable = () => {
+  if (hasDiceBoxTarget()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    hostAvailabilityWaiters.add(resolve);
+  });
+};
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+  const width = Number(rect?.width) || Number(element.clientWidth) || 0;
+  const height = Number(rect?.height) || Number(element.clientHeight) || 0;
+
+  return { width, height };
+};
+
+const isElementReadyForDiceBox = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if ('isConnected' in element && !element.isConnected) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForElementReadyForDiceBox = (element) => {
+  if (isElementReadyForDiceBox(element)) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let frameId = null;
+    let observer = null;
+
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+
+    const finish = (callback) => (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+
+    const resolveReady = finish(resolve);
+
+    const check = () => {
+      frameId = null;
+      if (isElementReadyForDiceBox(element)) {
+        resolveReady(true);
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      resolveReady(false);
+    }, DICEBOX_LAYOUT_TIMEOUT_MS);
+
+    if (typeof ResizeObserver === 'function') {
+      observer = new ResizeObserver(() => {
+        if (isElementReadyForDiceBox(element)) {
+          resolveReady(true);
+        }
+      });
+      observer.observe(element);
+    }
+
+    if (typeof requestAnimationFrame === 'function') {
+      frameId = requestAnimationFrame(check);
+    } else {
+      check();
+    }
+
+    if (isElementReadyForDiceBox(element)) {
+      resolveReady(true);
+    }
+  });
 };
 
 const withTimeout = (promise, timeoutMs, errorFactory) =>
@@ -592,7 +720,11 @@ async function ensureDiceBox() {
     return null;
   }
   const { element: targetElement, selector } = resolveDiceBoxTarget();
-  if (!targetElement && !selector) {
+  if (!targetElement) {
+    scheduleRetry();
+    return null;
+  }
+  if (!isElementReadyForDiceBox(targetElement)) {
     scheduleRetry();
     return null;
   }
@@ -616,8 +748,13 @@ async function ensureDiceBox() {
           return null;
         }
         const target = targetElement || selector;
-        if (!target) {
+        if (!target || !targetElement) {
           throw new Error('Dice box target was not available');
+        }
+        const targetReady = await waitForElementReadyForDiceBox(targetElement);
+        if (!targetReady) {
+          scheduleRetry();
+          return null;
         }
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
@@ -668,9 +805,15 @@ async function ensureDiceBox() {
         setAvailability(true);
         return instance;
       } catch (error) {
-        // eslint-disable-next-line no-console
         if (diceBoxGeneration === initGeneration) {
-          console.error('Dice box initialization failed', error);
+          // eslint-disable-next-line no-console
+          console.error('Dice box initialization failed', {
+            error,
+            hasHost: hasDiceBoxTarget(),
+            workerSupportState,
+            diceBoxGeneration,
+            initGeneration,
+          });
           const fatal =
             isSecurityPolicyViolation(error) ||
             (workerSupportState === 'blocked' &&
@@ -684,13 +827,68 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (diceBoxPromise === pending && !diceBoxInstance) {
         diceBoxPromise = null;
       }
     });
   }
   return diceBoxPromise;
 }
+
+const ensureDiceBoxForRoll = async () => {
+  const startedAt = Date.now();
+
+  while (true) {
+    const instance = await ensureDiceBox();
+    if (instance) {
+      return instance;
+    }
+
+    if (diceBoxFailed || diceBoxDisabled) {
+      return null;
+    }
+
+    const remaining = DICEBOX_ROLL_READY_TIMEOUT_MS - (Date.now() - startedAt);
+    if (remaining <= 0) {
+      // eslint-disable-next-line no-console
+      console.error('Dice box unavailable for roll after waiting for initialization', {
+        hasHost: hasDiceBoxTarget(),
+        hasInstance: Boolean(diceBoxInstance),
+        hasInitializationPromise: Boolean(diceBoxPromise),
+        failed: diceBoxFailed,
+        disabled: diceBoxDisabled,
+        workerSupportState,
+      });
+      return null;
+    }
+
+    const targetElement = getDiceBoxTargetElement();
+    if (!targetElement) {
+      await withTimeout(
+        waitForHostAvailable(),
+        remaining,
+        () => new Error('Timed out waiting for dice box host')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host was not available for roll', error);
+      });
+    } else if (!isElementReadyForDiceBox(targetElement)) {
+      const targetReady = await withTimeout(
+        waitForElementReadyForDiceBox(targetElement),
+        remaining,
+        () => new Error('Timed out waiting for dice box host layout')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host layout was not available for roll', error);
+        return false;
+      });
+
+      if (!targetReady) {
+        return null;
+      }
+    }
+  }
+};
 
 const collectNumericLeaves = (node, target) => {
   if (!node) return;
@@ -888,8 +1086,11 @@ export const registerDiceBoxContainer = (element) => {
   resetInstance();
   diceBoxFailed = false;
   diceBoxDisabled = false;
-  const { element: resolvedElement, selector } = resolveDiceBoxTarget();
-  if (!resolvedElement && !selector) {
+  const { element: resolvedElement } = resolveDiceBoxTarget();
+  if (resolvedElement) {
+    notifyHostAvailable();
+  }
+  if (!resolvedElement) {
     setAvailability(false);
     return () => {};
   }
@@ -973,7 +1174,7 @@ export const rollDiceWithBox = (requests) => {
   }
 
   const executeRoll = async () => {
-    const instance = await ensureDiceBox();
+    const instance = await ensureDiceBoxForRoll();
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {


### PR DESCRIPTION
### Motivation

- Ensure the dice renderer only initializes and is used for rolls when a host element exists and has non-zero layout to prevent failed inits and visual glitches.
- Add explicit timeouts and waiting for host availability or layout so roll requests can wait briefly for the UI to be ready instead of immediately falling back.
- Improve debug logging around dice box initialization failures and make host registration notify waiters when the host appears.
- Preserve HUD layout when hiding the damage roller so spell labels and resource layouts remain stable on mobile by using visibility/opacity instead of `display` toggling.

### Description

- Added host availability coordination including `hostAvailabilityWaiters`, `notifyHostAvailable`, `waitForHostAvailable`, `hasDiceBoxTarget`, and `getDiceBoxTargetElement` to let rolls wait for a host element. 
- Implemented layout readiness checks and waiting with `getElementLayoutSize`, `isElementReadyForDiceBox`, and `waitForElementReadyForDiceBox`, and introduced `DICEBOX_LAYOUT_TIMEOUT_MS` and `DICEBOX_ROLL_READY_TIMEOUT_MS` constants. 
- Require a ready target in `ensureDiceBox`, add `ensureDiceBoxForRoll` which loops with timeouts to wait for host/layout before attempting a roll, and switch `rollDiceWithBox` to use `ensureDiceBoxForRoll`. 
- Emit clearer structured error logs on initialization failure, adjust retry scheduling behavior, and notify waiters from `registerDiceBoxContainer`; also reset availability when the container is removed. 
- Change HUD CSS on `#damageAmount` so `damage-roller--hidden` uses `position:absolute`, `visibility:hidden`, `opacity:0`, and `pointer-events:none` while `damage-roller--visible` uses `display:flex`, `position:relative`, `visibility:visible`, and `opacity:1` to avoid layout reflow.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563fb0ca3c832eadf794a4295acba5)