### PR TITLE
Redesign character sheet Settings & Help hub

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12033,3 +12033,86 @@ body.character-creation-modal-open {
   .character-info-panel--identity .character-stat-grid { grid-template-columns: 1fr; }
   .character-info-footer { grid-template-columns: 1fr; }
 }
+
+/* Settings & Help hub */
+.settings-help-dialog { max-width: min(1040px, calc(100vw - 32px)); }
+.settings-help-modal .modal-content { overflow: hidden; }
+.settings-help-shell { min-height: min(760px, calc(100vh - 48px)); overflow: hidden !important; }
+.settings-help-header { display: flex; gap: 16px; }
+.settings-help-title-block { text-align: center; }
+.settings-help-title-block p { margin: 4px 0 0; color: var(--realm-muted, rgba(226,232,240,.72)); font-family: var(--realm-font-ui, system-ui, sans-serif); font-size: .92rem; }
+.settings-help-close { position: absolute; right: 18px; top: 16px; min-width: 44px; min-height: 44px; padding: 0 !important; font-size: 1.5rem; line-height: 1; }
+.settings-help-body { overflow: hidden !important; padding: 0 !important; }
+.settings-help-layout { display: grid; grid-template-columns: 230px minmax(0, 1fr); min-height: 0; height: min(650px, calc(100vh - 150px)); background: radial-gradient(circle at 20% 0%, rgba(78,161,255,.12), transparent 34%), rgba(3,7,16,.38); }
+.settings-help-sidebar { position: sticky; top: 0; display: flex; flex-direction: column; gap: 10px; padding: 18px; border-right: 1px solid var(--realm-border, rgba(151,190,255,.22)); background: linear-gradient(180deg, rgba(5,13,28,.92), rgba(4,8,18,.72)); overflow-y: auto; }
+.settings-help-nav-item { min-height: 58px; display: grid; grid-template-columns: 34px 1fr; gap: 10px; align-items: center; border: 1px solid rgba(151,190,255,.18); border-radius: 16px; padding: 10px; color: var(--realm-text, #eaf2ff); background: rgba(255,255,255,.035); text-align: left; }
+.settings-help-nav-item:hover, .settings-help-nav-item:focus-visible { border-color: rgba(78,161,255,.72); box-shadow: 0 0 0 3px rgba(78,161,255,.18); outline: none; }
+.settings-help-nav-item--active { border-color: rgba(216,183,106,.78); background: linear-gradient(135deg, rgba(78,161,255,.2), rgba(216,183,106,.11)); }
+.settings-help-nav-item__icon { width: 34px; height: 34px; border-radius: 12px; display: inline-flex; align-items: center; justify-content: center; background: rgba(78,161,255,.14); color: #d8b76a; font-weight: 900; }
+.settings-help-nav-item strong, .settings-help-nav-item small { display: block; font-family: var(--realm-font-ui, system-ui, sans-serif); }
+.settings-help-nav-item small { color: var(--realm-muted, rgba(226,232,240,.68)); font-size: .76rem; margin-top: 1px; }
+.settings-help-content { min-width: 0; padding: 24px; overflow-y: auto; scrollbar-color: rgba(216,183,106,.6) rgba(255,255,255,.08); }
+.settings-help-content__heading { margin-bottom: 18px; }
+.settings-help-content__heading span { color: #d8b76a; font-size: .78rem; letter-spacing: .14em; text-transform: uppercase; font-weight: 800; }
+.settings-help-content__heading h3 { margin: 2px 0 0; font-family: 'Cinzel', serif; color: #fff8df; font-size: clamp(1.5rem, 3vw, 2rem); }
+.settings-help-section__lead { max-width: 720px; color: var(--realm-muted, rgba(226,232,240,.76)); font-family: var(--realm-font-ui, system-ui, sans-serif); line-height: 1.55; }
+.settings-help-card { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 18px; margin-bottom: 14px; border: 1px solid rgba(151,190,255,.2); border-radius: 20px; background: linear-gradient(145deg, rgba(18,32,54,.72), rgba(7,12,25,.86)); box-shadow: inset 0 1px 0 rgba(255,255,255,.06), 0 16px 36px rgba(0,0,0,.26); }
+.settings-help-card__copy { display: flex; gap: 14px; align-items: flex-start; min-width: 0; }
+.settings-help-card__icon { flex: 0 0 42px; width: 42px; height: 42px; display: inline-flex; align-items: center; justify-content: center; border-radius: 15px; background: rgba(78,161,255,.14); color: #d8b76a; font-weight: 900; }
+.settings-help-card h4 { margin: 0 0 4px; color: #f8fafc; font-family: var(--realm-font-ui, system-ui, sans-serif); font-size: 1rem; font-weight: 800; }
+.settings-help-card p { margin: 0; color: var(--realm-muted, rgba(226,232,240,.72)); line-height: 1.45; }
+.settings-help-card__control { flex: 0 0 auto; }
+.settings-help-card--danger { border-color: rgba(248,113,113,.45); background: linear-gradient(145deg, rgba(80,20,28,.78), rgba(24,8,14,.9)); }
+.theme-preview-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 14px; }
+.theme-preview-card { min-height: 180px; display: flex; flex-direction: column; gap: 9px; padding: 14px; border: 1px solid rgba(151,190,255,.2); border-radius: 20px; background: rgba(255,255,255,.04); color: #edf5ff; text-align: left; }
+.theme-preview-card:focus-visible { outline: 3px solid rgba(78,161,255,.55); outline-offset: 2px; }
+.theme-preview-card--selected { border-color: #d8b76a; box-shadow: 0 0 0 1px rgba(216,183,106,.42), 0 18px 38px rgba(78,161,255,.14); }
+.theme-preview-card__swatch { height: 54px; border-radius: 15px; border: 1px solid rgba(255,255,255,.18); background: linear-gradient(135deg, #101b31, #4ea1ff); }
+.theme-preview-card__swatch--rust { background: linear-gradient(135deg, #34150f, #b45309); }
+.theme-preview-card__swatch--diceOfRolling { background: linear-gradient(135deg, #211247, #7c5cff, #d8b76a); }
+.theme-preview-card__swatch--gemstone { background: linear-gradient(135deg, #082f49, #14b8a6, #a78bfa); }
+.theme-preview-card__swatch--wooden { background: linear-gradient(135deg, #3b2414, #a16207); }
+.theme-preview-card__swatch--smooth { background: linear-gradient(135deg, #111827, #f8fafc); }
+.theme-preview-card__swatch--rock { background: linear-gradient(135deg, #27272a, #78716c); }
+.theme-preview-card__swatch--blueGreenMetal { background: linear-gradient(135deg, #0f3b46, #38bdf8, #22c55e); }
+.theme-preview-card__name { font-weight: 900; }
+.theme-preview-card__description { color: var(--realm-muted, rgba(226,232,240,.72)); font-size: .88rem; line-height: 1.35; }
+.theme-preview-card__selected { margin-top: auto; color: #d8b76a; font-weight: 800; }
+.dice-appearance-panel { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: 20px; align-items: center; width: min(100%, 720px); }
+.dice-preview { display: grid; place-items: center; gap: 12px; }
+.dice-preview__shape { width: 136px; height: 136px; display: inline-flex; align-items: center; justify-content: center; clip-path: polygon(50% 0%, 95% 25%, 95% 75%, 50% 100%, 5% 75%, 5% 25%); background: radial-gradient(circle at 35% 25%, rgba(255,255,255,.72), transparent 18%), linear-gradient(145deg, var(--dice-preview-color), #07111f 82%); color: #fff; font-size: 2.2rem; font-weight: 950; text-shadow: 0 2px 12px rgba(0,0,0,.8); box-shadow: 0 0 32px color-mix(in srgb, var(--dice-preview-color), transparent 45%); }
+.dice-preview__label { color: var(--realm-muted, rgba(226,232,240,.72)); font-weight: 700; }
+.dice-controls { min-width: 0; }
+.dice-color-input { width: 100%; min-height: 48px; border-radius: 14px; border: 1px solid rgba(151,190,255,.32); background: rgba(255,255,255,.06); padding: 4px; }
+.dice-preset-grid { display: flex; flex-wrap: wrap; gap: 10px; margin: 14px 0; }
+.dice-preset { width: 44px; height: 44px; border-radius: 14px; border: 2px solid rgba(255,255,255,.22); background: var(--preset-color); }
+.dice-preset[aria-pressed='true'] { border-color: #d8b76a; box-shadow: 0 0 0 3px rgba(216,183,106,.22); }
+.settings-help-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+.settings-save-status { margin: 10px 0 0; font-weight: 800; color: var(--realm-muted, rgba(226,232,240,.72)); }
+.settings-save-status--saved { color: #86efac; } .settings-save-status--error { color: #fca5a5; } .settings-save-status--saving, .settings-save-status--unsaved { color: #fde68a; }
+.help-topic-list { display: grid; gap: 12px; }
+.help-topic-card { border: 1px solid rgba(151,190,255,.2); border-radius: 16px; background: rgba(255,255,255,.04); padding: 0; overflow: hidden; }
+.help-topic-card summary { min-height: 52px; cursor: pointer; padding: 15px 18px; font-weight: 850; color: #f8fafc; }
+.help-topic-card p { margin: 0; padding: 0 18px 18px; color: var(--realm-muted, rgba(226,232,240,.74)); line-height: 1.55; }
+.campaign-action-grid { display: grid; gap: 14px; }
+.delete-character-confirmation { display: grid; gap: 14px; text-align: center; }
+.delete-character-confirmation__portrait { width: 76px; height: 76px; margin: 0 auto; border-radius: 24px; display: inline-flex; align-items: center; justify-content: center; background: linear-gradient(135deg, rgba(248,113,113,.26), rgba(216,183,106,.16)); border: 1px solid rgba(248,113,113,.42); color: #fff8df; font: 900 2rem 'Cinzel', serif; }
+.delete-character-footer { justify-content: flex-end !important; }
+@media (max-width: 767px) {
+  .settings-help-dialog { max-width: 100vw; margin: 0; min-height: 100%; }
+  .settings-help-dialog .modal-content { min-height: 100vh; border-radius: 0 !important; }
+  .settings-help-shell { min-height: 100vh; border-radius: 0 !important; }
+  .settings-help-header { min-height: 76px; padding: calc(12px + env(safe-area-inset-top)) 60px 12px 16px !important; justify-content: flex-start; }
+  .settings-help-title-block { text-align: left; }
+  .settings-help-title-block p { display: none; }
+  .settings-help-layout { display: block; height: calc(100vh - 76px); overflow-y: auto; padding-bottom: env(safe-area-inset-bottom); }
+  .settings-help-sidebar { position: sticky; top: 0; z-index: 3; display: grid; grid-auto-flow: column; grid-auto-columns: minmax(136px, 1fr); overflow-x: auto; padding: 12px; border-right: 0; border-bottom: 1px solid var(--realm-border, rgba(151,190,255,.22)); }
+  .settings-help-nav-item { min-height: 48px; grid-template-columns: 28px 1fr; }
+  .settings-help-nav-item__icon { width: 28px; height: 28px; border-radius: 10px; }
+  .settings-help-content { overflow: visible; padding: 18px 14px 28px; }
+  .settings-help-card, .dice-appearance-panel { display: grid; grid-template-columns: 1fr; }
+  .settings-help-card__control { width: 100%; }
+  .settings-help-card__control .btn, .settings-help-actions .btn { width: 100%; min-height: 44px; }
+  .theme-preview-grid { grid-template-columns: 1fr; }
+  .dice-preview__shape { width: 116px; height: 116px; }
+}

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'; // Import useState and React
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Table, Button, Alert, Form } from 'react-bootstrap'; // Adjust as per your actual UI library
+import { Modal, Card, Button, Alert, Form } from 'react-bootstrap';
 import { useNavigate, useParams } from "react-router-dom";
 import CampaignModals from "../components/CampaignModals";
 import useCampaignActions from "../hooks/useCampaignActions";
@@ -13,17 +13,37 @@ import {
 import { setDiceBoxTheme, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
 
 const DICE_THEME_OPTIONS = [
-  { value: 'default', label: 'Default' },
-  { value: 'rust', label: 'Rust' },
-  { value: 'diceOfRolling', label: 'Dice of Rolling' },
-  { value: 'gemstone', label: 'Gemstone' },
-  { value: 'wooden', label: 'Wooden' },
-  { value: 'smooth', label: 'Smooth' },
-  { value: 'rock', label: 'Rock' },
-  { value: 'blueGreenMetal', label: 'Blue Green Metal' },
+  { value: 'default', label: 'Default', description: 'Classic RealmTracker dice with crisp arcane faces.' },
+  { value: 'rust', label: 'Rust', description: 'Weathered metal and ember-worn edges.' },
+  { value: 'diceOfRolling', label: 'Dice of Rolling', description: 'A magical premium dice set for dramatic rolls.' },
+  { value: 'gemstone', label: 'Gemstone', description: 'Polished jewel tones with high contrast facets.' },
+  { value: 'wooden', label: 'Wooden', description: 'Warm carved wood for grounded tabletop sessions.' },
+  { value: 'smooth', label: 'Smooth', description: 'Clean, minimal faces for fast readability.' },
+  { value: 'rock', label: 'Rock', description: 'Rough-hewn stone for dungeon delves.' },
+  { value: 'blueGreenMetal', label: 'Blue Green Metal', description: 'Cool metallic teal with bright magical highlights.' },
 ];
 
 const DEFAULT_DICE_THEME = DICE_THEME_OPTIONS[0].value;
+const DICE_PRESETS = ['#4ea1ff', '#7c5cff', '#d8b76a', '#23d18b', '#ff6b6b', '#f59e0b', '#f8fafc', '#111827'];
+
+const SETTINGS_SECTIONS = [
+  { id: 'appearance', label: 'Appearance', eyebrow: 'Interface', icon: '✦' },
+  { id: 'dice', label: 'Dice', eyebrow: 'Roller', icon: '⚂' },
+  { id: 'help', label: 'Help', eyebrow: 'Guides', icon: '?' },
+  { id: 'campaign', label: 'Campaign', eyebrow: 'Adventures', icon: '⌁' },
+  { id: 'account', label: 'Account', eyebrow: 'Session', icon: '◎' },
+  { id: 'character', label: 'Character', eyebrow: 'Danger zone', icon: '!' },
+];
+
+const HELP_TOPICS = [
+  { title: 'Getting started', body: 'Use the character bar to move between sheet areas, roll from abilities and attacks, and keep campaign tools docked when you need them.' },
+  { title: 'Dice roller guide', body: 'Choose a dice theme and face color here. The preview updates immediately, then Save dice appearance persists it to this character.' },
+  { title: 'Combat controls', body: 'The combat HUD keeps quick actions, dice, health, and active combat information close to the bottom edge of the sheet.' },
+  { title: 'Death saves', body: 'When your character reaches 0 HP, track death save successes and failures from the health and combat areas until stabilized or healed.' },
+  { title: 'Inventory & equipment', body: 'Manage carried items separately from equipped weapons, armor, and accessories so combat values stay readable.' },
+  { title: 'Campaign joining', body: 'Use Join Campaign to enter an existing adventure, Host Campaign to launch a DM session, or Create Campaign to build a new one.' },
+  { title: 'How do I change my figurine?', body: 'Open Character Info and look for figurine or token artwork controls. Those changes are separate from dice appearance.' },
+];
 
 const normalizeDiceTheme = (value) => {
   if (typeof value !== 'string') {
@@ -39,6 +59,21 @@ const normalizeDiceTheme = (value) => {
   const match = DICE_THEME_OPTIONS.find((option) => option.value.toLowerCase() === lower);
   return match ? match.value : DEFAULT_DICE_THEME;
 };
+
+function SettingsCard({ icon, title, description, children, className = '' }) {
+  return (
+    <section className={`settings-help-card ${className}`.trim()}>
+      <div className="settings-help-card__copy">
+        <span className="settings-help-card__icon" aria-hidden="true">{icon}</span>
+        <div>
+          <h4>{title}</h4>
+          {description && <p>{description}</p>}
+        </div>
+      </div>
+      {children && <div className="settings-help-card__control">{children}</div>}
+    </section>
+  );
+}
 
 export default function Help({
   form,
@@ -70,27 +105,23 @@ export default function Help({
     updateCreateCampaignForm,
     submitCreateCampaign,
   } = useCampaignActions();
-  const [showDeleteCharacter, setShowDeleteCharacter] = useState(false);
-  const handleCloseDeleteCharacter = () => setShowDeleteCharacter(false);
-  const handleShowDeleteCharacter = () => setShowDeleteCharacter(true);
 
-  // This method will delete a record
-  async function deleteRecord() {
-    await apiFetch(`/characters/delete-character/${params.id}`, {
-      method: 'DELETE',
-    });
-    navigate(`/zombies-character-select/${form.campaign}`);
-  }
-
-  async function handleLogout() {
-    await apiFetch('/logout', { method: 'POST' });
-    window.location.assign('/');
-  }
-  //-------------------------------------------Help Module--------------------------------------------------------------------
+  const characterName = form?.characterName || form?.name || 'this character';
   const initialColor = normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR;
+  const [activeSection, setActiveSection] = useState('appearance');
   const [newColor, setNewColor] = useState(initialColor);
   const [newTheme, setNewTheme] = useState(() => normalizeDiceTheme(form?.diceTheme));
+  const [saveStatus, setSaveStatus] = useState('idle');
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [showDeleteCharacter, setShowDeleteCharacter] = useState(false);
+  const [deleteConfirmName, setDeleteConfirmName] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
   const themeOptions = useMemo(() => DICE_THEME_OPTIONS, []);
+
+  const persistedColor = normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR;
+  const persistedTheme = normalizeDiceTheme(form?.diceTheme);
+  const hasDiceChanges = newColor !== persistedColor || newTheme !== persistedTheme;
 
   useEffect(() => {
     applyDiceFaceColor(newColor);
@@ -103,50 +134,45 @@ export default function Help({
 
   useEffect(() => {
     const normalized = normalizeDiceColor(form?.diceColor);
-    if (normalized) {
-      setNewColor((prev) => (prev === normalized ? prev : normalized));
-    } else if (form?.diceColor === undefined || form?.diceColor === null) {
-      setNewColor((prev) => (prev === DEFAULT_DICE_COLOR ? prev : DEFAULT_DICE_COLOR));
-    }
+    setNewColor(normalized || DEFAULT_DICE_COLOR);
   }, [form?.diceColor]);
 
   useEffect(() => {
-    const normalizedTheme = normalizeDiceTheme(form?.diceTheme);
-    setNewTheme((prev) => (prev === normalizedTheme ? prev : normalizedTheme));
+    setNewTheme(normalizeDiceTheme(form?.diceTheme));
   }, [form?.diceTheme]);
 
   const handleColorChange = (event) => {
     const selectedColor = event?.target?.value;
     if (typeof selectedColor === 'string') {
       setNewColor(selectedColor);
+      setSaveStatus('unsaved');
     }
   };
 
-  const handleThemeChange = (event) => {
-    const selectedTheme = event?.target?.value;
-    if (typeof selectedTheme === 'string') {
-      setNewTheme(normalizeDiceTheme(selectedTheme));
-    }
+  const handleThemeChange = (selectedTheme) => {
+    setNewTheme(normalizeDiceTheme(selectedTheme));
+    setSaveStatus('unsaved');
   };
 
   async function diceColorUpdate() {
     const normalizedColor = normalizeDiceColor(newColor);
     if (!normalizedColor) {
+      setSaveStatus('error');
       return;
     }
 
     const normalizedTheme = normalizeDiceTheme(newTheme);
+    setSaveStatus('saving');
 
     try {
       const response = await apiFetch(`/characters/update-dice-color/${params.id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ diceColor: normalizedColor, diceTheme: normalizedTheme }),
       });
 
       if (!response.ok) {
+        setSaveStatus('error');
         return;
       }
 
@@ -163,22 +189,46 @@ export default function Help({
         nextTheme = normalizeDiceTheme(payload?.diceTheme);
       }
       setNewColor(nextColor);
-      setNewTheme((prev) => (prev === nextTheme ? prev : nextTheme));
+      setNewTheme(nextTheme);
+      setSaveStatus('saved');
 
       if (typeof onDiceColorChange === 'function') {
         onDiceColorChange(nextColor, nextTheme);
       }
     } catch (error) {
-      // Swallow fetch errors silently for now.
+      setSaveStatus('error');
+    }
+  }
+
+  async function handleLogout() {
+    setIsLoggingOut(true);
+    await apiFetch('/logout', { method: 'POST' });
+    window.location.assign('/');
+  }
+
+  async function deleteRecord() {
+    setIsDeleting(true);
+    setDeleteError('');
+    try {
+      const response = await apiFetch(`/characters/delete-character/${params.id}`, { method: 'DELETE' });
+      if (!response.ok) {
+        setDeleteError('Unable to delete character. Please try again.');
+        setIsDeleting(false);
+        return;
+      }
+      navigate(`/zombies-character-select/${form.campaign}`);
+    } catch (error) {
+      setDeleteError('Unable to delete character. Please try again.');
+      setIsDeleting(false);
     }
   }
 
   const dialogClassName = useMemo(() => {
     if (!isDocked) {
-      return undefined;
+      return 'settings-help-dialog';
     }
 
-    const classes = ['docked-modal'];
+    const classes = ['docked-modal', 'settings-help-dialog'];
     if (dockedSide) {
       classes.push(`docked-modal--${dockedSide}`);
     }
@@ -187,7 +237,7 @@ export default function Help({
   }, [isDocked, dockedSide]);
 
   const modalClassName = useMemo(() => {
-    const classes = ['dnd-modal', 'modern-modal', 'text-center'];
+    const classes = ['dnd-modal', 'modern-modal', 'settings-help-modal'];
     if (isDocked) {
       classes.push('docked-modal-container');
     }
@@ -196,174 +246,170 @@ export default function Help({
 
   const handleModalHide = useCallback(() => {
     if (isDocked) {
-      if (typeof onDockClose === 'function') {
-        onDockClose();
-      }
+      onDockClose?.();
       return;
     }
-
     handleCloseHelpModal?.();
   }, [handleCloseHelpModal, isDocked, onDockClose]);
 
+  const saveText = saveStatus === 'saving' ? 'Saving…' : saveStatus === 'saved' ? 'Dice appearance saved' : saveStatus === 'error' ? 'Unable to save settings' : hasDiceChanges ? 'Unsaved dice changes' : 'Settings up to date';
+  const canDelete = deleteConfirmName.trim() === characterName.trim();
+
+  const renderSection = (sectionId) => {
+    switch (sectionId) {
+      case 'appearance':
+        return (
+          <div className="settings-help-section">
+            <p className="settings-help-section__lead">Choose the visual style used by the 3D dice roller. Theme changes preview immediately and are saved with your dice appearance.</p>
+            <div className="theme-preview-grid" role="radiogroup" aria-label="Dice theme">
+              {themeOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`theme-preview-card ${newTheme === option.value ? 'theme-preview-card--selected' : ''}`}
+                  onClick={() => handleThemeChange(option.value)}
+                  role="radio"
+                  aria-checked={newTheme === option.value}
+                >
+                  <span className={`theme-preview-card__swatch theme-preview-card__swatch--${option.value}`} aria-hidden="true" />
+                  <span className="theme-preview-card__name">{option.label}</span>
+                  <span className="theme-preview-card__description">{option.description}</span>
+                  {newTheme === option.value && <span className="theme-preview-card__selected">Selected</span>}
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      case 'dice':
+        return (
+          <div className="settings-help-section">
+            <p className="settings-help-section__lead">Customize the dice face color with a live d20 preview, then save the appearance to this character.</p>
+            <SettingsCard icon="⚂" title="Dice appearance" description="Color and theme update the roller immediately for previewing.">
+              <div className="dice-appearance-panel">
+                <div className="dice-preview" style={{ '--dice-preview-color': newColor }} aria-label={`Dice preview using ${newColor}`}>
+                  <span className="dice-preview__shape">20</span>
+                  <span className="dice-preview__label">Live d20 preview</span>
+                </div>
+                <div className="dice-controls">
+                  <Form.Label htmlFor="diceColorPicker">Custom color</Form.Label>
+                  <input id="diceColorPicker" className="dice-color-input" type="color" value={newColor} onChange={handleColorChange} />
+                  <div className="dice-preset-grid" aria-label="Preset dice colors">
+                    {DICE_PRESETS.map((color) => (
+                      <button key={color} type="button" className="dice-preset" style={{ '--preset-color': color }} onClick={() => handleColorChange({ target: { value: color } })} aria-label={`Use ${color}`} aria-pressed={newColor === color} />
+                    ))}
+                  </div>
+                  <div className="settings-help-actions">
+                    <Button variant="outline-light" onClick={() => handleColorChange({ target: { value: DEFAULT_DICE_COLOR } })}>Reset color</Button>
+                    <Button onClick={diceColorUpdate} disabled={!hasDiceChanges || saveStatus === 'saving'}>{saveStatus === 'saving' ? 'Saving…' : 'Save dice appearance'}</Button>
+                  </div>
+                  <p className={`settings-save-status settings-save-status--${saveStatus}`} role="status">{saveText}</p>
+                </div>
+              </div>
+            </SettingsCard>
+          </div>
+        );
+      case 'help':
+        return (
+          <div className="settings-help-section">
+            <p className="settings-help-section__lead">Quick answers for common character sheet and campaign questions.</p>
+            <div className="help-topic-list">
+              {HELP_TOPICS.map((topic) => (
+                <details className="help-topic-card" key={topic.title}>
+                  <summary>{topic.title}</summary>
+                  <p>{topic.body}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        );
+      case 'campaign':
+        return (
+          <div className="settings-help-section">
+            <p className="settings-help-section__lead">Move between player and Dungeon Master campaign workflows.</p>
+            <div className="campaign-action-grid">
+              <SettingsCard icon="➹" title="Join Campaign" description="Find and enter an existing adventure."><Button onClick={openJoinCampaignModal}>Join</Button></SettingsCard>
+              <SettingsCard icon="♜" title="Host Campaign" description="Launch one of your campaigns as Dungeon Master."><Button onClick={openHostCampaignModal}>Host</Button></SettingsCard>
+              <SettingsCard icon="✧" title="Create Campaign" description="Build a new campaign for your party."><Button onClick={openCreateCampaignModal}>Create</Button></SettingsCard>
+            </div>
+          </div>
+        );
+      case 'account':
+        return (
+          <div className="settings-help-section">
+            <SettingsCard icon="◎" title="Signed-in session" description="Log out of RealmTracker on this device. Unsaved character edits elsewhere should be saved first.">
+              <Button variant="outline-warning" onClick={handleLogout} disabled={isLoggingOut}>{isLoggingOut ? 'Logging out…' : 'Logout'}</Button>
+            </SettingsCard>
+          </div>
+        );
+      case 'character':
+        return (
+          <div className="settings-help-section">
+            <SettingsCard icon="!" title="Danger Zone" description={`Delete ${characterName} permanently. This action cannot be undone.`} className="settings-help-card--danger">
+              <Button variant="danger" onClick={() => setShowDeleteCharacter(true)}>Delete Character</Button>
+            </SettingsCard>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <div>
-      <Modal
-        className={modalClassName}
-        size="lg"
-        aria-labelledby="contained-modal-title-vcenter"
-        centered={!isDocked}
-        scrollable
-        show={showHelpModal}
-        onHide={handleModalHide}
-        backdrop={isDocked ? false : true}
-        enforceFocus={!isDocked}
-        restoreFocus={!isDocked}
-        dialogClassName={dialogClassName}
-      >
-        <Card className="modern-card text-center">
-          <Card.Header className="modal-header">
-            <DockControls
-              dockedSide={dockedSide}
-              onDockChange={onDockChange}
-              isDocked={isDocked}
-            />
-            <Card.Title className="modal-title">Help</Card.Title>
-          </Card.Header>
-          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-            {campaignNotification && (
-              <Alert
-                variant="danger"
-                dismissible
-                onClose={clearNotification}
-                className="mb-3"
-              >
-                {campaignNotification}
-              </Alert>
-            )}
-            <div className="table-container">
-              <Table striped bordered hover size="sm" className="custom-table">
-                <tbody>
-                  <tr>
-                    <td className="center-td">
-                      <strong className="text-light">Change Dice Color:</strong>
-                    </td>
-                    <td className="center-td">
-                      <input
-                        type="color"
-                        id="colorPicker"
-                        value={newColor}
-                        onChange={handleColorChange}
-                      />
-                    </td>
-                    <td className="center-td" rowSpan={2}>
-                      <Button
-                        onClick={diceColorUpdate}
-                        className="action-btn save-btn fa-solid fa-floppy-disk"
-                        aria-label="Save dice preferences"
-                      ></Button>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className="center-td">
-                      <strong className="text-light">Change Theme:</strong>
-                    </td>
-                    <td className="center-td">
-                      <Form.Select
-                        aria-label="Select dice theme"
-                        value={newTheme}
-                        onChange={handleThemeChange}
-                      >
-                        {themeOptions.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </Form.Select>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className="center-td" colSpan={3}>
-                      <Button onClick={handleLogout} className="action-btn close-btn">
-                        Logout
-                      </Button>
-                    </td>
-                  </tr>
-                </tbody>
-              </Table>
+      <Modal className={modalClassName} size="xl" aria-labelledby="settings-help-title" centered={!isDocked} show={showHelpModal} onHide={handleModalHide} backdrop={isDocked ? false : true} enforceFocus={!isDocked} restoreFocus={!isDocked} dialogClassName={dialogClassName}>
+        <Card className="modern-card settings-help-shell">
+          <Card.Header className="modal-header settings-help-header">
+            <DockControls dockedSide={dockedSide} onDockChange={onDockChange} isDocked={isDocked} />
+            <div className="settings-help-title-block">
+              <Card.Title id="settings-help-title" className="modal-title">Settings & Help</Card.Title>
+              <p>Player preferences, guidance, campaigns, account, and character safety.</p>
             </div>
-            <div className="mt-3 d-flex flex-column flex-lg-row gap-2 justify-content-center align-items-center">
-              <Button
-                className="fantasy-button campaign-button"
-                style={{ borderColor: "transparent" }}
-                onClick={openJoinCampaignModal}
-              >
-                Join Campaign
-              </Button>
-              <Button
-                className="hostCampaign campaign-button hostCampaign"
-                style={{ borderColor: "transparent" }}
-                onClick={openHostCampaignModal}
-              >
-                Host Campaign
-              </Button>
-              <Button
-                className="fantasy-button campaign-button create-button"
-                style={{ borderColor: "transparent" }}
-                onClick={openCreateCampaignModal}
-              >
-                Create Campaign
-              </Button>
+            <Button className="settings-help-close" variant="outline-light" onClick={handleModalHide} aria-label="Close Settings & Help">×</Button>
+          </Card.Header>
+          <Card.Body className="settings-help-body">
+            {campaignNotification && <Alert variant="danger" dismissible onClose={clearNotification} className="mb-3">{campaignNotification}</Alert>}
+            <div className="settings-help-layout">
+              <nav className="settings-help-sidebar" aria-label="Settings sections">
+                {SETTINGS_SECTIONS.map((section) => (
+                  <button key={section.id} type="button" className={`settings-help-nav-item ${activeSection === section.id ? 'settings-help-nav-item--active' : ''}`} onClick={() => setActiveSection(section.id)} aria-current={activeSection === section.id ? 'page' : undefined}>
+                    <span className="settings-help-nav-item__icon" aria-hidden="true">{section.icon}</span>
+                    <span><strong>{section.label}</strong><small>{section.eyebrow}</small></span>
+                  </button>
+                ))}
+              </nav>
+              <main className="settings-help-content" tabIndex={-1}>
+                <div className="settings-help-content__heading">
+                  <span>{SETTINGS_SECTIONS.find((section) => section.id === activeSection)?.eyebrow}</span>
+                  <h3>{SETTINGS_SECTIONS.find((section) => section.id === activeSection)?.label}</h3>
+                </div>
+                {renderSection(activeSection)}
+              </main>
             </div>
           </Card.Body>
-          <Card.Footer className="modal-footer justify-content-between">
-            <Button className="action-btn btn-danger" onClick={handleShowDeleteCharacter}>
-              Delete Character
-            </Button>
-            <Button className="action-btn close-btn" onClick={handleModalHide}>
-              Close
-            </Button>
+        </Card>
+      </Modal>
+      <Modal className="dnd-modal modern-modal delete-character-modal" size="md" aria-labelledby="delete-character-title" centered show={showDeleteCharacter} onHide={() => setShowDeleteCharacter(false)}>
+        <Card className="modern-card">
+          <Card.Header className="modal-header"><Card.Title id="delete-character-title" className="modal-title">Confirm Character Deletion</Card.Title></Card.Header>
+          <Card.Body>
+            <div className="delete-character-confirmation">
+              <div className="delete-character-confirmation__portrait" aria-hidden="true">{String(characterName).charAt(0).toUpperCase()}</div>
+              <h3>Delete {characterName} permanently?</h3>
+              <p>This removes the character and related campaign references. This action cannot be undone.</p>
+              <Form.Group controlId="deleteCharacterName">
+                <Form.Label>Type <strong>{characterName}</strong> to confirm.</Form.Label>
+                <Form.Control value={deleteConfirmName} onChange={(event) => setDeleteConfirmName(event.target.value)} autoFocus autoComplete="off" />
+              </Form.Group>
+              {deleteError && <Alert variant="danger" role="alert">{deleteError}</Alert>}
+            </div>
+          </Card.Body>
+          <Card.Footer className="modal-footer delete-character-footer">
+            <Button variant="outline-light" onClick={() => setShowDeleteCharacter(false)} disabled={isDeleting}>Cancel</Button>
+            <Button variant="danger" onClick={deleteRecord} disabled={!canDelete || isDeleting}>{isDeleting ? 'Deleting…' : 'Delete Character'}</Button>
           </Card.Footer>
         </Card>
       </Modal>
-      <Modal
-        className="dnd-modal modern-modal text-center"
-        size="lg"
-        aria-labelledby="contained-modal-title-vcenter"
-        centered
-        scrollable
-        show={showDeleteCharacter}
-        onHide={handleCloseDeleteCharacter}
-      >
-        <Card className="modern-card text-center">
-          <Card.Header className="modal-header">
-            <Card.Title className="modal-title">Delete Character</Card.Title>
-          </Card.Header>
-          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
-            Are you sure you want to delete your character?
-          </Card.Body>
-          <Card.Footer className="modal-footer">
-            <Button className="btn-danger action-btn save-btn" onClick={deleteRecord}>
-              Im Sure
-            </Button>
-            <Button className="action-btn close-btn" onClick={handleCloseDeleteCharacter}>
-              Close
-            </Button>
-          </Card.Footer>
-        </Card>
-      </Modal>
-      <CampaignModals
-        playerCampaigns={playerCampaigns}
-        dmCampaigns={dmCampaigns}
-        showJoinCampaignModal={showJoinCampaignModal}
-        closeJoinCampaignModal={closeJoinCampaignModal}
-        showHostCampaignModal={showHostCampaignModal}
-        closeHostCampaignModal={closeHostCampaignModal}
-        showCreateCampaignModal={showCreateCampaignModal}
-        closeCreateCampaignModal={closeCreateCampaignModal}
-        createCampaignForm={createCampaignForm}
-        updateCreateCampaignForm={updateCreateCampaignForm}
-        submitCreateCampaign={submitCreateCampaign}
-      />
+      <CampaignModals playerCampaigns={playerCampaigns} dmCampaigns={dmCampaigns} showJoinCampaignModal={showJoinCampaignModal} closeJoinCampaignModal={closeJoinCampaignModal} showHostCampaignModal={showHostCampaignModal} closeHostCampaignModal={closeHostCampaignModal} showCreateCampaignModal={showCreateCampaignModal} closeCreateCampaignModal={closeCreateCampaignModal} createCampaignForm={createCampaignForm} updateCreateCampaignForm={updateCreateCampaignForm} submitCreateCampaign={submitCreateCampaign} />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Replace the existing overloaded "Help" modal with a focused, organized Settings & Help experience that matches RealmTracker design standards.
- Separate concerns so appearance, dice customization, help content, campaign actions, account actions, and destructive character management are visually and functionally distinct. 
- Improve UX for dice/theme customization with a live preview and clear save behavior while preserving existing persistence endpoints.

### Description

- Rebuilt the modal as `Settings & Help` with a desktop two-column layout (sidebar navigation + content panel) and a mobile-friendly stacked layout, moving away from the old table layout. (see `client/src/components/Zombies/attributes/Help.js`).
- Replaced dice controls with a `Dice appearance` panel that includes preset swatches, a color picker, a live d20 preview, a visual theme selector presented as cards, `Reset color` and `Save dice appearance` actions, and explicit save state handling that calls the existing `PUT /characters/update-dice-color/:id` endpoint. (presets and theme cards added in `Help.js`).
- Added structured sections and components: Appearance, Dice, Help (expandable topics), Campaign (action cards for Join/Host/Create), Account (logout with loading state), and Character (Danger Zone) with an improved deletion flow requiring typing the character name and showing loading/error feedback. (new navigation, help topics, and deletion confirmation in `Help.js`).
- Kept integration with existing utilities: applied live preview via `applyDiceFaceColor` and `setDiceBoxTheme*` from `utils`, reused `CampaignModals` and `useCampaignActions`, and preserved `onDiceColorChange` callback usage. (imports and calls remain in `Help.js`).
- Added comprehensive styling following the RealmTracker visual language in `client/src/App.scss`, including theme preview cards, dice preview shapes, sidebar navigation, responsive rules, and accessibility-friendly spacing and touch target sizes.

### Testing

- Ran the targeted unit tests with `npm test -- --watchAll=false --runTestsByPath client/src/components/Zombies/pages/ZombiesCharacterSheet.test.js` and the suite passed: `Tests: 59 passed, 59 total`.
- Built a production bundle with `npm run build` which completed successfully and produced an optimized `build/` output, though the build output contains pre-existing lint warnings and browserslist warnings unrelated to this change. 
- No automated tests were added or removed for the new UI file; manual QA still recommended for keyboard focus, color-picker clipping on small viewports, and integration with the live dice roller in different environments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591db79310832eb27fa4c955bd2111)