### PR TITLE
Track and sort recent campaign access

### DIFF
--- a/client/src/components/Zombies/hooks/useCampaignActions.js
+++ b/client/src/components/Zombies/hooks/useCampaignActions.js
@@ -53,6 +53,22 @@ const normalizeCampaignSummaries = (campaigns) => {
           ? campaign.activeMapId.trim()
           : null;
 
+      const recentAccess = Array.isArray(campaign.recentAccess)
+        ? campaign.recentAccess
+            .filter((entry) => entry && typeof entry === "object")
+            .map((entry) => ({
+              username:
+                typeof entry.username === "string"
+                  ? entry.username.trim()
+                  : "",
+              lastAccessedAt:
+                typeof entry.lastAccessedAt === "string"
+                  ? entry.lastAccessedAt.trim()
+                  : "",
+            }))
+            .filter((entry) => entry.username && entry.lastAccessedAt)
+        : [];
+
       return {
         campaignName,
         players,
@@ -60,6 +76,7 @@ const normalizeCampaignSummaries = (campaigns) => {
         ...(gameMode ? { gameMode } : {}),
         ...(maps.length > 0 ? { maps } : {}),
         ...(activeMapId ? { activeMapId } : {}),
+        ...(recentAccess.length > 0 ? { recentAccess } : {}),
       };
     })
     .filter(Boolean);

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -8,6 +8,36 @@ import logoLight from "../../../images/logo-light.png";
 
 const getCampaignTitle = (campaign) => campaign?.campaignName || "Untitled Realm";
 
+const getUserLastAccessedAt = (campaign, username) => {
+  if (!username || !Array.isArray(campaign?.recentAccess)) {
+    return null;
+  }
+
+  const accessEntry = campaign.recentAccess.find((entry) => entry?.username === username);
+  return typeof accessEntry?.lastAccessedAt === "string" ? accessEntry.lastAccessedAt : null;
+};
+
+const getAccessTimestamp = (lastAccessedAt) => {
+  if (!lastAccessedAt) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(lastAccessedAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+const formatLastAccessed = (lastAccessedAt) => {
+  const timestamp = getAccessTimestamp(lastAccessedAt);
+  if (!timestamp) {
+    return "Not opened yet";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+};
+
 function HomeActionCard({ icon, title, description, meta, onClick, featured = false }) {
   return (
     <button
@@ -26,7 +56,9 @@ function HomeActionCard({ icon, title, description, meta, onClick, featured = fa
   );
 }
 
-function RecentCampaignCard({ campaign, role, onResume }) {
+function RecentCampaignCard({ campaign, role, lastAccessedAt, onResume }) {
+  const lastAccessedLabel = formatLastAccessed(lastAccessedAt);
+
   return (
     <article className="realm-recent-campaign-card">
       <div className="realm-recent-campaign-card__art" aria-hidden="true">
@@ -35,7 +67,7 @@ function RecentCampaignCard({ campaign, role, onResume }) {
       <div className="realm-recent-campaign-card__body">
         <span className="realm-recent-campaign-card__eyebrow">{role === "dm" ? "Dungeon Master" : "Adventurer"}</span>
         <h3>{getCampaignTitle(campaign)}</h3>
-        <p>DM {campaign?.dm || "Unknown"} · Last opened recently</p>
+        <p>DM {campaign?.dm || "Unknown"} · Last opened {lastAccessedLabel}</p>
       </div>
       <button type="button" className="realm-recent-campaign-card__resume" onClick={onResume}>
         Resume
@@ -98,16 +130,35 @@ export default function Zombies() {
 
   const username = createCampaignForm.dm;
   const recentCampaigns = useMemo(() => {
-    const hosted = dmCampaigns.map((campaign) => ({ campaign, role: "dm" }));
-    const joined = playerCampaigns.map((campaign) => ({ campaign, role: "player" }));
-    return [...hosted, ...joined].slice(0, 3);
-  }, [dmCampaigns, playerCampaigns]);
+    const hosted = dmCampaigns.map((campaign) => ({
+      campaign,
+      role: "dm",
+      lastAccessedAt: getUserLastAccessedAt(campaign, username),
+    }));
+    const joined = playerCampaigns.map((campaign) => ({
+      campaign,
+      role: "player",
+      lastAccessedAt: getUserLastAccessedAt(campaign, username),
+    }));
+
+    return [...hosted, ...joined]
+      .sort((a, b) => getAccessTimestamp(b.lastAccessedAt) - getAccessTimestamp(a.lastAccessedAt))
+      .slice(0, 3);
+  }, [dmCampaigns, playerCampaigns, username]);
 
   const campaignCount = dmCampaigns.length + playerCampaigns.length;
   const characterCount = playerCampaigns.length;
 
-  const resumeCampaign = (campaign, role) => {
-    const encodedCampaign = encodeURIComponent(getCampaignTitle(campaign));
+  const resumeCampaign = async (campaign, role) => {
+    const campaignTitle = getCampaignTitle(campaign);
+    const encodedCampaign = encodeURIComponent(campaignTitle);
+
+    try {
+      await apiFetch(`/campaigns/${encodedCampaign}/access`, { method: "PUT" });
+    } catch (error) {
+      // Access tracking should not block users from entering their campaign.
+    }
+
     navigate(role === "dm" ? `/zombies-dm/${encodedCampaign}` : `/zombies-character-select/${encodedCampaign}`);
   };
 
@@ -154,11 +205,12 @@ export default function Zombies() {
             </div>
             {recentCampaigns.length > 0 ? (
               <div className="realm-home-recent__list">
-                {recentCampaigns.map(({ campaign, role }) => (
+                {recentCampaigns.map(({ campaign, role, lastAccessedAt }) => (
                   <RecentCampaignCard
                     key={`${role}-${getCampaignTitle(campaign)}`}
                     campaign={campaign}
                     role={role}
+                    lastAccessedAt={lastAccessedAt}
                     onResume={() => resumeCampaign(campaign, role)}
                   />
                 ))}

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -352,6 +352,78 @@ describe('Campaign routes', () => {
     );
   });
 
+  test('create campaign initializes recent access tracking', async () => {
+    const insertOne = jest.fn().mockResolvedValue({ acknowledged: true });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        insertOne,
+      }),
+    });
+
+    await request(app)
+      .post('/campaigns/add')
+      .send({ campaignName: 'Test', dm: 'DM' });
+
+    expect(insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recentAccess: [],
+      })
+    );
+  });
+
+  test('records campaign access for current user', async () => {
+    const updateOne = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: jest.fn().mockResolvedValue({
+          campaignName: 'Test',
+          dm: 'DM',
+          players: ['Player'],
+          recentAccess: [{ username: 'Player', lastAccessedAt: '2024-01-01T00:00:00.000Z' }],
+        }),
+        updateOne,
+      }),
+    });
+
+    const res = await request(app).put('/campaigns/Test/access');
+
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe('DM');
+    expect(Date.parse(res.body.lastAccessedAt)).not.toBeNaN();
+    expect(updateOne).toHaveBeenCalledWith(
+      { campaignName: 'Test' },
+      {
+        $set: {
+          recentAccess: expect.arrayContaining([
+            { username: 'Player', lastAccessedAt: '2024-01-01T00:00:00.000Z' },
+            { username: 'DM', lastAccessedAt: expect.any(String) },
+          ]),
+        },
+      }
+    );
+  });
+
+  test('rejects campaign access tracking for non-members', async () => {
+    mockUser = { username: 'Stranger' };
+    const updateOne = jest.fn();
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: jest.fn().mockResolvedValue({
+          campaignName: 'Test',
+          dm: 'DM',
+          players: ['Player'],
+          recentAccess: [],
+        }),
+        updateOne,
+      }),
+    });
+
+    const res = await request(app).put('/campaigns/Test/access');
+
+    expect(res.status).toBe(403);
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+
   test('create campaign failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -657,6 +657,7 @@ module.exports = (router) => {
       'maps.image': 1,
       'maps.thumbnailUrl': 1,
       activeMapId: 1,
+      recentAccess: 1,
     },
   };
 
@@ -1564,6 +1565,51 @@ module.exports = (router) => {
       }
     );
 
+  campaignRouter.route('/:campaign/access').put(
+    [param('campaign').trim().notEmpty().withMessage('campaign is required')],
+    handleValidationErrors,
+    async (req, res, next) => {
+      try {
+        const username = typeof req.user?.username === 'string' ? req.user.username.trim() : '';
+        if (!username) {
+          return res.status(401).json({ message: 'Unauthorized' });
+        }
+
+        const campaignName = req.params.campaign;
+        const collection = req.db.collection('Campaigns');
+        const campaign = await collection.findOne(
+          { campaignName },
+          { projection: { dm: 1, players: 1, recentAccess: 1 } }
+        );
+
+        if (!campaign) {
+          return res.status(404).json({ message: 'Campaign not found' });
+        }
+
+        const isDm = campaign.dm === username;
+        const isPlayer = Array.isArray(campaign.players) && campaign.players.includes(username);
+        if (!isDm && !isPlayer) {
+          return res.status(403).json({ message: 'Forbidden' });
+        }
+
+        const lastAccessedAt = new Date().toISOString();
+        const recentAccess = Array.isArray(campaign.recentAccess)
+          ? campaign.recentAccess.filter((entry) => entry && entry.username !== username)
+          : [];
+        recentAccess.push({ username, lastAccessedAt });
+
+        await collection.updateOne(
+          { campaignName },
+          { $set: { recentAccess } }
+        );
+
+        return res.json({ username, lastAccessedAt });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
   // This section will create a new campaign.
   campaignRouter.route('/add').post(async (req, response, next) => {
     const db_connect = req.db;
@@ -1578,6 +1624,7 @@ module.exports = (router) => {
       mapTokens: {},
       combat: createDefaultCombatState(),
       enemies: [],
+      recentAccess: [],
     };
     try {
       const result = await db_connect.collection("Campaigns").insertOne(myobj);


### PR DESCRIPTION
### Motivation

- Surface a per-user "last opened" timestamp for campaigns so the Recent Campaigns list shows when the logged-in user last accessed each campaign and can be sorted by recency.

### Description

- Server: include `recentAccess` in campaign summary projection, initialize `recentAccess: []` when creating a campaign, and add a protected `PUT /campaigns/:campaign/access` endpoint that verifies the requester is the DM or a player and records an ISO `lastAccessedAt` timestamp for that user.
- Client: validate and include `recentAccess` in `normalizeCampaignSummaries` (`useCampaignActions`), add helpers in `Zombies.js` to read/format per-user last-access times, display "Last opened <date/time>" in `RecentCampaignCard`, sort hosted+joined campaigns by the current user’s access timestamp, and call the new access endpoint before navigating into a campaign.
- Tests: add server unit tests in `server/__tests__/campaigns.test.js` that assert new campaigns initialize `recentAccess`, that access is recorded for a member, and that access tracking is rejected for non-members.

### Testing

- Ran `npm run build` (client) which completed successfully; build emitted existing lint/browserlist warnings but produced a build.
- Ran the server campaign tests with `npm --prefix server test -- --runInBand __tests__/campaigns.test.js`; the new `recentAccess` tests passed, but the full suite failed due to an existing unrelated test (`player controlling active participant can pass turn`) returning HTTP 500 instead of 200. The failure is pre-existing and not caused by the recent-access changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e5941c7c832eb716a38913177e3e)