### PR TITLE
Redesign equipment modal into premium RPG loadout

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentModal.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.js
@@ -79,7 +79,7 @@ export default function EquipmentModal({
       className={modalClassName}
       show={show}
       onHide={handleModalHide}
-      size="lg"
+      size="xl"
       centered={!isDocked}
       scrollable
       fullscreen="sm-down"
@@ -95,7 +95,7 @@ export default function EquipmentModal({
             onDockChange={onDockChange}
             isDocked={isDocked}
           />
-          <Card.Title className="modal-title">Equipment</Card.Title>
+          <Card.Title className="modal-title">Equipment Arsenal</Card.Title>
         </Card.Header>
         <Card.Body
           className="modal-body"

--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -1,5 +1,5 @@
-import React, { useMemo, useCallback } from 'react';
-import { Form, Button } from 'react-bootstrap';
+import React, { useMemo, useCallback, useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
 import { EQUIPMENT_SLOT_LAYOUT } from './equipmentSlots';
 import ItemIcon from '../../common/ItemIcon';
 import styles from './EquipmentRack.module.scss';
@@ -16,57 +16,56 @@ const SOURCE_DESCRIPTIONS = {
 };
 
 const DESCRIPTOR_KEYS = [
-  'category',
-  'categories',
-  'type',
-  'types',
-  'slot',
-  'slots',
-  'tags',
-  'subtype',
-  'subType',
-  'equipmentSlot',
-  'equipmentSlots',
-  'targetSlot',
-  'targetSlots',
+  'category', 'categories', 'type', 'types', 'slot', 'slots', 'tags', 'subtype',
+  'subType', 'equipmentSlot', 'equipmentSlots', 'targetSlot', 'targetSlots',
 ];
 
-const SLOT_METADATA_KEYS = [
-  'slot',
-  'equipmentSlot',
-  'slots',
-  'equipmentSlots',
-  'targetSlot',
-  'targetSlots',
-];
+const SLOT_METADATA_KEYS = ['slot', 'equipmentSlot', 'slots', 'equipmentSlots', 'targetSlot', 'targetSlots'];
+
+const RARITY_ORDER = ['all', 'common', 'uncommon', 'rare', 'epic', 'legendary', 'artifact'];
+
+const SLOT_LAYOUT = {
+  leftColumn: ['head', 'eyes', 'neck', 'shoulders', 'chest', 'back'],
+  rightColumn: ['arms', 'wrists', 'hands', 'waist', 'legs', 'feet'],
+  bottomRow: ['mainHand', 'offHand', 'ranged', 'ringLeft', 'ringRight'],
+};
+
+const ABILITY_LABELS = { str: 'Strength', dex: 'Dexterity', con: 'Constitution', int: 'Intelligence', wis: 'Wisdom', cha: 'Charisma' };
 
 const toLowercaseStrings = (value) => {
   if (!value) return [];
-  if (Array.isArray(value)) {
-    return value
-      .filter((entry) => typeof entry === 'string' && entry.trim().length)
-      .map((entry) => entry.toLowerCase());
-  }
-  if (typeof value === 'string') {
-    return value.trim().length ? [value.toLowerCase()] : [];
-  }
+  if (Array.isArray(value)) return value.filter((entry) => typeof entry === 'string' && entry.trim().length).map((entry) => entry.toLowerCase());
+  if (typeof value === 'string') return value.trim().length ? [value.toLowerCase()] : [];
   return [];
+};
+
+const normalizeSlotEntries = (value) => {
+  const normalized = new Set();
+  toLowercaseStrings(value).forEach((entry) => {
+    normalized.add(entry);
+    const compact = entry.replace(/[\s_-]+/g, '');
+    if (compact) normalized.add(compact);
+  });
+  return Array.from(normalized);
 };
 
 const getItemDescriptors = (item) => {
   if (!item || typeof item !== 'object') return [];
   const descriptors = new Set();
-  DESCRIPTOR_KEYS.forEach((key) => {
-    toLowercaseStrings(item[key]).forEach((descriptor) => {
-      descriptors.add(descriptor);
-    });
-  });
+  DESCRIPTOR_KEYS.forEach((key) => toLowercaseStrings(item[key]).forEach((descriptor) => descriptors.add(descriptor)));
   return Array.from(descriptors);
 };
 
+const getItemSlotMetadata = (item) => {
+  if (!item || typeof item !== 'object') return new Set();
+  const slots = new Set();
+  SLOT_METADATA_KEYS.forEach((key) => normalizeSlotEntries(item[key]).forEach((entry) => slots.add(entry)));
+  return slots;
+};
+
 const matchesAllowedValues = (descriptors, allowedValues = []) => {
-  if (!allowedValues || allowedValues.length === 0) return true;
-  if (!descriptors || descriptors.length === 0) return true;
+  if (!allowedValues?.length) return true;
+  if (!descriptors?.length) return true;
   return allowedValues.some((allowed) => {
     const normalized = allowed.toLowerCase();
     return descriptors.some((descriptor) => descriptor.includes(normalized));
@@ -77,36 +76,9 @@ const getMetadataFilterEntries = (filters) => {
   if (!filters || typeof filters !== 'object') return [];
   const entries = new Set();
   SLOT_METADATA_KEYS.forEach((key) => {
-    if (filters[key]) {
-      normalizeSlotEntries(filters[key]).forEach((entry) => {
-        entries.add(entry);
-      });
-    }
+    if (filters[key]) normalizeSlotEntries(filters[key]).forEach((entry) => entries.add(entry));
   });
   return Array.from(entries);
-};
-
-const normalizeSlotEntries = (value) => {
-  const normalized = new Set();
-  toLowercaseStrings(value).forEach((entry) => {
-    normalized.add(entry);
-    const compact = entry.replace(/[\s_-]+/g, '');
-    if (compact) {
-      normalized.add(compact);
-    }
-  });
-  return Array.from(normalized);
-};
-
-const getItemSlotMetadata = (item) => {
-  if (!item || typeof item !== 'object') return new Set();
-  const slots = new Set();
-  SLOT_METADATA_KEYS.forEach((key) => {
-    normalizeSlotEntries(item[key]).forEach((entry) => {
-      slots.add(entry);
-    });
-  });
-  return slots;
 };
 
 const matchesMetadataFilters = (item, filters) => {
@@ -118,298 +90,182 @@ const matchesMetadataFilters = (item, filters) => {
 };
 
 const slotMatchesItemMetadata = (slot, itemSlots) => {
-  if (!slot) return true;
-  if (!itemSlots || itemSlots.size === 0) return true;
-  const slotKeyEntries = normalizeSlotEntries(slot.key || slot);
-  return slotKeyEntries.some((entry) => itemSlots.has(entry));
+  if (!slot || !itemSlots || itemSlots.size === 0) return true;
+  return normalizeSlotEntries(slot.key || slot).some((entry) => itemSlots.has(entry));
 };
 
 const slotAllowsOption = (slot, option) => {
   if (!slot || !option) return false;
-  const allowedSources =
-    slot.allowedSources && slot.allowedSources.length
-      ? slot.allowedSources
-      : DEFAULT_ALLOWED_SOURCES;
-  if (!allowedSources.includes(option.source)) {
-    return false;
-  }
-
+  const allowedSources = slot.allowedSources?.length ? slot.allowedSources : DEFAULT_ALLOWED_SOURCES;
+  if (!allowedSources.includes(option.source)) return false;
   const sourceFilters = slot.filters?.[option.source];
   if (!sourceFilters) {
     if (option.source === 'armor' || option.source === 'accessory') {
       const itemSlots = getItemSlotMetadata(option.item);
-      if (itemSlots.size > 0 && !slotMatchesItemMetadata(slot, itemSlots)) {
-        return false;
-      }
+      if (itemSlots.size > 0 && !slotMatchesItemMetadata(slot, itemSlots)) return false;
     }
     return true;
   }
-
   const descriptors = getItemDescriptors(option.item);
-
-  if (
-    sourceFilters.categories &&
-    !matchesAllowedValues(descriptors, sourceFilters.categories)
-  ) {
-    return false;
-  }
-
-  if (sourceFilters.types && !matchesAllowedValues(descriptors, sourceFilters.types)) {
-    return false;
-  }
-
-  if (!matchesMetadataFilters(option.item, sourceFilters)) {
-    return false;
-  }
-
-  return true;
+  if (sourceFilters.categories && !matchesAllowedValues(descriptors, sourceFilters.categories)) return false;
+  if (sourceFilters.types && !matchesAllowedValues(descriptors, sourceFilters.types)) return false;
+  return matchesMetadataFilters(option.item, sourceFilters);
 };
 
 const buildSlotOptions = (slot, optionsBySource) => {
   if (!slot) return [];
-  const allowedSources =
-    slot.allowedSources && slot.allowedSources.length
-      ? slot.allowedSources
-      : DEFAULT_ALLOWED_SOURCES;
+  const allowedSources = slot.allowedSources?.length ? slot.allowedSources : DEFAULT_ALLOWED_SOURCES;
   const options = [];
-  allowedSources.forEach((source) => {
-    const sourceOptions = optionsBySource[source] || [];
-    sourceOptions.forEach((option) => {
-      if (slotAllowsOption(slot, option)) {
-        options.push(option);
-      }
-    });
-  });
+  allowedSources.forEach((source) => (optionsBySource[source] || []).forEach((option) => {
+    if (slotAllowsOption(slot, option)) options.push(option);
+  }));
   return options;
 };
-
-const SLOT_LAYOUT = {
-  leftColumn: ['head', 'eyes', 'neck', 'shoulders', 'chest', 'back'],
-  rightColumn: ['arms', 'wrists', 'hands', 'waist', 'legs', 'feet'],
-  bottomRow: ['mainHand', 'offHand', 'ranged', 'ringLeft', 'ringRight'],
-};
-
 
 const getItemName = (item) => {
   if (!item) return '';
   if (typeof item === 'string') return item;
   if (typeof item !== 'object') return String(item);
-  return (
-    item.displayName ||
-    item.name ||
-    item.itemName ||
-    item.accessoryName ||
-    item.armorName ||
-    item.title ||
-    ''
-  );
+  return item.displayName || item.name || item.itemName || item.accessoryName || item.armorName || item.title || '';
 };
 
-const getItemSource = (item) => {
-  if (!item || typeof item !== 'object') return undefined;
-  if (item.source) return item.source;
-  if (item.__source) return item.__source;
-  if (item.reference && item.reference.source) return item.reference.source;
-  return undefined;
+const getItemSource = (item) => item && typeof item === 'object' ? (item.source || item.__source || item.reference?.source) : undefined;
+const getItemRarity = (item) => String(item?.rarity || item?.quality || item?.tier || 'common').toLowerCase();
+const getItemDescription = (item) => item?.description || item?.desc || item?.details || item?.notes || 'No lore entry has been recorded for this piece yet.';
+
+const getStatLines = (item) => {
+  if (!item || typeof item !== 'object') return [];
+  const lines = [];
+  const add = (label, value, prefix = '+') => {
+    const number = Number(value);
+    if (Number.isFinite(number) && number !== 0) lines.push(`${number > 0 ? prefix : ''}${number} ${label}`);
+  };
+  add('AC', item.acBonus || item.armorClassBonus || item.bonusAc || item.bonusAC);
+  add('Attack', item.attackBonus || item.toHitBonus);
+  add('Damage', item.damageBonus || item.bonusDamage);
+  add('Speed', item.speedBonus || item.movementBonus, '+');
+  Object.entries(item.statBonuses || item.abilityBonuses || {}).forEach(([key, value]) => add(ABILITY_LABELS[key] || key, value));
+  Object.entries(item.statOverrides || {}).forEach(([key, value]) => lines.push(`${ABILITY_LABELS[key] || key} set to ${value}`));
+  if (item.damage) lines.push(`${item.damage} damage`);
+  if (item.properties) lines.push(Array.isArray(item.properties) ? item.properties.slice(0, 2).join(', ') : item.properties);
+  return lines.slice(0, 4);
 };
 
-export default function EquipmentRack({
-  equipment = {},
-  inventory = {},
-  onEquipmentChange,
-  onSlotChange,
-  disabled = false,
-}) {
-  const { weapons = [], armor = [], items = [], accessories = [] } =
-    inventory || {};
-  const slotLookup = useMemo(() => {
-    const map = new Map();
-    FLAT_SLOTS.forEach((slot) => {
-      map.set(slot.key, slot);
-    });
-    return map;
-  }, []);
+const getMetrics = (equipment) => Object.values(equipment || {}).filter(Boolean).reduce((acc, item) => {
+  acc.ac += Number(item.acBonus || item.armorClassBonus || item.bonusAc || item.bonusAC || 0);
+  acc.attack += Number(item.attackBonus || item.toHitBonus || 0);
+  acc.damage += Number(item.damageBonus || item.bonusDamage || 0);
+  acc.speed += Number(item.speedBonus || item.movementBonus || 0);
+  acc.passives += getStatLines(item).length;
+  return acc;
+}, { ac: 0, attack: 0, damage: 0, speed: 0, passives: 0 });
+
+const materializeOptionItem = (option) => {
+  if (!option) return null;
+  const base = option.item && typeof option.item === 'object' ? { ...option.item } : { name: getItemName(option.item) };
+  return { ...base, source: option.source, __source: option.source };
+};
+
+export default function EquipmentRack({ equipment = {}, inventory = {}, onEquipmentChange, onSlotChange, disabled = false }) {
+  const { weapons = [], armor = [], items = [], accessories = [] } = inventory || {};
+  const [selectedSlotKey, setSelectedSlotKey] = useState('mainHand');
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [rarityFilter, setRarityFilter] = useState('all');
+  const [previewOption, setPreviewOption] = useState(null);
+
+  const slotLookup = useMemo(() => new Map(FLAT_SLOTS.map((slot) => [slot.key, slot])), []);
+  const selectedSlot = slotLookup.get(selectedSlotKey) || FLAT_SLOTS[0];
+
   const inventoryOptions = useMemo(() => {
     const options = [];
     const bySource = {};
     const addOptions = (itemsList = [], source) => {
-      if (!itemsList || itemsList.length === 0) return;
-      if (!bySource[source]) {
-        bySource[source] = [];
-      }
+      if (!itemsList?.length) return;
+      bySource[source] = bySource[source] || [];
       itemsList.forEach((item, index) => {
-        if (!item) return;
         const name = getItemName(item);
         if (!name) return;
-        const value = `${source}-${index}-${name}`;
-        const option = {
-          value,
-          label: name,
-          item,
-          source,
-          description: SOURCE_DESCRIPTIONS[source] || 'Item',
-        };
-        options.push(option);
-        bySource[source].push(option);
+        const option = { value: `${source}-${index}-${name}`, label: name, item, source, description: SOURCE_DESCRIPTIONS[source] || 'Item' };
+        options.push(option); bySource[source].push(option);
       });
     };
-
-    addOptions(weapons, 'weapon');
-    addOptions(armor, 'armor');
-    addOptions(items, 'item');
-    addOptions(accessories, 'accessory');
-
+    addOptions(weapons, 'weapon'); addOptions(armor, 'armor'); addOptions(items, 'item'); addOptions(accessories, 'accessory');
     return { all: options, bySource };
   }, [accessories, armor, items, weapons]);
 
-  const optionMap = useMemo(() => {
-    const map = new Map();
-    inventoryOptions.all.forEach((opt) => {
-      map.set(opt.value, opt);
-    });
-    return map;
-  }, [inventoryOptions]);
-
-  const slotOptionsMap = useMemo(() => {
-    const map = new Map();
-    FLAT_SLOTS.forEach((slot) => {
-      map.set(slot.key, buildSlotOptions(slot, inventoryOptions.bySource));
-    });
-    return map;
-  }, [inventoryOptions]);
-
+  const slotOptionsMap = useMemo(() => new Map(FLAT_SLOTS.map((slot) => [slot.key, buildSlotOptions(slot, inventoryOptions.bySource)])), [inventoryOptions]);
   const hasOptions = inventoryOptions.all.length > 0;
 
-  const handleAssign = useCallback(
-    (slotKey, optionValue) => {
-      if (typeof onEquipmentChange !== 'function' && typeof onSlotChange !== 'function')
-        return;
+  const handleAssign = useCallback((slotKey, option) => {
+    if (typeof onEquipmentChange !== 'function' && typeof onSlotChange !== 'function') return;
+    const nextItem = option ? materializeOptionItem(option) : null;
+    const nextEquipment = { ...equipment, [slotKey]: nextItem };
+    onSlotChange?.(slotKey, nextItem);
+    onEquipmentChange?.(nextEquipment);
+    setPreviewOption(null);
+  }, [equipment, onEquipmentChange, onSlotChange]);
 
-      let nextItem = null;
-      if (optionValue) {
-        const option = optionMap.get(optionValue);
-        if (option) {
-          const base =
-            option.item && typeof option.item === 'object'
-              ? { ...option.item }
-              : { name: getItemName(option.item) };
-          nextItem = {
-            ...base,
-            source: option.source,
-            __source: option.source,
-          };
-        }
-      }
+  const openPicker = (slotKey) => { setSelectedSlotKey(slotKey); setPickerOpen(true); setQuery(''); setPreviewOption(null); };
+  const currentItem = equipment?.[selectedSlot.key];
+  const inspectedItem = previewOption ? materializeOptionItem(previewOption) : currentItem;
+  const currentMetrics = getMetrics(equipment);
+  const previewMetrics = getMetrics({ ...equipment, [selectedSlot.key]: inspectedItem || null });
 
-      const nextEquipment = { ...equipment };
-      if (nextItem) {
-        nextEquipment[slotKey] = nextItem;
-      } else {
-        nextEquipment[slotKey] = null;
-      }
+  const filteredOptions = (slotOptionsMap.get(selectedSlot.key) || [])
+    .filter((opt) => !query || opt.label.toLowerCase().includes(query.toLowerCase()))
+    .filter((opt) => rarityFilter === 'all' || getItemRarity(opt.item) === rarityFilter)
+    .sort((a, b) => getItemRarity(b.item).localeCompare(getItemRarity(a.item)) || a.label.localeCompare(b.label));
 
-      if (typeof onSlotChange === 'function') {
-        onSlotChange(slotKey, nextItem || null);
-      }
-      if (typeof onEquipmentChange === 'function') {
-        onEquipmentChange(nextEquipment);
-      }
-    },
-    [equipment, onEquipmentChange, onSlotChange, optionMap]
-  );
-
-  const renderSlot = (slot) => {
-    if (!slot) return null;
-    const current = equipment?.[slot.key];
-    const optionsForSlot = slotOptionsMap.get(slot.key) || [];
-    const selectedOption = optionsForSlot.find((opt) => {
-      const itemName = getItemName(current);
-      if (!itemName) return false;
-      const currentSource = getItemSource(current);
-      const candidateName = getItemName(opt.item);
-      if (currentSource) {
-        return opt.source === currentSource && candidateName === itemName;
-      }
-      return candidateName === itemName;
-    });
-
-    const selectedValue = selectedOption ? selectedOption.value : '';
-    const displayName = getItemName(current) || '—';
-
+  const renderSlotCard = (slot) => {
+    const item = equipment?.[slot.key];
+    const statLines = getStatLines(item);
+    const rarity = item ? getItemRarity(item) : 'empty';
     return (
-      <div key={slot.key} className={styles.slot}>
-        <div className={styles.slotHeader}>
-          <ItemIcon
-            equipmentSlot={slot.key}
-            size={28}
-            className={styles.slotIcon}
-            title={slot.label}
-          />
-          <span className={styles.slotLabel}>{slot.label}</span>
+      <article key={slot.key} className={`${styles.slotCard} ${styles[`rarity_${rarity}`] || ''} ${selectedSlotKey === slot.key ? styles.selected : ''}`}>
+        <button type="button" className={styles.slotButton} onClick={() => openPicker(slot.key)} aria-label={`${slot.label}: ${item ? `change ${getItemName(item)}` : 'choose equipment'}`} disabled={disabled}>
+          <span className={styles.slotHeader}><ItemIcon equipmentSlot={slot.key} size={30} className={styles.slotIcon} title="" /><span>{slot.label}</span></span>
+          <span className={styles.itemArt}><ItemIcon equipmentSlot={slot.key} item={item} size={46} title={getItemName(item) || slot.label} /></span>
+          <span className={styles.itemName}>{getItemName(item) || 'Empty Slot'}</span>
+          <span className={styles.rarityBadge}>{item ? rarity : 'Available'}</span>
+          <span className={styles.statLine}>{statLines[0] || (item ? 'No tracked bonuses' : 'Choose equipment')}</span>
+        </button>
+        <div className={styles.quickActions}>
+          <Button size="sm" className={styles.miniButton} onClick={() => openPicker(slot.key)} disabled={disabled}>{item ? 'Change' : 'Equip'}</Button>
+          <Button size="sm" className={styles.iconButton} title="Unequip" aria-label={`Unequip ${slot.label}`} onClick={() => handleAssign(slot.key, null)} disabled={disabled || !item}>✕</Button>
         </div>
-        <div
-          className={current ? styles.slotItem : styles.slotItemEmpty}
-          data-testid={`${slot.key}-item-display`}
-        >
-          {displayName}
-        </div>
-        <div className={styles.slotControls}>
-          <Form.Select
-            aria-label={`${slot.label} slot selection`}
-            value={selectedValue}
-            disabled={disabled}
-            className={styles.slotSelect}
-            size="sm"
-            onChange={(event) => handleAssign(slot.key, event.target.value)}
-          >
-            <option value="">Unequipped</option>
-            {optionsForSlot.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-                {opt.description ? ` (${opt.description})` : ''}
-              </option>
-            ))}
-          </Form.Select>
-          <Button
-            variant="outline-light"
-            size="sm"
-            disabled={disabled || !current}
-            onClick={() => handleAssign(slot.key, '')}
-            className={styles.clearButton}
-          >
-            Clear Slot
-          </Button>
-        </div>
-      </div>
+      </article>
     );
   };
 
   return (
-    <div className={styles.rackWrapper}>
-      <p className="text-muted small mb-3">
-        {hasOptions
-          ? "Assign owned items to equipment slots. Selecting an option will update the character's loadout immediately."
-          : "You do not have any owned inventory to assign yet. Equip gear from the inventory tabs to populate this rack."}
-      </p>
+    <div className={styles.equipmentShell}>
+      <section className={styles.bonusSummary} aria-label="Active equipment bonuses">
+        {[['Armor Class', currentMetrics.ac], ['Attack', currentMetrics.attack], ['Damage', currentMetrics.damage], ['Movement', currentMetrics.speed], ['Passive Lines', currentMetrics.passives]].map(([label, value]) => (
+          <div className={styles.bonusPill} key={label}><span>{label}</span><strong>{value > 0 ? `+${value}` : value}</strong></div>
+        ))}
+      </section>
       <div className={styles.rackLayout}>
-        <div className={styles.columns}>
-          <div className={styles.leftColumn}>
-            {SLOT_LAYOUT.leftColumn.map((slotKey) =>
-              renderSlot(slotLookup.get(slotKey))
-            )}
-          </div>
-          <div className={styles.rightColumn}>
-            {SLOT_LAYOUT.rightColumn.map((slotKey) =>
-              renderSlot(slotLookup.get(slotKey))
-            )}
-          </div>
+        <div className={styles.characterPreview}>
+          <div className={styles.previewSigil}>✦</div>
+          <h3>Loadout</h3>
+          <p>{hasOptions ? 'Select a slot, compare owned gear, and equip instantly.' : 'Owned gear will appear here when inventory is available.'}</p>
         </div>
-        <div className={styles.bottomRow}>
-          {SLOT_LAYOUT.bottomRow.map((slotKey) =>
-            renderSlot(slotLookup.get(slotKey))
-          )}
-        </div>
+        <div className={styles.leftColumn}>{SLOT_LAYOUT.leftColumn.map((slotKey) => renderSlotCard(slotLookup.get(slotKey)))}</div>
+        <div className={styles.rightColumn}>{SLOT_LAYOUT.rightColumn.map((slotKey) => renderSlotCard(slotLookup.get(slotKey)))}</div>
+        <div className={styles.bottomRow}>{SLOT_LAYOUT.bottomRow.map((slotKey) => renderSlotCard(slotLookup.get(slotKey)))}</div>
       </div>
+      <aside className={styles.detailsPanel} aria-live="polite">
+        <div className={styles.detailsHero}><ItemIcon equipmentSlot={selectedSlot.key} item={inspectedItem} size={58} /><div><span className={styles.eyebrow}>{selectedSlot.label}</span><h3>{getItemName(inspectedItem) || 'Empty Slot'}</h3><span className={styles.rarityBadge}>{inspectedItem ? getItemRarity(inspectedItem) : 'No item equipped'}</span></div></div>
+        <p>{inspectedItem ? getItemDescription(inspectedItem) : 'Pick owned equipment for this slot to see details, bonuses, and upgrade previews.'}</p>
+        <div className={styles.statChips}>{(getStatLines(inspectedItem).length ? getStatLines(inspectedItem) : ['No tracked bonuses']).map((line) => <span key={line}>{line}</span>)}</div>
+        <div className={styles.compareGrid}>{Object.keys(currentMetrics).map((key) => { const diff = previewMetrics[key] - currentMetrics[key]; return <div key={key}><span>{key}</span><strong>{currentMetrics[key]} → {previewMetrics[key]}</strong><em className={diff >= 0 ? styles.positive : styles.negative}>{diff === 0 ? '—' : `${diff > 0 ? '+' : ''}${diff}`}</em></div>; })}</div>
+      </aside>
+      {pickerOpen && <section className={styles.picker} role="dialog" aria-modal="false" aria-label={`${selectedSlot.label} equipment picker`}>
+        <div className={styles.pickerHeader}><div><span className={styles.eyebrow}>Owned equipment</span><h3>{selectedSlot.label}</h3></div><Button className={styles.iconButton} onClick={() => setPickerOpen(false)} aria-label="Close equipment picker">✕</Button></div>
+        <div className={styles.pickerControls}><Form.Control aria-label="Search owned equipment" placeholder="Search gear" value={query} onChange={(event) => setQuery(event.target.value)} /><Form.Select aria-label="Filter by rarity" value={rarityFilter} onChange={(event) => setRarityFilter(event.target.value)}>{RARITY_ORDER.map((rarity) => <option key={rarity} value={rarity}>{rarity === 'all' ? 'All rarities' : rarity}</option>)}</Form.Select></div>
+        <div className={styles.itemGrid}>{filteredOptions.map((opt) => { const equipped = getItemName(currentItem) === opt.label && getItemSource(currentItem) === opt.source; return <article key={opt.value} className={`${styles.itemCard} ${styles[`rarity_${getItemRarity(opt.item)}`] || ''}`} onMouseEnter={() => setPreviewOption(opt)}><button type="button" onClick={() => setPreviewOption(opt)}><ItemIcon equipmentSlot={selectedSlot.key} item={opt.item} size={34} /><span><strong>{opt.label}</strong><small>{getItemRarity(opt.item)} · {opt.description}</small></span></button><p>{getStatLines(opt.item).join(' · ') || 'No tracked bonuses'}</p><Button size="sm" className={styles.miniButton} onClick={() => { handleAssign(selectedSlot.key, opt); setPickerOpen(false); }} disabled={disabled}>{equipped ? 'Equipped' : 'Equip'}</Button></article>; })}{!filteredOptions.length && <div className={styles.emptyState}>No owned equipment matches this slot and filter.</div>}</div>
+      </section>}
     </div>
   );
 }

--- a/client/src/components/Zombies/attributes/EquipmentRack.module.scss
+++ b/client/src/components/Zombies/attributes/EquipmentRack.module.scss
@@ -1,229 +1,186 @@
-.rackWrapper {
-  --rack-border: rgba(255, 255, 255, 0.08);
-  --rack-shadow: rgba(0, 0, 0, 0.35);
-}
-
-.rackLayout {
-  background: radial-gradient(circle at top, rgba(73, 80, 87, 0.25), rgba(33, 37, 41, 0.85));
-  border: 1px solid var(--rack-border);
-  border-radius: 1rem;
-  padding: clamp(0.85rem, 2vw, 1.15rem);
-  box-shadow: 0 18px 36px var(--rack-shadow);
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.rackLayout::before,
-.rackLayout::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.rackLayout::before {
-  background:
-    radial-gradient(circle at 50% 22%, rgba(173, 181, 189, 0.38), rgba(173, 181, 189, 0) 54%),
-    radial-gradient(circle at 50% 84%, rgba(96, 112, 130, 0.46), rgba(15, 19, 28, 0.94) 70%),
-    linear-gradient(165deg, rgba(21, 26, 34, 0.96), rgba(9, 12, 19, 0.98));
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size:
-    clamp(200px, 32vw, 340px) 92%,
-    clamp(220px, 34vw, 360px) 100%,
-    clamp(220px, 34vw, 360px) 100%;
-  filter: saturate(0.85) contrast(1.12) drop-shadow(0 24px 40px rgba(0, 0, 0, 0.45));
-  opacity: 0.52;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  -webkit-mask-size: clamp(200px, 32vw, 340px) 100%;
-  mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  mask-size: clamp(200px, 32vw, 340px) 100%;
-}
-
-.rackLayout::after {
-  background:
-    radial-gradient(circle at 50% 16%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 62%),
-    radial-gradient(circle at 50% 95%, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 70%);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size:
-    clamp(210px, 32vw, 340px) 82%,
-    clamp(220px, 34vw, 360px) 100%;
-  mix-blend-mode: screen;
-  opacity: 0.3;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  -webkit-mask-size: clamp(200px, 32vw, 340px) 100%;
-  mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  mask-size: clamp(200px, 32vw, 340px) 100%;
-}
-
-.columns {
+.equipmentShell {
+  --eq-bg: #07111f;
+  --eq-panel: rgba(12, 24, 44, 0.78);
+  --eq-line: rgba(134, 189, 255, 0.18);
+  --eq-text: #edf6ff;
+  --eq-muted: rgba(226, 239, 255, 0.68);
   display: grid;
-  gap: clamp(0.75rem, 2.25vw, 2.25rem);
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
-  align-items: start;
-  position: relative;
-  z-index: 1;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.34fr);
+  gap: 1rem;
+  color: var(--eq-text);
 }
 
-.leftColumn,
-.rightColumn {
+.bonusSummary {
+  grid-column: 1 / -1;
   display: grid;
-  grid-auto-rows: minmax(0, auto);
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
   gap: 0.75rem;
 }
 
-.bottomRow {
-  margin-top: 1.1rem;
-  display: grid;
-  gap: clamp(0.65rem, 2vw, 0.9rem);
-  grid-template-columns: repeat(5, minmax(120px, 1fr));
-  position: relative;
-  z-index: 1;
+.bonusPill,
+.detailsPanel,
+.picker,
+.slotCard,
+.characterPreview {
+  background: linear-gradient(145deg, rgba(13, 28, 52, 0.9), rgba(15, 19, 43, 0.72));
+  border: 1px solid var(--eq-line);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(18px);
 }
 
-.slot {
+.bonusPill {
+  border-radius: 1rem;
+  padding: 0.8rem 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 56px;
+}
+
+.bonusPill span,
+.eyebrow {
+  color: #9cc8ff;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.bonusPill strong { color: #ffe7a3; font-size: 1.15rem; }
+
+.rackLayout {
   position: relative;
+  min-height: 640px;
+  display: grid;
+  grid-template-columns: minmax(170px, 0.9fr) minmax(220px, 1.08fr) minmax(170px, 0.9fr);
+  grid-template-areas: 'left preview right' 'bottom bottom bottom';
+  gap: 0.85rem;
+  padding: clamp(0.85rem, 2vw, 1.25rem);
+  border-radius: 1.4rem;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 20%, rgba(96, 165, 250, 0.22), transparent 35%),
+    radial-gradient(circle at 50% 85%, rgba(124, 58, 237, 0.20), transparent 42%),
+    linear-gradient(160deg, rgba(3, 8, 20, 0.98), rgba(7, 17, 31, 0.96));
+  border: 1px solid rgba(125, 174, 255, 0.16);
+}
+
+.leftColumn { grid-area: left; }
+.rightColumn { grid-area: right; }
+.leftColumn,
+.rightColumn { display: grid; gap: 0.7rem; align-content: start; }
+.bottomRow { grid-area: bottom; display: grid; grid-template-columns: repeat(5, minmax(130px, 1fr)); gap: 0.7rem; }
+
+.characterPreview {
+  grid-area: preview;
+  align-self: stretch;
+  border-radius: 1.5rem;
+  padding: 1.3rem;
+  text-align: center;
   display: flex;
   flex-direction: column;
-  min-height: 118px;
-  padding: 0.6rem;
-  border-radius: 0.8rem;
-  background: linear-gradient(135deg, rgba(33, 37, 41, 0.92), rgba(73, 80, 87, 0.7));
-  color: var(--bs-light, #f8f9fa);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+  justify-content: center;
+  position: relative;
   overflow: hidden;
 }
 
-.slot::before {
+.characterPreview::before {
   content: '';
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  mix-blend-mode: screen;
-  pointer-events: none;
+  inset: 8% 18%;
+  background: linear-gradient(180deg, rgba(160, 198, 255, 0.28), rgba(73, 43, 140, 0.16));
+  clip-path: polygon(50% 0, 68% 17%, 62% 45%, 78% 100%, 22% 100%, 38% 45%, 32% 17%);
+  filter: drop-shadow(0 0 35px rgba(98, 169, 255, 0.45));
+  opacity: 0.7;
 }
 
-.slotHeader {
+.previewSigil { position: relative; font-size: 3rem; color: #ffe7a3; text-shadow: 0 0 24px rgba(255, 210, 91, 0.8); }
+.characterPreview h3,
+.characterPreview p { position: relative; }
+.characterPreview p { color: var(--eq-muted); }
+
+.slotCard {
+  border-radius: 1rem;
+  min-height: 154px;
+  overflow: hidden;
   position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-size: 0.66rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-  color: rgba(248, 249, 250, 0.9);
+  border-color: rgba(111, 159, 221, 0.2);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+.slotCard:hover,
+.selected { transform: translateY(-2px); border-color: rgba(130, 195, 255, 0.58); box-shadow: 0 18px 48px rgba(30, 94, 180, 0.28); }
+.slotButton { width: 100%; min-height: 116px; border: 0; color: inherit; background: transparent; padding: 0.75rem; display: grid; gap: 0.3rem; text-align: left; }
+.slotButton:focus-visible,
+.itemCard button:focus-visible,
+.iconButton:focus-visible,
+.miniButton:focus-visible { outline: 3px solid #8bd3ff; outline-offset: 2px; }
+.slotHeader { display: flex; align-items: center; gap: 0.45rem; color: #9cc8ff; font-size: 0.72rem; font-weight: 800; letter-spacing: 0.11em; text-transform: uppercase; }
+.slotIcon,
+.itemArt { display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; background: rgba(146, 197, 255, 0.1); box-shadow: inset 0 0 0 1px rgba(190, 220, 255, 0.16); }
+.itemArt { width: 58px; height: 58px; justify-self: center; }
+.itemName { text-align: center; font-weight: 800; line-height: 1.15; }
+.rarityBadge { justify-self: center; border-radius: 999px; padding: 0.16rem 0.55rem; font-size: 0.68rem; font-weight: 900; letter-spacing: 0.08em; text-transform: uppercase; background: rgba(255,255,255,0.08); color: #dbeafe; }
+.statLine { text-align: center; color: var(--eq-muted); font-size: 0.78rem; min-height: 1rem; }
+.quickActions { display: flex; justify-content: center; gap: 0.45rem; padding: 0 0.6rem 0.6rem; }
+.miniButton,
+.iconButton { min-height: 36px; border: 1px solid rgba(143, 203, 255, 0.32) !important; background: linear-gradient(135deg, rgba(37, 99, 235, 0.84), rgba(91, 33, 182, 0.8)) !important; color: white !important; font-weight: 800; border-radius: 999px; }
+.iconButton { min-width: 38px; padding-inline: 0.65rem; }
+
+.detailsPanel { border-radius: 1.25rem; padding: 1rem; align-self: start; position: sticky; top: 0.75rem; }
+.detailsHero { display: flex; gap: 0.85rem; align-items: center; padding-bottom: 0.85rem; border-bottom: 1px solid rgba(255,255,255,0.1); }
+.detailsHero h3 { margin: 0.15rem 0; }
+.detailsPanel p { color: var(--eq-muted); margin: 1rem 0; }
+.statChips { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.statChips span { border-radius: 999px; padding: 0.35rem 0.65rem; background: rgba(125, 211, 252, 0.12); color: #dbeafe; font-weight: 700; }
+.compareGrid { display: grid; gap: 0.5rem; margin-top: 1rem; }
+.compareGrid div { display: grid; grid-template-columns: 0.8fr 1fr auto; gap: 0.5rem; padding: 0.55rem; border-radius: 0.75rem; background: rgba(255,255,255,0.055); }
+.compareGrid span { text-transform: capitalize; color: #9cc8ff; }
+.compareGrid em { font-style: normal; font-weight: 900; }
+.positive { color: #86efac; }
+.negative { color: #fca5a5; }
+
+.picker { grid-column: 1 / -1; border-radius: 1.25rem; padding: 1rem; animation: pickerIn 180ms ease both; }
+.pickerHeader { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+.pickerControls { display: grid; grid-template-columns: 1fr 180px; gap: 0.65rem; margin: 0.85rem 0; }
+.pickerControls :global(.form-control),
+.pickerControls :global(.form-select) { min-height: 44px; color: #eff6ff; background-color: rgba(4, 13, 28, 0.9); border-color: rgba(147, 197, 253, 0.3); }
+.itemGrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.7rem; max-height: 42vh; overflow: auto; padding-right: 0.25rem; }
+.itemCard { border-radius: 1rem; padding: 0.75rem; background: rgba(3, 10, 24, 0.76); border: 1px solid rgba(147, 197, 253, 0.16); }
+.itemCard button:first-child { width: 100%; display: flex; align-items: center; gap: 0.65rem; text-align: left; color: inherit; background: transparent; border: 0; padding: 0; }
+.itemCard small { display: block; color: var(--eq-muted); text-transform: capitalize; }
+.itemCard p { min-height: 1.2rem; color: #c7d2fe; font-size: 0.82rem; margin: 0.65rem 0; }
+.emptyState { grid-column: 1 / -1; padding: 1.5rem; text-align: center; color: var(--eq-muted); border: 1px dashed rgba(147, 197, 253, 0.28); border-radius: 1rem; }
+
+.rarity_uncommon { border-color: rgba(74, 222, 128, 0.52); box-shadow: 0 0 24px rgba(34,197,94,0.12); }
+.rarity_rare { border-color: rgba(96, 165, 250, 0.58); box-shadow: 0 0 26px rgba(59,130,246,0.16); }
+.rarity_epic { border-color: rgba(192, 132, 252, 0.6); box-shadow: 0 0 28px rgba(168,85,247,0.18); }
+.rarity_legendary { border-color: rgba(251, 191, 36, 0.7); box-shadow: 0 0 32px rgba(245,158,11,0.2); }
+.rarity_artifact { border-color: rgba(248, 113, 113, 0.72); box-shadow: 0 0 34px rgba(249,115,22,0.22); }
+
+@keyframes pickerIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+@media (max-width: 1100px) {
+  .equipmentShell { grid-template-columns: 1fr; }
+  .detailsPanel { position: static; }
+  .bonusSummary { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 }
 
-.slotIcon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
-  font-size: 0.95rem;
+@media (max-width: 820px) {
+  .rackLayout { grid-template-columns: 1fr 1fr; grid-template-areas: 'preview preview' 'left right' 'bottom bottom'; min-height: 0; }
+  .bottomRow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .pickerControls { grid-template-columns: 1fr; }
 }
 
-.slotLabel {
-  flex: 1;
-}
-
-%slotItemBase {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  border-radius: 0.65rem;
-  padding: 0.55rem;
-  margin-bottom: 0.5rem;
-  min-height: 2.6rem;
-  word-break: break-word;
-}
-
-.slotItem {
-  @extend %slotItemBase;
-  background: rgba(255, 255, 255, 0.08);
-  font-weight: 600;
-}
-
-.slotItemEmpty {
-  @extend %slotItemBase;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(248, 249, 250, 0.7);
-  font-style: italic;
-}
-
-.slotControls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.45rem;
-  margin-top: auto;
-}
-
-.slotSelect {
-  background: rgba(8, 12, 20, 0.75);
-  color: var(--bs-light, #f8f9fa);
-  border-radius: 0.55rem;
-  border-color: rgba(255, 255, 255, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
-  padding: 0.35rem 0.65rem;
-  font-size: 0.88rem;
-  flex: 1 1 160px;
-}
-
-.slotSelect:focus {
-  border-color: rgba(173, 181, 189, 0.8);
-  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.35);
-}
-
-.clearButton {
-  font-weight: 600;
-  padding: 0.25rem 0.75rem;
-  white-space: nowrap;
-}
-
-@media (max-width: 992px) {
-  .columns {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: clamp(0.75rem, 2.75vw, 1.75rem);
-  }
-
-  .bottomRow {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  }
-}
-
-@media (max-width: 768px) {
-  .rackLayout {
-    padding: 1rem;
-  }
-
-  .columns {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.25rem;
-  }
-
-  .leftColumn,
-  .rightColumn {
-    grid-template-columns: minmax(0, 1fr);
-  }
+@media (max-width: 560px) {
+  .equipmentShell { gap: 0.75rem; }
+  .rackLayout { grid-template-columns: 1fr; grid-template-areas: 'preview' 'left' 'right' 'bottom'; padding: 0.7rem; }
+  .bottomRow { grid-template-columns: 1fr; }
+  .bonusSummary { grid-template-columns: 1fr 1fr; }
+  .picker { position: sticky; bottom: 0; z-index: 5; border-radius: 1.25rem 1.25rem 0 0; }
+  .itemGrid { max-height: 55vh; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .slot,
-  .rackLayout {
-    transition: none !important;
-    animation: none !important;
-  }
+  .slotCard,
+  .picker { transition: none !important; animation: none !important; }
 }


### PR DESCRIPTION
### Motivation
- Replace the existing dropdown-first, gray-box equipment form with a premium, RPG-style equipment interface that matches RealmTracker visual language while preserving all equip/unequip gameplay logic.
- Improve information architecture so players immediately understand worn gear, slot meaning, allowed items, rarity, and stat differences at a glance. 
- Deliver a reusable, responsive component set (slot cards, picker, details panel) to be reused across character UIs without changing backend persistence or stat calculation rules.

### Description
- Rebuilt the modal shell (`EquipmentModal`) to an XL “Equipment Arsenal” presentation and wired it to the upgraded `EquipmentRack` while preserving the existing normalized inventory/equipment props and `onSlotChange`/`onEquipmentChange` persistence callbacks. (`client/src/components/Zombies/attributes/EquipmentModal.js`).
- Replaced dropdown-first rack with an interactive slot-card layout, owned-equipment picker (search + rarity filter), quick equip/unequip actions, stat/rarity badges, details panel, and live stat comparison preview; stateful selection and preview logic live in `EquipmentRack`. (`client/src/components/Zombies/attributes/EquipmentRack.js`).
- Added presentation utilities and read-only metric helpers (`getItemRarity`, `getStatLines`, `getMetrics`, `materializeOptionItem`) and preserved slot filtering and assignment logic (`slotAllowsOption`, `buildSlotOptions`) so gameplay behavior is unchanged. (`client/src/components/Zombies/attributes/EquipmentRack.js`).
- New visual polish and responsive layout implemented in `EquipmentRack.module.scss` including deep-navy glass panels, rarity treatments, focus indicators, animations, and reduced-motion support. (`client/src/components/Zombies/attributes/EquipmentRack.module.scss`).

### Testing
- Ran unit tests for the equipment modal with `cd client && npm test -- --runTestsByPath src/components/Zombies/attributes/EquipmentModal.test.js --watchAll=false`, which passed. 
- Ran combined tests `cd client && npm test -- --runTestsByPath src/components/Zombies/attributes/EquipmentModal.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js --watchAll=false`, and both suites passed (total 62 tests passed), with existing component test warnings about React `act(...)` and transition lifecycle but no failing tests. 
- Built the client with `cd client && npm run build`, which completed and produced a production build while emitting pre-existing lint/autoprefixer/browserslist warnings but no build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59229b6d50832e951e8f241570262a)