### PR TITLE
Show active map on Join Campaign cards; remove 5e eyebrow/badge

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10056,7 +10056,8 @@ h1 {
 .realm-campaign-card:active { transform: translateY(-1px) scale(0.985); }
 .realm-campaign-card--join { min-height: 220px; display: grid; grid-template-rows: 112px 1fr auto; gap: 14px; padding: 14px; }
 .realm-campaign-card--host { min-height: 138px; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 16px; padding: 20px; }
-.realm-campaign-card__art { display: grid; place-items: center; border-radius: 18px; background: radial-gradient(circle at 50% 35%, rgba(215, 180, 106, 0.2), rgba(56, 232, 255, 0.1) 42%, rgba(6, 12, 24, 0.86)); box-shadow: inset 0 0 0 1px rgba(143, 200, 255, 0.16); }
+.realm-campaign-card__art { display: grid; place-items: center; overflow: hidden; border-radius: 18px; background: radial-gradient(circle at 50% 35%, rgba(215, 180, 106, 0.2), rgba(56, 232, 255, 0.1) 42%, rgba(6, 12, 24, 0.86)); box-shadow: inset 0 0 0 1px rgba(143, 200, 255, 0.16); }
+.realm-campaign-card__art img { width: 100%; height: 100%; object-fit: cover; }
 .realm-campaign-card__art span { color: var(--realm-gold); font-size: 2rem; font-weight: 900; letter-spacing: 0.08em; text-shadow: 0 0 18px rgba(215, 180, 106, 0.32); }
 .realm-campaign-card__content { position: relative; z-index: 1; min-width: 0; display: grid; gap: 8px; }
 .realm-campaign-card h3 { margin: 0; font-size: clamp(1.18rem, 2.5vw, 1.7rem); font-weight: 900; line-height: 1.05; }

--- a/client/src/components/Zombies/components/CampaignModals.js
+++ b/client/src/components/Zombies/components/CampaignModals.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Button, Card, Form, Modal } from "react-bootstrap";
 import { Link } from "react-router-dom";
+import resolveMapImageSource from "../utils/mapImages";
 
 const getCampaignName = (campaign) => campaign?.campaignName || campaign?.name || "Untitled Realm";
 const getDungeonMaster = (campaign) => campaign?.dungeonMaster || campaign?.dm || campaign?.dmName || campaign?.owner || "Dungeon Master";
@@ -17,6 +18,14 @@ const getCharacterCount = (campaign) => {
 const getSessionCount = (campaign) => campaign?.sessions?.length || campaign?.sessionCount || 0;
 const getLastActive = (campaign) => campaign?.lastActive || campaign?.updatedAt || campaign?.lastOpened || "Awaiting first session";
 const campaignInitials = (name) => name.split(/\s+/).filter(Boolean).slice(0, 2).map((word) => word[0]).join("").toUpperCase() || "RT";
+const getActiveMapImage = (campaign) => {
+  const maps = Array.isArray(campaign?.maps) ? campaign.maps : [];
+  const activeMapId = typeof campaign?.activeMapId === "string" ? campaign.activeMapId.trim() : "";
+  const activeMap = activeMapId
+    ? maps.find((map) => map?.mapId === activeMapId || map?.id === activeMapId || map?.name === activeMapId)
+    : maps[0];
+  return resolveMapImageSource(activeMap);
+};
 
 function CampaignSearch({ value, onChange, placeholder }) {
   return (
@@ -106,17 +115,18 @@ export default function CampaignModals({
           <div className="realm-campaign-grid realm-campaign-grid--join">
             {filteredPlayerCampaigns.map((campaign) => {
               const name = getCampaignName(campaign);
+              const activeMapImage = getActiveMapImage(campaign);
               return (
                 <Link className="realm-campaign-card realm-campaign-card--join" key={name} to={`/zombies-character-select/${name}`} onClick={closeJoinCampaignModal}>
-                  <div className="realm-campaign-card__art" aria-hidden="true"><span>{campaignInitials(name)}</span></div>
+                  <div className="realm-campaign-card__art" aria-hidden="true">
+                    {activeMapImage ? <img src={activeMapImage} alt="" /> : <span>{campaignInitials(name)}</span>}
+                  </div>
                   <div className="realm-campaign-card__content">
-                    <span className="realm-campaign-card__eyebrow">D&D 5e · {getLastActive(campaign)}</span>
                     <h3>{name}</h3>
                     <p>{campaign?.description || `Run by ${getDungeonMaster(campaign)} with ${getPlayerCount(campaign)} players at the table.`}</p>
                     <div className="realm-campaign-card__meta">
                       <span>DM {getDungeonMaster(campaign)}</span>
                       <span>{getPlayerCount(campaign)} players</span>
-                      <span>5e</span>
                     </div>
                   </div>
                   <span className="realm-campaign-button realm-campaign-button--primary">Join</span>

--- a/client/src/components/Zombies/hooks/useCampaignActions.js
+++ b/client/src/components/Zombies/hooks/useCampaignActions.js
@@ -43,11 +43,23 @@ const normalizeCampaignSummaries = (campaigns) => {
           ? campaign.gameMode.trim()
           : null;
 
+      const maps = Array.isArray(campaign.maps)
+        ? campaign.maps.filter((map) => map && typeof map === "object")
+        : [];
+
+      const activeMapId =
+        typeof campaign.activeMapId === "string" &&
+        campaign.activeMapId.trim() !== ""
+          ? campaign.activeMapId.trim()
+          : null;
+
       return {
         campaignName,
         players,
         ...(dm ? { dm } : {}),
         ...(gameMode ? { gameMode } : {}),
+        ...(maps.length > 0 ? { maps } : {}),
+        ...(activeMapId ? { activeMapId } : {}),
       };
     })
     .filter(Boolean);

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -651,6 +651,12 @@ module.exports = (router) => {
       dm: 1,
       players: 1,
       gameMode: 1,
+      'maps.mapId': 1,
+      'maps.name': 1,
+      'maps.imageUrl': 1,
+      'maps.image': 1,
+      'maps.thumbnailUrl': 1,
+      activeMapId: 1,
     },
   };
 


### PR DESCRIPTION
### Motivation
- Clean up the Join Campaign cards by removing the static "D&D 5e · Awaiting first session" eyebrow and the bottom `5e` badge to make the UI less cluttered.
- Make the join card artwork more useful by showing the campaign's active map image (when present) instead of only campaign initials.
- Ensure the client receives minimal map metadata so the homepage can resolve and display the active map without fetching full campaign records.

### Description
- Replace the initials artwork in the join card with the campaign active map image when available, falling back to `campaignInitials` otherwise by adding `getActiveMapImage` and using `resolveMapImageSource` in `client/src/components/Zombies/components/CampaignModals.js`.
- Remove the eyebrow line that rendered `D&D 5e · {getLastActive(campaign)}` and drop the bottom `5e` badge from the join card metadata in `CampaignModals.js`.
- Extend the campaign normalization in `client/src/components/Zombies/hooks/useCampaignActions.js` to include `maps` and `activeMapId` when present so the homepage can render artwork without extra requests.
- Update the server-side campaign summary projection in `server/routes/campaigns.js` to include selected map fields (`maps.mapId`, `maps.name`, `maps.imageUrl`, `maps.image`, `maps.thumbnailUrl`) and `activeMapId` so summaries return the necessary image metadata.
- Add CSS to `client/src/App.scss` to allow images in `.realm-campaign-card__art` to fill the artwork area (`overflow: hidden;` plus `.realm-campaign-card__art img { object-fit: cover; }`).

### Testing
- Ran `npm test -- --runTestsByPath src/components/Zombies/utils/mapImages.test.js --watchAll=false` and the suite passed (`12 tests, 1 suite passed`).
- Ran `npm run build` for the client and the production build completed successfully (build produced expected artifacts; some existing lint/autoprefixer/browserlist warnings were reported but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a8b6acb4832ea775f4deb11e2199)