### PR TITLE
Add Character Generator UI, smart/AI generator utils, server AI endpoint, and tests

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11713,3 +11713,94 @@ body.character-creation-modal-open {
     padding-bottom: calc(0.85rem + env(safe-area-inset-bottom, 0px));
   }
 }
+
+
+.character-generator-modal .modal-content {
+  max-height: calc(100dvh - 24px);
+  overflow: hidden;
+  border-radius: 28px;
+  background: transparent;
+}
+.character-generator-modal__dialog {
+  max-width: min(1060px, calc(100vw - 32px));
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+.character-generator {
+  color:#eef6ff;
+  background:radial-gradient(circle at 18% 0%, rgba(84,151,255,.22), transparent 32%),radial-gradient(circle at 88% 12%, rgba(169,92,255,.18), transparent 34%),linear-gradient(145deg, rgba(7,13,29,.98), rgba(12,24,48,.98));
+  border:1px solid rgba(126,174,255,.28);
+  border-radius:28px;
+  box-shadow:0 26px 80px rgba(0,0,0,.58), inset 0 0 0 1px rgba(255,255,255,.05);
+  display:flex;
+  flex-direction:column;
+  max-height: calc(100dvh - 24px);
+  min-height: 0;
+  overflow:hidden;
+}
+.character-generator--ai { border-color:rgba(192,132,252,.38); }
+.character-generator__header,.character-generator__footer { display:flex; align-items:center; justify-content:space-between; gap:.85rem; padding:.85rem 1.15rem; background:rgba(5,10,22,.72); border-bottom:1px solid rgba(140,174,230,.18); flex-shrink:0; }
+.character-generator__header h2 { margin:0; font-size:clamp(1.35rem,2.55vw,2rem); line-height:1.05; }
+.character-generator__header span { color:rgba(226,238,255,.72); font-size:.95rem; }
+.character-generator__header button { width:38px; height:38px; border-radius:13px; border:1px solid rgba(255,255,255,.16); background:rgba(255,255,255,.06); color:#fff; font-size:1.35rem; }
+.character-generator__tabs { display:grid; grid-template-columns:1fr 1fr; gap:.6rem; padding:.75rem 1.15rem 0; flex-shrink:0; }
+.character-generator__tabs button { border:1px solid rgba(126,174,255,.22); border-radius:16px; padding:.62rem .85rem; color:rgba(235,244,255,.82); background:rgba(16,30,58,.58); transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
+.character-generator__tabs button.is-active { color:#fff; border-color:rgba(245,197,94,.7); box-shadow:0 0 20px rgba(80,150,255,.2), inset 0 0 16px rgba(245,197,94,.08); }
+.character-generator--ai .character-generator__tabs button.is-active { border-color:rgba(192,132,252,.72); box-shadow:0 0 22px rgba(168,85,247,.22), inset 0 0 16px rgba(34,211,238,.08); }
+.character-generator__body { display:grid; grid-template-columns:minmax(260px,.82fr) minmax(340px,1.18fr); gap:.85rem; padding:.85rem 1.15rem; min-height:0; overflow:auto; overscroll-behavior:contain; }
+.character-generator__controls,.generated-preview { border:1px solid rgba(133,172,232,.18); border-radius:20px; background:linear-gradient(180deg, rgba(11,22,46,.82), rgba(6,12,28,.78)); box-shadow:inset 0 0 0 1px rgba(255,255,255,.035); min-height:0; }
+.character-generator__controls { overflow:auto; }
+.generator-panel { padding:.85rem; }
+.generator-panel h3,.generated-preview h3 { margin-top:0; font-size:clamp(1.25rem,2.2vw,1.55rem); }
+.generator-panel p,.generated-preview__empty p,.character-generator__status span { color:rgba(225,238,255,.72); }
+.generator-panel p { margin-bottom:.75rem; line-height:1.45; }
+.generator-panel input,.generator-panel textarea,.generated-preview input { width:100%; border:1px solid rgba(139,185,255,.24); border-radius:13px; background:rgba(2,8,20,.62); color:#f8fbff; padding:.58rem .7rem; }
+.generator-panel textarea { min-height:118px; max-height:24dvh; resize:vertical; }
+.character-generator__examples { display:grid; gap:.4rem; margin:.65rem 0; }
+.character-generator__examples button { text-align:left; border:1px solid rgba(192,132,252,.2); border-radius:11px; padding:.48rem .62rem; color:rgba(239,226,255,.88); background:rgba(88,28,135,.22); font-size:.92rem; }
+.character-generator__status { margin:.85rem; padding:.75rem; border-radius:16px; background:rgba(255,255,255,.055); display:grid; gap:.25rem; }
+.character-generator__error { color:#fecaca; margin:.35rem 0 0; }
+.generated-preview { padding:.85rem; min-height:420px; overflow:auto; }
+.generated-preview__empty { min-height:360px; display:grid; place-items:center; align-content:center; text-align:center; }
+.generated-preview__empty span { font-size:2.4rem; color:#f5c55e; text-shadow:0 0 20px rgba(245,197,94,.32); }
+.generated-preview__hero { display:grid; grid-template-columns:88px 1fr; gap:.85rem; align-items:center; }
+.generated-preview__figurine { width:88px; height:88px; border-radius:24px; display:grid; place-items:center; overflow:hidden; background:radial-gradient(circle, rgba(96,165,250,.3), rgba(15,23,42,.9)); border:1px solid rgba(147,197,253,.3); }
+.generated-preview__figurine img { width:100%; height:100%; object-fit:cover; }
+.generated-preview__figurine span { font-size:2.4rem; }
+.generated-preview__concept { margin:.8rem 0; padding:.7rem; border-radius:14px; background:rgba(255,255,255,.05); color:rgba(234,242,255,.82); }
+.generated-preview__stats { display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:.45rem; }
+.generated-preview__stats label { display:grid; gap:.28rem; padding:.45rem; border-radius:14px; background:rgba(31,49,88,.62); text-align:center; }
+.generated-preview__stats input { text-align:center; padding:.32rem; }
+.generated-preview__stats small { color:#93c5fd; }
+.generated-preview__details { display:grid; grid-template-columns:repeat(4,1fr); gap:.5rem; margin-top:.8rem; }
+.generated-preview__details label { color:rgba(226,238,255,.72); font-size:.8rem; }
+.generated-preview__actions { display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.8rem; }
+.generated-preview__validation { margin-top:.8rem; padding:.62rem; border-radius:13px; background:rgba(239,68,68,.14); color:#fecaca; }
+.generated-preview__validation.is-valid { background:rgba(34,197,94,.14); color:#bbf7d0; }
+.character-generator__footer { position:static; border-top:1px solid rgba(140,174,230,.18); border-bottom:0; justify-content:flex-end; padding:.75rem 1.15rem; }
+@media (prefers-reduced-motion: no-preference) {
+  .generated-preview__hero,.generated-preview__stats label { animation:generatedReveal .28s ease both; }
+  @keyframes generatedReveal { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+}
+@media (max-width:820px) {
+  .character-generator-modal__dialog { max-width:100vw; margin:0; min-height:100dvh; }
+  .character-generator-modal .modal-content { max-height:100dvh; border-radius:0; }
+  .character-generator { border-radius:0; min-height:100dvh; max-height:100dvh; }
+  .character-generator__header { align-items:flex-start; padding:.8rem; }
+  .character-generator__header h2 { font-size:1.45rem; }
+  .character-generator__header span { display:block; font-size:.85rem; margin-top:.2rem; }
+  .character-generator__tabs { grid-template-columns:1fr 1fr; padding:.65rem .8rem 0; gap:.45rem; }
+  .character-generator__tabs button { padding:.55rem .45rem; font-size:.9rem; }
+  .character-generator__body { grid-template-columns:1fr; padding:.65rem .8rem; gap:.65rem; }
+  .generator-panel { padding:.75rem; }
+  .generator-panel textarea { min-height:96px; max-height:22dvh; }
+  .character-generator__examples { max-height:132px; overflow:auto; padding-right:.2rem; }
+  .generated-preview { min-height:260px; padding:.75rem; }
+  .generated-preview__empty { min-height:220px; }
+  .generated-preview__hero { grid-template-columns:72px 1fr; }
+  .generated-preview__figurine { width:72px; height:72px; border-radius:20px; }
+  .generated-preview__stats { grid-template-columns:repeat(3,1fr); }
+  .generated-preview__details { grid-template-columns:repeat(2,1fr); }
+  .character-generator__footer { display:grid; grid-template-columns:1fr 1fr; padding:.65rem .8rem; }
+  .character-generator__footer .btn:last-child { grid-column:1 / -1; }
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSelect.js
@@ -14,6 +14,7 @@ import { notify } from '../../../utils/notification';
 import { calculateCharacterHitPoints } from '../utils/characterMetrics';
 import TokenPickerModal from '../components/TokenPickerModal';
 import buildPlayerTokenFolderScope from '../utils/playerTokenFilters';
+import { createCharacterFromGeneratedData, generateSmartCharacter, normalizeAICharacter, rollAbilityPool, assignAbilityScores, chooseClassBuildProfile, validateGeneratedCharacter } from '../utils/characterGenerator';
 
 const DEFAULT_SIZE_OPTIONS = ["Tiny", "Small", "Medium", "Large"];
 
@@ -473,6 +474,12 @@ const sizeOptionsForManual = useMemo(() => {
 const [show, setShow] = useState(false);
 const handleClose = () => setShow(false);
 const handleShow = () => setShow(true);
+const [generatorMode, setGeneratorMode] = useState('smart');
+const [generatedCharacter, setGeneratedCharacter] = useState(null);
+const [generatorPrompt, setGeneratorPrompt] = useState('');
+const [generatorError, setGeneratorError] = useState('');
+const [isGeneratingCharacter, setIsGeneratingCharacter] = useState(false);
+const [generatorStatus, setGeneratorStatus] = useState('');
 
 const [showAbilitySkillModal, setShowAbilitySkillModal] = useState(false);
 const [abilitySelections, setAbilitySelections] = useState([]);
@@ -1212,12 +1219,19 @@ const handleCreationTokenSelection = useCallback((asset) => {
   const figurineImageUrl = asset ? ((typeof asset.secureUrl === "string" && asset.secureUrl.trim()) || (typeof asset.url === "string" && asset.url.trim()) || "") : "";
   const figurineImagePublicId = asset && typeof asset.publicId === "string" ? asset.publicId.trim() : "";
   setForm((prev) => ({ ...prev, figurineImageUrl, figurineImagePublicId }));
+  setGeneratedCharacter((prev) => prev ? { ...prev, figurineImageUrl, figurineImagePublicId } : prev);
   setShowCreationTokenPicker(false);
 }, []);
-const handleClearCreationFigurine = useCallback(() => setForm((prev) => ({ ...prev, figurineImageUrl: "", figurineImagePublicId: "" })), []);
+const handleClearCreationFigurine = useCallback(() => {
+  setForm((prev) => ({ ...prev, figurineImageUrl: "", figurineImagePublicId: "" }));
+  setGeneratedCharacter((prev) => prev ? { ...prev, figurineImageUrl: "", figurineImagePublicId: "" } : prev);
+}, []);
 
 const [selectedOccupation, setSelectedOccupation] = useState(null);
-const creationTokenPickerFilterScope = useMemo(() => buildPlayerTokenFolderScope(form?.race, selectedOccupation || form?.occupation), [form?.occupation, form?.race, selectedOccupation]);
+const creationTokenPickerFilterScope = useMemo(() => {
+  const scopedOccupation = show5 ? (selectedOccupation || form?.occupation) : form?.occupation;
+  return buildPlayerTokenFolderScope(form?.race, scopedOccupation);
+}, [form?.occupation, form?.race, selectedOccupation, show5]);
 const selectedAddOccupationRef = useRef();
 
 const [getOccupation, setGetOccupation] = useState([]);
@@ -2303,6 +2317,183 @@ const getAvailableSkillOptions = (index) => {
   return base.filter((opt) => !taken.includes(opt));
 };
 
+
+const openCharacterGenerator = () => {
+  const freshForm = { ...createDefaultForm(params.campaign), token: user?.username || form.token || "" };
+  setForm(freshForm);
+  setGeneratedCharacter(null);
+  setGeneratorError('');
+  setGeneratorStatus('Ready to forge a hero.');
+  setGeneratorMode('smart');
+  handleShow();
+};
+
+const applyGeneratedCharacterToForm = (next) => {
+  setGeneratedCharacter(next);
+  setForm(createCharacterFromGeneratedData(next));
+};
+
+const getTokenAssetImageData = (asset) => ({
+  figurineImageUrl:
+    (typeof asset?.secureUrl === 'string' && asset.secureUrl.trim()) ||
+    (typeof asset?.url === 'string' && asset.url.trim()) ||
+    (typeof asset?.imageUrl === 'string' && asset.imageUrl.trim()) ||
+    '',
+  figurineImagePublicId: typeof asset?.publicId === 'string' ? asset.publicId.trim() : '',
+});
+
+const fetchRandomFigurineForCharacter = async (character) => {
+  const scope = buildPlayerTokenFolderScope(character?.race, character?.occupation);
+  const classNames = (Array.isArray(character?.occupation) ? character.occupation : [])
+    .map((job) => String(job?.Occupation || job?.name || '').toLowerCase())
+    .filter(Boolean);
+  const folderCandidates = Array.from(new Set((scope || [])
+    .filter((entry) => typeof entry === 'string' && entry.startsWith('folder:'))
+    .map((entry) => entry.slice('folder:'.length).trim())
+    .filter(Boolean)))
+    .sort((left, right) => {
+      const leftLower = left.toLowerCase();
+      const rightLower = right.toLowerCase();
+      const leftClassMatch = classNames.some((name) => leftLower.includes(name));
+      const rightClassMatch = classNames.some((name) => rightLower.includes(name));
+      if (leftClassMatch === rightClassMatch) return 0;
+      return leftClassMatch ? -1 : 1;
+    });
+
+  const folderBatches = folderCandidates.length
+    ? [folderCandidates.slice(0, 6), ['Tokens/Adventurers']]
+    : [['Tokens/Adventurers']];
+
+  for (const folders of folderBatches) {
+    const queryParams = new URLSearchParams();
+    queryParams.set('folders', folders.join(','));
+    const endpoint = `/campaigns/${encodeURIComponent(params.campaign.toString())}/token-manifest?${queryParams.toString()}`;
+    const response = await apiFetch(endpoint);
+    if (!response.ok) {
+      continue;
+    }
+    const manifest = await response.json();
+    const assets = Array.isArray(manifest?.assets) ? manifest.assets.filter(Boolean) : [];
+    if (assets.length) {
+      const selected = assets[Math.floor(Math.random() * assets.length)];
+      const imageData = getTokenAssetImageData(selected);
+      if (imageData.figurineImageUrl || imageData.figurineImagePublicId) {
+        return imageData;
+      }
+    }
+  }
+
+  return null;
+};
+
+const attachRandomFigurineAsset = async (character) => {
+  try {
+    const figurineAsset = await fetchRandomFigurineForCharacter(character);
+    if (figurineAsset) {
+      return { ...character, ...figurineAsset };
+    }
+    setGeneratorError('No matching figurine asset was found automatically. You can still change the figurine manually.');
+  } catch (error) {
+    setGeneratorError('Could not automatically choose a figurine. You can still change the figurine manually.');
+  }
+  return { ...character, figurineImageUrl: '', figurineImagePublicId: '' };
+};
+
+const runSmartGenerator = async (overrides = {}) => {
+  setGeneratorError('');
+  setGeneratorStatus('Rolling ancestry, class, stats, and figurine...');
+  const generated = generateSmartCharacter({
+    baseForm: { ...createDefaultForm(params.campaign), token: user?.username || form.token || "" },
+    races,
+    classes: Object.fromEntries(getOccupation.map((item) => [String(item.name || '').toLowerCase(), item])),
+    backgrounds,
+    preferredName: overrides.preferredName || form.characterName,
+  });
+  setGeneratorStatus('Choosing a matching figurine...');
+  const next = await attachRandomFigurineAsset(generated);
+  applyGeneratedCharacterToForm(next);
+  setGeneratorStatus('Character validated and ready to preview.');
+};
+
+const regenerateGeneratedName = () => {
+  if (!generatedCharacter) return runSmartGenerator();
+  const next = generateSmartCharacter({ baseForm: { ...createDefaultForm(params.campaign), token: user?.username || form.token || "" }, races: { temp: generatedCharacter.race }, classes: { [String(generatedCharacter.occupation?.[0]?.Occupation || '').toLowerCase()]: getOccupation.find((item) => item.name === generatedCharacter.occupation?.[0]?.Occupation) || getOccupation[0] }, backgrounds: { temp: generatedCharacter.background } });
+  applyGeneratedCharacterToForm({ ...generatedCharacter, characterName: next.characterName, validation: validateGeneratedCharacter({ ...generatedCharacter, characterName: next.characterName }) });
+};
+
+const regenerateGeneratedStats = () => {
+  if (!generatedCharacter) return runSmartGenerator();
+  const classKey = String(generatedCharacter.occupation?.[0]?.Occupation || '').toLowerCase();
+  const scores = assignAbilityScores(rollAbilityPool(), chooseClassBuildProfile(classKey));
+  const next = { ...generatedCharacter, ...scores };
+  next.startStatTotal = STATS.reduce((sum, stat) => sum + Number(next[stat.key] || 0), 0);
+  next.validation = validateGeneratedCharacter(next);
+  applyGeneratedCharacterToForm(next);
+};
+
+const runAIGenerator = async () => {
+  const prompt = generatorPrompt.trim();
+  if (!prompt) {
+    setGeneratorError('Describe your character before using AI generation.');
+    return;
+  }
+  if (prompt.length > 1200) {
+    setGeneratorError('Keep prompts under 1200 characters.');
+    return;
+  }
+  setIsGeneratingCharacter(true);
+  setGeneratorError('');
+  setGeneratorStatus('Generating concept...');
+  try {
+    const response = await apiFetch('/ai/character-concept', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt,
+        supportedRaces: Object.values(races).map((race) => race.name),
+        supportedClasses: getOccupation.map((item) => item.name),
+        supportedBackgrounds: Object.values(backgrounds).map((bg) => bg.name),
+      }),
+    });
+    if (!response.ok) throw new Error('AI generation is temporarily unavailable. Smart Random is still available.');
+    setGeneratorStatus('Validating build and assigning stats...');
+    const aiData = await response.json();
+    const normalized = normalizeAICharacter({
+      aiData,
+      baseForm: { ...createDefaultForm(params.campaign), token: user?.username || form.token || "" },
+      races,
+      classes: Object.fromEntries(getOccupation.map((item) => [String(item.name || '').toLowerCase(), item])),
+      backgrounds,
+    });
+    setGeneratorStatus('Choosing a matching figurine...');
+    const next = await attachRandomFigurineAsset(normalized);
+    applyGeneratedCharacterToForm(next);
+    setGeneratorStatus('AI concept normalized with RealmTracker rules.');
+  } catch (error) {
+    setGeneratorError(error.message || 'RealmTracker could not generate a valid character. Try again or simplify your description.');
+  } finally {
+    setIsGeneratingCharacter(false);
+  }
+};
+
+const createGeneratedCharacter = async (event) => {
+  event.preventDefault();
+  if (!generatedCharacter?.validation?.valid) {
+    setGeneratorError('Generate a valid character before creating it.');
+    return;
+  }
+  await sendToDb(createCharacterFromGeneratedData(generatedCharacter));
+};
+
+const editGeneratedManually = () => {
+  if (generatedCharacter) setForm(createCharacterFromGeneratedData(generatedCharacter));
+  handleClose();
+  setManualStep(0);
+  setManualTouched({});
+  initialManualSnapshot.current = JSON.stringify(form);
+  setShow5(true);
+};
+
   return (
     <div className="character-select-page" style={{ backgroundImage: `url(${loginbg})` }}>
       <div className="character-select-shell">
@@ -2311,7 +2502,7 @@ const getAvailableSkillOptions = (index) => {
           dmName={dmName}
           playerCount={campaignPlayerCount}
           onCreateManual={(e) => { e.preventDefault(); handleShow5(); }}
-          onCreateRandom={(e) => { e.preventDefault(); bigMaff(); handleShow(); }}
+          onCreateRandom={(e) => { e.preventDefault(); openCharacterGenerator(); }}
         />
 
         <section className="character-select-library">
@@ -2326,33 +2517,51 @@ const getAvailableSkillOptions = (index) => {
 
     
       </div>
-    {/* ---------------------------Create Character (Random)------------------------------------------------------- */}
-    <Modal className="dnd-modal" centered show={show} onHide={handleClose}>
-       <div className="text-center">
-        <Card className="dnd-background">
-          <Card.Title>Create Random</Card.Title>
-        <Card.Body>   
-        <div className="text-center">
-      <Form onSubmit={onSubmit} className="px-5">
-      <Form.Group className="mb-3 pt-3">
-       <Form.Label className="text-light">Character Name</Form.Label>
-       <Form.Control className="mb-2" onChange={(e) => updateForm({ characterName: e.target.value })}
-        type="text" placeholder="Enter character name" />        
-     </Form.Group>
-     <div className="text-center">
-     <Button variant="primary" onClick={handleClose} type="submit">
-            Create
-          </Button>
-          <Button className="ms-4" variant="secondary" onClick={handleClose}>
-            Close
-          </Button>
+    {/* ---------------------------Character Generator------------------------------------------------------- */}
+    <Modal className="dnd-modal character-generator-modal" dialogClassName="character-generator-modal__dialog" centered show={show} onHide={handleClose} backdrop="static" keyboard={false}>
+      <section className={`character-generator character-generator--${generatorMode}`}>
+        <header className="character-generator__header">
+          <div>
+            <p className="character-select-kicker">Hero Forge</p>
+            <h2>Create a Character</h2>
+            <span>Generate a coherent RealmTracker hero, preview the sheet, then create only when ready.</span>
           </div>
-     </Form>
-     </div>
-     </Card.Body> 
-     </Card>  
-     </div>      
-      </Modal>
+          <button type="button" onClick={handleClose} aria-label="Close character generator">×</button>
+        </header>
+        <div className="character-generator__tabs" role="tablist" aria-label="Character generator modes">
+          <button type="button" className={generatorMode === 'smart' ? 'is-active' : ''} onClick={() => setGeneratorMode('smart')}>✦ Smart Random</button>
+          <button type="button" className={generatorMode === 'ai' ? 'is-active' : ''} onClick={() => setGeneratorMode('ai')}>✧ Create with AI</button>
+        </div>
+        <div className="character-generator__body">
+          <aside className="character-generator__controls">
+            {generatorMode === 'smart' ? <div className="generator-panel">
+              <h3>Smart Random Generator</h3>
+              <p>RealmTracker chooses ancestry, class, background, rolled scores, physical details, and a token using class-aware build priorities.</p>
+              <CharacterFormField id="generator-name" label="Optional Name" helper="Leave blank to generate a short fantasy name."><input id="generator-name" value={form.characterName || ''} maxLength="12" onChange={(e) => updateForm({ characterName: e.target.value })} placeholder="Optional" /></CharacterFormField>
+              <Button type="button" onClick={() => runSmartGenerator()} disabled={!Object.keys(races).length || !getOccupation.length || !Object.keys(backgrounds).length}>Generate Character</Button>
+            </div> : <div className="generator-panel generator-panel--ai">
+              <h3>Create with AI</h3>
+              <p>Describe ancestry, class, personality, fighting style, background, or appearance. Leave details out and RealmTracker will choose them.</p>
+              <textarea value={generatorPrompt} onChange={(e) => setGeneratorPrompt(e.target.value)} maxLength="1200" placeholder="A grizzled dwarf barbarian with a two-handed axe..." />
+              <div className="character-generator__examples">{['A noble elven wizard obsessed with forbidden history.', 'A cheerful halfling rogue who fights with daggers.', 'A battle-scarred human paladin devoted to protecting the weak.', 'Surprise me with a strange but playable character.'].map((example) => <button type="button" key={example} onClick={() => setGeneratorPrompt(example)}>{example}</button>)}</div>
+              <Button type="button" onClick={runAIGenerator} disabled={isGeneratingCharacter}>{isGeneratingCharacter ? 'Generating...' : 'Generate Character'}</Button>
+            </div>}
+            <div className="character-generator__status"><strong>{isGeneratingCharacter ? 'Working' : generatedCharacter ? 'Preview ready' : 'Awaiting generation'}</strong><span>{generatorStatus}</span>{generatorError && <p className="character-generator__error">{generatorError}</p>}</div>
+          </aside>
+          <main className="generated-preview">
+            {generatedCharacter ? <>
+              <div className="generated-preview__hero"><div className="generated-preview__figurine">{generatedCharacter.figurineImageUrl ? <img src={generatedCharacter.figurineImageUrl} alt="Selected figurine" /> : <span>♟</span>}</div><div><p className="character-select-kicker">Generated Hero</p><input value={generatedCharacter.characterName || ''} maxLength="12" onChange={(e) => applyGeneratedCharacterToForm({ ...generatedCharacter, characterName: e.target.value, validation: validateGeneratedCharacter({ ...generatedCharacter, characterName: e.target.value }) })} /><strong>{generatedCharacter.race?.name} {generatedCharacter.occupation?.[0]?.Occupation}</strong><small>{generatedCharacter.background?.name} • {generatedCharacter.buildArchetype}</small></div></div>
+              <p className="generated-preview__concept">{generatedCharacter.shortConcept}</p>
+              <div className="generated-preview__stats">{STATS.map((stat) => <label key={stat.key}><span>{stat.key.toUpperCase()}</span><input type="number" min="1" max="30" value={generatedCharacter[stat.key] || ''} onChange={(e) => { const next = { ...generatedCharacter, [stat.key]: Number(e.target.value) }; next.validation = validateGeneratedCharacter(next); applyGeneratedCharacterToForm(next); }} /><small>{abilityModifier(generatedCharacter[stat.key])}</small></label>)}</div>
+              <div className="generated-preview__details"><label>Age<input type="number" value={generatedCharacter.age || ''} onChange={(e) => applyGeneratedCharacterToForm({ ...generatedCharacter, age: Number(e.target.value) })} /></label><label>Sex<input value={generatedCharacter.sex || ''} onChange={(e) => applyGeneratedCharacterToForm({ ...generatedCharacter, sex: e.target.value })} /></label><label>Size<input value={generatedCharacter.size || ''} onChange={(e) => applyGeneratedCharacterToForm({ ...generatedCharacter, size: e.target.value })} /></label><label>Weight<input type="number" value={generatedCharacter.weight || ''} onChange={(e) => applyGeneratedCharacterToForm({ ...generatedCharacter, weight: Number(e.target.value) })} /></label></div>
+              <div className="generated-preview__actions"><Button type="button" variant="secondary" onClick={regenerateGeneratedName}>Regenerate Name</Button><Button type="button" variant="secondary" onClick={regenerateGeneratedStats}>Regenerate Stats</Button><Button type="button" variant="secondary" onClick={() => setShowCreationTokenPicker(true)}>Change Figurine</Button><Button type="button" variant="secondary" onClick={editGeneratedManually}>Edit Manually</Button></div>
+              <div className={generatedCharacter.validation?.valid ? 'generated-preview__validation is-valid' : 'generated-preview__validation'}>{generatedCharacter.validation?.valid ? '✓ Valid RealmTracker character' : generatedCharacter.validation?.errors?.join(' ')}</div>
+            </> : <div className="generated-preview__empty"><span>✦</span><h3>Your hero preview appears here</h3><p>Generate first, review every field, then create the character.</p></div>}
+          </main>
+        </div>
+        <footer className="character-generator__footer"><Button type="button" variant="secondary" onClick={handleClose}>Cancel</Button><Button type="button" variant="secondary" onClick={() => generatorMode === 'ai' ? runAIGenerator() : runSmartGenerator()}>{generatedCharacter ? 'Regenerate All' : 'Generate'}</Button><Button type="button" onClick={createGeneratedCharacter} disabled={!generatedCharacter?.validation?.valid || isGeneratingCharacter}>Create Character</Button></footer>
+      </section>
+    </Modal>
        {/* ---------------------------Create Character (Manual)------------------------------------------------------- */}
     <Modal className="dnd-modal manual-character-modal" dialogClassName="manual-character-modal__dialog" centered show={show5} onHide={requestCloseManual} backdrop="static" keyboard={false}>
       <CharacterCreationWizard
@@ -2386,16 +2595,16 @@ const getAvailableSkillOptions = (index) => {
         onClearFigurine={handleClearCreationFigurine}
         tokenPickerAvailable={Boolean(creationTokenPickerFilterScope)}
       />
-      <TokenPickerModal
-        show={showCreationTokenPicker}
-        onHide={() => setShowCreationTokenPicker(false)}
-        campaignId={params.campaign || undefined}
-        onSelect={handleCreationTokenSelection}
-        allowClear={Boolean(form.figurineImageUrl || form.figurineImagePublicId)}
-        onClear={() => handleCreationTokenSelection(null)}
-        filterScope={creationTokenPickerFilterScope}
-      />
     </Modal>
+    <TokenPickerModal
+      show={showCreationTokenPicker}
+      onHide={() => setShowCreationTokenPicker(false)}
+      campaignId={params.campaign || undefined}
+      onSelect={handleCreationTokenSelection}
+      allowClear={Boolean(form.figurineImageUrl || form.figurineImagePublicId)}
+      onClear={() => handleCreationTokenSelection(null)}
+      filterScope={creationTokenPickerFilterScope}
+    />
     <Modal className="dnd-modal unsaved-character-modal" centered show={showUnsavedManualDialog} onHide={() => setShowUnsavedManualDialog(false)}>
       <Card className="dnd-background unsaved-character-modal__card">
         <Card.Body>

--- a/client/src/components/Zombies/utils/characterGenerator.js
+++ b/client/src/components/Zombies/utils/characterGenerator.js
@@ -1,0 +1,151 @@
+import { STATS } from '../statSchema';
+
+export const STAT_KEYS = STATS.map((stat) => stat.key);
+export const STAT_LABELS = Object.fromEntries(STATS.map((stat) => [stat.key, stat.label]));
+
+export const classBuildProfiles = {
+  barbarian: { primary: ['str'], secondary: ['con', 'dex'], lowPriority: ['int', 'cha'], archetype: 'Primal bruiser', tags: ['barbarian', 'martial', 'axe'] },
+  bard: { primary: ['cha'], secondary: ['dex', 'con'], lowPriority: ['str'], archetype: 'Silver-tongued performer', tags: ['bard', 'caster', 'lightly-armored'] },
+  cleric: { variants: [
+    { name: 'Devout battle-priest', primary: ['wis'], secondary: ['con', 'str'], lowPriority: ['dex'], tags: ['cleric', 'armored', 'shield'] },
+    { name: 'Temple spellcaster', primary: ['wis'], secondary: ['con', 'cha'], lowPriority: ['str'], tags: ['cleric', 'caster', 'staff'] },
+  ] },
+  druid: { primary: ['wis'], secondary: ['con', 'dex'], lowPriority: ['str'], archetype: 'Wild mystic', tags: ['druid', 'caster', 'staff'] },
+  fighter: { variants: [
+    { name: 'Strength melee fighter', primary: ['str'], secondary: ['con', 'dex'], lowPriority: ['int'], tags: ['fighter', 'martial', 'armored', 'sword', 'shield'] },
+    { name: 'Dexterity duelist', primary: ['dex'], secondary: ['con', 'str'], lowPriority: ['cha'], tags: ['fighter', 'martial', 'lightly-armored', 'sword'] },
+    { name: 'Dexterity archer', primary: ['dex'], secondary: ['con', 'wis'], lowPriority: ['cha'], tags: ['fighter', 'martial', 'bow'] },
+  ] },
+  monk: { primary: ['dex', 'wis'], secondary: ['con'], lowPriority: ['str', 'cha'], archetype: 'Disciplined ascetic', tags: ['monk', 'martial', 'unarmored'] },
+  paladin: { primary: ['str', 'cha'], secondary: ['con'], lowPriority: ['int'], archetype: 'Oathbound protector', tags: ['paladin', 'martial', 'armored', 'shield'] },
+  ranger: { variants: [
+    { name: 'Wilderness archer', primary: ['dex', 'wis'], secondary: ['con'], lowPriority: ['cha'], tags: ['ranger', 'martial', 'bow'] },
+    { name: 'Two-weapon ranger', primary: ['dex', 'wis'], secondary: ['con', 'str'], lowPriority: ['cha'], tags: ['ranger', 'martial', 'lightly-armored', 'sword'] },
+  ] },
+  rogue: { variants: [
+    { name: 'Stealth infiltrator', primary: ['dex'], secondary: ['con', 'wis'], lowPriority: ['str'], tags: ['rogue', 'lightly-armored', 'dagger'] },
+    { name: 'Charming scoundrel', primary: ['dex'], secondary: ['cha', 'con'], lowPriority: ['str'], tags: ['rogue', 'lightly-armored', 'dagger'] },
+  ] },
+  sorcerer: { primary: ['cha'], secondary: ['con', 'dex'], lowPriority: ['str'], archetype: 'Innate spellcaster', tags: ['sorcerer', 'caster', 'robes', 'staff'] },
+  warlock: { primary: ['cha'], secondary: ['con', 'dex'], lowPriority: ['str'], archetype: 'Pact-bound occultist', tags: ['warlock', 'caster', 'robes', 'wand'] },
+  wizard: { primary: ['int'], secondary: ['con', 'dex'], lowPriority: ['str', 'cha'], archetype: 'Arcane scholar', tags: ['wizard', 'caster', 'robes', 'staff'] },
+};
+
+const fantasyNames = ['Aelar', 'Borin', 'Cora', 'Dain', 'Elora', 'Finn', 'Kael', 'Mira', 'Nix', 'Orin', 'Perrin', 'Rook', 'Tavi', 'Vexa', 'Wren'].map((name) => name.slice(0, 12));
+const alignments = ['Lawful Good', 'Neutral Good', 'Chaotic Good', 'Lawful Neutral', 'True Neutral', 'Chaotic Neutral'];
+const physicalBySize = { Tiny: { age: [18, 120], weight: [25, 70] }, Small: { age: [18, 180], weight: [35, 90] }, Medium: { age: [18, 220], weight: [90, 260] }, Large: { age: [18, 160], weight: [250, 520] } };
+
+const randomInt = (min, max, random = Math.random) => Math.floor(random() * (max - min + 1)) + min;
+const choice = (items, random = Math.random) => items[Math.floor(random() * items.length)];
+const clone = (value) => JSON.parse(JSON.stringify(value));
+const normalize = (value) => String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
+export const getClassKey = (className, classes = {}) => Object.keys(classes).find((key) => normalize(key) === normalize(className) || normalize(classes[key]?.name) === normalize(className));
+export const chooseClassBuildProfile = (classKey, random = Math.random) => {
+  const config = classBuildProfiles[classKey];
+  if (!config) return { name: 'Balanced adventurer', primary: ['con'], secondary: ['dex'], lowPriority: [], tags: ['adventurer'] };
+  if (Array.isArray(config.variants)) return choice(config.variants, random);
+  return { name: config.archetype || 'Balanced adventurer', ...config };
+};
+
+export const rollAbilityPool = (random = Math.random) => Array.from({ length: 6 }, () => {
+  const rolls = Array.from({ length: 4 }, () => randomInt(1, 6, random)).sort((a, b) => a - b);
+  return rolls.slice(1).reduce((total, roll) => total + roll, 0);
+});
+
+export const assignAbilityScores = (pool, profile) => {
+  const scores = {};
+  const orderedStats = [...new Set([...(profile.primary || []), ...(profile.secondary || []), ...STAT_KEYS.filter((key) => !(profile.lowPriority || []).includes(key)), ...(profile.lowPriority || [])])].filter((key) => STAT_KEYS.includes(key));
+  const sorted = [...pool].sort((a, b) => b - a);
+  orderedStats.forEach((key, index) => { scores[key] = Math.min(30, Math.max(1, sorted[index] ?? 10)); });
+  STAT_KEYS.forEach((key) => { if (!scores[key]) scores[key] = 10; });
+  return scores;
+};
+
+const normalizeOccupation = (klass, random = Math.random) => {
+  const prof = klass?.proficiencies || {};
+  const available = [...(prof.skills?.options || [])];
+  const skills = {};
+  for (let i = 0; i < (prof.skills?.count || 0); i += 1) {
+    if (!available.length) break;
+    const skill = available.splice(Math.floor(random() * available.length), 1)[0];
+    skills[skill] = { proficient: true };
+  }
+  return { Occupation: klass.name, Health: klass.hitDie, Level: 1, proficiencyPoints: prof.skills?.count || 0, armor: prof.armor || [], weapons: prof.weapons || [], tools: prof.tools || [], savingThrows: prof.savingThrows || [], skills };
+};
+
+export const figurineMetadata = [
+  { id: 'fighter-human', name: 'Armored Adventurer', publicId: 'Tokens/Adventurers/Core_Class_Tokens/Fighter', supportedClasses: ['fighter', 'paladin'], tags: ['human', 'martial', 'armored', 'sword', 'shield'] },
+  { id: 'wizard-robe', name: 'Robed Spellcaster', publicId: 'Tokens/Adventurers/Core_Class_Tokens/Wizard', supportedClasses: ['wizard', 'sorcerer', 'warlock'], tags: ['caster', 'robes', 'staff', 'wand'] },
+  { id: 'rogue-hood', name: 'Hooded Scout', publicId: 'Tokens/Adventurers/Core_Class_Tokens/Rogue', supportedClasses: ['rogue', 'ranger'], tags: ['rogue', 'lightly-armored', 'dagger', 'bow'] },
+  { id: 'barbarian-axe', name: 'Axe Champion', publicId: 'Tokens/Adventurers/Core_Class_Tokens/Barbarian', supportedClasses: ['barbarian'], tags: ['barbarian', 'martial', 'axe'] },
+  { id: 'neutral', name: 'Neutral Adventurer', publicId: 'Tokens/Adventurers/Core_Class_Tokens/Adventurer', supportedClasses: [], tags: ['adventurer', 'neutral'] },
+];
+
+export const scoreFigurine = (figurine, character) => {
+  const race = normalize(character?.race?.name || character?.race);
+  const klass = normalize(character?.classKey || character?.occupation?.[0]?.Occupation);
+  const tags = new Set((character?.appearanceTags || []).map(normalize));
+  let score = figurine.id === 'neutral' ? 1 : 0;
+  if ((figurine.supportedClasses || []).some((item) => normalize(item) === klass)) score += 8;
+  if ((figurine.supportedRaces || []).some((item) => normalize(item) === race)) score += 5;
+  (figurine.tags || []).forEach((tag) => { if (tags.has(normalize(tag))) score += 2; if (normalize(tag) === race) score += 2; });
+  return score;
+};
+
+export const chooseFigurine = (character, figurines = figurineMetadata, random = Math.random) => {
+  const scored = figurines.map((figurine) => ({ figurine, score: scoreFigurine(figurine, character) })).sort((a, b) => b.score - a.score);
+  const topScore = scored[0]?.score ?? 0;
+  const top = scored.filter((entry) => entry.score === topScore && topScore > 0).map((entry) => entry.figurine);
+  const selected = top.length ? choice(top, random) : figurines.find((item) => item.id === 'neutral');
+  return { figurineImagePublicId: selected?.publicId || '', figurineName: selected?.name || 'Neutral adventurer', figurineScore: topScore };
+};
+
+export const validateGeneratedCharacter = (character) => {
+  const errors = [];
+  if (!character.characterName?.trim()) errors.push('Name is required.');
+  if ((character.characterName || '').length > 12) errors.push('Name must be 12 characters or fewer.');
+  if (!character.race) errors.push('Race is required.');
+  if (!character.occupation?.length) errors.push('Class is required.');
+  if (!character.background) errors.push('Background is required.');
+  STAT_KEYS.forEach((key) => { const value = Number(character[key]); if (!Number.isFinite(value) || value < 1 || value > 30) errors.push(`${STAT_LABELS[key]} must be 1-30.`); });
+  return { valid: errors.length === 0, errors };
+};
+
+export const generateSmartCharacter = ({ baseForm, races, classes, backgrounds, preferredName = '', random = Math.random }) => {
+  const classKey = choice(Object.keys(classes || {}).filter((key) => classBuildProfiles[key]), random) || Object.keys(classes || {})[0];
+  const raceKey = choice(Object.keys(races || {}), random);
+  const backgroundKeys = Object.keys(backgrounds || {});
+  const backgroundKey = choice(backgroundKeys, random);
+  const race = races?.[raceKey] ? clone(races[raceKey]) : null;
+  const klass = classes?.[classKey];
+  const background = backgrounds?.[backgroundKey] ? clone(backgrounds[backgroundKey]) : null;
+  const sizeOptions = race ? (Array.isArray(race.sizeOptions) && race.sizeOptions.length ? race.sizeOptions : race.size ? [race.size] : ['Medium']) : ['Medium'];
+  const size = choice(sizeOptions, random);
+  const profile = chooseClassBuildProfile(classKey, random);
+  const scores = assignAbilityScores(rollAbilityPool(random), profile);
+  const range = physicalBySize[size] || physicalBySize.Medium;
+  const appearanceTags = [race?.name, classKey, ...(profile.tags || [])].filter(Boolean);
+  const selectedFigurine = chooseFigurine({ race, classKey, appearanceTags }, figurineMetadata, random);
+  const conMod = Math.floor((Number(scores.con) - 10) / 2);
+  const character = { ...baseForm, characterName: (preferredName || choice(fantasyNames, random)).slice(0, 12), race, background, occupation: klass ? [normalizeOccupation(klass, random)] : [], alignment: choice(alignments, random), size, age: randomInt(range.age[0], range.age[1], random), sex: choice(['Female', 'Male', 'Nonbinary'], random), weight: randomInt(range.weight[0], range.weight[1], random), ...scores, startStatTotal: STAT_KEYS.reduce((sum, key) => sum + Number(scores[key] || 0), 0), health: klass?.hitDie || 8, tempHealth: Math.max(1, (klass?.hitDie || 8) + conMod), buildArchetype: profile.name, shortConcept: `${profile.name} shaped by the ${background?.name || 'adventurer'} background.`, appearanceTags, ...selectedFigurine };
+  return { ...character, validation: validateGeneratedCharacter(character) };
+};
+
+export const normalizeAICharacter = ({ aiData, baseForm, races, classes, backgrounds, random = Math.random }) => {
+  if (!aiData || typeof aiData !== 'object') throw new Error('Malformed AI response.');
+  const classKey = getClassKey(aiData.class || aiData.classKey, classes) || Object.keys(classes || {})[0];
+  const raceKey = Object.keys(races || {}).find((key) => normalize(key) === normalize(aiData.race) || normalize(races[key]?.name) === normalize(aiData.race)) || Object.keys(races || {})[0];
+  const backgroundKey = Object.keys(backgrounds || {}).find((key) => normalize(key) === normalize(aiData.background) || normalize(backgrounds[key]?.name) === normalize(aiData.background)) || Object.keys(backgrounds || {})[0];
+  if (!classKey || !raceKey || !backgroundKey) throw new Error('AI response did not include supported options.');
+  const generated = generateSmartCharacter({ baseForm, races: { [raceKey]: races[raceKey] }, classes: { [classKey]: classes[classKey] }, backgrounds: { [backgroundKey]: backgrounds[backgroundKey] }, preferredName: aiData.name, random });
+  const concept = typeof aiData.shortConcept === 'string' ? aiData.shortConcept.slice(0, 140) : generated.shortConcept;
+  const tags = Array.isArray(aiData.appearanceTags) ? aiData.appearanceTags.slice(0, 8) : generated.appearanceTags;
+  const figurine = chooseFigurine({ ...generated, classKey, appearanceTags: tags }, figurineMetadata, random);
+  return { ...generated, shortConcept: concept, appearanceTags: tags, buildArchetype: aiData.buildArchetype || generated.buildArchetype, ...figurine, validation: validateGeneratedCharacter(generated), source: 'ai' };
+};
+
+export const createCharacterFromGeneratedData = (generated) => {
+  const { validation, source, classKey, appearanceTags, figurineName, figurineScore, ...character } = generated || {};
+  return character;
+};

--- a/client/src/components/Zombies/utils/characterGenerator.test.js
+++ b/client/src/components/Zombies/utils/characterGenerator.test.js
@@ -1,0 +1,70 @@
+import { assignAbilityScores, chooseClassBuildProfile, chooseFigurine, classBuildProfiles, figurineMetadata, generateSmartCharacter, normalizeAICharacter, scoreFigurine, validateGeneratedCharacter } from './characterGenerator';
+
+const classes = {
+  barbarian: { name: 'Barbarian', hitDie: 12, proficiencies: { skills: { count: 0, options: [] } } },
+  wizard: { name: 'Wizard', hitDie: 6, proficiencies: { skills: { count: 0, options: [] } } },
+  monk: { name: 'Monk', hitDie: 8, proficiencies: { skills: { count: 0, options: [] } } },
+  paladin: { name: 'Paladin', hitDie: 10, proficiencies: { skills: { count: 0, options: [] } } },
+  fighter: { name: 'Fighter', hitDie: 10, proficiencies: { skills: { count: 0, options: [] } } },
+};
+const races = { human: { name: 'Human', size: 'Medium' }, dwarf: { name: 'Dwarf', size: 'Medium' } };
+const backgrounds = { soldier: { name: 'Soldier' }, sage: { name: 'Sage' } };
+const baseForm = { campaign: 'camp', token: 'player' };
+const pool = [15, 14, 13, 12, 10, 8];
+
+test('barbarian prioritizes Strength and Constitution', () => {
+  const scores = assignAbilityScores(pool, classBuildProfiles.barbarian);
+  expect(scores.str).toBe(15);
+  expect(scores.con).toBeGreaterThanOrEqual(13);
+});
+
+test('wizard prioritizes Intelligence', () => {
+  const scores = assignAbilityScores(pool, classBuildProfiles.wizard);
+  expect(scores.int).toBe(15);
+});
+
+test('monk prioritizes Dexterity and Wisdom', () => {
+  const scores = assignAbilityScores(pool, classBuildProfiles.monk);
+  expect([scores.dex, scores.wis].sort((a, b) => b - a)).toEqual([15, 14]);
+});
+
+test('paladin prioritizes Strength and Charisma', () => {
+  const scores = assignAbilityScores(pool, classBuildProfiles.paladin);
+  expect([scores.str, scores.cha].sort((a, b) => b - a)).toEqual([15, 14]);
+});
+
+test('class variants produce valid score assignments', () => {
+  const profile = chooseClassBuildProfile('fighter', () => 0.9);
+  const scores = assignAbilityScores(pool, profile);
+  expect(Math.max(...Object.values(scores))).toBe(scores.dex);
+  Object.values(scores).forEach((value) => expect(value).toBeGreaterThanOrEqual(1));
+});
+
+test('generated character passes validation and conditional ancestry is absent unless relevant', () => {
+  const character = generateSmartCharacter({ baseForm, races, classes: { barbarian: classes.barbarian }, backgrounds, random: () => 0 });
+  expect(validateGeneratedCharacter(character).valid).toBe(true);
+  expect(character.dragonAncestryKey || '').toBe('');
+});
+
+test('figurine scoring favors matching race/class tags and fallback is neutral', () => {
+  const barbarian = { race: { name: 'Human' }, classKey: 'barbarian', appearanceTags: ['barbarian', 'axe'] };
+  expect(scoreFigurine(figurineMetadata[3], barbarian)).toBeGreaterThan(scoreFigurine(figurineMetadata[1], barbarian));
+  expect(chooseFigurine({ classKey: 'unknown', appearanceTags: [] }, [{ id: 'neutral', name: 'Neutral', publicId: 'Tokens/Neutral', tags: ['neutral'] }]).figurineImagePublicId).toBe('Tokens/Neutral');
+});
+
+test('repeated generation produces variety', () => {
+  const first = generateSmartCharacter({ baseForm, races, classes, backgrounds, random: () => 0 });
+  const second = generateSmartCharacter({ baseForm, races, classes, backgrounds, random: () => 0.99 });
+  expect(`${first.characterName}-${first.occupation[0].Occupation}`).not.toEqual(`${second.characterName}-${second.occupation[0].Occupation}`);
+});
+
+test('AI normalization repairs unsupported data, clamps through local rules, and selects figurine locally', () => {
+  const result = normalizeAICharacter({ aiData: { name: 'VeryLongCharacterName', class: 'Unsupported', race: 'Dwarf', background: 'Sage', abilityScores: { str: 99 }, shortConcept: 'A repaired hero.' }, baseForm, races, classes, backgrounds, random: () => 0 });
+  expect(result.characterName.length).toBeLessThanOrEqual(12);
+  Object.values({ str: result.str, dex: result.dex, con: result.con, int: result.int, wis: result.wis, cha: result.cha }).forEach((value) => expect(value).toBeGreaterThanOrEqual(1));
+  expect(result.figurineImagePublicId).toBeTruthy();
+});
+
+test('malformed AI response does not create a character', () => {
+  expect(() => normalizeAICharacter({ aiData: null, baseForm, races, classes, backgrounds })).toThrow('Malformed AI response.');
+});

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -16,6 +16,8 @@ const {
 } = require('../data/accessories');
 const { skillNames } = require('./fieldConstants');
 const createMapSchema = require('../schemas/map');
+const classes = require('../data/classes');
+const backgrounds = require('../data/backgrounds');
 const { deriveMapTitle } = require('../utils/mapTitle');
 
 const resolveOpenAI = () => {
@@ -80,6 +82,55 @@ module.exports = (router) => {
     }
     return mapSchemas;
   };
+
+
+  aiRouter.post('/character-concept', async (req, res) => {
+    const { prompt, supportedRaces = [], supportedClasses = [], supportedBackgrounds = [] } = req.body || {};
+    if (typeof prompt !== 'string' || !prompt.trim()) return res.status(400).json({ message: 'Prompt is required' });
+    if (prompt.length > 1200) return res.status(400).json({ message: 'Prompt is too long' });
+    const OpenAIClient = resolveOpenAI();
+    const Z = resolveZod();
+    if (!OpenAIClient || !Z || !resolveZodResponseFormat()) return res.status(500).json({ message: 'OpenAI not configured' });
+    const classNames = supportedClasses.length ? supportedClasses : Object.values(classes).map((item) => item.name);
+    const backgroundNames = supportedBackgrounds.length ? supportedBackgrounds : Object.values(backgrounds).map((item) => item.name);
+    const raceNames = supportedRaces.length ? supportedRaces : ['Human', 'Elf', 'Dwarf', 'Halfling', 'Dragonborn', 'Gnome', 'Tiefling', 'Goliath'];
+    const CharacterConceptSchema = Z.object({
+      name: Z.string().max(12),
+      race: Z.string(),
+      class: Z.string(),
+      subclass: Z.string().nullable().optional(),
+      background: Z.string(),
+      buildArchetype: Z.string().nullable().optional(),
+      abilityPriorities: Z.array(Z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha'])).optional(),
+      age: Z.number().nullable().optional(),
+      sex: Z.string().nullable().optional(),
+      size: Z.string().nullable().optional(),
+      weight: Z.number().nullable().optional(),
+      dragonAncestry: Z.string().nullable().optional(),
+      appearanceTags: Z.array(Z.string()).optional(),
+      shortConcept: Z.string().max(180),
+    });
+    try {
+      const openai = new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY, timeout: 20000 });
+      const format = buildFormat(CharacterConceptSchema, 'character_concept');
+      const response = await openai.responses.parse({
+        model: 'gpt-4o-2024-08-06',
+        input: [
+          { role: 'system', content: `Create a concise RealmTracker D&D character concept. Only use supported races (${raceNames.join(', ')}), classes (${classNames.join(', ')}), and backgrounds (${backgroundNames.join(', ')}). Return structured data only. The local rules engine will assign legal ability scores, validate fields, choose figurines, and save only after user confirmation. Do not copy famous copyrighted characters or unsupported details.` },
+          { role: 'user', content: prompt.trim() },
+        ],
+        text: { format },
+        max_output_tokens: 700,
+      });
+      const data = response.output?.[0]?.content?.[0]?.parsed;
+      const parsed = CharacterConceptSchema.safeParse(data);
+      if (!parsed.success) return res.status(422).json({ message: 'Invalid structured character response' });
+      return res.json(parsed.data);
+    } catch (err) {
+      logger.warn('AI character concept generation failed', { error: err.message });
+      return res.status(503).json({ message: 'AI generation is temporarily unavailable. Smart Random is still available.' });
+    }
+  });
 
   aiRouter.post('/weapon', async (req, res) => {
     const { prompt } = req.body || {};


### PR DESCRIPTION
### Motivation
- Provide an integrated character generator so players can create RealmTracker characters via a Smart Random flow or an AI-assisted concept flow. 
- Encapsulate generation logic in a reusable utility module that assigns ability scores, chooses figurines, and validates builds against local rules. 
- Add a backend endpoint to safely request structured AI character concepts and ensure responses are validated before client-side normalization. 

### Description
- Added a full-featured character generator UI modal with Smart Random and Create-with-AI modes in `ZombiesCharacterSelect.js`, including preview, regenerate, edit-manual, and figurine pick actions. 
- Introduced client generator state and helper functions (`runSmartGenerator`, `runAIGenerator`, `attachRandomFigurine`, `applyGeneratedCharacterToForm`, etc.) and adjusted token picker scope and figurine handling to work with generated characters. 
- Implemented generator logic in `client/src/components/Zombies/utils/characterGenerator.js` exposing functions such as `generateSmartCharacter`, `normalizeAICharacter`, `chooseFigurine`, `assignAbilityScores`, `validateGeneratedCharacter`, and `createCharacterFromGeneratedData`. 
- Added styling for the generator in `client/src/App.scss` and included a unit test suite `characterGenerator.test.js` for the generator logic. 
- Added a server route `POST /ai/character-concept` in `server/routes/ai.js` which calls OpenAI responses.parse with a Zod schema to return structured, validated AI character concepts and returns safe error messages when unavailable. 

### Testing
- Added unit tests in `client/src/components/Zombies/utils/characterGenerator.test.js` covering score assignment, class build selection, figurine scoring, smart generation variety, and AI normalization, and they passed when run with the project test runner. 
- Exercised the new generator utility test file with the repository test command (`npm test` / project test runner) and observed all new tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58d694f2f4832eb77715f4744389d7)