### PR TITLE
Redesign Equipment modal into premium paper-doll equipment screen

### DIFF
--- a/client/src/components/Zombies/attributes/EquipmentModal.js
+++ b/client/src/components/Zombies/attributes/EquipmentModal.js
@@ -79,7 +79,7 @@ export default function EquipmentModal({
       className={modalClassName}
       show={show}
       onHide={handleModalHide}
-      size="lg"
+      size="xl"
       centered={!isDocked}
       scrollable
       fullscreen="sm-down"
@@ -112,6 +112,7 @@ export default function EquipmentModal({
               }}
               onEquipmentChange={onEquipmentChange}
               onSlotChange={onEquipmentSlotChange}
+              character={form}
             />
           )}
         </Card.Body>

--- a/client/src/components/Zombies/attributes/EquipmentRack.js
+++ b/client/src/components/Zombies/attributes/EquipmentRack.js
@@ -1,114 +1,55 @@
-import React, { useMemo, useCallback } from 'react';
-import { Form, Button } from 'react-bootstrap';
+import React, { useMemo, useCallback, useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
+import { Search, Shield, Sparkles, Sword, X, CheckCircle2 } from 'lucide-react';
 import { EQUIPMENT_SLOT_LAYOUT } from './equipmentSlots';
 import ItemIcon from '../../common/ItemIcon';
 import styles from './EquipmentRack.module.scss';
 
 const FLAT_SLOTS = EQUIPMENT_SLOT_LAYOUT.flat();
-
 const DEFAULT_ALLOWED_SOURCES = ['weapon', 'armor', 'item', 'accessory'];
-
-const SOURCE_DESCRIPTIONS = {
-  weapon: 'Weapon',
-  armor: 'Armor',
-  item: 'Item',
-  accessory: 'Accessory',
-};
-
-const DESCRIPTOR_KEYS = [
-  'category',
-  'categories',
-  'type',
-  'types',
-  'slot',
-  'slots',
-  'tags',
-  'subtype',
-  'subType',
-  'equipmentSlot',
-  'equipmentSlots',
-  'targetSlot',
-  'targetSlots',
-];
-
-const SLOT_METADATA_KEYS = [
-  'slot',
-  'equipmentSlot',
-  'slots',
-  'equipmentSlots',
-  'targetSlot',
-  'targetSlots',
-];
+const SOURCE_DESCRIPTIONS = { weapon: 'Weapon', armor: 'Armor', item: 'Item', accessory: 'Accessory' };
+const DESCRIPTOR_KEYS = ['category', 'categories', 'type', 'types', 'slot', 'slots', 'tags', 'subtype', 'subType', 'equipmentSlot', 'equipmentSlots', 'targetSlot', 'targetSlots'];
+const SLOT_METADATA_KEYS = ['slot', 'equipmentSlot', 'slots', 'equipmentSlots', 'targetSlot', 'targetSlots'];
+const STAT_LABELS = { str: 'STR', dex: 'DEX', con: 'CON', int: 'INT', wis: 'WIS', cha: 'CHA' };
+const RARITIES = ['all', 'common', 'uncommon', 'rare', 'epic', 'legendary', 'artifact'];
 
 const toLowercaseStrings = (value) => {
   if (!value) return [];
-  if (Array.isArray(value)) {
-    return value
-      .filter((entry) => typeof entry === 'string' && entry.trim().length)
-      .map((entry) => entry.toLowerCase());
-  }
-  if (typeof value === 'string') {
-    return value.trim().length ? [value.toLowerCase()] : [];
-  }
+  if (Array.isArray(value)) return value.filter((entry) => typeof entry === 'string' && entry.trim().length).map((entry) => entry.toLowerCase());
+  if (typeof value === 'string') return value.trim().length ? [value.toLowerCase()] : [];
   return [];
 };
-
-const getItemDescriptors = (item) => {
-  if (!item || typeof item !== 'object') return [];
-  const descriptors = new Set();
-  DESCRIPTOR_KEYS.forEach((key) => {
-    toLowercaseStrings(item[key]).forEach((descriptor) => {
-      descriptors.add(descriptor);
-    });
-  });
-  return Array.from(descriptors);
-};
-
-const matchesAllowedValues = (descriptors, allowedValues = []) => {
-  if (!allowedValues || allowedValues.length === 0) return true;
-  if (!descriptors || descriptors.length === 0) return true;
-  return allowedValues.some((allowed) => {
-    const normalized = allowed.toLowerCase();
-    return descriptors.some((descriptor) => descriptor.includes(normalized));
-  });
-};
-
-const getMetadataFilterEntries = (filters) => {
-  if (!filters || typeof filters !== 'object') return [];
-  const entries = new Set();
-  SLOT_METADATA_KEYS.forEach((key) => {
-    if (filters[key]) {
-      normalizeSlotEntries(filters[key]).forEach((entry) => {
-        entries.add(entry);
-      });
-    }
-  });
-  return Array.from(entries);
-};
-
 const normalizeSlotEntries = (value) => {
   const normalized = new Set();
   toLowercaseStrings(value).forEach((entry) => {
     normalized.add(entry);
     const compact = entry.replace(/[\s_-]+/g, '');
-    if (compact) {
-      normalized.add(compact);
-    }
+    if (compact) normalized.add(compact);
   });
   return Array.from(normalized);
 };
-
+const getItemDescriptors = (item) => {
+  if (!item || typeof item !== 'object') return [];
+  const descriptors = new Set();
+  DESCRIPTOR_KEYS.forEach((key) => toLowercaseStrings(item[key]).forEach((descriptor) => descriptors.add(descriptor)));
+  return Array.from(descriptors);
+};
+const matchesAllowedValues = (descriptors, allowedValues = []) => {
+  if (!allowedValues?.length || !descriptors?.length) return true;
+  return allowedValues.some((allowed) => descriptors.some((descriptor) => descriptor.includes(allowed.toLowerCase())));
+};
+const getMetadataFilterEntries = (filters) => {
+  if (!filters || typeof filters !== 'object') return [];
+  const entries = new Set();
+  SLOT_METADATA_KEYS.forEach((key) => filters[key] && normalizeSlotEntries(filters[key]).forEach((entry) => entries.add(entry)));
+  return Array.from(entries);
+};
 const getItemSlotMetadata = (item) => {
-  if (!item || typeof item !== 'object') return new Set();
   const slots = new Set();
-  SLOT_METADATA_KEYS.forEach((key) => {
-    normalizeSlotEntries(item[key]).forEach((entry) => {
-      slots.add(entry);
-    });
-  });
+  if (!item || typeof item !== 'object') return slots;
+  SLOT_METADATA_KEYS.forEach((key) => normalizeSlotEntries(item[key]).forEach((entry) => slots.add(entry)));
   return slots;
 };
-
 const matchesMetadataFilters = (item, filters) => {
   const metadataFilters = getMetadataFilterEntries(filters);
   if (!metadataFilters.length) return true;
@@ -116,300 +57,115 @@ const matchesMetadataFilters = (item, filters) => {
   if (itemSlots.size === 0) return true;
   return metadataFilters.some((entry) => itemSlots.has(entry));
 };
-
 const slotMatchesItemMetadata = (slot, itemSlots) => {
-  if (!slot) return true;
-  if (!itemSlots || itemSlots.size === 0) return true;
-  const slotKeyEntries = normalizeSlotEntries(slot.key || slot);
-  return slotKeyEntries.some((entry) => itemSlots.has(entry));
+  if (!slot || !itemSlots?.size) return true;
+  return normalizeSlotEntries(slot.key || slot).some((entry) => itemSlots.has(entry));
 };
-
 const slotAllowsOption = (slot, option) => {
   if (!slot || !option) return false;
-  const allowedSources =
-    slot.allowedSources && slot.allowedSources.length
-      ? slot.allowedSources
-      : DEFAULT_ALLOWED_SOURCES;
-  if (!allowedSources.includes(option.source)) {
-    return false;
-  }
-
+  const allowedSources = slot.allowedSources?.length ? slot.allowedSources : DEFAULT_ALLOWED_SOURCES;
+  if (!allowedSources.includes(option.source)) return false;
   const sourceFilters = slot.filters?.[option.source];
   if (!sourceFilters) {
     if (option.source === 'armor' || option.source === 'accessory') {
       const itemSlots = getItemSlotMetadata(option.item);
-      if (itemSlots.size > 0 && !slotMatchesItemMetadata(slot, itemSlots)) {
-        return false;
-      }
+      if (itemSlots.size > 0 && !slotMatchesItemMetadata(slot, itemSlots)) return false;
     }
     return true;
   }
-
   const descriptors = getItemDescriptors(option.item);
-
-  if (
-    sourceFilters.categories &&
-    !matchesAllowedValues(descriptors, sourceFilters.categories)
-  ) {
-    return false;
-  }
-
-  if (sourceFilters.types && !matchesAllowedValues(descriptors, sourceFilters.types)) {
-    return false;
-  }
-
-  if (!matchesMetadataFilters(option.item, sourceFilters)) {
-    return false;
-  }
-
-  return true;
+  if (sourceFilters.categories && !matchesAllowedValues(descriptors, sourceFilters.categories)) return false;
+  if (sourceFilters.types && !matchesAllowedValues(descriptors, sourceFilters.types)) return false;
+  return matchesMetadataFilters(option.item, sourceFilters);
 };
-
 const buildSlotOptions = (slot, optionsBySource) => {
-  if (!slot) return [];
-  const allowedSources =
-    slot.allowedSources && slot.allowedSources.length
-      ? slot.allowedSources
-      : DEFAULT_ALLOWED_SOURCES;
-  const options = [];
-  allowedSources.forEach((source) => {
-    const sourceOptions = optionsBySource[source] || [];
-    sourceOptions.forEach((option) => {
-      if (slotAllowsOption(slot, option)) {
-        options.push(option);
-      }
-    });
-  });
-  return options;
+  const allowedSources = slot?.allowedSources?.length ? slot.allowedSources : DEFAULT_ALLOWED_SOURCES;
+  return allowedSources.flatMap((source) => (optionsBySource[source] || []).filter((option) => slotAllowsOption(slot, option)));
+};
+const getItemName = (item) => !item ? '' : typeof item === 'string' ? item : item.displayName || item.name || item.itemName || item.accessoryName || item.armorName || item.title || '';
+const getItemSource = (item) => item && typeof item === 'object' ? item.source || item.__source || item.reference?.source : undefined;
+const normalizeRarity = (item) => String(item?.rarity || item?.quality || 'common').toLowerCase();
+const getDescription = (item) => item?.description || item?.notes || item?.detail || item?.flavor || 'No description recorded for this piece of gear.';
+const getStatLines = (item) => {
+  if (!item) return [];
+  const lines = [];
+  if (item.acBonus !== undefined && item.acBonus !== '') lines.push(`+${item.acBonus} AC`);
+  if (item.attackBonus) lines.push(`+${item.attackBonus} Attack`);
+  if (item.damage) lines.push(item.damage);
+  Object.entries(item.statBonuses || {}).forEach(([key, value]) => Number(value) ? lines.push(`${Number(value) > 0 ? '+' : ''}${value} ${STAT_LABELS[key] || key.toUpperCase()}`) : null);
+  Object.entries(item.statOverrides || {}).forEach(([key, value]) => value ? lines.push(`${STAT_LABELS[key] || key.toUpperCase()} set to ${value}`) : null);
+  return lines;
+};
+const optionMatchesItem = (option, current) => {
+  const itemName = getItemName(current);
+  if (!itemName) return false;
+  const currentSource = getItemSource(current);
+  const candidateName = getItemName(option.item);
+  return currentSource ? option.source === currentSource && candidateName === itemName : candidateName === itemName;
 };
 
-const SLOT_LAYOUT = {
-  leftColumn: ['head', 'eyes', 'neck', 'shoulders', 'chest', 'back'],
-  rightColumn: ['arms', 'wrists', 'hands', 'waist', 'legs', 'feet'],
-  bottomRow: ['mainHand', 'offHand', 'ranged', 'ringLeft', 'ringRight'],
-};
-
-
-const getItemName = (item) => {
-  if (!item) return '';
-  if (typeof item === 'string') return item;
-  if (typeof item !== 'object') return String(item);
-  return (
-    item.displayName ||
-    item.name ||
-    item.itemName ||
-    item.accessoryName ||
-    item.armorName ||
-    item.title ||
-    ''
-  );
-};
-
-const getItemSource = (item) => {
-  if (!item || typeof item !== 'object') return undefined;
-  if (item.source) return item.source;
-  if (item.__source) return item.__source;
-  if (item.reference && item.reference.source) return item.reference.source;
-  return undefined;
-};
-
-export default function EquipmentRack({
-  equipment = {},
-  inventory = {},
-  onEquipmentChange,
-  onSlotChange,
-  disabled = false,
-}) {
-  const { weapons = [], armor = [], items = [], accessories = [] } =
-    inventory || {};
-  const slotLookup = useMemo(() => {
-    const map = new Map();
-    FLAT_SLOTS.forEach((slot) => {
-      map.set(slot.key, slot);
-    });
-    return map;
-  }, []);
+export default function EquipmentRack({ equipment = {}, inventory = {}, onEquipmentChange, onSlotChange, disabled = false, character = {} }) {
+  const [selectedSlotKey, setSelectedSlotKey] = useState('chest');
+  const [search, setSearch] = useState('');
+  const [rarityFilter, setRarityFilter] = useState('all');
+  const { weapons = [], armor = [], items = [], accessories = [] } = inventory || {};
+  const slotLookup = useMemo(() => new Map(FLAT_SLOTS.map((slot) => [slot.key, slot])), []);
+  const selectedSlot = slotLookup.get(selectedSlotKey) || FLAT_SLOTS[0];
+  const equippedItems = useMemo(() => Object.values(equipment || {}).filter(Boolean), [equipment]);
   const inventoryOptions = useMemo(() => {
-    const options = [];
-    const bySource = {};
-    const addOptions = (itemsList = [], source) => {
-      if (!itemsList || itemsList.length === 0) return;
-      if (!bySource[source]) {
-        bySource[source] = [];
-      }
-      itemsList.forEach((item, index) => {
-        if (!item) return;
-        const name = getItemName(item);
-        if (!name) return;
-        const value = `${source}-${index}-${name}`;
-        const option = {
-          value,
-          label: name,
-          item,
-          source,
-          description: SOURCE_DESCRIPTIONS[source] || 'Item',
-        };
-        options.push(option);
-        bySource[source].push(option);
-      });
-    };
-
-    addOptions(weapons, 'weapon');
-    addOptions(armor, 'armor');
-    addOptions(items, 'item');
-    addOptions(accessories, 'accessory');
-
-    return { all: options, bySource };
+    const all = []; const bySource = {};
+    const addOptions = (itemsList = [], source) => itemsList.forEach((item, index) => {
+      const name = getItemName(item); if (!name) return;
+      const option = { value: `${source}-${index}-${name}`, label: name, item, source, description: SOURCE_DESCRIPTIONS[source] || 'Item' };
+      all.push(option); (bySource[source] ||= []).push(option);
+    });
+    addOptions(weapons, 'weapon'); addOptions(armor, 'armor'); addOptions(items, 'item'); addOptions(accessories, 'accessory');
+    return { all, bySource };
   }, [accessories, armor, items, weapons]);
-
-  const optionMap = useMemo(() => {
-    const map = new Map();
-    inventoryOptions.all.forEach((opt) => {
-      map.set(opt.value, opt);
+  const optionMap = useMemo(() => new Map(inventoryOptions.all.map((opt) => [opt.value, opt])), [inventoryOptions]);
+  const slotOptionsMap = useMemo(() => new Map(FLAT_SLOTS.map((slot) => [slot.key, buildSlotOptions(slot, inventoryOptions.bySource)])), [inventoryOptions]);
+  const selectedOptions = slotOptionsMap.get(selectedSlot.key) || [];
+  const currentItem = equipment?.[selectedSlot.key];
+  const compatibleOptions = selectedOptions.filter((opt) => {
+    const haystack = `${opt.label} ${opt.description} ${getStatLines(opt.item).join(' ')}`.toLowerCase();
+    const matchesSearch = !search || haystack.includes(search.toLowerCase());
+    const matchesRarity = rarityFilter === 'all' || normalizeRarity(opt.item) === rarityFilter;
+    return matchesSearch && matchesRarity;
+  });
+  const summary = useMemo(() => {
+    const stats = { ac: 0, attack: 0, weight: 0, passive: 0 };
+    equippedItems.forEach((item) => {
+      stats.ac += Number(item.acBonus) || 0; stats.attack += Number(item.attackBonus) || 0; stats.weight += Number(item.weight) || 0;
+      stats.passive += Object.values(item.statBonuses || {}).filter(Boolean).length + Object.values(item.statOverrides || {}).filter(Boolean).length;
     });
-    return map;
-  }, [inventoryOptions]);
-
-  const slotOptionsMap = useMemo(() => {
-    const map = new Map();
-    FLAT_SLOTS.forEach((slot) => {
-      map.set(slot.key, buildSlotOptions(slot, inventoryOptions.bySource));
-    });
-    return map;
-  }, [inventoryOptions]);
-
-  const hasOptions = inventoryOptions.all.length > 0;
-
-  const handleAssign = useCallback(
-    (slotKey, optionValue) => {
-      if (typeof onEquipmentChange !== 'function' && typeof onSlotChange !== 'function')
-        return;
-
-      let nextItem = null;
-      if (optionValue) {
-        const option = optionMap.get(optionValue);
-        if (option) {
-          const base =
-            option.item && typeof option.item === 'object'
-              ? { ...option.item }
-              : { name: getItemName(option.item) };
-          nextItem = {
-            ...base,
-            source: option.source,
-            __source: option.source,
-          };
-        }
-      }
-
-      const nextEquipment = { ...equipment };
-      if (nextItem) {
-        nextEquipment[slotKey] = nextItem;
-      } else {
-        nextEquipment[slotKey] = null;
-      }
-
-      if (typeof onSlotChange === 'function') {
-        onSlotChange(slotKey, nextItem || null);
-      }
-      if (typeof onEquipmentChange === 'function') {
-        onEquipmentChange(nextEquipment);
-      }
-    },
-    [equipment, onEquipmentChange, onSlotChange, optionMap]
-  );
-
+    return stats;
+  }, [equippedItems]);
+  const handleAssign = useCallback((slotKey, optionValue) => {
+    if (typeof onEquipmentChange !== 'function' && typeof onSlotChange !== 'function') return;
+    const option = optionValue ? optionMap.get(optionValue) : null;
+    const nextItem = option ? { ...(typeof option.item === 'object' ? option.item : { name: getItemName(option.item) }), source: option.source, __source: option.source } : null;
+    const nextEquipment = { ...equipment, [slotKey]: nextItem };
+    onSlotChange?.(slotKey, nextItem); onEquipmentChange?.(nextEquipment);
+  }, [equipment, onEquipmentChange, onSlotChange, optionMap]);
   const renderSlot = (slot) => {
-    if (!slot) return null;
-    const current = equipment?.[slot.key];
-    const optionsForSlot = slotOptionsMap.get(slot.key) || [];
-    const selectedOption = optionsForSlot.find((opt) => {
-      const itemName = getItemName(current);
-      if (!itemName) return false;
-      const currentSource = getItemSource(current);
-      const candidateName = getItemName(opt.item);
-      if (currentSource) {
-        return opt.source === currentSource && candidateName === itemName;
-      }
-      return candidateName === itemName;
-    });
-
-    const selectedValue = selectedOption ? selectedOption.value : '';
-    const displayName = getItemName(current) || '—';
-
-    return (
-      <div key={slot.key} className={styles.slot}>
-        <div className={styles.slotHeader}>
-          <ItemIcon
-            equipmentSlot={slot.key}
-            size={28}
-            className={styles.slotIcon}
-            title={slot.label}
-          />
-          <span className={styles.slotLabel}>{slot.label}</span>
-        </div>
-        <div
-          className={current ? styles.slotItem : styles.slotItemEmpty}
-          data-testid={`${slot.key}-item-display`}
-        >
-          {displayName}
-        </div>
-        <div className={styles.slotControls}>
-          <Form.Select
-            aria-label={`${slot.label} slot selection`}
-            value={selectedValue}
-            disabled={disabled}
-            className={styles.slotSelect}
-            size="sm"
-            onChange={(event) => handleAssign(slot.key, event.target.value)}
-          >
-            <option value="">Unequipped</option>
-            {optionsForSlot.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-                {opt.description ? ` (${opt.description})` : ''}
-              </option>
-            ))}
-          </Form.Select>
-          <Button
-            variant="outline-light"
-            size="sm"
-            disabled={disabled || !current}
-            onClick={() => handleAssign(slot.key, '')}
-            className={styles.clearButton}
-          >
-            Clear Slot
-          </Button>
-        </div>
-      </div>
-    );
+    const item = equipment?.[slot.key]; const rarity = normalizeRarity(item); const lines = getStatLines(item).slice(0, 2);
+    return <button key={slot.key} type="button" className={`${styles.socket} ${styles[`rarity_${rarity}`] || ''} ${selectedSlot.key === slot.key ? styles.selected : ''}`} onClick={() => setSelectedSlotKey(slot.key)} disabled={disabled} aria-label={`${slot.label} equipment slot${item ? ` equipped with ${getItemName(item)}` : ', empty'}`}>
+      <span className={styles.socketLabel}>{slot.label}</span><span className={styles.socketIcon}><ItemIcon item={item} equipmentSlot={slot.key} size={40} title={slot.label} /></span>
+      <span className={styles.socketName}>{item ? getItemName(item) : 'Empty Slot'}</span><span className={styles.socketMeta}>{item ? (lines[0] || SOURCE_DESCRIPTIONS[getItemSource(item)] || 'Equipped') : 'Choose equipment'}</span>
+    </button>;
   };
-
-  return (
-    <div className={styles.rackWrapper}>
-      <p className="text-muted small mb-3">
-        {hasOptions
-          ? "Assign owned items to equipment slots. Selecting an option will update the character's loadout immediately."
-          : "You do not have any owned inventory to assign yet. Equip gear from the inventory tabs to populate this rack."}
-      </p>
-      <div className={styles.rackLayout}>
-        <div className={styles.columns}>
-          <div className={styles.leftColumn}>
-            {SLOT_LAYOUT.leftColumn.map((slotKey) =>
-              renderSlot(slotLookup.get(slotKey))
-            )}
-          </div>
-          <div className={styles.rightColumn}>
-            {SLOT_LAYOUT.rightColumn.map((slotKey) =>
-              renderSlot(slotLookup.get(slotKey))
-            )}
-          </div>
-        </div>
-        <div className={styles.bottomRow}>
-          {SLOT_LAYOUT.bottomRow.map((slotKey) =>
-            renderSlot(slotLookup.get(slotKey))
-          )}
-        </div>
-      </div>
+  const detailItem = currentItem;
+  return <div className={styles.rackWrapper}>
+    <div className={styles.bonusSummary} aria-label="Active equipment bonuses"><div><strong>{summary.ac >= 0 ? '+' : ''}{summary.ac}</strong><span>Armor Class</span></div><div><strong>{summary.attack >= 0 ? '+' : ''}{summary.attack}</strong><span>Attack Bonus</span></div><div><strong>{summary.passive}</strong><span>Passive Effects</span></div><div><strong>{summary.weight}</strong><span>Weight</span></div></div>
+    <div className={styles.equipmentShell}>
+      <section className={styles.paperDoll} aria-label="Character equipment rack">
+        <div className={styles.leftRail}>{['mainHand','ringLeft','hands','arms','wrists'].map((key) => renderSlot(slotLookup.get(key)))}</div>
+        <div className={styles.centerRail}>{renderSlot(slotLookup.get('head'))}<div className={styles.characterPreview}><div className={styles.characterAura}><Shield size={54}/></div><h3>{character.name || 'Adventurer'}</h3><p>{[character.race, character.className || character.occupation?.[0]?.Name, character.level && `Level ${character.level}`].filter(Boolean).join(' • ') || 'Equipped hero'}</p><span><Sword size={15}/> {equippedItems.length} slots active</span></div>{renderSlot(slotLookup.get('chest'))}{renderSlot(slotLookup.get('waist'))}</div>
+        <div className={styles.rightRail}>{['offHand','neck','ringRight','back','legs','feet','ranged','eyes','shoulders'].map((key) => renderSlot(slotLookup.get(key)))}</div>
+      </section>
+      <aside className={styles.detailPanel} aria-live="polite"><div className={styles.panelHeader}><span>{selectedSlot.label}</span><strong>{detailItem ? getItemName(detailItem) : 'Empty Slot'}</strong></div>{detailItem ? <><div className={`${styles.itemHero} ${styles[`rarity_${normalizeRarity(detailItem)}`] || ''}`}><ItemIcon item={detailItem} equipmentSlot={selectedSlot.key} size={72}/><span>{normalizeRarity(detailItem)}</span></div><p>{getDescription(detailItem)}</p><div className={styles.statList}>{getStatLines(detailItem).map((line) => <span key={line}>{line}</span>)}</div><dl className={styles.itemFacts}><dt>Type</dt><dd>{SOURCE_DESCRIPTIONS[getItemSource(detailItem)] || 'Gear'}</dd><dt>Weight</dt><dd>{detailItem.weight || '—'}</dd><dt>Value</dt><dd>{detailItem.cost || detailItem.value || '—'}</dd></dl><Button variant="outline-light" className={styles.unequipButton} onClick={() => handleAssign(selectedSlot.key, '')} disabled={disabled}><X size={16}/> Unequip</Button></> : <div className={styles.emptyDetail}><Sparkles size={42}/><p>Select compatible owned gear below to fill this socket.</p></div>}
+        <div className={styles.picker}><div className={styles.pickerTools}><label><Search size={15}/><Form.Control size="sm" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search compatible gear" aria-label="Search compatible gear" /></label><Form.Select size="sm" value={rarityFilter} onChange={(e) => setRarityFilter(e.target.value)} aria-label="Filter by rarity">{RARITIES.map((rarity) => <option key={rarity} value={rarity}>{rarity === 'all' ? 'All rarities' : rarity}</option>)}</Form.Select></div><div className={styles.itemList}>{compatibleOptions.length ? compatibleOptions.map((opt) => { const equipped = optionMatchesItem(opt, currentItem); const rarity = normalizeRarity(opt.item); return <button key={opt.value} type="button" className={`${styles.itemCard} ${styles[`rarity_${rarity}`] || ''}`} onClick={() => handleAssign(selectedSlot.key, opt.value)} disabled={disabled} title={`${opt.label} - ${getDescription(opt.item)}`}><ItemIcon item={opt.item} equipmentSlot={selectedSlot.key} size={34}/><span><strong>{opt.label}</strong><small>{rarity} • {getStatLines(opt.item).slice(0, 2).join(' • ') || opt.description}</small></span>{equipped ? <CheckCircle2 size={18}/> : <em>Equip</em>}</button>; }) : <p className={styles.noItems}>No owned compatible equipment found for this slot.</p>}</div></div>
+      </aside>
     </div>
-  );
+  </div>;
 }

--- a/client/src/components/Zombies/attributes/EquipmentRack.module.scss
+++ b/client/src/components/Zombies/attributes/EquipmentRack.module.scss
@@ -1,229 +1,52 @@
-.rackWrapper {
-  --rack-border: rgba(255, 255, 255, 0.08);
-  --rack-shadow: rgba(0, 0, 0, 0.35);
-}
-
-.rackLayout {
-  background: radial-gradient(circle at top, rgba(73, 80, 87, 0.25), rgba(33, 37, 41, 0.85));
-  border: 1px solid var(--rack-border);
-  border-radius: 1rem;
-  padding: clamp(0.85rem, 2vw, 1.15rem);
-  box-shadow: 0 18px 36px var(--rack-shadow);
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.rackLayout::before,
-.rackLayout::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.rackLayout::before {
-  background:
-    radial-gradient(circle at 50% 22%, rgba(173, 181, 189, 0.38), rgba(173, 181, 189, 0) 54%),
-    radial-gradient(circle at 50% 84%, rgba(96, 112, 130, 0.46), rgba(15, 19, 28, 0.94) 70%),
-    linear-gradient(165deg, rgba(21, 26, 34, 0.96), rgba(9, 12, 19, 0.98));
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size:
-    clamp(200px, 32vw, 340px) 92%,
-    clamp(220px, 34vw, 360px) 100%,
-    clamp(220px, 34vw, 360px) 100%;
-  filter: saturate(0.85) contrast(1.12) drop-shadow(0 24px 40px rgba(0, 0, 0, 0.45));
-  opacity: 0.52;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  -webkit-mask-size: clamp(200px, 32vw, 340px) 100%;
-  mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  mask-size: clamp(200px, 32vw, 340px) 100%;
-}
-
-.rackLayout::after {
-  background:
-    radial-gradient(circle at 50% 16%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 62%),
-    radial-gradient(circle at 50% 95%, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 70%);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size:
-    clamp(210px, 32vw, 340px) 82%,
-    clamp(220px, 34vw, 360px) 100%;
-  mix-blend-mode: screen;
-  opacity: 0.3;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  -webkit-mask-size: clamp(200px, 32vw, 340px) 100%;
-  mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20200%20320%27%3E%3Cpath%20fill%3D%27white%27%20fill-rule%3D%27evenodd%27%20d%3D%27M100%2018c17%200%2033%2013%2037%2032%203%2013%201%2029-3%2043l-5%2018%2012%2016c11%2016%2017%2037%2017%2058v16l11%2032c6%2015%209%2031%209%2047v58H22v-58c0-16%203-32%209-47l11-32v-16c0-21%206-42%2017-58l12-16-5-18c-4-14-6-30-3-43%204-19%2020-32%2037-32zm0%2034c-7%200-13%205-14%2012-2%209%201%2021%204%2031l10%2030%2010-30c3-10%206-22%204-31-1-7-7-12-14-12zm-19%20118-11%2056%2030%2028%2030-28-11-56-19%2030-19-30zm-6%2076%2025%2023%2025-23%2020%2057H55l20-57z%27/%3E%3C/svg%3E") no-repeat center;
-  mask-size: clamp(200px, 32vw, 340px) 100%;
-}
-
-.columns {
-  display: grid;
-  gap: clamp(0.75rem, 2.25vw, 2.25rem);
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
-  align-items: start;
-  position: relative;
-  z-index: 1;
-}
-
-.leftColumn,
-.rightColumn {
-  display: grid;
-  grid-auto-rows: minmax(0, auto);
-  gap: 0.75rem;
-}
-
-.bottomRow {
-  margin-top: 1.1rem;
-  display: grid;
-  gap: clamp(0.65rem, 2vw, 0.9rem);
-  grid-template-columns: repeat(5, minmax(120px, 1fr));
-  position: relative;
-  z-index: 1;
-}
-
-.slot {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  min-height: 118px;
-  padding: 0.6rem;
-  border-radius: 0.8rem;
-  background: linear-gradient(135deg, rgba(33, 37, 41, 0.92), rgba(73, 80, 87, 0.7));
-  color: var(--bs-light, #f8f9fa);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
-  overflow: hidden;
-}
-
-.slot::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  mix-blend-mode: screen;
-  pointer-events: none;
-}
-
-.slotHeader {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-size: 0.66rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-  color: rgba(248, 249, 250, 0.9);
-}
-
-.slotIcon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
-  font-size: 0.95rem;
-}
-
-.slotLabel {
-  flex: 1;
-}
-
-%slotItemBase {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  border-radius: 0.65rem;
-  padding: 0.55rem;
-  margin-bottom: 0.5rem;
-  min-height: 2.6rem;
-  word-break: break-word;
-}
-
-.slotItem {
-  @extend %slotItemBase;
-  background: rgba(255, 255, 255, 0.08);
-  font-weight: 600;
-}
-
-.slotItemEmpty {
-  @extend %slotItemBase;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(248, 249, 250, 0.7);
-  font-style: italic;
-}
-
-.slotControls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.45rem;
-  margin-top: auto;
-}
-
-.slotSelect {
-  background: rgba(8, 12, 20, 0.75);
-  color: var(--bs-light, #f8f9fa);
-  border-radius: 0.55rem;
-  border-color: rgba(255, 255, 255, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
-  padding: 0.35rem 0.65rem;
-  font-size: 0.88rem;
-  flex: 1 1 160px;
-}
-
-.slotSelect:focus {
-  border-color: rgba(173, 181, 189, 0.8);
-  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.35);
-}
-
-.clearButton {
-  font-weight: 600;
-  padding: 0.25rem 0.75rem;
-  white-space: nowrap;
-}
-
-@media (max-width: 992px) {
-  .columns {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: clamp(0.75rem, 2.75vw, 1.75rem);
-  }
-
-  .bottomRow {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  }
-}
-
-@media (max-width: 768px) {
-  .rackLayout {
-    padding: 1rem;
-  }
-
-  .columns {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.25rem;
-  }
-
-  .leftColumn,
-  .rightColumn {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .slot,
-  .rackLayout {
-    transition: none !important;
-    animation: none !important;
-  }
-}
+.rackWrapper { --panel: rgba(6, 14, 31, .82); --line: rgba(142, 188, 255, .18); --glow: rgba(80, 160, 255, .28); color: #eef6ff; }
+.bonusSummary { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:.75rem; margin-bottom:1rem; }
+.bonusSummary > div { min-height:64px; border:1px solid var(--line); border-radius:18px; padding:.7rem .9rem; background:linear-gradient(145deg,rgba(20,34,63,.86),rgba(7,14,31,.72)); box-shadow:0 14px 40px rgba(0,0,0,.24), inset 0 1px 0 rgba(255,255,255,.08); }
+.bonusSummary strong { display:block; font-size:1.25rem; color:#bfe4ff; line-height:1; }
+.bonusSummary span { display:block; margin-top:.32rem; color:rgba(238,246,255,.68); font-size:.72rem; text-transform:uppercase; letter-spacing:.08em; }
+.equipmentShell { display:grid; grid-template-columns:minmax(520px,1fr) minmax(320px,380px); gap:1rem; align-items:start; }
+.paperDoll { position:relative; display:grid; grid-template-columns:minmax(130px,.72fr) minmax(190px,.86fr) minmax(130px,.72fr); gap:.8rem; min-height:650px; padding:1rem; border:1px solid rgba(120,170,255,.2); border-radius:28px; overflow:hidden; background:radial-gradient(circle at 50% 24%,rgba(87,124,255,.24),transparent 30%),radial-gradient(circle at 50% 90%,rgba(171,117,255,.16),transparent 42%),linear-gradient(160deg,rgba(11,24,51,.95),rgba(2,7,20,.98)); box-shadow:0 26px 70px rgba(0,0,0,.42); isolation:isolate; }
+.paperDoll:before { content:""; position:absolute; inset:12px; border-radius:22px; border:1px solid rgba(255,255,255,.06); background:linear-gradient(90deg,transparent,rgba(120,170,255,.06),transparent); pointer-events:none; }
+.leftRail,.rightRail,.centerRail { position:relative; z-index:1; display:grid; gap:.65rem; align-content:center; }
+.centerRail { align-content:start; padding-top:.2rem; }
+.characterPreview { min-height:205px; display:grid; place-items:center; text-align:center; padding:1rem; border:1px solid rgba(185,210,255,.16); border-radius:100px 100px 28px 28px; background:radial-gradient(circle,rgba(99,166,255,.22),rgba(9,21,45,.35) 62%,rgba(0,0,0,.1)); box-shadow:inset 0 0 70px rgba(74,129,255,.12); }
+.characterAura { width:96px; height:96px; display:grid; place-items:center; border-radius:999px; color:#c9e6ff; background:radial-gradient(circle,rgba(115,191,255,.28),rgba(84,53,165,.12)); box-shadow:0 0 38px rgba(93,166,255,.24); }
+.characterPreview h3 { margin:.7rem 0 .1rem; font-size:1.1rem; }
+.characterPreview p { margin:0; color:rgba(238,246,255,.7); font-size:.86rem; }
+.characterPreview span { margin-top:.55rem; display:inline-flex; align-items:center; gap:.35rem; color:#ffe7a8; font-size:.8rem; }
+.socket { position:relative; min-height:104px; width:100%; border:1px solid rgba(167,198,255,.16); border-radius:18px; padding:.58rem; color:#eef6ff; background:linear-gradient(145deg,rgba(8,19,42,.92),rgba(3,8,20,.94)); box-shadow:inset 0 0 0 1px rgba(255,255,255,.04), inset 0 16px 24px rgba(0,0,0,.25), 0 12px 28px rgba(0,0,0,.28); transition:transform .18s ease,border-color .18s ease,box-shadow .18s ease; text-align:left; cursor:pointer; }
+.socket:hover,.socket:focus-visible,.selected { transform:translateY(-2px); border-color:rgba(122,190,255,.75); box-shadow:0 0 0 3px rgba(66,153,225,.18),0 18px 42px rgba(0,0,0,.35),inset 0 0 34px rgba(78,148,255,.12); outline:0; }
+.socketLabel { display:block; font-size:.64rem; letter-spacing:.11em; text-transform:uppercase; color:rgba(218,234,255,.58); }
+.socketIcon { width:48px; height:48px; margin:.35rem auto; display:grid; place-items:center; border-radius:14px; background:radial-gradient(circle,rgba(255,255,255,.1),rgba(255,255,255,.025)); }
+.socketName { display:block; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:800; font-size:.88rem; }
+.socketMeta { display:block; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:rgba(238,246,255,.64); font-size:.73rem; }
+.detailPanel { position:sticky; top:.5rem; border:1px solid var(--line); border-radius:24px; padding:1rem; background:linear-gradient(155deg,rgba(13,28,58,.94),rgba(3,9,23,.96)); box-shadow:0 22px 58px rgba(0,0,0,.38); max-height:calc(80vh - 1rem); overflow:auto; }
+.panelHeader span { display:block; color:#8fcaff; text-transform:uppercase; letter-spacing:.12em; font-size:.68rem; }
+.panelHeader strong { display:block; font-size:1.25rem; margin-top:.15rem; }
+.itemHero { display:grid; place-items:center; gap:.45rem; min-height:135px; margin:1rem 0; border-radius:20px; border:1px solid rgba(255,255,255,.1); background:radial-gradient(circle,rgba(255,255,255,.1),rgba(255,255,255,.025)); text-transform:uppercase; letter-spacing:.12em; font-size:.7rem; }
+.detailPanel p { color:rgba(238,246,255,.76); }
+.statList { display:flex; flex-wrap:wrap; gap:.45rem; margin:.75rem 0; }
+.statList span { border:1px solid rgba(126,211,255,.24); background:rgba(61,143,255,.12); color:#d8f2ff; border-radius:999px; padding:.32rem .58rem; font-size:.78rem; }
+.itemFacts { display:grid; grid-template-columns:auto 1fr; gap:.2rem .7rem; color:rgba(238,246,255,.72); font-size:.84rem; }
+.itemFacts dt { color:rgba(143,202,255,.8); }
+.unequipButton { display:inline-flex; align-items:center; gap:.35rem; min-height:42px; border-radius:999px; }
+.emptyDetail { display:grid; place-items:center; min-height:180px; text-align:center; color:rgba(238,246,255,.65); }
+.picker { margin-top:1rem; padding-top:1rem; border-top:1px solid rgba(255,255,255,.09); }
+.pickerTools { display:grid; grid-template-columns:1fr 130px; gap:.5rem; margin-bottom:.65rem; }
+.pickerTools label { display:flex; align-items:center; gap:.35rem; margin:0; }
+.pickerTools input,.pickerTools select { background:rgba(3,9,23,.85); color:#eef6ff; border-color:rgba(142,188,255,.22); }
+.itemList { display:grid; gap:.5rem; }
+.itemCard { display:grid; grid-template-columns:40px 1fr auto; gap:.6rem; align-items:center; min-height:64px; padding:.5rem; border-radius:16px; border:1px solid rgba(255,255,255,.1); background:rgba(255,255,255,.045); color:#eef6ff; text-align:left; }
+.itemCard:hover,.itemCard:focus-visible { border-color:rgba(122,190,255,.7); outline:0; background:rgba(80,150,255,.12); }
+.itemCard small { display:block; color:rgba(238,246,255,.62); }
+.itemCard em { font-style:normal; color:#9bd6ff; font-size:.75rem; }
+.noItems { margin:0; padding:1rem; border:1px dashed rgba(255,255,255,.16); border-radius:16px; text-align:center; }
+.rarity_common { --rarity:#a8b3c1; }
+.rarity_uncommon { --rarity:#6ee787; }
+.rarity_rare { --rarity:#63b3ff; }
+.rarity_epic { --rarity:#c084fc; }
+.rarity_legendary { --rarity:#f4c76b; }
+.rarity_artifact { --rarity:#ff8a5b; }
+.rarity_common,.rarity_uncommon,.rarity_rare,.rarity_epic,.rarity_legendary,.rarity_artifact { border-color:color-mix(in srgb,var(--rarity) 62%,transparent); box-shadow:0 0 0 1px color-mix(in srgb,var(--rarity) 20%,transparent),0 14px 34px rgba(0,0,0,.28),inset 0 0 28px color-mix(in srgb,var(--rarity) 12%,transparent); }
+@media (max-width: 1100px) { .equipmentShell { grid-template-columns:1fr; } .detailPanel { position:relative; max-height:none; } .paperDoll { grid-template-columns:repeat(3,minmax(0,1fr)); min-height:auto; } }
+@media (max-width: 720px) { .bonusSummary { grid-template-columns:repeat(2,minmax(0,1fr)); } .paperDoll { grid-template-columns:1fr; padding:.75rem; } .leftRail,.rightRail,.centerRail { align-content:stretch; } .equipmentShell { gap:.75rem; } .pickerTools { grid-template-columns:1fr; } .detailPanel { border-radius:22px 22px 0 0; } }
+@media (prefers-reduced-motion: reduce) { .socket,.itemCard { transition:none!important; animation:none!important; } }


### PR DESCRIPTION
### Motivation
- Replace the current dropdown-first administrative inventory UI with a premium paper-doll equipment experience that communicates what a character is wearing and how items affect stats. 
- Preserve all gameplay logic (compatibility rules, equip/unequip callbacks, normalization, and stat aggregation) while changing only presentation and interaction.
- Provide a clear, readable details panel, rarity treatments, and a more discoverable equipment picker to speed up equipment management.

### Description
- Rebuilt the equipment rack UI into a paper-doll layout with fixed body-location sockets, character centerpiece, and left/right rails; slot sockets are clickable instead of showing inline dropdowns (`client/src/components/Zombies/attributes/EquipmentRack.js`).
- Added an Equipment Details / Picker panel with search, rarity filter, compatible owned-item cards, stat summary lines, and quick unequip action (`client/src/components/Zombies/attributes/EquipmentRack.js`).
- Implemented a new visual language and responsive styles (deep navy glass panels, rarity color treatments, hover/focus states, reduced-motion support) in `EquipmentRack.module.scss`.
- Expanded the modal size and injected `character` context into the rack so the centerpiece can show character info (`client/src/components/Zombies/attributes/EquipmentModal.js`).
- Kept existing slot filtering, descriptor/metadata matching, inventory normalization, and equip/unequip persistence callbacks intact by reusing the same normalization and option-building logic.

### Testing
- Ran the component unit tests with `CI=true npm --prefix client test -- --runTestsByPath src/components/Zombies/attributes/EquipmentModal.test.js --watchAll=false`, which passed (3 tests).
- Built the client with `npm --prefix client run build`, which completed successfully; the build emitted pre-existing project warnings unrelated to this change (Browserslist/baseline data and existing ESLint warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59411db264832eb747fe1840dec678)