### PR TITLE
Fix mobile map zoom and health drag gestures

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -8628,13 +8628,18 @@ h1 {
   }
 }
 
-/* Allow mobile pinch gestures to reach the map/background instead of being fully suppressed by legacy touch-action rules. */
+/* Keep map zoom gestures inside the custom map handlers instead of allowing viewport pinch zoom. */
 .map-modal-background__board,
 .map-modal-background__board-inner,
 .campaign-map-board,
 .campaign-map-board__stage,
 .campaign-map-board__tokens-layer {
-  touch-action: pinch-zoom;
+  touch-action: none;
+}
+
+.footer-character-slot__health-inline {
+  touch-action: none;
+  user-select: none;
 }
 
 /* Mobile resource drawer/damage polish. */

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -263,6 +263,10 @@ const FooterCharacterSlot = ({
         return;
       }
 
+      if (typeof event?.preventDefault === 'function') {
+        event.preventDefault();
+      }
+
       dragStateRef.current = {
         pointerId: event.pointerId,
         startX: event.clientX,
@@ -281,6 +285,10 @@ const FooterCharacterSlot = ({
       const dragState = dragStateRef.current;
       if (!dragState || dragState.pointerId !== event.pointerId) {
         return;
+      }
+
+      if (typeof event?.preventDefault === 'function') {
+        event.preventDefault();
       }
 
       const delta = Math.round((event.clientX - dragState.startX) / 8);
@@ -302,6 +310,10 @@ const FooterCharacterSlot = ({
         return;
       }
 
+      if (typeof event?.preventDefault === 'function') {
+        event.preventDefault();
+      }
+
       dragStateRef.current = null;
       event.currentTarget.releasePointerCapture?.(event.pointerId);
       delete event.currentTarget.dataset.dragging;
@@ -320,6 +332,10 @@ const FooterCharacterSlot = ({
       const dragState = dragStateRef.current;
       if (!dragState || dragState.pointerId !== event.pointerId) {
         return;
+      }
+
+      if (typeof event?.preventDefault === 'function') {
+        event.preventDefault();
       }
 
       dragStateRef.current = null;


### PR DESCRIPTION
### Motivation

- Prevent the browser viewport from pinching/zooming when interacting with in-app map controls so only the map zoom is handled by the app.
- Make the footer health readout draggable on mobile the same way it works on desktop by ensuring touch/pointer events don’t trigger native browser gestures.

### Description

- Update `client/src/App.scss` to set `touch-action: none` on map surface selectors so pinch gestures are routed to the app’s custom handlers instead of the viewport. 
- Add `touch-action: none` and `user-select: none` for `.footer-character-slot__health-inline` in `client/src/App.scss` to disable native touch selection/scrolling while dragging the HP control.
- Add calls to `event.preventDefault()` in `handleHealthDragStart`, `handleHealthDragMove`, `finishHealthDrag`, and `cancelHealthDrag` in `client/src/components/Zombies/pages/components/FooterCharacterSlot.js` so pointer drag interactions do not invoke native browser touch behavior while dragging.

### Testing

- Ran `npm --prefix client test -- --watchAll=false CampaignMapBoard.test.js` and the suite passed (`13` tests passed). 
- Searched for tests matching `FooterCharacterSlot` and none were found, so no unit tests ran for the updated health drag handlers. 
- Performed a production build with `npm run build`, which completed successfully (build warnings pre-existed and were not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57c44ecd80832e8b53760792b978fe)