### PR TITLE
Update host campaign card metadata

### DIFF
--- a/client/src/components/Zombies/components/CampaignModals.js
+++ b/client/src/components/Zombies/components/CampaignModals.js
@@ -10,12 +10,6 @@ const getPlayerCount = (campaign) => {
   if (typeof campaign?.playerCount === "number") return campaign.playerCount;
   return 0;
 };
-const getCharacterCount = (campaign) => {
-  if (Array.isArray(campaign?.characters)) return campaign.characters.length;
-  if (typeof campaign?.characterCount === "number") return campaign.characterCount;
-  return getPlayerCount(campaign);
-};
-const getSessionCount = (campaign) => campaign?.sessions?.length || campaign?.sessionCount || 0;
 const campaignInitials = (name) => name.split(/\s+/).filter(Boolean).slice(0, 2).map((word) => word[0]).join("").toUpperCase() || "RT";
 const getActiveMapImage = (campaign) => {
   const maps = Array.isArray(campaign?.maps) ? campaign.maps : [];
@@ -163,7 +157,7 @@ export default function CampaignModals({
                   <div className="realm-campaign-card__content">
                     <h3>{name}</h3>
                     <div className="realm-campaign-card__meta realm-campaign-card__meta--launcher">
-                      <span>DM badge</span><span>{campaign?.status || "Ready"}</span><span>{getCharacterCount(campaign)} characters</span><span>{getSessionCount(campaign)} sessions</span>
+                      <span>DM badge</span><span>{getPlayerCount(campaign)} players</span>
                     </div>
                   </div>
                   <span className="realm-campaign-button realm-campaign-button--primary">Host</span>


### PR DESCRIPTION
### Motivation
- Host campaign cards should not show the `Ready` status pill or session counts and must display player counts (number of players) rather than character totals.

### Description
- Removed `getCharacterCount` and `getSessionCount` usages from `client/src/components/Zombies/components/CampaignModals.js` and simplified the host card metadata.
- Replaced the metadata line to render the DM badge and player count via `getPlayerCount(campaign)` instead of showing status, character count, and sessions.
- Kept join-campaign card behavior unchanged and reused the existing `getPlayerCount` helper for correctness.

### Testing
- Ran the component test command `CI=true npm --prefix client test -- --runInBand --watchAll=false client/src/components/Zombies/components/CampaignModals.js`, which found no matching test file (no tests run).
- Built the client with `npm --prefix client run build`, which completed successfully (production build created) with unrelated lint/autoprefixer warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57df228c70832e9379ddd87c845ae1)