### PR TITLE
Spellbook UI overhaul: new modal, search/filters, inspector, icons and styles

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12116,3 +12116,235 @@ body.character-creation-modal-open {
   .theme-preview-grid { grid-template-columns: 1fr; }
   .dice-preview__shape { width: 116px; height: 116px; }
 }
+
+/* RealmTracker premium spellbook overhaul */
+.docked-modal--spells,
+.modern-modal .modal-dialog:has(.spellbook-shell) {
+  max-width: min(1540px, 96vw);
+}
+
+.spellbook-modal-body {
+  max-height: min(78vh, 920px);
+  overflow: hidden;
+  padding: 0 !important;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(101, 78, 184, 0.28), transparent 32%),
+    radial-gradient(circle at 85% 12%, rgba(42, 177, 255, 0.18), transparent 30%),
+    linear-gradient(135deg, rgba(5, 10, 25, 0.98), rgba(18, 13, 34, 0.96));
+}
+
+.spellbook-shell { padding: 1rem; color: #edf6ff; }
+.spellbook-hero {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(260px, 420px) minmax(160px, 220px);
+  gap: 1rem;
+  align-items: stretch;
+  margin-bottom: 1rem;
+}
+.spellbook-kicker,
+.spellbook-filter-label {
+  display: block;
+  color: #d8b76a;
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  margin-bottom: .45rem;
+}
+.spellbook-hero h2 { margin: 0; font-family: 'Cinzel', serif; color: #fff8df; font-size: clamp(1.6rem, 3vw, 2.6rem); }
+.spellbook-hero p { margin: .25rem 0 0; color: rgba(226,238,255,.72); }
+.spellbook-search-wrap,
+.spellbook-points,
+.spellbook-sidebar,
+.spellbook-library,
+.spellbook-inspector {
+  border: 1px solid rgba(121,184,255,.18);
+  background: linear-gradient(145deg, rgba(12,22,45,.78), rgba(31,22,55,.72));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.08), 0 18px 44px rgba(0,0,0,.28);
+  backdrop-filter: blur(18px);
+  border-radius: 22px;
+}
+.spellbook-search-wrap { display:flex; align-items:center; gap:.75rem; padding:.85rem 1rem; }
+.spellbook-search-wrap i { color:#7dd3ff; }
+.spellbook-search { background: transparent !important; border: 0 !important; color: #fff !important; box-shadow: none !important; }
+.spellbook-search::placeholder { color: rgba(226,238,255,.52); }
+.spellbook-points { padding: .85rem 1rem; display:flex; flex-direction:column; justify-content:center; }
+.spellbook-points span { color: rgba(226,238,255,.72); font-size:.75rem; text-transform:uppercase; letter-spacing:.11em; }
+.spellbook-points strong { color:#7cffb2; font-size:2rem; line-height:1; text-shadow:0 0 18px rgba(124,255,178,.42); }
+.spellbook-points.is-low strong { color:#ffce73; }
+.spellbook-points small { color:rgba(226,238,255,.62); }
+
+.spellbook-tabs > .nav-tabs { border:0; gap:.5rem; margin-bottom: .75rem; }
+.spellbook-tabs .nav-link { border:1px solid rgba(121,184,255,.16) !important; color:#cfe8ff !important; border-radius:999px !important; background:rgba(9,17,35,.74) !important; padding:.55rem 1rem; }
+.spellbook-tabs .nav-link.active { color:#fff8df !important; border-color:rgba(216,183,106,.55) !important; box-shadow:0 0 22px rgba(121,184,255,.22); }
+.spellbook-layout { display:grid; grid-template-columns: 250px minmax(0, 1fr) 330px; gap:1rem; min-height: 54vh; }
+.spellbook-sidebar,
+.spellbook-inspector,
+.spellbook-library { padding:1rem; overflow:auto; max-height: 58vh; }
+.spellbook-filter-group { margin-bottom:1rem; }
+.spellbook-class-list { display:grid; gap:.5rem; }
+.spellbook-class-pill,
+.spellbook-rune-toggle {
+  width:100%; border:1px solid rgba(121,184,255,.16); color:#dcecff; background:rgba(7,15,33,.72); border-radius:14px; padding:.65rem .75rem; display:flex; gap:.6rem; align-items:center; transition:.18s ease;
+}
+.spellbook-class-pill:hover,
+.spellbook-class-pill.is-active,
+.spellbook-rune-toggle:hover,
+.spellbook-rune-toggle.is-active { border-color:rgba(216,183,106,.55); color:#fff8df; transform:translateY(-1px); box-shadow:0 0 18px rgba(121,184,255,.18); }
+.spellbook-select { background-color: rgba(7,15,33,.86) !important; color:#eef7ff !important; border-color:rgba(121,184,255,.2) !important; border-radius:14px !important; }
+.spellbook-rune-toggles { display:grid; grid-template-columns:1fr; gap:.5rem; }
+.spellbook-library-header { display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:1rem; color:rgba(226,238,255,.72); }
+.spellbook-card-grid { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); align-items: stretch; }
+.spellbook-card {
+  position:relative; min-height: 285px; cursor:pointer; overflow:hidden;
+  background:
+    radial-gradient(circle at 20% 5%, rgba(121,184,255,.2), transparent 36%),
+    linear-gradient(145deg, rgba(20,30,58,.9), rgba(21,15,40,.94)) !important;
+  border:1px solid rgba(121,184,255,.22) !important;
+  border-radius:22px !important;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.04), 0 18px 34px rgba(0,0,0,.3);
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+.spellbook-card:hover,
+.spellbook-card:focus-visible { transform:translateY(-4px); border-color:rgba(216,183,106,.62) !important; box-shadow:0 0 32px rgba(121,184,255,.22), 0 22px 42px rgba(0,0,0,.36); outline:none; }
+.spellbook-card.is-selected { border-color:rgba(124,255,178,.55) !important; }
+.spellbook-card-topline { display:flex; justify-content:space-between; align-items:center; }
+.spellbook-icon,
+.spellbook-art { display:grid; place-items:center; color:#9fe4ff; background:radial-gradient(circle, rgba(121,184,255,.24), rgba(122,80,255,.12)); border:1px solid rgba(121,184,255,.22); }
+.spellbook-icon { width:48px; height:48px; border-radius:16px; font-size:1.35rem; }
+.spell-level-badge { background:rgba(216,183,106,.16) !important; color:#fff0b8 !important; border:1px solid rgba(216,183,106,.35); border-radius:999px; }
+.spellbook-card .form-check-input { width:1.2rem; height:1.2rem; background-color:rgba(7,15,33,.9); border-color:rgba(216,183,106,.55); }
+.spellbook-card .form-check-input:checked { background-color:#7cffb2; border-color:#7cffb2; }
+.spellbook-card-preview { color:rgba(226,238,255,.68); font-size:.9rem; margin:0; }
+.spellbook-card-traits { display:flex; gap:.35rem; flex-wrap:wrap; margin-top:auto; }
+.spellbook-card-traits span { font-size:.72rem; color:#d8b76a; border:1px solid rgba(216,183,106,.28); border-radius:999px; padding:.15rem .5rem; }
+.spellbook-empty { color:rgba(226,238,255,.72); padding:2rem; text-align:center; border:1px dashed rgba(121,184,255,.24); border-radius:20px; }
+
+.spellbook-art { height:150px; border-radius:24px; font-size:4rem; margin-bottom:1rem; }
+.spellbook-inspector-heading h3 { font-family:'Cinzel', serif; color:#fff8df; margin:.55rem 0 0; }
+.spellbook-inspector-heading p { color:#9fe4ff; margin:0 0 1rem; }
+.spellbook-stat-grid { display:grid; grid-template-columns:1fr 1fr; gap:.6rem; margin-bottom:1rem; }
+.spellbook-stat-grid div { border:1px solid rgba(121,184,255,.14); border-radius:14px; padding:.55rem; background:rgba(7,15,33,.48); }
+.spellbook-stat-grid span { display:block; color:rgba(226,238,255,.58); font-size:.7rem; text-transform:uppercase; }
+.spellbook-stat-grid strong { color:#fff; font-size:.88rem; }
+.spellbook-description,
+.spellbook-higher { color:rgba(226,238,255,.78); line-height:1.55; }
+.spellbook-inspector-actions { position:sticky; bottom:0; display:grid; grid-template-columns:1fr 1fr; gap:.6rem; padding-top:.75rem; background:linear-gradient(transparent, rgba(12,22,45,.96) 30%); }
+.spellbook-learn-btn,
+.spellbook-preview-btn { border:1px solid rgba(216,183,106,.38) !important; border-radius:14px !important; background:linear-gradient(135deg, rgba(216,183,106,.28), rgba(121,184,255,.16)) !important; color:#fff8df !important; }
+
+@media (max-width: 991.98px) {
+  .spellbook-modal-body { max-height: 84vh; overflow:auto; }
+  .spellbook-hero { grid-template-columns: 1fr; }
+  .spellbook-layout { grid-template-columns: 1fr; }
+  .spellbook-sidebar { max-height:none; }
+  .spellbook-library { max-height:none; }
+  .spellbook-inspector { max-height:none; position: sticky; bottom: 0; z-index: 3; border-radius: 24px 24px 0 0; }
+  .spellbook-card-grid { grid-template-columns: 1fr; }
+}
+
+/* Spellbook modal footer/scroll refinements */
+.modern-card:has(.spellbook-shell) {
+  display: flex;
+  max-height: 92vh;
+  min-height: 0;
+}
+
+.modern-card:has(.spellbook-shell) .spellbook-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: calc(92vh - 132px);
+  overflow: auto;
+  padding-bottom: 1rem !important;
+}
+
+.modern-card:has(.spellbook-shell) .modal-footer {
+  justify-content: flex-end;
+  padding: 0.65rem 1rem 0.85rem;
+  background: linear-gradient(180deg, rgba(6, 12, 28, 0.82), rgba(7, 13, 30, 0.96));
+}
+
+.spellbook-modal-close-btn {
+  width: auto;
+  min-width: 92px;
+  border-radius: 999px !important;
+  padding: 0.45rem 1.15rem !important;
+  border: 1px solid rgba(121, 184, 255, 0.28) !important;
+  background: linear-gradient(135deg, rgba(79, 110, 255, 0.78), rgba(121, 184, 255, 0.72)) !important;
+  color: #fff !important;
+  font-weight: 800;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24), 0 0 18px rgba(121, 184, 255, 0.18);
+}
+
+.spellbook-sidebar,
+.spellbook-inspector,
+.spellbook-library {
+  padding-bottom: 2rem;
+  scrollbar-gutter: stable;
+}
+
+.spellbook-inspector {
+  position: relative;
+}
+
+.spellbook-inspector-dismiss {
+  position: sticky;
+  top: 0;
+  float: right;
+  z-index: 4;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin: -0.25rem -0.25rem 0.25rem 0.5rem;
+  padding: 0 !important;
+  border: 1px solid rgba(121, 184, 255, 0.26) !important;
+  border-radius: 999px !important;
+  background: rgba(8, 16, 35, 0.82) !important;
+  color: #dcecff !important;
+  text-decoration: none !important;
+  box-shadow: 0 0 18px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(12px);
+}
+
+.spellbook-inspector-dismiss:hover,
+.spellbook-inspector-dismiss:focus-visible {
+  color: #fff8df !important;
+  border-color: rgba(216, 183, 106, 0.5) !important;
+  outline: none;
+}
+
+@media (min-width: 992px) {
+  .modern-card:has(.spellbook-shell) .spellbook-sidebar,
+  .modern-card:has(.spellbook-shell) .spellbook-inspector,
+  .modern-card:has(.spellbook-shell) .spellbook-library {
+    max-height: calc(92vh - 360px);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .modern-card:has(.spellbook-shell) {
+    max-height: 94vh;
+  }
+
+  .modern-card:has(.spellbook-shell) .spellbook-modal-body {
+    max-height: calc(94vh - 126px);
+    padding-bottom: 1.25rem !important;
+  }
+
+  .modern-card:has(.spellbook-shell) .modal-footer {
+    padding: 0.55rem 1rem 0.75rem;
+  }
+
+  .spellbook-modal-close-btn {
+    min-width: 84px;
+    padding: 0.42rem 1rem !important;
+  }
+
+  .spellbook-inspector-dismiss {
+    width: 2.75rem;
+    height: 2.75rem;
+    font-size: 1.1rem;
+  }
+}

--- a/client/src/components/Zombies/attributes/SpellSelector.js
+++ b/client/src/components/Zombies/attributes/SpellSelector.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import apiFetch from '../../../utils/apiFetch';
-import { Modal, Card, Button, Form, Tabs, Tab } from 'react-bootstrap';
+import { Modal, Card, Button, Form, Tabs, Tab, Badge } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 import UpcastModal from './UpcastModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
@@ -70,6 +70,51 @@ const SPELLCASTING_CLASSES = {
   wizard: 'full',
   paladin: 'half',
   ranger: 'half',
+};
+
+
+const SCHOOL_ICONS = {
+  abjuration: 'fa-shield-halved',
+  conjuration: 'fa-circle-nodes',
+  divination: 'fa-eye',
+  enchantment: 'fa-heart',
+  evocation: 'fa-fire-flame-curved',
+  illusion: 'fa-masks-theater',
+  necromancy: 'fa-skull',
+  transmutation: 'fa-wand-magic-sparkles',
+};
+
+const CLASS_ICONS = {
+  bard: 'fa-music',
+  cleric: 'fa-sun',
+  druid: 'fa-leaf',
+  paladin: 'fa-shield-heart',
+  ranger: 'fa-feather',
+  sorcerer: 'fa-bolt',
+  warlock: 'fa-hand-sparkles',
+  wizard: 'fa-hat-wizard',
+};
+
+const normalizeToken = (value) =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+const spellIconClass = (spell) => {
+  const text = `${spell?.name || ''} ${spell?.school || ''} ${spell?.description || ''}`.toLowerCase();
+  if (/fire|flame|burn|scorch/.test(text)) return 'fa-fire-flame-curved';
+  if (/ice|cold|frost|sleet/.test(text)) return 'fa-snowflake';
+  if (/heal|cure|restore|reviv/.test(text)) return 'fa-hand-holding-heart';
+  if (/poison|acid|venom/.test(text)) return 'fa-flask-vial';
+  if (/lightning|thunder|storm|bolt/.test(text)) return 'fa-bolt-lightning';
+  if (/charm|suggest|friend|dominat/.test(text)) return 'fa-heart';
+  if (/dead|death|necrotic|zombie/.test(text)) return 'fa-skull';
+  if (/invisible|illusion|mirror|phantom/.test(text)) return 'fa-masks-theater';
+  return SCHOOL_ICONS[normalizeToken(spell?.school)] || 'fa-sparkles';
+};
+
+const summarizeSpell = (description = '') => {
+  const clean = String(description || '').replace(/\s+/g, ' ').trim();
+  if (!clean) return 'An arcane entry from the RealmTracker archives.';
+  return clean.length > 150 ? `${clean.slice(0, 147)}…` : clean;
 };
 
 const STAT_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
@@ -240,6 +285,16 @@ export default function SpellSelector({
   const [spellsKnown, setSpellsKnown] = useState({});
   const [showUpcast, setShowUpcast] = useState(false);
   const [pendingSpell, setPendingSpell] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [schoolFilter, setSchoolFilter] = useState('all');
+  const [castingFilter, setCastingFilter] = useState('all');
+  const [rangeFilter, setRangeFilter] = useState('all');
+  const [traitFilters, setTraitFilters] = useState({
+    concentration: false,
+    ritual: false,
+    cantrip: false,
+    known: false,
+  });
 
   const getScaledDamage = useCallback(
     (spell) => {
@@ -375,12 +430,52 @@ export default function SpellSelector({
     fetchSpellsKnown();
   }, [classesInfo, chaMod, wisMod]);
 
+  const spellList = useMemo(() => Object.values(allSpells), [allSpells]);
+
+  const filterOptions = useMemo(() => {
+    const schools = new Set();
+    const castingTimes = new Set();
+    const ranges = new Set();
+    spellList.forEach((spell) => {
+      if (spell.school) schools.add(spell.school);
+      if (spell.castingTime) castingTimes.add(spell.castingTime);
+      if (spell.range) ranges.add(spell.range);
+    });
+    return {
+      schools: Array.from(schools).sort(),
+      castingTimes: Array.from(castingTimes).sort(),
+      ranges: Array.from(ranges).sort(),
+    };
+  }, [spellList]);
+
+  const selectedSpellSet = useMemo(() => new Set(selectedSpells), [selectedSpells]);
+
+  const filteredSpellsForClass = useCallback(
+    (cls) => {
+      const term = searchTerm.trim().toLowerCase();
+      return spellList.filter((spell) => {
+        if (!spellSupportsClass(spell, cls)) return false;
+        if (spell.level !== Number(selectedLevels[cls])) return false;
+        if (term) {
+          const haystack = `${spell.name || ''} ${spell.school || ''} ${spell.description || ''}`.toLowerCase();
+          if (!haystack.includes(term)) return false;
+        }
+        if (schoolFilter !== 'all' && spell.school !== schoolFilter) return false;
+        if (castingFilter !== 'all' && spell.castingTime !== castingFilter) return false;
+        if (rangeFilter !== 'all' && spell.range !== rangeFilter) return false;
+        const duration = String(spell.duration || '').toLowerCase();
+        if (traitFilters.concentration && !duration.includes('concentration')) return false;
+        if (traitFilters.ritual && !spell.ritual) return false;
+        if (traitFilters.cantrip && spell.level !== 0) return false;
+        if (traitFilters.known && !selectedSpellSet.has(spell.name)) return false;
+        return true;
+      });
+    },
+    [castingFilter, rangeFilter, schoolFilter, searchTerm, selectedLevels, selectedSpellSet, spellList, traitFilters]
+  );
+
   function spellsForClass(cls) {
-    return Object.values(allSpells).filter(
-      (spell) =>
-        spellSupportsClass(spell, cls) &&
-        spell.level === Number(selectedLevels[cls])
-    );
+    return filteredSpellsForClass(cls);
   }
 
   useEffect(() => {
@@ -421,20 +516,171 @@ export default function SpellSelector({
     saveSpells(updatedSpells, updatedCasters);
   }
 
+  const handleModalHide = useCallback(() => {
+    if (isDocked) {
+      if (typeof onDockClose === 'function') {
+        onDockClose();
+      }
+      return;
+    }
+
+    handleClose?.();
+  }, [handleClose, isDocked, onDockClose]);
+
+  const castSpell = useCallback(
+    (spell, isSelected) => {
+      if (!isSelected) return;
+      if (spell.higherLevels) {
+        setPendingSpell(spell);
+        setShowUpcast(true);
+      } else {
+        const damage = getScaledDamage(spell);
+        onCastSpell?.({
+          level: spell.level,
+          damage,
+          castingTime: spell.castingTime,
+          name: spell.name,
+        });
+        handleModalHide();
+      }
+    },
+    [getScaledDamage, handleModalHide, onCastSpell]
+  );
+
+  const FilterPanel = ({ cls }) => (
+    <aside className="spellbook-sidebar" aria-label="Spell filters">
+      <div className="spellbook-filter-group spellbook-filter-group--classes">
+        <span className="spellbook-filter-label">Class</span>
+        <div className="spellbook-class-list" role="list">
+          {classesInfo.map(({ name }) => {
+            const key = normalizeToken(name);
+            return (
+              <button
+                type="button"
+                key={name}
+                className={`spellbook-class-pill${activeClass === name ? ' is-active' : ''}`}
+                onClick={() => setActiveClass(name)}
+                aria-pressed={activeClass === name}
+              >
+                <i className={`fa-solid ${CLASS_ICONS[key] || 'fa-book-sparkles'}`} aria-hidden="true" />
+                <span>{name}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <Form.Group className="spellbook-filter-group">
+        <Form.Label htmlFor={`spellLevel-${cls}`} className="spellbook-filter-label">Level</Form.Label>
+        <Form.Select
+          id={`spellLevel-${cls}`}
+          value={selectedLevels[cls]}
+          onChange={(e) => setSelectedLevels((prev) => ({ ...prev, [cls]: Number(e.target.value) }))}
+          className="spellbook-select"
+        >
+          {(levelOptions[cls] || []).map((lvl) => (
+            <option key={lvl} value={lvl}>{lvl}</option>
+          ))}
+        </Form.Select>
+      </Form.Group>
+
+      <Form.Group className="spellbook-filter-group">
+        <Form.Label className="spellbook-filter-label">School</Form.Label>
+        <Form.Select value={schoolFilter} onChange={(e) => setSchoolFilter(e.target.value)} className="spellbook-select" aria-label="Spell school">
+          <option value="all">All Schools</option>
+          {filterOptions.schools.map((school) => <option key={school} value={school}>{school}</option>)}
+        </Form.Select>
+      </Form.Group>
+
+      <Form.Group className="spellbook-filter-group">
+        <Form.Label className="spellbook-filter-label">Casting Time</Form.Label>
+        <Form.Select value={castingFilter} onChange={(e) => setCastingFilter(e.target.value)} className="spellbook-select" aria-label="Casting time">
+          <option value="all">Any Time</option>
+          {filterOptions.castingTimes.map((time) => <option key={time} value={time}>{time}</option>)}
+        </Form.Select>
+      </Form.Group>
+
+      <Form.Group className="spellbook-filter-group">
+        <Form.Label className="spellbook-filter-label">Range</Form.Label>
+        <Form.Select value={rangeFilter} onChange={(e) => setRangeFilter(e.target.value)} className="spellbook-select" aria-label="Range">
+          <option value="all">Any Range</option>
+          {filterOptions.ranges.map((range) => <option key={range} value={range}>{range}</option>)}
+        </Form.Select>
+      </Form.Group>
+
+      <div className="spellbook-filter-group spellbook-rune-toggles" aria-label="Spell traits">
+        {[['concentration', 'Concentration'], ['ritual', 'Ritual'], ['cantrip', 'Cantrip'], ['known', 'Known only']].map(([key, label]) => (
+          <button
+            type="button"
+            key={key}
+            className={`spellbook-rune-toggle${traitFilters[key] ? ' is-active' : ''}`}
+            onClick={() => setTraitFilters((prev) => ({ ...prev, [key]: !prev[key] }))}
+            aria-pressed={traitFilters[key]}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+
+  const SpellInspector = ({ spell, cls }) => {
+    const activeSpell = spell && spellSupportsClass(spell, cls) ? spell : null;
+    if (!activeSpell) {
+      return <aside className="spellbook-inspector spellbook-inspector--empty">Select a spell to open its illuminated page.</aside>;
+    }
+    const isSelected = selectedSpellSet.has(activeSpell.name);
+    const disableSelection = !isSelected && (pointsLeft[cls] || 0) <= 0;
+    return (
+      <aside className="spellbook-inspector" aria-label="Selected spell details">
+        <div className="spellbook-art"><i className={`fa-solid ${spellIconClass(activeSpell)}`} aria-hidden="true" /></div>
+        <Button
+          type="button"
+          variant="link"
+          className="spellbook-inspector-dismiss"
+          aria-label="Close selected spell details"
+          onClick={() => setViewSpell(null)}
+        >
+          <i className="fa-solid fa-xmark" aria-hidden="true" />
+        </Button>
+        <div className="spellbook-inspector-heading">
+          <span className="spell-level-badge">Level {activeSpell.level}</span>
+          <h3>{activeSpell.name}</h3>
+          <p>{activeSpell.school || 'Unknown School'}</p>
+        </div>
+        <div className="spellbook-stat-grid">
+          {['castingTime','range','duration','damage'].map((key) => activeSpell[key] ? <div key={key}><span>{key === 'castingTime' ? 'Casting' : key}</span><strong>{activeSpell[key]}</strong></div> : null)}
+          {activeSpell.components?.length ? <div><span>Components</span><strong>{activeSpell.components.join(', ')}</strong></div> : null}
+        </div>
+        <p className="spellbook-description">{activeSpell.description || 'No description recorded.'}</p>
+        {activeSpell.higherLevels ? <p className="spellbook-higher"><strong>Higher Levels.</strong> {activeSpell.higherLevels}</p> : null}
+        <div className="spellbook-inspector-actions">
+          <Button className="spellbook-learn-btn" disabled={disableSelection} onClick={() => toggleSpell(activeSpell.name, cls)}>{isSelected ? 'Remove' : 'Learn'}</Button>
+          <Button className="spellbook-preview-btn" disabled={!isSelected} onClick={() => castSpell(activeSpell, isSelected)}><i className="fa-solid fa-wand-sparkles" /> Preview</Button>
+        </div>
+      </aside>
+    );
+  };
+
   const renderSpellCards = (cls) => {
     const spells = spellsForClass(cls);
     if (!spells.length) {
-      return <div className="text-light">No spells available.</div>;
+      return <div className="spellbook-empty">No spells match these runes.</div>;
     }
 
     return (
-      <div className="spell-card-grid">
+      <div className="spell-card-grid spellbook-card-grid">
         {spells.map((spell) => {
-          const isSelected = selectedSpells.includes(spell.name);
+          const isSelected = selectedSpellSet.has(spell.name);
           const disableSelection = !isSelected && (pointsLeft[cls] || 0) <= 0;
+          const duration = String(spell.duration || '');
 
           return (
-            <div key={spell.name} className="spell-card">
+            <article key={spell.name} className={`spell-card spellbook-card${isSelected ? ' is-selected' : ''}`} tabIndex={0} onClick={() => setViewSpell(spell)} onKeyDown={(e) => { if (e.key === 'Enter') setViewSpell(spell); }}>
+              <div className="spellbook-card-topline">
+                <div className="spellbook-icon"><i className={`fa-solid ${spellIconClass(spell)}`} aria-hidden="true" /></div>
+                <Badge className="spell-level-badge">{spell.level === 0 ? 'Cantrip' : `Lv ${spell.level}`}</Badge>
+              </div>
               <div className="spell-card-header">
                 <Form.Check
                   id={`spell-${cls}-${spell.name}`}
@@ -442,55 +688,26 @@ export default function SpellSelector({
                   label={spell.name}
                   checked={isSelected}
                   disabled={disableSelection}
+                  onClick={(e) => e.stopPropagation()}
                   onChange={() => toggleSpell(spell.name, cls)}
                 />
                 <div className="spell-card-actions">
-                  <Button
-                    variant="link"
-                    onClick={() => setViewSpell(spell)}
-                  >
-                    <i className="fa-solid fa-eye"></i>
-                  </Button>
-                  <Button
-                    variant="link"
-                    disabled={!isSelected}
-                    className={!isSelected ? 'text-secondary' : ''}
-                    onClick={() => {
-                      if (!isSelected) return;
-                      if (spell.higherLevels) {
-                        setPendingSpell(spell);
-                        setShowUpcast(true);
-                      } else {
-                        const damage = getScaledDamage(spell);
-                        onCastSpell?.({
-                          level: spell.level,
-                          damage,
-                          castingTime: spell.castingTime,
-                          name: spell.name,
-                        });
-                        handleModalHide();
-                      }
-                    }}
-                  >
-                    <i className="fa-solid fa-wand-sparkles" />
-                  </Button>
+                  <Button variant="link" aria-label={`View ${spell.name}`} onClick={(e) => { e.stopPropagation(); setViewSpell(spell); }}><i className="fa-solid fa-eye"></i></Button>
+                  <Button variant="link" aria-label={`Preview ${spell.name}`} disabled={!isSelected} className={!isSelected ? 'text-secondary' : ''} onClick={(e) => { e.stopPropagation(); castSpell(spell, isSelected); }}><i className="fa-solid fa-wand-sparkles" /></Button>
                 </div>
               </div>
               <div className="spell-card-details">
-                <span>
-                  <strong>School:</strong> {spell.school}
-                </span>
-                <span>
-                  <strong>Casting Time:</strong> {spell.castingTime}
-                </span>
-                <span>
-                  <strong>Range:</strong> {spell.range}
-                </span>
-                <span>
-                  <strong>Duration:</strong> {spell.duration}
-                </span>
+                <span><strong>School:</strong> {spell.school}</span>
+                <span><strong>Casting Time:</strong> {spell.castingTime}</span>
+                <span><strong>Range:</strong> {spell.range}</span>
+                <span><strong>Duration:</strong> {spell.duration}</span>
               </div>
-            </div>
+              <p className="spellbook-card-preview">{summarizeSpell(spell.description)}</p>
+              <div className="spellbook-card-traits">
+                {duration.toLowerCase().includes('concentration') && <span>Concentration</span>}
+                {spell.ritual && <span>Ritual</span>}
+              </div>
+            </article>
           );
         })}
       </div>
@@ -573,17 +790,6 @@ export default function SpellSelector({
     return classes.join(' ');
   }, [isDocked]);
 
-  const handleModalHide = useCallback(() => {
-    if (isDocked) {
-      if (typeof onDockClose === 'function') {
-        onDockClose();
-      }
-      return;
-    }
-
-    handleClose?.();
-  }, [handleClose, isDocked, onDockClose]);
-
   return (
     <>
       <Modal
@@ -606,129 +812,63 @@ export default function SpellSelector({
             />
             <Card.Title className="modal-title">Spells</Card.Title>
           </Card.Header>
-          <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+          <Card.Body className="spellbook-modal-body">
             {error && <div className="text-danger mb-2">{error}</div>}
             {classesInfo.length === 0 ? (
               <div className="text-light">No spellcasting classes available.</div>
-            ) : classesInfo.length === 1 ? (
-              (() => {
-                const cls = classesInfo[0].name;
-                return (
-                  <>
-                    <Form className="mb-3">
-                      <Form.Group>
-                        <Form.Label htmlFor={`spellLevel-${cls}`}>
-                          Level
-                        </Form.Label>
-                        <Form.Select
-                          id={`spellLevel-${cls}`}
-                          value={selectedLevels[cls]}
-                          onChange={(e) =>
-                            setSelectedLevels((prev) => ({
-                              ...prev,
-                              [cls]: Number(e.target.value),
-                            }))
-                          }
-                        >
-                          {levelOptions[cls].map((lvl) => (
-                            <option key={lvl} value={lvl}>
-                              {lvl}
-                            </option>
-                          ))}
-                        </Form.Select>
-                      </Form.Group>
-                    </Form>
-                    <div className="points-container" style={{ display: 'flex' }}>
-                      <span className="points-label text-light">
-                        Points Left:
-                      </span>
-                      <span className="points-value">
-                        {pointsLeft[cls] === Infinity
-                          ? '∞'
-                          : pointsLeft[cls] || 0}
-                      </span>
-                    </div>
-                    {renderSpellCards(cls)}
-                  </>
-                );
-              })()
             ) : (
-              <Tabs
-                activeKey={activeClass}
-                onSelect={(k) => setActiveClass(k || '')}
-                className="mb-3"
-              >
-                {classesInfo.map(({ name }) => (
-                  <Tab eventKey={name} title={name} key={name}>
-                    <Form className="mb-3">
-                      <Form.Group>
-                        <Form.Label htmlFor={`spellLevel-${name}`}>
-                          Level
-                        </Form.Label>
-                        <Form.Select
-                          id={`spellLevel-${name}`}
-                          value={selectedLevels[name]}
-                          onChange={(e) =>
-                            setSelectedLevels((prev) => ({
-                              ...prev,
-                              [name]: Number(e.target.value),
-                            }))
-                          }
-                        >
-                          {levelOptions[name].map((lvl) => (
-                            <option key={lvl} value={lvl}>
-                              {lvl}
-                            </option>
-                          ))}
-                        </Form.Select>
-                      </Form.Group>
-                    </Form>
-                    <div className="points-container" style={{ display: 'flex' }}>
-                      <span className="points-label text-light">
-                        Points Left:
-                      </span>
-                      <span className="points-value">
-                        {pointsLeft[name] === Infinity
-                          ? '∞'
-                          : pointsLeft[name] || 0}
-                      </span>
-                    </div>
-                    {renderSpellCards(name)}
-                  </Tab>
-                ))}
-              </Tabs>
+              <div className="spellbook-shell">
+                <div className="spellbook-hero">
+                  <div>
+                    <span className="spellbook-kicker">Arcane Library</span>
+                    <h2>Spell Selection</h2>
+                    <p>Search, filter, learn, and preview your character's magic without leaving the tome.</p>
+                  </div>
+                  <div className="spellbook-search-wrap">
+                    <i className="fa-solid fa-magnifying-glass" aria-hidden="true" />
+                    <Form.Control
+                      type="search"
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      placeholder="Search the stacks..."
+                      aria-label="Search spells"
+                      className="spellbook-search"
+                    />
+                  </div>
+                  <div className={`spellbook-points ${(pointsLeft[activeClass] || 0) <= 1 ? 'is-low' : ''}`}>
+                    <span>Spell Points Remaining</span>
+                    <strong>{pointsLeft[activeClass] === Infinity ? '∞' : pointsLeft[activeClass] || 0}</strong>
+                    <small>{activeClass || 'Class'} • Level {selectedLevels[activeClass] ?? '—'}</small>
+                  </div>
+                </div>
+
+                <Tabs activeKey={activeClass} onSelect={(k) => setActiveClass(k || '')} className="spellbook-tabs mb-3">
+                  {classesInfo.map(({ name }) => (
+                    <Tab eventKey={name} title={name} key={name}>
+                      <div className="spellbook-layout">
+                        <FilterPanel cls={name} />
+                        <main className="spellbook-library" aria-label={`${name} spell library`}>
+                          <div className="spellbook-library-header">
+                            <div>
+                              <span className="points-label">Points Left:</span>
+                              <span className="points-value">{pointsLeft[name] === Infinity ? '∞' : pointsLeft[name] || 0}</span>
+                            </div>
+                            <span>{spellsForClass(name).length} spells discovered</span>
+                          </div>
+                          {renderSpellCards(name)}
+                        </main>
+                        <SpellInspector spell={viewSpell} cls={name} />
+                      </div>
+                    </Tab>
+                  ))}
+                </Tabs>
+              </div>
             )}
           </Card.Body>
           <Card.Footer className="modal-footer">
             <Button
-              className="action-btn close-btn"
+              className="spellbook-modal-close-btn"
               onClick={handleModalHide}
-            >
-              Close
-            </Button>
-          </Card.Footer>
-        </Card>
-      </Modal>
-      <Modal
-        show={!!viewSpell}
-        onHide={() => setViewSpell(null)}
-        centered
-        size="lg"
-        className="dnd-modal modern-modal"
-      >
-        <Card className="modern-card text-center">
-          <Card.Header className="modal-header">
-            <Card.Title className="modal-title">
-              {viewSpell?.name}
-            </Card.Title>
-          </Card.Header>
-          <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
-            {viewSpell?.description}
-          </Card.Body>
-          <Card.Footer className="modal-footer">
-            <Button
-              className="action-btn close-btn"
-              onClick={() => setViewSpell(null)}
             >
               Close
             </Button>


### PR DESCRIPTION
### Motivation

- Provide a modern, discoverable spellbook UI for RealmTracker with search, filtering, and a richer spell inspector to improve spell selection and preview workflows.
- Replace the legacy list/modal interactions with a card-based library and inspector so users can learn, preview, and cast spells from the same panel.
- Add responsive styling and modal/scroll refinements to ensure consistent behavior both docked and undocked.

### Description

- Added an extensive new spellbook stylesheet to `client/src/App.scss` that implements the modal layout, card grid, sidebar filters, inspector, responsive rules, and footer refinements for the spellbook experience.
- Reworked `client/src/components/Zombies/attributes/SpellSelector.js` to introduce search and filter state (`searchTerm`, `schoolFilter`, `castingFilter`, `rangeFilter`, `traitFilters`) and new computed helpers (`filterOptions`, `filteredSpellsForClass`, `selectedSpellSet`).
- Added icon+summary utilities (`SCHOOL_ICONS`, `CLASS_ICONS`, `normalizeToken`, `spellIconClass`, `summarizeSpell`) and UI components `FilterPanel` and `SpellInspector` to render the new sidebar, class pills, level selector, and the detailed inspector with learn/preview actions.
- Replaced the old tab/list rendering with a three-column `spellbook-layout` per class that shows filters, the card-based library (`spellbook-card-grid`), and the inspector; cards include badges, trait tags, and improved interactions (click to open, keyboard Enter support, checkbox to learn, preview handling via `castSpell`).
- Adjusted modal hide behavior to respect docking via `handleModalHide`, integrated cast preview/upcast flow with `UpcastModal`, and removed the separate `viewSpell` modal in favor of the inspector panel.

### Testing

- Ran a production build with `npm run build` which completed successfully. 
- Executed the existing unit test suite with `npm test` and all tests passed. 
- Ran the frontend lint step with `npm run lint` which reported no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a3230757c832ea583f1731cd9115d)