### PR TITLE
Fix dice overlay blocking map interaction

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8817,6 +8817,11 @@ h1 {
   pointer-events: none;
 }
 
+.zombies-character-sheet-layout--map-interaction-active #damageAmount,
+.zombies-character-sheet-layout--map-interaction-active #damageAmount.damage-roller--visible {
+  pointer-events: none;
+}
+
 #damageAmount.damage-roller--visible {
   display: flex;
   position: relative;


### PR DESCRIPTION
### Motivation
- The animated damage/dice roller surface could intercept pointer events after a roll and prevent map clicks and drags while the character sheet was in map-interaction mode.

### Description
- Add CSS rules to `client/src/App.scss` so that when `.zombies-character-sheet-layout--map-interaction-active` is present `#damageAmount` (including the visible damage roller) has `pointer-events: none`, preventing the dice overlay from blocking map interaction while preserving normal behavior outside that mode.

### Testing
- Ran `npm --prefix client run build` which completed successfully (with existing lint/autoprefixer warnings), and ran `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/PlayerTurnActions.test.js` which failed due to pre-existing `PlayerTurnActions` expectation failures unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57bb0c39fc832e916f28a9c912d7b6)