### PR TITLE
Remove campaign artwork slot from Create Campaign modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10084,9 +10084,7 @@ h1 {
 .realm-campaign-empty__sigil { width: 78px; height: 78px; display: grid; place-items: center; color: var(--realm-cyan); border-radius: 24px; background: rgba(56, 232, 255, 0.08); box-shadow: inset 0 0 0 1px rgba(56, 232, 255, 0.24), 0 0 32px rgba(56, 232, 255, 0.15); font-size: 2.2rem; }
 .realm-campaign-empty h3 { margin: 0; color: var(--hud-text); font-weight: 900; }
 .realm-campaign-empty p { max-width: 420px; margin: 0; }
-.realm-create-campaign-form { display: grid; grid-template-columns: minmax(190px, 0.42fr) minmax(0, 1fr); gap: 24px; align-items: stretch; }
-.realm-create-campaign-form__art { min-height: 250px; display: grid; place-items: center; align-content: center; gap: 12px; color: var(--hud-muted); border-radius: 24px; background: radial-gradient(circle at 50% 35%, rgba(215, 180, 106, 0.18), rgba(56, 232, 255, 0.09) 44%, rgba(6, 12, 24, 0.82)); box-shadow: inset 0 0 0 1px rgba(143, 200, 255, 0.16); }
-.realm-create-campaign-form__art span { width: 62px; height: 62px; display: grid; place-items: center; color: var(--realm-cyan); border-radius: 20px; background: rgba(56, 232, 255, 0.08); font-size: 2rem; }
+.realm-create-campaign-form { display: grid; gap: 24px; }
 .realm-create-campaign-form__fields { display: grid; align-content: center; gap: 16px; }
 .realm-floating-field { position: relative; display: block; }
 .realm-floating-field input { width: 100%; min-height: 64px; padding: 24px 18px 10px; color: var(--hud-text); border: 1px solid rgba(143, 200, 255, 0.22); border-radius: 18px; background: rgba(255,255,255,0.06); outline: 0; box-shadow: inset 0 1px 0 rgba(255,255,255,0.05); transition: border-color 180ms ease, box-shadow 180ms ease; }
@@ -10097,7 +10095,7 @@ h1 {
 .realm-create-campaign-form__actions { display: flex; flex-wrap: wrap; gap: 12px; }
 @keyframes realmCampaignModalEnter { from { opacity: 0; transform: translateY(18px) scale(0.98); } to { opacity: 1; transform: translateY(0) scale(1); } }
 @keyframes realmCampaignCardIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
-@media (max-width: 760px) { .realm-campaign-grid { --realm-campaign-card-width: 1fr; } .realm-campaign-modal__dialog { width: 100vw; max-width: 100vw; min-height: 100dvh; margin: 0; } .realm-campaign-modal .modal-content, .realm-campaign-panel { min-height: 100dvh; border-radius: 0; } .realm-campaign-panel { padding: max(18px, env(safe-area-inset-top)) 16px max(18px, env(safe-area-inset-bottom)); } .realm-campaign-toolbar { align-items: stretch; flex-direction: column; gap: 10px; } .realm-campaign-grid { max-height: none; overflow: visible; } .realm-campaign-card--host { grid-template-columns: 1fr; align-items: stretch; } .realm-create-campaign-form { grid-template-columns: 1fr; gap: 16px; } .realm-create-campaign-form__art { min-height: 150px; } .realm-create-campaign-form__actions .realm-campaign-button { width: 100%; } }
+@media (max-width: 760px) { .realm-campaign-grid { --realm-campaign-card-width: 1fr; } .realm-campaign-modal__dialog { width: 100vw; max-width: 100vw; min-height: 100dvh; margin: 0; } .realm-campaign-modal .modal-content, .realm-campaign-panel { min-height: 100dvh; border-radius: 0; } .realm-campaign-panel { padding: max(18px, env(safe-area-inset-top)) 16px max(18px, env(safe-area-inset-bottom)); } .realm-campaign-toolbar { align-items: stretch; flex-direction: column; gap: 10px; } .realm-campaign-grid { max-height: none; overflow: visible; } .realm-campaign-card--host { grid-template-columns: 1fr; align-items: stretch; } .realm-create-campaign-form { gap: 16px; } .realm-create-campaign-form__actions .realm-campaign-button { width: 100%; } }
 @media (max-width: 420px) { .realm-campaign-card--join { grid-template-rows: 88px 1fr auto; } .realm-campaign-card__meta span { font-size: 0.76rem; } .realm-campaign-panel__header h2 { font-size: 2rem; } }
 
 /* Mobile launcher tuning: compact toolbar and reliable full-sheet scrolling. */

--- a/client/src/components/Zombies/components/CampaignModals.js
+++ b/client/src/components/Zombies/components/CampaignModals.js
@@ -175,10 +175,9 @@ export default function CampaignModals({
         onHide={closeCreateCampaignModal}
         eyebrow="New Realm Setup"
         title="Create Campaign"
-        subtitle="Name the world now. Artwork, player invites, and launch options can grow here next."
+        subtitle="Name the world now. Player invites and launch options can grow here next."
       >
         <Form onSubmit={submitCreateCampaign} className="realm-create-campaign-form">
-          <div className="realm-create-campaign-form__art" aria-hidden="true"><span>+</span><strong>Artwork slot</strong></div>
           <div className="realm-create-campaign-form__fields">
             <label className="realm-floating-field">
               <input onChange={(e) => updateCreateCampaignForm({ campaignName: e.target.value })} type="text" value={createCampaignForm.campaignName} placeholder=" " />


### PR DESCRIPTION
### Motivation
- The create-campaign modal previously included an artwork placeholder and referenced artwork in the subtitle even though images will not be added.
- Remove the unused artwork UI so the form is simpler and focused on the campaign name and launch options.

### Description
- Remove the artwork placeholder element from the Create Campaign modal in `client/src/components/Zombies/components/CampaignModals.js` and update the modal subtitle to no longer mention artwork.
- Simplify the create campaign form layout by removing the two-column/grid artwork column and making the form single-column in `client/src/App.scss`.
- Remove related artwork-specific CSS rules and adjust the mobile media query so the form layout remains correct without the artwork slot.

### Testing
- Ran `npm --prefix client run build`, which completed successfully (build produced standard lint/autoprefixer warnings but no failures).
- Ran `git diff --check` which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e122ad78832e8ee9ec6f2ade28cb)