### PR TITLE
Update campaign hero to use RealmTracker logo and adjust mobile layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10208,9 +10208,11 @@ h1 {
   box-shadow: inset 0 0 4rem rgba(7, 12, 28, 0.75), 0 0 3rem rgba(89, 132, 255, 0.24);
 }
 
-.character-select-hero__art span { font-size: clamp(4rem, 9vw, 8rem); text-shadow: 0 0 2rem rgba(255,255,255,.65); }
+.character-select-hero__art img { width: min(66%, 220px); filter: drop-shadow(0 0 2rem rgba(255,255,255,.58)); }
 .character-select-kicker { color: #91b7ff; letter-spacing: .18em; text-transform: uppercase; font-size: .78rem; font-weight: 800; margin-bottom: .35rem; }
+.character-select-hero__title-row { display: flex; align-items: flex-start; gap: clamp(.75rem, 2vw, 1.25rem); }
 .character-select-hero h1 { font-size: clamp(2.4rem, 6vw, 5.7rem); line-height: .92; margin: 0 0 1rem; font-weight: 900; }
+.character-select-hero__mobile-logo { display: none; }
 .character-select-hero p, .character-select-create p, .character-select-empty p { color: rgba(230, 237, 255, 0.78); }
 .character-select-hero__facts { display: flex; flex-wrap: wrap; gap: .7rem; margin-top: 1.25rem; }
 .character-select-hero__facts span, .character-select-tools span, .character-select-card__chips span { border: 1px solid rgba(145,183,255,.22); background: rgba(10, 20, 45, .55); border-radius: 999px; padding: .45rem .75rem; color: rgba(238, 243, 255, .78); }
@@ -10261,7 +10263,11 @@ h1 {
 
 @media (max-width: 640px) {
   .character-select-page { padding: .75rem; }
-  .character-select-hero { border-radius: 24px; max-height: none; }
+  .character-select-hero { border-radius: 24px; max-height: none; padding-top: 1rem; }
+  .character-select-hero__art { display: none; }
+  .character-select-hero__title-row { align-items: center; justify-content: space-between; }
+  .character-select-hero__mobile-logo { display: block; flex: 0 0 auto; width: clamp(58px, 18vw, 86px); filter: drop-shadow(0 0 1.25rem rgba(145,183,255,.62)); }
+  .character-select-hero h1 { margin-bottom: .65rem; }
   .character-select-hero__facts span, .character-select-tools span { width: 100%; }
   .character-select-grid { grid-template-columns: 1fr; }
   .character-select-card { padding: 1.1rem; }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -5,6 +5,7 @@ import { Form, Modal, Card } from 'react-bootstrap';
 import { useParams, useNavigate } from "react-router-dom";
 import '../../../App.scss';
 import loginbg from "../../../images/loginbg.png";
+import logoLight from "../../../images/logo-light.png";
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import useUser from '../../../hooks/useUser';
 import { SKILLS } from "../skillSchema";
@@ -122,10 +123,13 @@ const CharacterCard = ({ character, onContinue }) => {
 
 const CampaignHero = ({ campaignName, playerCount, onCreateManual, onCreateRandom }) => (
   <section className="character-select-hero">
-    <div className="character-select-hero__art" aria-hidden="true"><span>✦</span></div>
+    <div className="character-select-hero__art" aria-hidden="true"><img src={logoLight} alt="" /></div>
     <div className="character-select-hero__content">
       <p className="character-select-kicker">RealmTracker Campaign</p>
-      <h1>{campaignName}</h1>
+      <div className="character-select-hero__title-row">
+        <h1>{campaignName}</h1>
+        <img className="character-select-hero__mobile-logo" src={logoLight} alt="" aria-hidden="true" />
+      </div>
       <p>Gather your party, choose the hero who will step through the portal, and continue the next chapter of the adventure.</p>
       <div className="character-select-hero__facts">
         <span>Dungeon Master <strong>{campaignName}</strong></span>


### PR DESCRIPTION
### Motivation
- Replace the decorative star on the campaign hero with the RealmTracker brand mark to match the login page and strengthen branding. 
- On small screens, move the logo to the right of the campaign name and reduce the top spacing so the campaign name and logo sit closer to the top of the viewport. 

### Description
- Imported `logo-light.png` and replaced the star glyph with an `<img>` in `client/src/components/Zombies/pages/ZombiesCharacterSelect.js` to show the RealmTracker logo in the hero art panel. 
- Added a second, mobile-only logo element next to the campaign title by wrapping the `h1` in a `.character-select-hero__title-row` and inserting an `<img className="character-select-hero__mobile-logo">`. 
- Updated `client/src/App.scss` to style the logo (`.character-select-hero__art img`), add `.character-select-hero__title-row`, hide the large art panel on small screens, show the mobile logo on small screens, and reduce top spacing and heading margins for mobile. 

### Testing
- Ran the unit tests with `npm test -- --watchAll=false --runTestsByPath src/components/Login/Login.test.js`, and the test suite passed. 
- Ran `npm run build`, which completed successfully; the build produced warnings (autoprefixer/browserlist notices and existing ESLint warnings) but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5798313f14832e8a68e05b6277ac4e)