### PR TITLE
Track recent campaign access per user/role and show last-opened timestamps

### DIFF
--- a/client/src/components/Zombies/hooks/useCampaignActions.js
+++ b/client/src/components/Zombies/hooks/useCampaignActions.js
@@ -53,6 +53,26 @@ const normalizeCampaignSummaries = (campaigns) => {
           ? campaign.activeMapId.trim()
           : null;
 
+      const recentAccess = Array.isArray(campaign.recentAccess)
+        ? campaign.recentAccess
+            .filter((entry) => entry && typeof entry === "object")
+            .map((entry) => ({
+              username:
+                typeof entry.username === "string"
+                  ? entry.username.trim()
+                  : "",
+              role:
+                entry.role === "dm" || entry.role === "player"
+                  ? entry.role
+                  : "",
+              lastAccessedAt:
+                typeof entry.lastAccessedAt === "string"
+                  ? entry.lastAccessedAt.trim()
+                  : "",
+            }))
+            .filter((entry) => entry.username && entry.role && entry.lastAccessedAt)
+        : [];
+
       return {
         campaignName,
         players,
@@ -60,6 +80,7 @@ const normalizeCampaignSummaries = (campaigns) => {
         ...(gameMode ? { gameMode } : {}),
         ...(maps.length > 0 ? { maps } : {}),
         ...(activeMapId ? { activeMapId } : {}),
+        ...(recentAccess.length > 0 ? { recentAccess } : {}),
       };
     })
     .filter(Boolean);

--- a/client/src/components/Zombies/pages/Zombies.js
+++ b/client/src/components/Zombies/pages/Zombies.js
@@ -8,6 +8,36 @@ import logoLight from "../../../images/logo-light.png";
 
 const getCampaignTitle = (campaign) => campaign?.campaignName || "Untitled Realm";
 
+const getUserLastAccessedAt = (campaign, username, role) => {
+  if (!username || !role || !Array.isArray(campaign?.recentAccess)) {
+    return null;
+  }
+
+  const accessEntry = campaign.recentAccess.find((entry) => entry?.username === username && entry?.role === role);
+  return typeof accessEntry?.lastAccessedAt === "string" ? accessEntry.lastAccessedAt : null;
+};
+
+const getAccessTimestamp = (lastAccessedAt) => {
+  if (!lastAccessedAt) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(lastAccessedAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+const formatLastAccessed = (lastAccessedAt) => {
+  const timestamp = getAccessTimestamp(lastAccessedAt);
+  if (!timestamp) {
+    return "Not opened yet";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+};
+
 function HomeActionCard({ icon, title, description, meta, onClick, featured = false }) {
   return (
     <button
@@ -26,7 +56,9 @@ function HomeActionCard({ icon, title, description, meta, onClick, featured = fa
   );
 }
 
-function RecentCampaignCard({ campaign, role, onResume }) {
+function RecentCampaignCard({ campaign, role, lastAccessedAt, onResume }) {
+  const lastAccessedLabel = formatLastAccessed(lastAccessedAt);
+
   return (
     <article className="realm-recent-campaign-card">
       <div className="realm-recent-campaign-card__art" aria-hidden="true">
@@ -35,7 +67,7 @@ function RecentCampaignCard({ campaign, role, onResume }) {
       <div className="realm-recent-campaign-card__body">
         <span className="realm-recent-campaign-card__eyebrow">{role === "dm" ? "Dungeon Master" : "Adventurer"}</span>
         <h3>{getCampaignTitle(campaign)}</h3>
-        <p>DM {campaign?.dm || "Unknown"} · Last opened recently</p>
+        <p>DM {campaign?.dm || "Unknown"} · Last opened {lastAccessedLabel}</p>
       </div>
       <button type="button" className="realm-recent-campaign-card__resume" onClick={onResume}>
         Resume
@@ -98,16 +130,39 @@ export default function Zombies() {
 
   const username = createCampaignForm.dm;
   const recentCampaigns = useMemo(() => {
-    const hosted = dmCampaigns.map((campaign) => ({ campaign, role: "dm" }));
-    const joined = playerCampaigns.map((campaign) => ({ campaign, role: "player" }));
-    return [...hosted, ...joined].slice(0, 3);
-  }, [dmCampaigns, playerCampaigns]);
+    const hosted = dmCampaigns.map((campaign) => ({
+      campaign,
+      role: "dm",
+      lastAccessedAt: getUserLastAccessedAt(campaign, username, "dm"),
+    }));
+    const joined = playerCampaigns.map((campaign) => ({
+      campaign,
+      role: "player",
+      lastAccessedAt: getUserLastAccessedAt(campaign, username, "player"),
+    }));
+
+    return [...hosted, ...joined]
+      .sort((a, b) => getAccessTimestamp(b.lastAccessedAt) - getAccessTimestamp(a.lastAccessedAt))
+      .slice(0, 3);
+  }, [dmCampaigns, playerCampaigns, username]);
 
   const campaignCount = dmCampaigns.length + playerCampaigns.length;
   const characterCount = playerCampaigns.length;
 
-  const resumeCampaign = (campaign, role) => {
-    const encodedCampaign = encodeURIComponent(getCampaignTitle(campaign));
+  const resumeCampaign = async (campaign, role) => {
+    const campaignTitle = getCampaignTitle(campaign);
+    const encodedCampaign = encodeURIComponent(campaignTitle);
+
+    try {
+      await apiFetch(`/campaigns/${encodedCampaign}/access`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: role === "dm" ? "dm" : "player" }),
+      });
+    } catch (error) {
+      // Access tracking should not block users from entering their campaign.
+    }
+
     navigate(role === "dm" ? `/zombies-dm/${encodedCampaign}` : `/zombies-character-select/${encodedCampaign}`);
   };
 
@@ -154,11 +209,12 @@ export default function Zombies() {
             </div>
             {recentCampaigns.length > 0 ? (
               <div className="realm-home-recent__list">
-                {recentCampaigns.map(({ campaign, role }) => (
+                {recentCampaigns.map(({ campaign, role, lastAccessedAt }) => (
                   <RecentCampaignCard
                     key={`${role}-${getCampaignTitle(campaign)}`}
                     campaign={campaign}
                     role={role}
+                    lastAccessedAt={lastAccessedAt}
                     onResume={() => resumeCampaign(campaign, role)}
                   />
                 ))}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -310,6 +310,18 @@ export default function RecordList() {
   }, []);
 
   useEffect(() => {
+    if (!user || !params.campaign) {
+      return;
+    }
+
+    apiFetch(`/campaigns/${encodeURIComponent(params.campaign)}/access`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "player" }),
+    }).catch(() => {});
+  }, [params.campaign, user]);
+
+  useEffect(() => {
     if (!user) {
       return;
     }

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -1846,6 +1846,18 @@ export default function ZombiesDM() {
     );
 
 
+    useEffect(() => {
+      if (!user || !encodedCampaign) {
+        return;
+      }
+
+      apiFetch(`/campaigns/${encodedCampaign}/access`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "dm" }),
+      }).catch(() => {});
+    }, [encodedCampaign, user]);
+
     const waitForNextAnimationFrame = useCallback(
       () =>
         new Promise((resolve) => {

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -352,6 +352,116 @@ describe('Campaign routes', () => {
     );
   });
 
+  test('create campaign initializes recent access tracking', async () => {
+    const insertOne = jest.fn().mockResolvedValue({ acknowledged: true });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        insertOne,
+      }),
+    });
+
+    await request(app)
+      .post('/campaigns/add')
+      .send({ campaignName: 'Test', dm: 'DM' });
+
+    expect(insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recentAccess: [],
+      })
+    );
+  });
+
+  test('records campaign access for current user', async () => {
+    const updateOne = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: jest.fn().mockResolvedValue({
+          campaignName: 'Test',
+          dm: 'DM',
+          players: ['Player'],
+          recentAccess: [{ username: 'Player', role: 'player', lastAccessedAt: '2024-01-01T00:00:00.000Z' }],
+        }),
+        updateOne,
+      }),
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/access')
+      .send({ role: 'dm' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe('DM');
+    expect(res.body.role).toBe('dm');
+    expect(Date.parse(res.body.lastAccessedAt)).not.toBeNaN();
+    expect(updateOne).toHaveBeenCalledWith(
+      { campaignName: 'Test' },
+      {
+        $set: {
+          recentAccess: expect.arrayContaining([
+            { username: 'Player', role: 'player', lastAccessedAt: '2024-01-01T00:00:00.000Z' },
+            { username: 'DM', role: 'dm', lastAccessedAt: expect.any(String) },
+          ]),
+        },
+      }
+    );
+  });
+
+  test('records campaign access independently per role', async () => {
+    const updateOne = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: jest.fn().mockResolvedValue({
+          campaignName: 'Legendary Campaign',
+          dm: 'DM',
+          players: ['DM'],
+          recentAccess: [{ username: 'DM', role: 'dm', lastAccessedAt: '2024-01-01T00:00:00.000Z' }],
+        }),
+        updateOne,
+      }),
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Legendary%20Campaign/access')
+      .send({ role: 'player' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe('player');
+    expect(updateOne).toHaveBeenCalledWith(
+      { campaignName: 'Legendary Campaign' },
+      {
+        $set: {
+          recentAccess: expect.arrayContaining([
+            { username: 'DM', role: 'dm', lastAccessedAt: '2024-01-01T00:00:00.000Z' },
+            { username: 'DM', role: 'player', lastAccessedAt: expect.any(String) },
+          ]),
+        },
+      }
+    );
+  });
+
+  test('rejects campaign access tracking for non-members', async () => {
+    mockUser = { username: 'Stranger' };
+    const updateOne = jest.fn();
+    dbo.mockResolvedValue({
+      collection: () => ({
+        findOne: jest.fn().mockResolvedValue({
+          campaignName: 'Test',
+          dm: 'DM',
+          players: ['Player'],
+          recentAccess: [],
+        }),
+        updateOne,
+      }),
+    });
+
+    const res = await request(app)
+      .put('/campaigns/Test/access')
+      .send({ role: 'player' });
+
+    expect(res.status).toBe(403);
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+
   test('create campaign failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -657,6 +657,7 @@ module.exports = (router) => {
       'maps.image': 1,
       'maps.thumbnailUrl': 1,
       activeMapId: 1,
+      recentAccess: 1,
     },
   };
 
@@ -1564,6 +1565,63 @@ module.exports = (router) => {
       }
     );
 
+  campaignRouter.route('/:campaign/access').put(
+    [param('campaign').trim().notEmpty().withMessage('campaign is required')],
+    handleValidationErrors,
+    async (req, res, next) => {
+      try {
+        const username = typeof req.user?.username === 'string' ? req.user.username.trim() : '';
+        if (!username) {
+          return res.status(401).json({ message: 'Unauthorized' });
+        }
+
+        const requestedRole = typeof req.body?.role === 'string'
+          ? req.body.role.trim().toLowerCase()
+          : typeof req.query?.role === 'string'
+            ? req.query.role.trim().toLowerCase()
+            : '';
+        const role = requestedRole === 'dm' || requestedRole === 'player' ? requestedRole : '';
+        if (!role) {
+          return res.status(400).json({ message: 'role must be dm or player' });
+        }
+
+        const campaignName = req.params.campaign;
+        const collection = req.db.collection('Campaigns');
+        const campaign = await collection.findOne(
+          { campaignName },
+          { projection: { dm: 1, players: 1, recentAccess: 1 } }
+        );
+
+        if (!campaign) {
+          return res.status(404).json({ message: 'Campaign not found' });
+        }
+
+        const isDm = campaign.dm === username;
+        const isPlayer = Array.isArray(campaign.players) && campaign.players.includes(username);
+        if ((role === 'dm' && !isDm) || (role === 'player' && !isPlayer)) {
+          return res.status(403).json({ message: 'Forbidden' });
+        }
+
+        const lastAccessedAt = new Date().toISOString();
+        const recentAccess = Array.isArray(campaign.recentAccess)
+          ? campaign.recentAccess.filter((entry) => (
+              entry && (entry.username !== username || entry.role !== role)
+            ))
+          : [];
+        recentAccess.push({ username, role, lastAccessedAt });
+
+        await collection.updateOne(
+          { campaignName },
+          { $set: { recentAccess } }
+        );
+
+        return res.json({ username, role, lastAccessedAt });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
   // This section will create a new campaign.
   campaignRouter.route('/add').post(async (req, response, next) => {
     const db_connect = req.db;
@@ -1578,6 +1636,7 @@ module.exports = (router) => {
       mapTokens: {},
       combat: createDefaultCombatState(),
       enemies: [],
+      recentAccess: [],
     };
     try {
       const result = await db_connect.collection("Campaigns").insertOne(myobj);


### PR DESCRIPTION
### Motivation
- Provide per-user, per-role "last opened" tracking for campaigns so recent activity can be surfaced in the UI.
- Ensure the server stores and maintains a compact `recentAccess` history for a campaign and prevents non-members from spoofing access.

### Description
- Added a new `recentAccess` field to campaign creation initialization with `recentAccess: []` and included `recentAccess` in campaign summary projection.
- Implemented a new endpoint `PUT /campaigns/:campaign/access` that validates the caller, accepts a `role` of `dm` or `player`, and records or updates the caller's `{ username, role, lastAccessedAt }` in the campaign's `recentAccess` array.
- Client-side: sanitized and normalized `recentAccess` in `useCampaignActions`, added utilities to parse/format access timestamps and sort recent campaigns, and updated `Zombies`, `ZombiesCharacterSelect`, and `ZombiesDM` to record access when resuming or entering a campaign and to display the formatted "Last opened" label in recent campaign cards.
- The resume flow now issues an access `PUT` before navigating, and the character-select and DM pages issue a non-blocking access `PUT` on mount.

### Testing
- Added Jest tests in `server/__tests__/campaigns.test.js` for `recentAccess` including initialization, recording access for the current user, role-independent records, and denial for non-members, and ran the test suite with `npm test`; all new and existing campaign route tests passed.
- Existing endpoint tests such as campaign creation success/failure and `GET /campaigns/:campaign` continued to pass under the updated behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e5941c7c832eb716a38913177e3e)