### PR TITLE
Fix attack modal scrolling

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -2669,12 +2669,19 @@ const isDamageRollResultVisible = hasDamageRoll && !isDiceRollPending;
       />
 {/* Attack Modal */}
 
-      <Modal size="lg" className="dnd-modal modern-modal" centered show={showAttack} onHide={handleCloseAttack}>
+      <Modal
+        size="lg"
+        className="dnd-modal modern-modal"
+        centered
+        scrollable
+        show={showAttack}
+        onHide={handleCloseAttack}
+      >
         <Card className="modern-card">
           <Card.Header className="modal-header">
             <Card.Title className="modal-title">Attacks</Card.Title>
           </Card.Header>
-          <Card.Body>
+          <Card.Body className="modal-body attack-modal__body">
             <Card.Title className="modal-title">Weapons</Card.Title>
             <div className="attack-card-grid">
               {equippedWeapons.length === 0 ? (


### PR DESCRIPTION
### Motivation
- The attack modal could not scroll on desktop or mobile, making long weapon or spell lists unreachable inside the modal viewport.

### Description
- Enable React-Bootstrap scrolling by adding the `scrollable` prop to the attack `<Modal>`.
- Add the `modal-body` hook class to the modal `Card.Body` (also added `attack-modal__body`) so the existing modal overflow and mobile-scroll CSS applies to weapons, breath attacks, and spells.

### Testing
- Ran the focused test for the modal rendering: `cd client && npm test -- --runTestsByPath src/components/Zombies/attributes/PlayerTurnActions.test.js --testNamePattern="renders fiendish legacy damaging spells and rolls on click" --watchAll=false`, which passed.
- Ran the full `PlayerTurnActions` test file: `cd client && npm test -- --runTestsByPath src/components/Zombies/attributes/PlayerTurnActions.test.js --watchAll=false`, which currently reports 12 failed, 41 passed (53 total) — these failures are in pre-existing damage/spell assertions and are unrelated to the scrollability change.
- Verified no lint/diff issues after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57be8ca958832eb28c65dd68f4622d)