### PR TITLE
Character select: show campaign DM, use logo art, and improve mobile layout

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10208,9 +10208,11 @@ h1 {
   box-shadow: inset 0 0 4rem rgba(7, 12, 28, 0.75), 0 0 3rem rgba(89, 132, 255, 0.24);
 }
 
-.character-select-hero__art span { font-size: clamp(4rem, 9vw, 8rem); text-shadow: 0 0 2rem rgba(255,255,255,.65); }
+.character-select-hero__art img { width: min(66%, 220px); filter: drop-shadow(0 0 2rem rgba(255,255,255,.58)); }
 .character-select-kicker { color: #91b7ff; letter-spacing: .18em; text-transform: uppercase; font-size: .78rem; font-weight: 800; margin-bottom: .35rem; }
+.character-select-hero__title-row { display: flex; align-items: flex-start; gap: clamp(.75rem, 2vw, 1.25rem); }
 .character-select-hero h1 { font-size: clamp(2.4rem, 6vw, 5.7rem); line-height: .92; margin: 0 0 1rem; font-weight: 900; }
+.character-select-hero__mobile-logo { display: none; }
 .character-select-hero p, .character-select-create p, .character-select-empty p { color: rgba(230, 237, 255, 0.78); }
 .character-select-hero__facts { display: flex; flex-wrap: wrap; gap: .7rem; margin-top: 1.25rem; }
 .character-select-hero__facts span, .character-select-tools span, .character-select-card__chips span { border: 1px solid rgba(145,183,255,.22); background: rgba(10, 20, 45, .55); border-radius: 999px; padding: .45rem .75rem; color: rgba(238, 243, 255, .78); }
@@ -10261,7 +10263,11 @@ h1 {
 
 @media (max-width: 640px) {
   .character-select-page { padding: .75rem; }
-  .character-select-hero { border-radius: 24px; max-height: none; }
+  .character-select-hero { border-radius: 24px; max-height: none; padding-top: 1rem; }
+  .character-select-hero__art { display: none; }
+  .character-select-hero__title-row { align-items: center; justify-content: space-between; }
+  .character-select-hero__mobile-logo { display: block; flex: 0 0 auto; width: clamp(58px, 18vw, 86px); filter: drop-shadow(0 0 1.25rem rgba(145,183,255,.62)); }
+  .character-select-hero h1 { margin-bottom: .65rem; }
   .character-select-hero__facts span, .character-select-tools span { width: 100%; }
   .character-select-grid { grid-template-columns: 1fr; }
   .character-select-card { padding: 1.1rem; }

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -5,6 +5,7 @@ import { Form, Modal, Card } from 'react-bootstrap';
 import { useParams, useNavigate } from "react-router-dom";
 import '../../../App.scss';
 import loginbg from "../../../images/loginbg.png";
+import logoLight from "../../../images/logo-light.png";
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import useUser from '../../../hooks/useUser';
 import { SKILLS } from "../skillSchema";
@@ -120,15 +121,18 @@ const CharacterCard = ({ character, onContinue }) => {
   );
 };
 
-const CampaignHero = ({ campaignName, playerCount, onCreateManual, onCreateRandom }) => (
+const CampaignHero = ({ campaignName, dmName, playerCount, onCreateManual, onCreateRandom }) => (
   <section className="character-select-hero">
-    <div className="character-select-hero__art" aria-hidden="true"><span>✦</span></div>
+    <div className="character-select-hero__art" aria-hidden="true"><img src={logoLight} alt="" /></div>
     <div className="character-select-hero__content">
       <p className="character-select-kicker">RealmTracker Campaign</p>
-      <h1>{campaignName}</h1>
+      <div className="character-select-hero__title-row">
+        <h1>{campaignName}</h1>
+        <img className="character-select-hero__mobile-logo" src={logoLight} alt="" aria-hidden="true" />
+      </div>
       <p>Gather your party, choose the hero who will step through the portal, and continue the next chapter of the adventure.</p>
       <div className="character-select-hero__facts">
-        <span>Dungeon Master <strong>{campaignName}</strong></span>
+        <span>Dungeon Master <strong>{dmName || "Unknown"}</strong></span>
         <span>Players <strong>{playerCount}</strong></span>
       </div>
     </div>
@@ -290,6 +294,7 @@ const CharacterCreationWizard = ({ form, updateForm, races, backgrounds, occupat
 export default function RecordList() {
   const params = useParams();
   const [records, setRecords] = useState([]);
+  const [dmName, setDmName] = useState("");
   const navigate = useNavigate();
   const user = useUser();
 
@@ -302,6 +307,28 @@ export default function RecordList() {
       document.documentElement.classList.remove("character-select-scroll-enabled");
     };
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+    async function getCampaign() {
+      const response = await apiFetch(`/campaigns/${params.campaign}`);
+
+      if (!response.ok) {
+        const message = `An error occurred: ${response.statusText}`;
+        notify(message);
+        return;
+      }
+
+      const campaign = await response.json();
+      setDmName(campaign?.dm || "");
+    }
+
+    getCampaign();
+
+    return;
+  }, [params.campaign, user]);
 
   useEffect(() => {
     if (!user) {
@@ -2247,6 +2274,7 @@ const getAvailableSkillOptions = (index) => {
       <div className="character-select-shell">
         <CampaignHero
           campaignName={params.campaign.toString()}
+          dmName={dmName}
           playerCount={records.length}
           onCreateManual={(e) => { e.preventDefault(); handleShow5(); }}
           onCreateRandom={(e) => { e.preventDefault(); bigMaff(); handleShow(); }}


### PR DESCRIPTION
### Motivation
- Replace the placeholder glyph in the campaign hero with the app logo and surface the campaign Dungeon Master name fetched from the API to make the hero header more informative and brand-aligned. 
- Improve mobile layout so the hero artwork is hidden on small viewports and a compact mobile logo is shown instead for better responsiveness. 

### Description
- Import `logoLight` and replace the decorative hero span with an `<img>` inside `.character-select-hero__art`, and add a compact `.character-select-hero__mobile-logo` used in the title row. 
- Add CSS rules for `.character-select-hero__art img`, `.character-select-hero__title-row`, `.character-select-hero__mobile-logo`, and mobile breakpoint changes that hide the large art, adjust spacing, and add `padding-top` for the hero on small screens. 
- Extend `CampaignHero` to accept a `dmName` prop and show `dmName || "Unknown"` for the Dungeon Master instead of repeating the campaign name. 
- Add `dmName` state and an effect in the record list to fetch `/campaigns/{campaign}` with `apiFetch` and set the DM name, then pass it into `CampaignHero`. 

### Testing
- Ran `npm run build` locally and the frontend built successfully. 
- Executed the existing test suite with `npm test` and all tests passed. 
- Ran `npm run lint` to validate styling and static checks and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5798313f14832e8a68e05b6277ac4e)