### PR TITLE
Overhaul character management modals

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11804,3 +11804,100 @@ body.character-creation-modal-open {
   .character-generator__footer { display:grid; grid-template-columns:1fr 1fr; padding:.65rem .8rem; }
   .character-generator__footer .btn:last-child { grid-column:1 / -1; }
 }
+
+/* Premium character management modals */
+.character-info-modal .modal-dialog { max-width: min(1180px, calc(100vw - 32px)); }
+.progression-modal .modal-dialog { max-width: min(920px, calc(100vw - 32px)); }
+.character-info-shell,
+.progression-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-height: min(88vh, 980px);
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+}
+.character-info-shell .realm-modal-header,
+.progression-shell .realm-modal-header {
+  min-height: 88px;
+  padding: 18px 72px 18px 24px;
+  border-bottom: 1px solid rgba(121,184,255,.18);
+  background: linear-gradient(180deg, rgba(14,30,54,.96), rgba(5,11,24,.92));
+  position: sticky;
+  top: 0;
+  z-index: 3;
+}
+.realm-modal-header__titles { min-width: 150px; }
+.realm-modal-header__subtitle { color: #d8b76a; font-size: .76rem; letter-spacing: .14em; text-transform: uppercase; font-weight: 800; }
+.realm-modal-header__title { color: #fff8df; font-family: 'Cinzel', serif; margin: 0; font-size: clamp(1.25rem, 2vw, 1.8rem); }
+.realm-modal-header__content { flex: 1; min-width: 0; }
+.realm-modal-header__actions { order: -1; }
+.realm-modal-header__close { position: absolute; right: 18px; top: 18px; min-width: 44px; min-height: 44px; }
+.character-summary-header { display: flex; align-items: center; gap: 14px; min-width: 0; }
+.character-summary-header__portrait { width: 64px; height: 64px; border-radius: 20px; display: grid; place-items: center; flex: 0 0 auto; overflow: hidden; color: #d8b76a; font-size: 1.6rem; background: radial-gradient(circle at 35% 20%, rgba(216,183,106,.28), rgba(30,55,90,.52)); border: 1px solid rgba(216,183,106,.28); box-shadow: inset 0 1px 0 rgba(255,255,255,.14); }
+.character-summary-header__portrait img { width: 100%; height: 100%; object-fit: contain; }
+.character-summary-header__copy { min-width: 0; display: grid; gap: 2px; text-align: left; }
+.character-summary-header__copy h3 { margin: 0; color: #fff; font-weight: 900; font-size: clamp(1.1rem, 2vw, 1.55rem); }
+.character-summary-header__copy p, .character-summary-header__copy span, .character-summary-header__copy small { margin: 0; color: rgba(238,246,255,.78); }
+.character-summary-header__copy span { white-space: normal; overflow-wrap: anywhere; }
+.character-info-body,
+.progression-body { min-height: 0; overflow-y: auto; padding: 22px !important; }
+.character-info-layout { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(280px, .8fr); gap: 16px; align-items: start; }
+.character-info-panel { padding: 18px; background: linear-gradient(145deg, rgba(15,29,52,.82), rgba(5,10,22,.88)); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
+.character-info-panel--progression { grid-row: span 2; }
+.character-info-section-heading { margin-bottom: 14px; text-align: left; }
+.character-info-section-heading span { color: #79b8ff; text-transform: uppercase; letter-spacing: .13em; font-size: .74rem; font-weight: 900; }
+.character-info-section-heading h4 { margin: 2px 0 0; color: #fff8df; font-weight: 900; }
+.character-stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 10px; }
+.character-stat-grid--compact { grid-template-columns: repeat(3, minmax(0, 1fr)); margin-bottom: 14px; }
+.realm-stat-card { padding: 14px; text-align: left; gap: 3px; min-width: 0; }
+.realm-stat-card span { color: rgba(218,232,255,.68); font-size: .72rem; letter-spacing: .11em; text-transform: uppercase; font-weight: 800; }
+.realm-stat-card strong { color: #fff; font-size: clamp(1.05rem, 2vw, 1.4rem); overflow-wrap: anywhere; }
+.realm-stat-card small { color: rgba(238,246,255,.66); }
+.character-class-list, .levelup-choice-grid, .class-browser-grid { display: grid; gap: 10px; }
+.character-class-list { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); }
+.realm-action-card { width: 100%; min-height: 44px; padding: 14px; border-radius: 16px; border: 1px solid rgba(121,184,255,.18); background: linear-gradient(145deg, rgba(22,39,65,.78), rgba(7,13,27,.9)); color: var(--realm-text); text-align: left; display: grid; gap: 5px; transition: transform .16s ease, border-color .16s ease, box-shadow .16s ease, background .16s ease; }
+.realm-action-card:hover:not(:disabled):not(.is-disabled), .realm-action-card:focus-visible { transform: translateY(-1px); border-color: rgba(121,184,255,.5); box-shadow: 0 0 0 .18rem rgba(78,161,255,.18), 0 18px 36px rgba(0,0,0,.25); outline: none; }
+.realm-action-card.is-selected { border-color: rgba(216,183,106,.8); background: linear-gradient(145deg, rgba(92,70,30,.76), rgba(13,25,45,.92)); box-shadow: 0 0 28px rgba(216,183,106,.18); }
+.realm-action-card:disabled, .realm-action-card.is-disabled { opacity: .55; cursor: not-allowed; }
+.realm-class-card { grid-template-columns: auto 1fr auto; align-items: center; }
+.realm-class-card strong { color: #fff; }
+.realm-class-card small, .realm-class-card span, .realm-class-card em { color: rgba(238,246,255,.72); font-style: normal; }
+.class-card__icon { width: 38px; height: 38px; border-radius: 13px; display: grid; place-items: center; color: #d8b76a; background: rgba(216,183,106,.12); border: 1px solid rgba(216,183,106,.18); }
+.character-class-list__level { justify-self: end; color: #d8b76a !important; font-weight: 900; }
+.is-primary-class { border-color: rgba(216,183,106,.46); }
+.rest-action-grid { display: grid; gap: 10px; }
+.rest-action-card--short { border-color: rgba(78,202,255,.28); }
+.rest-action-card--long { border-color: rgba(216,183,106,.38); background: radial-gradient(circle at 100% 0%, rgba(155,112,255,.2), transparent 42%), linear-gradient(145deg, rgba(35,31,62,.82), rgba(9,14,28,.92)); }
+.character-info-footer,
+.progression-footer { justify-content: flex-end; flex-wrap: wrap; padding-bottom: calc(16px + env(safe-area-inset-bottom)) !important; }
+.progression-entry-button { display: inline-flex !important; flex-direction: column; align-items: flex-start; line-height: 1.05; background: linear-gradient(135deg, #224fb1, #d8a928) !important; border-color: rgba(216,183,106,.74) !important; }
+.progression-entry-button span { font-size: .76rem; opacity: .9; }
+.levelup-summary { display: grid; grid-template-columns: minmax(170px, .35fr) 1fr; gap: 12px; align-items: stretch; margin-bottom: 16px; }
+.levelup-summary__classes { border: 1px solid rgba(121,184,255,.16); border-radius: 16px; padding: 14px; background: rgba(255,255,255,.04); color: rgba(238,246,255,.82); display: flex; align-items: center; }
+.levelup-choice-grid { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); }
+.realm-class-card--add { border-style: dashed; border-color: rgba(216,183,106,.5); }
+.add-class-step { display: grid; gap: 14px; animation: realmStepIn .18s ease-out; }
+.class-browser-grid { grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); max-height: 42vh; overflow-y: auto; padding-right: 4px; }
+.selected-class-preview { padding: 14px; }
+.selected-class-preview p { margin: 4px 0 0; color: rgba(238,246,255,.74); }
+.barbarian-followup { margin-top: 14px; display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+@keyframes realmStepIn { from { opacity: 0; transform: translateX(14px); } to { opacity: 1; transform: translateX(0); } }
+@media (prefers-reduced-motion: reduce) { .add-class-step, .realm-action-card { animation: none; transition: none; } }
+@media (max-width: 900px) { .character-info-layout { grid-template-columns: 1fr; } .character-info-panel--progression { grid-row: auto; } }
+@media (max-width: 768px) {
+  .character-info-modal .modal-dialog, .progression-modal .modal-dialog { max-width: 100%; }
+  .character-info-shell, .progression-shell { max-height: 92vh; }
+  .character-info-shell .realm-modal-header, .progression-shell .realm-modal-header { padding: 14px 60px 14px 16px; align-items: flex-start; flex-direction: column; }
+  .realm-modal-header__actions { order: 0; }
+  .character-summary-header__portrait { width: 52px; height: 52px; border-radius: 16px; }
+  .character-stat-grid--compact, .levelup-summary { grid-template-columns: 1fr; }
+  .character-info-footer .hud-button, .progression-footer .hud-button { flex: 1 1 160px; min-height: 44px; }
+  .progression-entry-button { flex-basis: 100% !important; }
+  .class-browser-grid { max-height: none; overflow: visible; }
+}
+@media (max-width: 420px) {
+  .character-summary-header { align-items: flex-start; }
+  .realm-class-card { grid-template-columns: auto 1fr; }
+  .character-class-list__level { grid-column: 2; justify-self: start; }
+}

--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -1,8 +1,9 @@
 import React, { useState, useMemo, useCallback } from "react";
-import { Card, Modal, Button } from "react-bootstrap";
+import { Modal } from "react-bootstrap";
 import DockControls from '../components/DockControls';
-import levelup from "../../../images/levelup.png";
-import LevelUp from "./LevelUp"; // Import LevelUp component
+import LevelUp from "./LevelUp";
+import { ModalShell, ModalHeader, ModalBody, ModalFooter, Section, StatCard, ActionCard, ClassCard, Button } from "../common/HudPrimitives";
+import { getCharacterTotalLevel, getMulticlassSummary } from "./characterProgression";
 
 export default function CharacterInfo({
   form,
@@ -19,7 +20,7 @@ export default function CharacterInfo({
   handleOpenTokenPicker,
   tokenPickerSaving = false,
 }) {
-  const totalLevel = form.occupation.reduce((total, el) => total + Number(el.Level), 0);
+  const totalLevel = getCharacterTotalLevel(form);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
 
   const handleShowLevelUpModal = () => {
@@ -203,12 +204,16 @@ export default function CharacterInfo({
     handleOpenTokenPicker();
   }, [canOpenTokenPicker, handleOpenTokenPicker, tokenPickerSaving]);
 
+  const sortedClasses = [...(form.occupation || [])].sort((a, b) => Number(b.Level || 0) - Number(a.Level || 0));
+  const primaryClass = sortedClasses[0]?.Occupation || 'Adventurer';
+  const characterName = form.name || form.characterName || 'Unnamed Hero';
+
   return (
     <Modal
-      className={modalClassName}
+      className={`${modalClassName} character-info-modal`}
       show={show}
       onHide={handleModalHide}
-      size="lg"
+      size="xl"
       centered={!isDocked}
       scrollable
       backdrop={isDocked ? false : true}
@@ -216,152 +221,95 @@ export default function CharacterInfo({
       restoreFocus={!isDocked}
       dialogClassName={dialogClassName}
     >
-      <Card className="modern-card text-center">
-        <Card.Header className="modal-header">
-          <DockControls
-            dockedSide={dockedSide}
-            onDockChange={onDockChange}
-            isDocked={isDocked}
-          />
-          <Card.Title className="modal-title">Character Info</Card.Title>
-        </Card.Header>
-        <Card.Body className="modal-body character-info-body" style={{ maxHeight: "60vh" }}>
-          <div className="character-info-figurine">
-            <div className="character-info-figurine__preview" aria-live="polite">
+      <ModalShell className="character-info-shell">
+        <ModalHeader
+          title="Character Overview"
+          subtitle={`${primaryClass} dossier`}
+          onClose={handleModalHide}
+          actions={
+            <DockControls
+              dockedSide={dockedSide}
+              onDockChange={onDockChange}
+              isDocked={isDocked}
+            />
+          }
+        >
+          <div className="character-summary-header">
+            <div className="character-summary-header__portrait" aria-live="polite">
               {characterFigurine?.figurineImageUrl ? (
-                <img
-                  src={characterFigurine.figurineImageUrl}
-                  alt="Selected figurine token"
-                  className="character-info-figurine__image"
-                />
+                <img src={characterFigurine.figurineImageUrl} alt="Selected figurine token" />
               ) : (
-                <div className="character-info-figurine__placeholder" aria-hidden="true">
-                  <i className="fas fa-chess-king"></i>
+                <i className="fas fa-chess-king" aria-hidden="true"></i>
+              )}
+            </div>
+            <div className="character-summary-header__copy">
+              <h3>{characterName}</h3>
+              <p>{form.race?.name || 'Unknown race'} • Level {totalLevel}</p>
+              <span>{getMulticlassSummary(form)}</span>
+              {form.background?.name && <small>{form.background.name} background</small>}
+            </div>
+          </div>
+        </ModalHeader>
+        <ModalBody className="character-info-body">
+          <div className="character-info-layout">
+            <Section className="character-info-panel character-info-panel--progression">
+              <div className="character-info-section-heading"><span>Progression</span><h4>Level & classes</h4></div>
+              <div className="character-stat-grid character-stat-grid--compact">
+                <StatCard label="Total Level" value={totalLevel} detail={`Next: ${totalLevel + 1}`} />
+                <StatCard label="Classes" value={(form.occupation || []).length || '—'} detail="Multiclass count" />
+                <StatCard label="Proficiency" value={form.proficiencyBonus || form.proficiency || '—'} detail="If tracked" />
+              </div>
+              <div className="character-class-list" aria-label="Character classes">
+                {sortedClasses.length ? sortedClasses.map((el, i) => (
+                  <ClassCard as="div" key={`${el.Occupation}-${i}`} className={i === 0 ? 'is-primary-class' : ''}>
+                    <span className="class-card__icon" aria-hidden="true">✦</span>
+                    <div><strong>{el.Occupation}</strong><small>{el.Subclass || el.subclass || (i === 0 ? 'Primary class' : 'Class')}</small></div>
+                    <span className="character-class-list__level">Level {el.Level}</span>
+                  </ClassCard>
+                )) : <div className="character-info-empty">No classes recorded.</div>}
+              </div>
+            </Section>
+
+            <Section className="character-info-panel character-info-panel--identity">
+              <div className="character-info-section-heading"><span>Identity</span><h4>Details</h4></div>
+              <div className="character-stat-grid">
+                <StatCard label="Race" value={form.race?.name || '—'} detail={[goliathAncestryName, dragonbornAncestryName, elvenLineageName, tieflingLegacySubtext].filter(Boolean).join(' • ')} className="character-info-item" />
+                <StatCard label="Background" value={form.background?.name || '—'} className="character-info-item"><Button variant="ghost" onClick={onShowBackground} aria-label="Show Background" className="stat-card-view"><i className="fa-solid fa-eye"></i></Button></StatCard>
+                <StatCard label="Languages" value={raceLanguages || '—'} className="character-info-item" />
+                <StatCard label="Age" value={form.age || '—'} className="character-info-item" />
+                <StatCard label="Sex" value={form.sex || '—'} className="character-info-item" />
+                <StatCard label="Size" value={displaySize} className="character-info-item" />
+                <StatCard label="Weight" value={form.weight ? `${form.weight} lbs` : '—'} className="character-info-item" />
+              </div>
+            </Section>
+
+            <Section className="character-info-panel character-info-panel--recovery">
+              <div className="character-info-section-heading"><span>Rest & recovery</span><h4>Recover resources</h4></div>
+              <div className="rest-action-grid">
+                <ActionCard type="button" className="rest-action-card rest-action-card--short" onClick={onShortRest}>
+                  <strong>Short Rest</strong><span>Recover short-rest resources and spend recovery as supported.</span>
+                </ActionCard>
+                <ActionCard type="button" className="rest-action-card rest-action-card--long" onClick={onLongRest}>
+                  <strong>Long Rest</strong><span>Restore hit points and long-rest resources through existing rest rules.</span>
+                </ActionCard>
+              </div>
+              <div className="character-info-figurine">
+                <div className="character-info-figurine__preview" aria-live="polite">
+                  {characterFigurine?.figurineImageUrl ? <img src={characterFigurine.figurineImageUrl} alt="Selected figurine token" className="character-info-figurine__image" /> : <div className="character-info-figurine__placeholder" aria-hidden="true"><i className="fas fa-chess-king"></i></div>}
+                  <div className="character-info-figurine__details">{hasFigurineSelection ? 'Figurine selected' : 'No figurine selected'}</div>
                 </div>
-              )}
-              {!characterFigurine?.figurineImageUrl && hasFigurineSelection && (
-                <div className="character-info-figurine__details">Figurine selected</div>
-              )}
-              {!hasFigurineSelection && (
-                <div className="character-info-figurine__details">No figurine selected</div>
-              )}
-            </div>
-            <Button
-              variant="outline-light"
-              size="sm"
-              onClick={handleFigurineButtonClick}
-              disabled={isFigurineButtonDisabled}
-            >
-              {figurineButtonLabel}
-            </Button>
+                <Button variant="ghost" size="sm" onClick={handleFigurineButtonClick} disabled={isFigurineButtonDisabled}>{figurineButtonLabel}</Button>
+              </div>
+            </Section>
           </div>
-          <div className="character-info-grid">
-            <div className="character-info-item">
-              <div className="character-info-label">Level</div>
-              <div className="character-info-value">{totalLevel}</div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Classes</div>
-              <div className="character-info-value character-info-value--stacked">
-                {form.occupation.length
-                  ? form.occupation.map((el, i) => (
-                      <span key={`${el.Occupation}-${i}`}>
-                        {el.Level} {el.Occupation}
-                      </span>
-                    ))
-                  : "—"}
-              </div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Race</div>
-              <div className="character-info-value character-info-value--stacked">
-                <span>{form.race?.name || "—"}</span>
-                {isGoliath && goliathAncestryName && (
-                  <span className="character-info-subtext">{goliathAncestryName}</span>
-                )}
-                {isDragonborn && dragonbornAncestryName && (
-                  <span className="character-info-subtext">{dragonbornAncestryName}</span>
-                )}
-                {isElf && elvenLineageName && (
-                  <span className="character-info-subtext">{elvenLineageName}</span>
-                )}
-                {isTiefling && tieflingLegacySubtext && (
-                  <span className="character-info-subtext">{tieflingLegacySubtext}</span>
-                )}
-              </div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Background</div>
-              <div className="character-info-value">
-                <span>{form.background?.name || "—"}</span>
-                <Button
-                  onClick={onShowBackground}
-                  variant="link"
-                  aria-label="Show Background"
-                  className="stat-card-view"
-                  size="sm"
-                >
-                  <i className="fa-solid fa-eye"></i>
-                </Button>
-              </div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Languages</div>
-              <div className="character-info-value">
-                {raceLanguages || "—"}
-              </div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Age</div>
-              <div className="character-info-value">{form.age || "—"}</div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Sex</div>
-              <div className="character-info-value">{form.sex || "—"}</div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Size</div>
-              <div className="character-info-value">{displaySize}</div>
-            </div>
-            <div className="character-info-item">
-              <div className="character-info-label">Weight</div>
-              <div className="character-info-value">
-                {form.weight ? `${form.weight} lbs` : "—"}
-              </div>
-            </div>
-          </div>
-        </Card.Body>
-        <Card.Footer className="modal-footer">
-          <Button
-            className="action-btn"
-            variant="secondary"
-            onClick={handleShowLevelUpModal}
-          >
-            <img src={levelup} alt="Level Up" height="24" />
-          </Button>
-          <Button
-            className="action-btn"
-            variant="secondary"
-            onClick={onLongRest}
-          >
-            Long Rest
-          </Button>
-          <Button
-            className="action-btn"
-            variant="secondary"
-            onClick={onShortRest}
-          >
-            Short Rest
-          </Button>
-          <Button
-            className="action-btn close-btn"
-            variant="primary"
-            onClick={handleModalHide}
-          >
-            Close
-          </Button>
-        </Card.Footer>
-      </Card>
+        </ModalBody>
+        <ModalFooter className="character-info-footer">
+          <Button className="progression-entry-button" variant="primary" onClick={handleShowLevelUpModal}>Level Up <span>Level {totalLevel} → {totalLevel + 1}</span></Button>
+          <Button variant="secondary" onClick={onLongRest}>Long Rest</Button>
+          <Button variant="ghost" onClick={onShortRest}>Short Rest</Button>
+          <Button variant="ghost" onClick={handleModalHide}>Close</Button>
+        </ModalFooter>
+      </ModalShell>
       <LevelUp show={showLevelUpModal} handleClose={handleCloseLevelUpModal} form={form} />
     </Modal>
   );

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -66,8 +66,8 @@ test('calls rest handlers when buttons clicked', () => {
 
   renderCharacterInfo({ onLongRest, onShortRest });
 
-  fireEvent.click(screen.getByText('Long Rest'));
-  fireEvent.click(screen.getByText('Short Rest'));
+  fireEvent.click(screen.getAllByRole('button', { name: 'Long Rest' }).pop());
+  fireEvent.click(screen.getAllByRole('button', { name: 'Short Rest' }).pop());
   expect(onLongRest).toHaveBeenCalled();
   expect(onShortRest).toHaveBeenCalled();
 });
@@ -161,7 +161,7 @@ test('disables figurine button while saving and shows current figurine', () => {
     tokenPickerSaving: true,
   });
 
-  expect(screen.getByAltText('Selected figurine token')).toHaveAttribute(
+  expect(screen.getAllByAltText('Selected figurine token')[0]).toHaveAttribute(
     'src',
     'https://example.com/token.png'
   );

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -1,333 +1,216 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import apiFetch from '../../../utils/apiFetch';
-import { Card, Modal, Button, Form, Alert } from "react-bootstrap";
+import { Modal, Alert, Form } from "react-bootstrap";
 import { useParams, useNavigate } from "react-router-dom";
 import useUser from '../../../hooks/useUser';
 import { BARBARIAN_LEVEL_1_SKILLS, BARBARIAN_SUBCLASSES } from '../utils/barbarian';
 import { SKILLS } from '../skillSchema';
+import { ModalShell, ModalHeader, ModalBody, ModalFooter, ClassCard, StatCard, SearchBar, ConfirmationDialog, Button } from '../common/HudPrimitives';
+import { getAvailableLevelUpClasses, getAvailableNewClasses, getCharacterTotalLevel, getMulticlassSummary, validateAddClassSelection, validateLevelUpSelection } from './characterProgression';
 
 export default function LevelUp({ show, handleClose, form }) {
-  //--------------------------------------------Level Up--------------------------------------------------------------------------------------------------------------------------------------------
-  const [showLvlModal, setShowLvlModal] = useState(show);
-  const [chosenOccupation, setChosenOccupation] = useState('');
-  const selectedOccupationRef = useRef();
   const params = useParams();
   const navigate = useNavigate();
   const user = useUser();
-
-  useEffect(() => {
-    setShowLvlModal(show);
-  }, [show]);
-
-  const handleChosenOccupationChange = (e) => {
-    setChosenOccupation(e.target.value);
-  };
-
-  const handleCloseLvlModal = () => {
-    setChosenOccupation('');
-    setShowLvlModal(false);
-    setNotification('');
-    setError('');
-    handleClose();
-  };
-
-  const levelUpdate = async () => {
-    const selectedOccupation = selectedOccupationRef.current.value;
-    const selectedOccupationObject = form.occupation.find(
-      (occupation) => occupation.Occupation === selectedOccupation
-    );
-
-    if (!selectedOccupationObject) {
-      console.error("Selected occupation not found");
-      return;
-    }
-
-    const newLevel = Number(selectedOccupationObject.Level) + 1;
-    const newHealth = Math.floor(Math.random() * Number(selectedOccupationObject.Health)) + 1 + Number(form.health);
-
-    const updatedLevelForm = {
-      selectedOccupation,
-      level: newLevel,
-      health: newHealth,
-    };
-
-    if (selectedOccupation === 'Barbarian' && newLevel >= 3) {
-      updatedLevelForm.barbarianSubclass = barbarianSubclass;
-      if (newLevel === 3) {
-        updatedLevelForm.primalKnowledgeSkill = primalKnowledgeSkill;
-      }
-    }
-
-    try {
-      await apiFetch(`/characters/update-level/${params.id}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updatedLevelForm),
-      });
-      navigate(0);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  //--------------------------------------------Add Class--------------------------------------------------------------------------------------------------------------------------------------------
-  const [showAddClassModal, setShowAddClassModal] = useState(false);
-  const [selectedOccupation, setSelectedOccupation] = useState(null);
-  const selectedAddOccupationRef = useRef();
-  const [getOccupation, setGetOccupation] = useState([]);
-  const [chosenAddOccupation, setChosenAddOccupation] = useState('');
+  const [step, setStep] = useState('choose-progression');
+  const [selectedExistingClassId, setSelectedExistingClassId] = useState('');
+  const [selectedNewClassId, setSelectedNewClassId] = useState('');
+  const [classRecords, setClassRecords] = useState([]);
+  const [search, setSearch] = useState('');
   const [notification, setNotification] = useState('');
   const [error, setError] = useState('');
   const [validationError, setValidationError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [barbarianSubclass, setBarbarianSubclass] = useState('path-of-the-berserker');
   const [primalKnowledgeSkill, setPrimalKnowledgeSkill] = useState('');
 
-  const handleAddOccupationClick = () => {
-    setShowAddClassModal(true);
-    setChosenAddOccupation('');
-    setValidationError('');
-    setError('');
+  const totalLevel = getCharacterTotalLevel(form);
+  const levelUpClasses = useMemo(() => getAvailableLevelUpClasses(form), [form]);
+  const newClasses = useMemo(() => getAvailableNewClasses(form, classRecords), [form, classRecords]);
+  const filteredNewClasses = useMemo(() => newClasses.filter((entry) => entry.name.toLowerCase().includes(search.toLowerCase())), [newClasses, search]);
+  const selectedExisting = levelUpClasses.find((entry) => entry.name === selectedExistingClassId);
+  const selectedNew = newClasses.find((entry) => entry.name === selectedNewClassId);
+
+  const resetFlow = () => {
+    setStep('choose-progression');
+    setSelectedExistingClassId('');
+    setSelectedNewClassId('');
+    setSearch('');
     setNotification('');
-  };
-
-  const handleOccupationChange = (event) => {
-    const selectedIndex = event.target.selectedIndex;
-    setSelectedOccupation(getOccupation[selectedIndex - 1]); // Subtract 1 because the first option is empty
-    setChosenAddOccupation(event.target.value);
-  };
-
-  const handleConfirmClick = async () => {
-    if (selectedOccupation) {
-      setValidationError('');
-      setError('');
-      setNotification('');
-      const selectedAddOccupation = selectedAddOccupationRef.current.value;
-      try {
-        const response = await apiFetch(`/characters/multiclass/${params.id}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ newOccupation: selectedAddOccupation }),
-        });
-        const data = await response.json();
-        if (response.ok) {
-          setNotification('Database update complete');
-          setShowAddClassModal(false);
-          navigate(0);
-        } else if (response.status === 400) {
-          setValidationError(data.message || 'Multiclass validation failed');
-        } else {
-          setError(data.message || 'Database update failed');
-        }
-      } catch (err) {
-        console.error(err);
-        setError('Database update failed');
-      }
-    } else {
-      setValidationError('Please select a class.');
-    }
+    setError('');
+    setValidationError('');
+    setIsSubmitting(false);
+    setPrimalKnowledgeSkill('');
   };
 
   useEffect(() => {
-    if (!user) return;
+    if (!show) resetFlow();
+  }, [show]);
+
+  useEffect(() => {
+    if (!user || !show) return;
     async function fetchData() {
-      const response = await apiFetch('/classes');
-
-      if (!response.ok) {
-        const message = `An error has occurred: ${response.statusText}`;
-        setError(message);
-        return;
+      try {
+        const response = await apiFetch('/classes');
+        if (!response.ok) {
+          setError(`Class catalogue failed to load: ${response.statusText}`);
+          return;
+        }
+        const record = await response.json();
+        setClassRecords(Object.values(record || {}));
+      } catch (err) {
+        setError('Class catalogue failed to load.');
       }
-
-      const record = await response.json();
-      if (!record) {
-        setError('Record not found');
-        navigate("/");
-        return;
-      }
-      setGetOccupation(Object.values(record));
     }
     fetchData();
-    return;
+  }, [show, user]);
 
-  }, [navigate, user]);
+  const close = () => {
+    resetFlow();
+    handleClose?.();
+  };
+
+  const requiresBarbarianPrimalSkill = selectedExistingClassId === 'Barbarian' && selectedExisting?.nextLevel === 3;
+  const barbarianValidation = requiresBarbarianPrimalSkill && !primalKnowledgeSkill ? 'Choose a Primal Knowledge skill before leveling Barbarian.' : '';
+
+  const levelExisting = async () => {
+    const validation = validateLevelUpSelection(form, selectedExistingClassId);
+    if (!validation.valid || barbarianValidation) {
+      setValidationError(barbarianValidation || validation.message);
+      return;
+    }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    const selectedOccupationObject = form.occupation.find((occupation) => occupation.Occupation === selectedExistingClassId);
+    const newLevel = Number(selectedOccupationObject.Level) + 1;
+    const newHealth = Math.floor(Math.random() * Number(selectedOccupationObject.Health)) + 1 + Number(form.health);
+    const updatedLevelForm = { selectedOccupation: selectedExistingClassId, level: newLevel, health: newHealth };
+    if (selectedExistingClassId === 'Barbarian' && newLevel >= 3) {
+      updatedLevelForm.barbarianSubclass = barbarianSubclass;
+      if (newLevel === 3) updatedLevelForm.primalKnowledgeSkill = primalKnowledgeSkill;
+    }
+    try {
+      await apiFetch(`/characters/update-level/${params.id}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updatedLevelForm) });
+      setNotification(`${form.name || 'Character'} is now a Level ${newLevel} ${selectedExistingClassId}.`);
+      navigate(0);
+    } catch (err) {
+      setError('Level up failed. Please try again.');
+      setIsSubmitting(false);
+    }
+  };
+
+  const addNewClass = async () => {
+    const validation = validateAddClassSelection(form, classRecords, selectedNewClassId);
+    if (!validation.valid) {
+      setValidationError(validation.message);
+      return;
+    }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const response = await apiFetch(`/characters/multiclass/${params.id}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ newOccupation: selectedNewClassId }) });
+      const data = await response.json();
+      if (response.ok) {
+        setNotification(`${form.name || 'Character'} added ${selectedNewClassId} and is now Level ${totalLevel + 1}.`);
+        navigate(0);
+      } else if (response.status === 400) {
+        setValidationError(data.message || 'Multiclass validation failed');
+        setIsSubmitting(false);
+      } else {
+        setError(data.message || 'Database update failed');
+        setIsSubmitting(false);
+      }
+    } catch (err) {
+      setError('Database update failed');
+      setIsSubmitting(false);
+    }
+  };
+
+  const skillLabels = Object.fromEntries(SKILLS.map((skill) => [skill.key, skill.label]));
+  const currentSkills = form.skills || {};
+  const alreadyProficient = new Set([
+    ...Object.entries(currentSkills).filter(([, info]) => info?.proficient).map(([key]) => key),
+    ...Object.entries(form.race?.skills || {}).filter(([, info]) => info?.proficient).map(([key]) => key),
+    ...Object.entries(form.background?.skills || {}).filter(([, info]) => info?.proficient).map(([key]) => key),
+  ]);
+  const availablePrimalSkills = BARBARIAN_LEVEL_1_SKILLS.filter((skill) => !alreadyProficient.has(skill));
 
   return (
-    <div>
-      <Modal className="dnd-modal modern-modal" show={showLvlModal} onHide={handleCloseLvlModal} size="md" centered>
-        <div className="text-center">
-          <Card className="modern-card">
-            <Card.Header className="modal-header">
-              <Card.Title className="modal-title">Level Up</Card.Title>
-            </Card.Header>
-            <Card.Body>
-              {notification && (
-                <Alert variant="success" onClose={() => setNotification('')} dismissible>
-                  {notification}
-                </Alert>
-              )}
-                {error && (
-                  <Alert variant="danger" onClose={() => setError('')} dismissible>
-                    {error}
-                  </Alert>
-                )}
-                {validationError && (
-                  <Alert variant="warning" onClose={() => setValidationError('')} dismissible>
-                    {validationError}
-                  </Alert>
-                )}
-                {/* Add class */}
-                <Form>
-                  <Button className="action-btn" onClick={handleAddOccupationClick}>
-                    Add Class
-                  </Button>
-                  <Modal
-                  className="dnd-modal modern-modal"
-                  centered
-                  show={showAddClassModal}
-                  onHide={() => { setShowAddClassModal(false); setChosenAddOccupation(''); setError(''); setNotification(''); }}
-                >
-                  <Card className="modern-card text-center">
-                    <Card.Header className="modal-header">
-                      <Card.Title className="modal-title">Add Class</Card.Title>
-                    </Card.Header>
-                    <Card.Body>
-                      {notification && (
-                        <Alert variant="success" onClose={() => setNotification('')} dismissible>
-                          {notification}
-                        </Alert>
-                      )}
-                      {error && (
-                        <Alert variant="danger" onClose={() => setError('')} dismissible>
-                          {error}
-                        </Alert>
-                      )}
-                      <Form.Group className="mb-3 mx-5">
-                        <Form.Label className="text-light">Select Class</Form.Label>
-                        <Form.Select
-                          ref={selectedAddOccupationRef}
-                          onChange={handleOccupationChange}
-                          defaultValue=""
-                        >
-                          <option value="" disabled>Select your class</option>
-                          {getOccupation.map((occupation, i) => {
-                            const isOccupationSelected = form.occupation.some(
-                              (item) => item.Occupation === occupation.name
-                            );
-
-                            return (
-                              <option key={i} disabled={isOccupationSelected}>
-                                {occupation.name}
-                              </option>
-                            );
-                          })}
-                        </Form.Select>
-                      </Form.Group>
-                      {validationError && <div className="text-danger">{validationError}</div>}
-                    </Card.Body>
-                    <Card.Footer className="modal-footer">
-                          <Button
-                            className="action-btn close-btn"
-                            onClick={() => { setShowAddClassModal(false); setChosenAddOccupation(''); setError(''); setNotification(''); }}
-                          >
-                          Close
-                        </Button>
-                      <Button
-                        className="action-btn save-btn"
-                        onClick={handleConfirmClick}
-                        disabled={!chosenAddOccupation}
-                      >
-                        Confirm
-                      </Button>
-                    </Card.Footer>
-                  </Card>
-                </Modal>
-              </Form>
-              {/* Level up known occupation */}
-              <Form
-                id="level-up-form"
-                onSubmit={(e) => { e.preventDefault(); handleCloseLvlModal(); levelUpdate(); }}
-              >
-                <br />
-                <span>or</span>
-                <Form.Group className="mb-3 mx-5">
-                  <Form.Label className="text-light">Select Class</Form.Label>
-                  <Form.Select
-                    ref={selectedOccupationRef}
-                    defaultValue=""
-                    onChange={handleChosenOccupationChange}
-                  >
-                    <option value="" disabled>Select your class</option>
-                    {form.occupation.map((occupation, i) => (
-                      <option key={i}>{occupation.Occupation}</option>
-                    ))}
-                  </Form.Select>
-                </Form.Group>
-                {chosenOccupation === 'Barbarian' && (() => {
-                  const barbarian = form.occupation.find((occupation) => occupation.Occupation === 'Barbarian');
-                  const nextLevel = Number(barbarian?.Level || 0) + 1;
-                  if (nextLevel < 3) return null;
-                  const skillLabels = Object.fromEntries(SKILLS.map((skill) => [skill.key, skill.label]));
-                  const currentSkills = form.skills || {};
-                  const alreadyProficient = new Set([
-                    ...Object.entries(currentSkills).filter(([, info]) => info?.proficient).map(([key]) => key),
-                    ...Object.entries(form.race?.skills || {}).filter(([, info]) => info?.proficient).map(([key]) => key),
-                    ...Object.entries(form.background?.skills || {}).filter(([, info]) => info?.proficient).map(([key]) => key),
-                  ]);
-                  const availablePrimalSkills = BARBARIAN_LEVEL_1_SKILLS.filter((skill) => !alreadyProficient.has(skill));
-                  return (
-                    <>
-                      <Form.Group className="mb-3 mx-5">
-                        <Form.Label className="text-light">Barbarian Subclass</Form.Label>
-                        <Form.Select value={barbarianSubclass} onChange={(event) => setBarbarianSubclass(event.target.value)}>
-                          {BARBARIAN_SUBCLASSES.map((subclass) => (
-                            <option key={subclass.id} value={subclass.id}>{subclass.name}</option>
-                          ))}
-                        </Form.Select>
-                      </Form.Group>
-                      {nextLevel === 3 && (
-                        <Form.Group className="mb-3 mx-5">
-                          <Form.Label className="text-light">Primal Knowledge Skill</Form.Label>
-                          <Form.Select value={primalKnowledgeSkill} onChange={(event) => setPrimalKnowledgeSkill(event.target.value)}>
-                            <option value="" disabled>Select one skill</option>
-                            {availablePrimalSkills.map((skill) => (
-                              <option key={skill} value={skill}>{skillLabels[skill] || skill}</option>
-                            ))}
-                          </Form.Select>
-                        </Form.Group>
-                      )}
-                    </>
-                  );
-                })()}
-
-              </Form>
-            </Card.Body>
-            <Card.Footer className="modal-footer">
-              <Button className="action-btn close-btn" onClick={handleCloseLvlModal}>
-                Close
-              </Button>
-              <Button
-                className="action-btn save-btn"
-                type="submit"
-                form="level-up-form"
-                disabled={!chosenOccupation 
-                  || (
-                    chosenOccupation === 'Barbarian' 
-                    && form.occupation.find((occupation) => occupation.Occupation === 'Barbarian') 
-                    && Number(form.occupation.find((occupation) => occupation.Occupation === 'Barbarian').Level || 0) + 1 === 3 
-                    && !primalKnowledgeSkill
-                  )
-                }
-              >
-                Level Up
-              </Button>
-            </Card.Footer>
-          </Card>
-        </div>
-      </Modal>
-    </div>
+    <Modal className="dnd-modal modern-modal progression-modal" show={show} onHide={close} centered size="lg" scrollable restoreFocus>
+      <ModalShell className="progression-shell">
+        <ModalHeader
+          title={step === 'add-class' ? 'Add a Class' : 'Level Up'}
+          subtitle={step === 'add-class' ? `Choose a new class for ${form.name || 'this character'}.` : `Choose how ${form.name || 'this character'} advances to level ${totalLevel + 1}.`}
+          onClose={close}
+          actions={step === 'add-class' ? <Button variant="ghost" onClick={() => { setStep('choose-progression'); setSelectedNewClassId(''); }}>← Back</Button> : null}
+        />
+        <ModalBody className="progression-body">
+          {notification && <Alert variant="success">{notification}</Alert>}
+          {error && <Alert variant="danger">{error}</Alert>}
+          {validationError && <Alert variant="warning">{validationError}</Alert>}
+          <div className="levelup-summary">
+            <StatCard label="Total Level" value={`${totalLevel} → ${totalLevel + 1}`} detail="Progression preview" />
+            <div className="levelup-summary__classes">{getMulticlassSummary(form)}</div>
+          </div>
+          {step === 'choose-progression' ? (
+            <div className="levelup-choice-grid" role="list" aria-label="Progression choices">
+              {levelUpClasses.map((entry) => (
+                <ClassCard key={entry.name} type="button" selected={selectedExistingClassId === entry.name} disabled={entry.disabled} onClick={() => { setSelectedExistingClassId(entry.name); setSelectedNewClassId(''); setValidationError(''); }}>
+                  <span className="class-card__icon" aria-hidden="true">✦</span>
+                  <strong>{entry.name}</strong>
+                  <span>{entry.disabled ? `Level ${entry.level}` : `Level ${entry.level} → ${entry.nextLevel}`}</span>
+                  {entry.subclass && <small>{entry.subclass}</small>}
+                  {entry.hitDie && <small>Hit Die {entry.hitDie}</small>}
+                  {entry.disabled && <em>{entry.reason}</em>}
+                </ClassCard>
+              ))}
+              <ClassCard type="button" className="realm-class-card--add" onClick={() => { setStep('add-class'); setSelectedExistingClassId(''); setValidationError(''); }}>
+                <span className="class-card__icon" aria-hidden="true">＋</span>
+                <strong>Add a New Class</strong>
+                <span>Begin multiclassing into another discipline.</span>
+                <small>Resulting total level: {totalLevel + 1}</small>
+              </ClassCard>
+            </div>
+          ) : (
+            <div className="add-class-step">
+              <SearchBar value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search classes" aria-label="Search classes" />
+              <div className="class-browser-grid">
+                {filteredNewClasses.map((entry) => (
+                  <ClassCard key={entry.name} type="button" selected={selectedNewClassId === entry.name} disabled={entry.disabled} onClick={() => { setSelectedNewClassId(entry.name); setValidationError(''); }}>
+                    <span className="class-card__icon" aria-hidden="true">◆</span>
+                    <strong>{entry.name}</strong>
+                    <span>{entry.description || 'Adventuring discipline'}</span>
+                    {entry.primaryAbility && <small>Primary: {entry.primaryAbility}</small>}
+                    {entry.hitDie && <small>Hit Die: {entry.hitDie}</small>}
+                    {entry.disabled && <em>{entry.reason}</em>}
+                  </ClassCard>
+                ))}
+              </div>
+              <ConfirmationDialog className="selected-class-preview" aria-live="polite">
+                <strong>{selectedNew ? selectedNew.name : 'Select a class to preview the result.'}</strong>
+                <p>{selectedNew ? `${form.name || 'Character'} will add ${selectedNew.name} 1 and become total level ${totalLevel + 1}. Class feature and subclass choices continue in the existing character progression flow when supported.` : 'Duplicate classes are disabled and backend multiclass validation still applies on confirmation.'}</p>
+              </ConfirmationDialog>
+            </div>
+          )}
+          {selectedExistingClassId === 'Barbarian' && selectedExisting?.nextLevel >= 3 && (
+            <div className="barbarian-followup">
+              <Form.Group>
+                <Form.Label>Barbarian Subclass</Form.Label>
+                <Form.Select value={barbarianSubclass} onChange={(event) => setBarbarianSubclass(event.target.value)}>
+                  {BARBARIAN_SUBCLASSES.map((subclass) => <option key={subclass.id} value={subclass.id}>{subclass.name}</option>)}
+                </Form.Select>
+              </Form.Group>
+              {requiresBarbarianPrimalSkill && <Form.Group><Form.Label>Primal Knowledge Skill</Form.Label><Form.Select value={primalKnowledgeSkill} onChange={(event) => setPrimalKnowledgeSkill(event.target.value)}><option value="" disabled>Select one skill</option>{availablePrimalSkills.map((skill) => <option key={skill} value={skill}>{skillLabels[skill] || skill}</option>)}</Form.Select></Form.Group>}
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter className="progression-footer">
+          {step === 'add-class' ? <Button variant="ghost" onClick={() => setStep('choose-progression')}>Back</Button> : <Button variant="ghost" onClick={close}>Cancel</Button>}
+          <Button variant="primary" onClick={step === 'add-class' ? addNewClass : levelExisting} disabled={isSubmitting || (step === 'add-class' ? !selectedNewClassId : !selectedExistingClassId) || Boolean(barbarianValidation)}>
+            {isSubmitting ? 'Saving…' : step === 'add-class' ? 'Confirm Class' : 'Confirm Level Up'}
+          </Button>
+        </ModalFooter>
+      </ModalShell>
+    </Modal>
   );
 }

--- a/client/src/components/Zombies/attributes/characterProgression.js
+++ b/client/src/components/Zombies/attributes/characterProgression.js
@@ -1,0 +1,79 @@
+export const CLASS_LEVEL_LIMIT = 20;
+
+export function getCharacterTotalLevel(character = {}) {
+  return (character.occupation || []).reduce((total, entry) => total + Number(entry.Level || 0), 0);
+}
+
+export function getClassName(entry = {}) {
+  return entry.Occupation || entry.name || 'Unknown Class';
+}
+
+export function getClassLevel(entry = {}) {
+  return Number(entry.Level || entry.level || 0);
+}
+
+export function getMulticlassSummary(character = {}) {
+  const classes = character.occupation || [];
+  if (!classes.length) return 'No class selected';
+  return [...classes]
+    .sort((a, b) => getClassLevel(b) - getClassLevel(a))
+    .map((entry) => `${getClassName(entry)} ${getClassLevel(entry)}`)
+    .join(' / ');
+}
+
+export function getAvailableLevelUpClasses(character = {}) {
+  return (character.occupation || []).map((entry) => {
+    const level = getClassLevel(entry);
+    const isMaxLevel = level >= CLASS_LEVEL_LIMIT;
+    return {
+      id: getClassName(entry),
+      name: getClassName(entry),
+      level,
+      nextLevel: level + 1,
+      hitDie: entry.Health ? `d${entry.Health}` : null,
+      subclass: entry.Subclass || entry.subclass || entry.subClass || null,
+      disabled: isMaxLevel,
+      reason: isMaxLevel ? 'Maximum class level reached' : '',
+    };
+  });
+}
+
+export function normalizeClassRecord(record = {}) {
+  return {
+    id: record._id || record.id || record.name,
+    name: record.name || record.Occupation || 'Unknown Class',
+    primaryAbility: record.primaryAbility || record.primary_ability || record.ability || null,
+    hitDie: record.hitDie || record.hit_die || (record.Health ? `d${record.Health}` : null),
+    description: record.description || record.role || record.summary || null,
+  };
+}
+
+export function getAvailableNewClasses(character = {}, classRecords = []) {
+  const existing = new Set((character.occupation || []).map((entry) => getClassName(entry)));
+  return classRecords.map((record) => {
+    const normalized = normalizeClassRecord(record);
+    const duplicate = existing.has(normalized.name);
+    return {
+      ...normalized,
+      currentLevel: duplicate ? getClassLevel((character.occupation || []).find((entry) => getClassName(entry) === normalized.name)) : 0,
+      disabled: duplicate,
+      reason: duplicate ? 'Already part of this character' : '',
+    };
+  });
+}
+
+export function validateLevelUpSelection(character = {}, className) {
+  if (!className) return { valid: false, message: 'Choose a class to advance.' };
+  const option = getAvailableLevelUpClasses(character).find((entry) => entry.name === className);
+  if (!option) return { valid: false, message: 'Selected class is not on this character.' };
+  if (option.disabled) return { valid: false, message: option.reason };
+  return { valid: true, message: '' };
+}
+
+export function validateAddClassSelection(character = {}, classRecords = [], className) {
+  if (!className) return { valid: false, message: 'Choose a new class.' };
+  const option = getAvailableNewClasses(character, classRecords).find((entry) => entry.name === className);
+  if (!option) return { valid: false, message: 'Selected class is unavailable.' };
+  if (option.disabled) return { valid: false, message: option.reason };
+  return { valid: true, message: '' };
+}

--- a/client/src/components/Zombies/attributes/characterProgression.test.js
+++ b/client/src/components/Zombies/attributes/characterProgression.test.js
@@ -1,0 +1,33 @@
+import { getCharacterTotalLevel, getMulticlassSummary, getAvailableLevelUpClasses, getAvailableNewClasses, validateAddClassSelection, validateLevelUpSelection } from './characterProgression';
+
+const character = {
+  occupation: [
+    { Occupation: 'Fighter', Level: 2, Health: 10 },
+    { Occupation: 'Sorcerer', Level: 20, Health: 6 },
+    { Occupation: 'Warlock', Level: 5, Health: 8 },
+  ],
+};
+
+const classRecords = [
+  { name: 'Fighter', hitDie: 'd10', primaryAbility: 'Strength' },
+  { name: 'Barbarian', hitDie: 'd12', primaryAbility: 'Strength' },
+];
+
+test('calculates total level and sorted multiclass summary', () => {
+  expect(getCharacterTotalLevel(character)).toBe(27);
+  expect(getMulticlassSummary(character)).toBe('Sorcerer 20 / Warlock 5 / Fighter 2');
+});
+
+test('marks max-level existing classes disabled while allowing valid selections', () => {
+  const options = getAvailableLevelUpClasses(character);
+  expect(options.find((entry) => entry.name === 'Sorcerer')).toMatchObject({ disabled: true, reason: 'Maximum class level reached' });
+  expect(validateLevelUpSelection(character, 'Fighter')).toEqual({ valid: true, message: '' });
+  expect(validateLevelUpSelection(character, 'Sorcerer').valid).toBe(false);
+});
+
+test('prevents duplicate new classes and validates add-class selections', () => {
+  const options = getAvailableNewClasses(character, classRecords);
+  expect(options.find((entry) => entry.name === 'Fighter')).toMatchObject({ disabled: true, currentLevel: 2 });
+  expect(validateAddClassSelection(character, classRecords, 'Barbarian')).toEqual({ valid: true, message: '' });
+  expect(validateAddClassSelection(character, classRecords, 'Fighter').valid).toBe(false);
+});

--- a/client/src/components/Zombies/common/HudPrimitives.js
+++ b/client/src/components/Zombies/common/HudPrimitives.js
@@ -77,6 +77,32 @@ export function StatCard({ label, value, detail, className, children }) {
   return <Card className={join('realm-stat-card', className)}><span>{label}</span><strong>{value}</strong>{detail && <small>{detail}</small>}{children}</Card>;
 }
 
+export function ActionCard({ as: Component = 'button', className, selected, disabled, children, ...props }) {
+  return (
+    <Component
+      className={join('realm-action-card', selected && 'is-selected', disabled && 'is-disabled', className)}
+      disabled={Component === 'button' ? disabled : undefined}
+      aria-pressed={Component === 'button' && selected ? true : undefined}
+      aria-disabled={disabled || undefined}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export function ClassCard({ className, children, ...props }) {
+  return <ActionCard className={join('realm-class-card', className)} {...props}>{children}</ActionCard>;
+}
+
+export function ConfirmationDialog({ className, children, ...props }) {
+  return <InfoCard className={join('realm-confirmation-dialog', className)} {...props}>{children}</InfoCard>;
+}
+
+export function MobileBottomSheet({ className, children, ...props }) {
+  return <BottomSheet className={join('realm-mobile-bottom-sheet', className)} {...props}>{children}</BottomSheet>;
+}
+
 export function ActionBar({ className, children, ...props }) {
   return <div className={join('realm-action-bar', className)} {...props}>{children}</div>;
 }


### PR DESCRIPTION
### Motivation

- Replace the old, stacked administrative dialogs for character management with a single cohesive, premium UX that matches the RealmTracker modal system and design language. 
- Remove nested full-width modals for the Level Up → Add Class flow and provide a clear step-based progression with connected child views and preserved progression rules. 
- Improve information hierarchy, responsiveness, accessibility, and reuse of shared modal primitives to make character review and progression feel deliberate and polished.

### Description

- Reworked the Character Info modal into a premium overview using the shared modal primitives by replacing the old `Card/Modal` shell with `ModalShell`, `ModalHeader`, `ModalBody`, `ModalFooter`, `Section`, and `StatCard` (changes in `client/src/components/Zombies/attributes/CharacterInfo.js` and layout/CSS in `client/src/App.scss`).
- Consolidated the Level Up and Add Class flows into a single step-based `LevelUp` component that switches between `choose-progression` and `add-class` internally and uses `ClassCard`, `ActionCard`, `ConfirmationDialog` and other HUD primitives for consistent UI (changes in `client/src/components/Zombies/attributes/LevelUp.js`).
- Added a new progression helper module `client/src/components/Zombies/attributes/characterProgression.js` providing `getCharacterTotalLevel()`, `getMulticlassSummary()`, `getAvailableLevelUpClasses()`, `getAvailableNewClasses()`, `validateLevelUpSelection()`, and `validateAddClassSelection()` to centralize level calculations and validation.
- Extended HUD primitives in `client/src/components/Zombies/common/HudPrimitives.js` with `ActionCard`, `ClassCard`, `ConfirmationDialog`, and `MobileBottomSheet` to ensure the three modals share the same visual and interaction system.
- Implemented responsive, accessible, and animated styling for the new modal flows in `client/src/App.scss` including sticky headers/footers, focused card states, mobile bottom-sheet behavior and reduced-motion support.
- Preserved existing progression and special-case logic (for example Barbarian subclass and primal-skill follow-ups) and preserved backend interactions (`/characters/update-level` and `/characters/multiclass`) while adding request deduplication and loading/validation states.
- Updated tests and added new unit tests in `client/src/components/Zombies/attributes/characterProgression.test.js` and adjusted `CharacterInfo.test.js` to match the new structure and ensure interactions (rest actions, figurine behavior, multiclass summary, validation) are covered.

### Testing

- Ran unit tests: `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/attributes/CharacterInfo.test.js src/components/Zombies/attributes/characterProgression.test.js`, and all tests passed.
- Built the client: `npm --prefix client run build`; build completed successfully but emitted project-level warnings from Browserslist/autoprefixer/ESLint (non-blocking). 
- Ran quick checks: `git diff --check` produced no issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591091b434832e89451e09ad39f976)