### PR TITLE
Wait for DiceBox host/surface before rolling; smooth damage roller visibility and expose roll-surface event

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8811,11 +8811,29 @@ h1 {
 
 /* User-requested HUD fit fixes: keep spell labels visible, make resources four-wide, and tuck pact magic under level IX. */
 #damageAmount.damage-roller--hidden {
-  display: none;
+  position: absolute;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
 }
 
 #damageAmount.damage-roller--visible {
-  display: block;
+  display: flex;
+  position: relative;
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#damageAmount.damage-roller--result-hidden #damageValue {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+#damageAmount.damage-roller--result-visible #damageValue {
+  visibility: visible;
+  opacity: 1;
 }
 
 .combat-hud-dock__resource-rail {

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -21,6 +21,7 @@ import DamageDiceCanvas from './DamageDiceCanvas';
 import DiceRollerModal from '../common/DiceRollerModal';
 import {
   clearDiceBoxResults,
+  DICE_BOX_ROLL_SURFACE_EVENT,
   rollDiceWithBox,
   setDiceBoxThemeColor,
 } from '../../../utils/diceBoxManager';
@@ -482,6 +483,45 @@ const PlayerTurnActions = React.forwardRef(
   };
 
   const [footerHeight, setFooterHeight] = useState(0);
+  // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
+  const [damageValue, setDamageValue] = useState(0);
+  const [hasDamageRoll, setHasDamageRoll] = useState(false);
+  const [damageRollLabel, setDamageRollLabel] = useState('Damage');
+  const [damageLog, setDamageLog] = useState([]);
+  const [showLog, setShowLog] = useState(false);
+  const [activeDice, setActiveDice] = useState([]);
+  const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
+  const [isDiceRollPending, setIsDiceRollPending] = useState(false);
+
+  const showDiceRollSurface = useCallback((label = 'Roll') => {
+    setDamageRollLabel(label);
+    setIsDiceRollPending(true);
+  }, []);
+
+  const prepareDiceRollSurface = useCallback(async (label = 'Roll') => {
+    showDiceRollSurface(label);
+    await waitForNextAnimationFrame();
+  }, [showDiceRollSurface]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleDiceRollSurfaceRequest = (event) => {
+      const requestedLabel =
+        typeof event?.detail?.label === 'string' && event.detail.label.trim()
+          ? event.detail.label.trim()
+          : 'Roll';
+      showDiceRollSurface(requestedLabel);
+    };
+
+    window.addEventListener(DICE_BOX_ROLL_SURFACE_EVENT, handleDiceRollSurfaceRequest);
+    return () => {
+      window.removeEventListener(DICE_BOX_ROLL_SURFACE_EVENT, handleDiceRollSurfaceRequest);
+    };
+  }, [showDiceRollSurface]);
+
 
   useEffect(() => {
     const observed = new Map();
@@ -1519,6 +1559,8 @@ const manualCriticalRef = useRef(false);
         return staticResult ? { ...staticResult, rollValues: undefined } : null;
       }
 
+      await prepareDiceRollSurface('Damage');
+
       const rollPlan = (() => {
         if (!Array.isArray(requests) || requests.length === 0) {
           return [];
@@ -1716,6 +1758,7 @@ const manualCriticalRef = useRef(false);
     [
       diceFaceColor,
       normalizeDamageTypeForClass,
+      prepareDiceRollSurface,
       resolveDamageTypeColor,
       rollDiceWithBox,
       setDiceBoxThemeColor,
@@ -1816,6 +1859,7 @@ const manualCriticalRef = useRef(false);
       isUnarmedStrike: isUnarmedAttack(weapon),
     };
     const rollModeResult = resolveAttackRollMode(form, attackContext);
+    await prepareDiceRollSurface('Roll');
     const { result, d20, rolledD20s, keptD20, rollMode } = await rollSkillWithDiceBox(bonus, {
       diceColor: diceFaceColor,
       rollMode: rollModeResult.mode,
@@ -1867,6 +1911,7 @@ const manualCriticalRef = useRef(false);
       }
 
       const { total, abilityBonus, proficiencyBonus, extraBonus } = attackDetails;
+      await prepareDiceRollSurface('Roll');
       const { result, d20 } = await rollSkillWithDiceBox(total, {
         diceColor: diceFaceColor,
       });
@@ -1906,6 +1951,7 @@ const manualCriticalRef = useRef(false);
       diceFaceColor,
       formatModifier,
       getSpellAttackDetails,
+      prepareDiceRollSurface,
       spellAbilityLabel,
     ],
   );
@@ -2043,15 +2089,6 @@ const sortedSpells = useMemo(() => {
     );
 }, [form.spells]);
 
-// -----------------------------------------Dice roller for damage-------------------------------------------------------------------
-const [damageValue, setDamageValue] = useState(0);
-  const [hasDamageRoll, setHasDamageRoll] = useState(false);
-  const [damageRollLabel, setDamageRollLabel] = useState('Damage');
-  const [damageLog, setDamageLog] = useState([]);
-  const [showLog, setShowLog] = useState(false);
-  const [activeDice, setActiveDice] = useState([]);
-  const [lastRollTimestamp, setLastRollTimestamp] = useState(0);
-
 const triggerDiceAnimation = useCallback((diceDetails = []) => {
   if (!Array.isArray(diceDetails) || diceDetails.length === 0) {
     setActiveDice([]);
@@ -2118,6 +2155,7 @@ const updateDamageValueWithAnimation = (
   setPulseClass('');
   setDamageValue(newValue);
   setHasDamageRoll(newValue !== undefined);
+  setIsDiceRollPending(false);
   setDamageRollLabel(
     typeof extra?.rollLabel === 'string' && extra.rollLabel.trim()
       ? extra.rollLabel.trim()
@@ -2403,6 +2441,8 @@ const damageAmountStyle = {
   '--damage-roller-min-height': `${damageContainerMinHeight}px`,
   '--damage-dice-area-size': `${resolvedDiceSize}px`,
 };
+const isDamageRollSurfaceVisible = hasDamageRoll || isDiceRollPending;
+const isDamageRollResultVisible = hasDamageRoll && !isDiceRollPending;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div
@@ -2418,7 +2458,9 @@ const damageAmountStyle = {
           id="damageAmount"
           ref={damageAmountRef}
           style={damageAmountStyle}
-          className={`${hasDamageRoll ? 'damage-roller--visible' : 'damage-roller--hidden'} ${pulseClass} ${isCritical ? 'critical-active' : ''} ${
+          className={`${isDamageRollSurfaceVisible ? 'damage-roller--visible' : 'damage-roller--hidden'} ${
+            isDamageRollResultVisible ? 'damage-roller--result-visible' : 'damage-roller--result-hidden'
+          } ${pulseClass} ${isCritical ? 'critical-active' : ''} ${
             isFumble ? 'critical-failure' : ''
           }`}
         >

--- a/client/src/utils/diceBoxManager.js
+++ b/client/src/utils/diceBoxManager.js
@@ -44,9 +44,13 @@ let warmupPromise = null;
 let retryTimeoutId = null;
 let diceBoxGeneration = 0;
 let pendingResolutionFrame = null;
+let hostAvailabilityWaiters = new Set();
 
 const DICEBOX_INIT_TIMEOUT_MS = 10000;
 const RETRY_DELAY_MS = 4000;
+const DICEBOX_ROLL_READY_TIMEOUT_MS = 10000;
+const DICEBOX_LAYOUT_TIMEOUT_MS = 3000;
+export const DICE_BOX_ROLL_SURFACE_EVENT = 'dice-box-roll-surface-requested';
 
 const clearScheduledRetry = () => {
   if (retryTimeoutId) {
@@ -104,6 +108,131 @@ const setAvailability = (ready) => {
   notifyAvailability(ready);
 };
 
+const hasDiceBoxTarget = () => {
+  const { element } = resolveDiceBoxTarget();
+  return Boolean(element);
+};
+
+const getDiceBoxTargetElement = () => {
+  const { element } = resolveDiceBoxTarget();
+  return element || null;
+};
+
+const notifyHostAvailable = () => {
+  if (hostAvailabilityWaiters.size === 0) {
+    return;
+  }
+
+  const waiters = Array.from(hostAvailabilityWaiters);
+  hostAvailabilityWaiters.clear();
+  waiters.forEach((resolve) => resolve());
+};
+
+const waitForHostAvailable = () => {
+  if (hasDiceBoxTarget()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    hostAvailabilityWaiters.add(resolve);
+  });
+};
+
+const getElementLayoutSize = (element) => {
+  if (!element || typeof element !== 'object') {
+    return { width: 0, height: 0 };
+  }
+
+  const rect =
+    typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+  const width = Number(rect?.width) || Number(element.clientWidth) || 0;
+  const height = Number(rect?.height) || Number(element.clientHeight) || 0;
+
+  return { width, height };
+};
+
+const isElementReadyForDiceBox = (element) => {
+  if (!element || typeof element !== 'object') {
+    return false;
+  }
+
+  if ('isConnected' in element && !element.isConnected) {
+    return false;
+  }
+
+  const { width, height } = getElementLayoutSize(element);
+  return width > 0 && height > 0;
+};
+
+const waitForElementReadyForDiceBox = (element) => {
+  if (isElementReadyForDiceBox(element)) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let frameId = null;
+    let observer = null;
+
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+
+    const finish = (callback) => (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+
+    const resolveReady = finish(resolve);
+
+    const check = () => {
+      frameId = null;
+      if (isElementReadyForDiceBox(element)) {
+        resolveReady(true);
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      resolveReady(false);
+    }, DICEBOX_LAYOUT_TIMEOUT_MS);
+
+    if (typeof ResizeObserver === 'function') {
+      observer = new ResizeObserver(() => {
+        if (isElementReadyForDiceBox(element)) {
+          resolveReady(true);
+        }
+      });
+      observer.observe(element);
+    }
+
+    if (typeof requestAnimationFrame === 'function') {
+      frameId = requestAnimationFrame(check);
+    } else {
+      check();
+    }
+
+    if (isElementReadyForDiceBox(element)) {
+      resolveReady(true);
+    }
+  });
+};
+
 const withTimeout = (promise, timeoutMs, errorFactory) =>
   new Promise((resolve, reject) => {
     let settled = false;
@@ -126,6 +255,46 @@ const withTimeout = (promise, timeoutMs, errorFactory) =>
 
     promise.then(finalize(resolve), finalize(reject));
   });
+
+const waitForNextRenderFrame = () =>
+  new Promise((resolve) => {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => resolve());
+      return;
+    }
+
+    if (typeof setTimeout === 'function') {
+      setTimeout(resolve, 0);
+      return;
+    }
+
+    resolve();
+  });
+
+const requestVisibleDiceRollSurface = async (requests) => {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.dispatchEvent !== 'function' ||
+    typeof CustomEvent !== 'function'
+  ) {
+    return;
+  }
+
+  const firstRequest = Array.isArray(requests) ? requests[0] : null;
+  const label =
+    firstRequest && Number(firstRequest?.sides) === 20 ? 'Roll' : 'Damage';
+
+  window.dispatchEvent(
+    new CustomEvent(DICE_BOX_ROLL_SURFACE_EVENT, {
+      detail: {
+        label,
+        requests,
+      },
+    })
+  );
+
+  await waitForNextRenderFrame();
+};
 
 const markDiceBoxFailure = ({ fatal = false } = {}) => {
   diceBoxFailed = true;
@@ -592,7 +761,11 @@ async function ensureDiceBox() {
     return null;
   }
   const { element: targetElement, selector } = resolveDiceBoxTarget();
-  if (!targetElement && !selector) {
+  if (!targetElement) {
+    scheduleRetry();
+    return null;
+  }
+  if (!isElementReadyForDiceBox(targetElement)) {
     scheduleRetry();
     return null;
   }
@@ -616,8 +789,13 @@ async function ensureDiceBox() {
           return null;
         }
         const target = targetElement || selector;
-        if (!target) {
+        if (!target || !targetElement) {
           throw new Error('Dice box target was not available');
+        }
+        const targetReady = await waitForElementReadyForDiceBox(targetElement);
+        if (!targetReady) {
+          scheduleRetry();
+          return null;
         }
 
         const normalizedPendingTheme = normalizeThemeName(pendingThemeName);
@@ -668,9 +846,15 @@ async function ensureDiceBox() {
         setAvailability(true);
         return instance;
       } catch (error) {
-        // eslint-disable-next-line no-console
         if (diceBoxGeneration === initGeneration) {
-          console.error('Dice box initialization failed', error);
+          // eslint-disable-next-line no-console
+          console.error('Dice box initialization failed', {
+            error,
+            hasHost: hasDiceBoxTarget(),
+            workerSupportState,
+            diceBoxGeneration,
+            initGeneration,
+          });
           const fatal =
             isSecurityPolicyViolation(error) ||
             (workerSupportState === 'blocked' &&
@@ -684,13 +868,68 @@ async function ensureDiceBox() {
     })();
     diceBoxPromise = pending;
     pending.finally(() => {
-      if (diceBoxPromise === pending && diceBoxGeneration !== initGeneration) {
+      if (diceBoxPromise === pending && !diceBoxInstance) {
         diceBoxPromise = null;
       }
     });
   }
   return diceBoxPromise;
 }
+
+const ensureDiceBoxForRoll = async () => {
+  const startedAt = Date.now();
+
+  while (true) {
+    const instance = await ensureDiceBox();
+    if (instance) {
+      return instance;
+    }
+
+    if (diceBoxFailed || diceBoxDisabled) {
+      return null;
+    }
+
+    const remaining = DICEBOX_ROLL_READY_TIMEOUT_MS - (Date.now() - startedAt);
+    if (remaining <= 0) {
+      // eslint-disable-next-line no-console
+      console.error('Dice box unavailable for roll after waiting for initialization', {
+        hasHost: hasDiceBoxTarget(),
+        hasInstance: Boolean(diceBoxInstance),
+        hasInitializationPromise: Boolean(diceBoxPromise),
+        failed: diceBoxFailed,
+        disabled: diceBoxDisabled,
+        workerSupportState,
+      });
+      return null;
+    }
+
+    const targetElement = getDiceBoxTargetElement();
+    if (!targetElement) {
+      await withTimeout(
+        waitForHostAvailable(),
+        remaining,
+        () => new Error('Timed out waiting for dice box host')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host was not available for roll', error);
+      });
+    } else if (!isElementReadyForDiceBox(targetElement)) {
+      const targetReady = await withTimeout(
+        waitForElementReadyForDiceBox(targetElement),
+        remaining,
+        () => new Error('Timed out waiting for dice box host layout')
+      ).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Dice box host layout was not available for roll', error);
+        return false;
+      });
+
+      if (!targetReady) {
+        return null;
+      }
+    }
+  }
+};
 
 const collectNumericLeaves = (node, target) => {
   if (!node) return;
@@ -888,8 +1127,11 @@ export const registerDiceBoxContainer = (element) => {
   resetInstance();
   diceBoxFailed = false;
   diceBoxDisabled = false;
-  const { element: resolvedElement, selector } = resolveDiceBoxTarget();
-  if (!resolvedElement && !selector) {
+  const { element: resolvedElement } = resolveDiceBoxTarget();
+  if (resolvedElement) {
+    notifyHostAvailable();
+  }
+  if (!resolvedElement) {
     setAvailability(false);
     return () => {};
   }
@@ -973,7 +1215,8 @@ export const rollDiceWithBox = (requests) => {
   }
 
   const executeRoll = async () => {
-    const instance = await ensureDiceBox();
+    await requestVisibleDiceRollSurface(requests);
+    const instance = await ensureDiceBoxForRoll();
     const fallback = requests.map(({ count, sides }) => fallbackRoll(count, sides));
 
     if (!instance) {


### PR DESCRIPTION
### Motivation

- Ensure the dice-box UI surface is available and laid out before initiating visual rolls so animations and layout don't race with initialization. 
- Provide a mechanism to request the roll surface be shown (with a label) from other modules before rolling. 
- Improve the damage roller visibility transition to use visibility/opacity/position instead of display for smoother animated state changes.

### Description

- Exported `DICE_BOX_ROLL_SURFACE_EVENT` and added `requestVisibleDiceRollSurface` to dispatch a `CustomEvent` so other components can request the dice-roll surface be displayed with a label.  
- Added host availability waiters and functions (`waitForHostAvailable`, `waitForElementReadyForDiceBox`, `isElementReadyForDiceBox`, `getElementLayoutSize`) to detect and await the dice-box host element and its layout readiness.  
- Implemented `ensureDiceBoxForRoll` which waits (with timeouts) for the dice box instance and host layout to be ready before proceeding with a roll, with improved logging and retry behavior.  
- Updated `rollDiceWithBox` to call `requestVisibleDiceRollSurface` and `ensureDiceBoxForRoll` so rolls are only attempted after the UI is visible and prepared.  
- Enhanced `registerDiceBoxContainer` to notify pending waiters when the host becomes available.  
- Introduced timeouts and layout observation (using `ResizeObserver` when available) to avoid indefinite waits for layout readiness.  
- In `PlayerTurnActions.js` added state and handlers to show a dice-roll surface label (`prepareDiceRollSurface`, `showDiceRollSurface`), wired an event listener for the exported roll-surface event, and awaited the surface before performing certain dice-based actions (`rollDamageExpression`, attack/spell attack roll flows).  
- Reworked damage-roller visibility logic and classes to support three states (hidden, surface-visible, result-visible) and switched CSS from `display:none` to `position/visibility/opacity/pointer-events` for smoother transitions; added selectors for result visibility targeting `#damageValue`.  
- Minor cleanup: consolidated duplicated damage-roller state definitions and improved error logging around dice-box initialization failures.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563fb0ca3c832eadf794a4295acba5)