### PR TITLE
Make Continue button full-width; show accurate HP; persist last-played on continue

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10238,7 +10238,8 @@ h1 {
 .character-select-card__stats strong { display: block; color: #fff; font-size: 1.25rem; }
 .character-select-card__meta span { color: rgba(230,237,255,.7); font-size: .78rem; }
 .character-select-card__meta strong { color: #fff; }
-.character-select-card__actions { display: grid; grid-template-columns: 1fr 1fr auto; gap: .55rem; margin-top: 1rem; align-items: center; }
+.character-select-card__actions { display: grid; grid-template-columns: 1fr; gap: .55rem; margin-top: 1rem; align-items: center; }
+.character-select-card__continue { width: 100%; }
 .character-select-card__ghost { border-radius: 999px; background: rgba(145,183,255,.12); border: 1px solid rgba(145,183,255,.25); color: #eef4ff; font-weight: 800; }
 .character-select-card__more { position: relative; }
 .character-select-card__more summary { list-style: none; cursor: pointer; border-radius: 999px; padding: .55rem .75rem; background: rgba(255,255,255,.08); }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -10,6 +10,7 @@ import useUser from '../../../hooks/useUser';
 import { SKILLS } from "../skillSchema";
 import { STATS } from "../statSchema";
 import { notify } from '../../../utils/notification';
+import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 
 const DEFAULT_SIZE_OPTIONS = ["Tiny", "Small", "Medium", "Large"];
 
@@ -92,7 +93,9 @@ const CharacterCard = ({ character, onContinue }) => {
   const name = character?.characterName || "Unnamed Hero";
   const race = character?.race?.name || character?.race || "Unknown Lineage";
   const background = character?.background?.name || character?.background || "Unwritten Legend";
-  const health = character?.health || character?.maxHealth || character?.hp;
+  const { currentHp, maxHp } = calculateCharacterHitPoints(character);
+  const health = currentHp !== null ? currentHp : character?.hp ?? null;
+  const healthLabel = health !== null && maxHp !== null ? `${health} / ${maxHp}` : health;
   return (
     <article className="character-select-card">
       <CharacterPortrait character={character} />
@@ -108,7 +111,7 @@ const CharacterCard = ({ character, onContinue }) => {
         <CharacterStats character={character} />
         <div className="character-select-card__meta">
           <span>Status <strong>Ready</strong></span>
-          {health && <span>HP <strong>{health}</strong></span>}
+          {healthLabel !== null && healthLabel !== undefined && <span>HP <strong>{healthLabel}</strong></span>}
           <span>Last played <strong>{formatCharacterDate(character?.lastPlayed || character?.updatedAt)}</strong></span>
         </div>
       </div>
@@ -322,8 +325,16 @@ export default function RecordList() {
     return;
   }, [params.campaign, user]);
 
-  const navigateToCharacter = (id) => {
-    navigate(`/zombies-character-sheet/${id}`);
+  const navigateToCharacter = async (id) => {
+    const lastPlayed = new Date().toISOString();
+    setRecords((prev) => prev.map((record) => (record._id === id ? { ...record, lastPlayed } : record)));
+    try {
+      await apiFetch(`/characters/${id}/last-played`, { method: 'PUT' });
+    } catch (error) {
+      // Navigating should not be blocked if this best-effort timestamp update fails.
+    } finally {
+      navigate(`/zombies-character-sheet/${id}`);
+    }
   }
 
 // --------------------------Random Character Creator Section------------------------------------

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -529,6 +529,31 @@ module.exports = (router) => {
     }
   });
 
+  characterRouter.route('/:id/last-played').put(async (req, res, next) => {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
+
+    const db_connect = req.db;
+    const lastPlayed = new Date().toISOString();
+
+    try {
+      const result = await db_connect.collection('Characters').findOneAndUpdate(
+        { _id: ObjectId(req.params.id) },
+        { $set: { lastPlayed } },
+        { returnDocument: 'after' }
+      );
+
+      if (!result.value) {
+        return res.status(404).json({ message: 'Character not found' });
+      }
+
+      res.json({ lastPlayed });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // This section will update level.
   characterRouter.route('/update-level/:id').put(
     [


### PR DESCRIPTION
### Motivation
- Improve the character library UX by making the `Continue Adventure` action visually full-width and easier to tap. 
- Ensure the card shows an accurate remaining HP value derived from the same calculation used elsewhere. 
- Record and display an accurate "Last played" timestamp when a player opens a character, using an optimistic update for smooth navigation.

### Description
- Updated layout CSS in `client/src/App.scss` to use a single-column action grid and set `.character-select-card__continue { width: 100%; }` so the Continue button spans the card. 
- Modified `client/src/components/Zombies/pages/ZombiesCharacterSelect.js` to import and use `calculateCharacterHitPoints` and display a `healthLabel` that shows current and max HP when available. 
- Changed `navigateToCharacter` to perform an optimistic update of the record's `lastPlayed` timestamp and send a best-effort `PUT /characters/:id/last-played` request before navigating. 
- Added a server route `PUT /characters/:id/last-played` in `server/routes/characters/base.js` that sets `lastPlayed` to the current ISO timestamp and returns it.

### Testing
- Ran the character HP unit tests with `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/utils/characterMetrics.test.js`, and the suite passed. 
- Built the client with `npm --prefix client run build`, which completed successfully (the build emitted unrelated autoprefixer/ESLint warnings but exited successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5795650c5c832eb84b0ad123e3d36c)