### PR TITLE
Load hosted campaigns on home page

### DIFF
--- a/client/src/components/Zombies/hooks/useCampaignActions.js
+++ b/client/src/components/Zombies/hooks/useCampaignActions.js
@@ -155,8 +155,8 @@ export default function useCampaignActions() {
   }, [navigate, username]);
 
   useEffect(() => {
-    fetchPlayerCampaigns();
-  }, [fetchPlayerCampaigns]);
+    Promise.all([fetchPlayerCampaigns(), fetchDmCampaigns()]);
+  }, [fetchDmCampaigns, fetchPlayerCampaigns]);
 
   const updateCreateCampaignForm = useCallback((value) => {
     setCreateCampaignForm((prev) => ({ ...prev, ...value }));


### PR DESCRIPTION
### Motivation
- The hosted realms count on the home page was not populated until opening the Host Campaign modal, so both player and DM campaign lists should be fetched when the home page initializes.

### Description
- In `client/src/components/Zombies/hooks/useCampaignActions.js` the mount `useEffect` now runs `Promise.all([fetchPlayerCampaigns(), fetchDmCampaigns()])` and the effect dependency array was updated to include `fetchDmCampaigns` so hosted campaign counts appear on page load.

### Testing
- Ran `npm --prefix client test -- --watchAll=false`; the test run completed but reported failures in pre-existing/unrelated suites including `WeaponList.test.js`, `ZombiesDM.test.js`, `ItemList.test.js`, and `ActiveEnemyQuickList.test.js`, while the remaining suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e33174b0832e95770f1a1f450034)