### PR TITLE
Add Combat Arsenal attack modal UI and styles to PlayerTurnActions

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12503,3 +12503,112 @@ ul.spellbook-tabs.nav-tabs {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+/* Combat Arsenal attack modal */
+.combat-arsenal-modal .modal-dialog { max-width: min(1420px, calc(100vw - 28px)); }
+.combat-arsenal { overflow: hidden; background: radial-gradient(circle at 18% 0%, rgba(91, 169, 255, .18), transparent 32%), radial-gradient(circle at 82% 12%, rgba(154, 103, 255, .18), transparent 34%), rgba(7, 13, 28, .96); border: 1px solid rgba(158, 205, 255, .22); box-shadow: 0 26px 90px rgba(0,0,0,.58), inset 0 1px rgba(255,255,255,.08); }
+.combat-arsenal__header { position: sticky; top: 0; z-index: 5; display: grid; grid-template-columns: minmax(0, 1fr) minmax(260px, 420px); gap: 1rem; align-items: center; padding: 1.25rem; border-bottom: 1px solid rgba(143, 200, 255, .14); background: linear-gradient(135deg, rgba(6, 14, 30, .96), rgba(20, 15, 43, .92)); }
+.combat-arsenal__eyebrow { color: #d7b46a; font-size: .72rem; letter-spacing: .18em; text-transform: uppercase; font-weight: 800; }
+.combat-arsenal__title { margin: .1rem 0; color: #f7fbff; font-size: clamp(1.55rem, 2.6vw, 2.4rem); letter-spacing: .03em; }
+.combat-arsenal__subtitle { margin: 0; color: rgba(220,235,255,.68); }
+.combat-arsenal__search-wrap { min-height: 48px; display: flex; align-items: center; gap: .75rem; padding: 0 .95rem; border: 1px solid rgba(143,200,255,.2); border-radius: 18px; background: rgba(255,255,255,.065); box-shadow: inset 0 0 24px rgba(91,169,255,.08); color: #8fc8ff; }
+.combat-arsenal__search { width: 100%; border: 0; outline: 0; background: transparent; color: #fff; font-weight: 700; }
+.combat-arsenal__search::placeholder { color: rgba(220,235,255,.46); }
+.combat-arsenal__body { padding: 1rem; }
+.combat-arsenal__quick-filters { display: flex; flex-wrap: wrap; gap: .55rem; margin-bottom: 1rem; }
+.combat-filter-chip { min-height: 36px; padding: .35rem .75rem; border: 1px solid rgba(143,200,255,.18); border-radius: 999px; color: rgba(232,242,255,.78); background: rgba(255,255,255,.05); text-decoration: none; font-weight: 800; font-size: .78rem; letter-spacing: .04em; transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
+.combat-filter-chip:hover, .combat-filter-chip.is-active { color: #fff; border-color: rgba(215,180,106,.54); box-shadow: 0 0 22px rgba(91,169,255,.13), inset 0 0 18px rgba(215,180,106,.08); transform: translateY(-1px); text-decoration: none; }
+.combat-arsenal__layout { display: grid; grid-template-columns: 190px minmax(0, 1fr) 330px; gap: 1rem; align-items: start; }
+.combat-arsenal__sidebar, .combat-inspector { border: 1px solid rgba(143,200,255,.14); border-radius: 22px; background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.03)); backdrop-filter: blur(14px); }
+.combat-arsenal__sidebar { position: sticky; top: 102px; display: grid; gap: .35rem; padding: .7rem; }
+.combat-category { display: flex; align-items: center; gap: .65rem; min-height: 40px; border: 0; border-radius: 14px; padding: .45rem .65rem; color: rgba(232,242,255,.72); background: transparent; text-align: left; font-weight: 800; }
+.combat-category:hover, .combat-category.is-active { color: #fff; background: linear-gradient(90deg, rgba(91,169,255,.18), rgba(154,103,255,.08)); box-shadow: inset 3px 0 #8fc8ff; }
+.combat-arsenal__toolbar { display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: .75rem; color: rgba(220,235,255,.72); font-weight: 800; }
+.combat-arsenal__toolbar .form-select { width: 190px; color: #fff; border-color: rgba(143,200,255,.2); background-color: rgba(255,255,255,.08); }
+.combat-attack-grid { grid-template-columns: repeat(auto-fill, minmax(285px, 1fr)); align-items: stretch; }
+.combat-action-card { position: relative; min-height: 258px; padding: 1rem; border-radius: 24px; overflow: hidden; border-color: rgba(143,200,255,.18); background: linear-gradient(145deg, rgba(10,22,46,.88), rgba(17,14,35,.78)); box-shadow: inset 0 1px rgba(255,255,255,.08), 0 16px 32px rgba(0,0,0,.28); transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease; cursor: pointer; }
+.combat-action-card:hover, .combat-action-card.is-selected { transform: translateY(-4px); border-color: rgba(143,200,255,.46); box-shadow: 0 24px 46px rgba(0,0,0,.36), 0 0 28px rgba(91,169,255,.12); }
+.combat-action-card.is-favorite { border-color: rgba(215,180,106,.44); box-shadow: 0 0 22px rgba(215,180,106,.11), inset 0 1px rgba(255,255,255,.1); }
+.combat-action-card::before { content: ''; position: absolute; inset: 0; pointer-events: none; background: radial-gradient(circle at 18% 16%, rgba(143,200,255,.18), transparent 28%); opacity: .75; }
+.combat-action-card--spell::before { background: radial-gradient(circle at 18% 16%, rgba(179,128,255,.26), transparent 30%); }
+.combat-action-card--cantrip::before { background: radial-gradient(circle at 18% 16%, rgba(91,210,255,.24), transparent 30%); }
+.combat-action-card--feature::before { background: radial-gradient(circle at 18% 16%, rgba(215,180,106,.26), transparent 30%); }
+.combat-action-card__topline, .combat-action-card__tags { display: flex; flex-wrap: wrap; gap: .4rem; justify-content: space-between; color: rgba(220,235,255,.58); font-size: .7rem; text-transform: uppercase; letter-spacing: .1em; font-weight: 900; }
+.combat-action-card__hero { position: relative; display: grid; grid-template-columns: 62px minmax(0, 1fr); gap: .8rem; align-items: center; margin: .8rem 0; }
+.combat-action-card__icon { width: 62px; height: 62px; display: grid; place-items: center; border-radius: 18px; font-size: 1.75rem; background: linear-gradient(145deg, rgba(143,200,255,.2), rgba(255,255,255,.05)); border: 1px solid rgba(255,255,255,.14); box-shadow: 0 0 26px rgba(91,169,255,.12); }
+.combat-action-card h3 { margin: 0; color: #fff; font-size: 1.18rem; line-height: 1.1; }
+.combat-action-card p { margin: .25rem 0 0; color: rgba(220,235,255,.66); font-size: .85rem; }
+.combat-action-card__stats { position: relative; display: grid; grid-template-columns: 1.25fr .8fr .8fr; gap: .5rem; }
+.combat-action-card__stats div { min-width: 0; padding: .55rem; border-radius: 14px; background: rgba(0,0,0,.18); border: 1px solid rgba(255,255,255,.08); }
+.combat-action-card__stats strong { display: block; color: #fff; font-size: .96rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.combat-action-card__stats span { color: rgba(220,235,255,.52); font-size: .68rem; text-transform: uppercase; letter-spacing: .09em; font-weight: 900; }
+.combat-action-card__tags { justify-content: flex-start; margin-top: .7rem; }
+.combat-action-card__tags span { padding: .2rem .45rem; border-radius: 999px; background: rgba(143,200,255,.09); color: rgba(232,242,255,.76); }
+.combat-action-card__actions { position: relative; display: flex; flex-wrap: wrap; gap: .45rem; margin-top: auto; padding-top: .8rem; }
+.combat-icon-button, .combat-favorite-button { color: rgba(255,255,255,.8); text-decoration: none; border: 1px solid rgba(255,255,255,.12); border-radius: 12px; background: rgba(255,255,255,.05); }
+.combat-icon-button:hover, .combat-icon-button.is-active, .combat-favorite-button:hover, .combat-favorite-button.is-active { color: #ffe39a; text-decoration: none; box-shadow: 0 0 18px rgba(215,180,106,.16); }
+.combat-roll-button { border: 1px solid rgba(215,180,106,.42); border-radius: 14px; color: #fff; background: linear-gradient(135deg, rgba(215,180,106,.28), rgba(91,169,255,.14)); font-weight: 900; box-shadow: 0 10px 22px rgba(0,0,0,.22); }
+.combat-roll-button--attack { border-color: rgba(143,200,255,.42); background: linear-gradient(135deg, rgba(91,169,255,.28), rgba(154,103,255,.14)); }
+.combat-roll-button:hover { filter: brightness(1.12); transform: translateY(-1px); }
+.combat-inspector { position: sticky; top: 102px; padding: .9rem; max-height: calc(100vh - 190px); overflow: auto; animation: combatInspectorIn .22s ease both; }
+@keyframes combatInspectorIn { from { opacity: 0; transform: translateX(12px); } to { opacity: 1; transform: translateX(0); } }
+.combat-inspector__art { height: 150px; display: grid; place-items: center; border-radius: 20px; border: 1px solid rgba(255,255,255,.12); background: radial-gradient(circle, rgba(143,200,255,.25), rgba(9,17,34,.72) 62%); font-size: 4rem; }
+.combat-inspector__art--spell, .combat-inspector__art--cantrip { background: radial-gradient(circle, rgba(174,119,255,.28), rgba(9,17,34,.72) 62%); }
+.combat-inspector__preview { display: grid; grid-template-columns: 1fr 1fr; gap: .55rem; margin: .75rem 0; }
+.combat-inspector__preview h3 { grid-column: 1 / -1; margin: 0; color: #fff; }
+.combat-inspector__preview div { padding: .6rem; border-radius: 14px; background: rgba(0,0,0,.2); }
+.combat-inspector__preview span { display: block; color: #fff; font-weight: 900; }
+.combat-inspector__preview small, .combat-inspector__description { color: rgba(220,235,255,.62); }
+.combat-inspector__properties { display: grid; gap: .55rem; margin: .75rem 0; }
+.combat-inspector__properties div { padding: .65rem; border: 1px solid rgba(143,200,255,.12); border-radius: 14px; background: rgba(255,255,255,.045); }
+.combat-inspector__properties strong, .combat-inspector__properties span { display: block; }
+.combat-inspector__properties strong { color: #f4dca0; }
+.combat-inspector__properties span { color: rgba(232,242,255,.72); font-size: .86rem; }
+.combat-inspector__buttons { display: flex; flex-wrap: wrap; gap: .5rem; }
+@media (max-width: 1100px) { .combat-arsenal__layout { grid-template-columns: 1fr; } .combat-arsenal__sidebar { position: static; display: flex; overflow-x: auto; } .combat-category { white-space: nowrap; } .combat-inspector { position: fixed; left: 10px; right: 10px; bottom: 10px; top: auto; z-index: 20; max-height: 46vh; border-radius: 24px; box-shadow: 0 -20px 60px rgba(0,0,0,.55); animation: combatSheetIn .24s ease both; } @keyframes combatSheetIn { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } } .combat-arsenal__footer { padding-bottom: calc(46vh + 1.25rem); } }
+@media (max-width: 720px) { .combat-arsenal-modal .modal-dialog { max-width: 100vw; margin: 0; min-height: 100vh; } .combat-arsenal-modal .modal-content { min-height: 100vh; border-radius: 0; } .combat-arsenal__header { grid-template-columns: 1fr; padding: .95rem; } .combat-arsenal__quick-filters { flex-wrap: nowrap; overflow-x: auto; padding-bottom: .25rem; } .combat-attack-grid { grid-template-columns: 1fr; } .combat-action-card { min-height: 236px; } .combat-action-card__stats { grid-template-columns: 1fr; } .combat-roll-button { flex: 1 1 130px; min-height: 42px; } .combat-inspector__art { height: 92px; font-size: 2.5rem; } }
+
+/* Combat Arsenal viewport and scroll refinements */
+.combat-arsenal-modal .modal-content { max-height: calc(100dvh - 32px); overflow: hidden; }
+.combat-arsenal { max-height: calc(100dvh - 32px); display: flex; flex-direction: column; }
+.combat-arsenal__body { min-height: 0; overflow-y: auto; padding-bottom: 1.25rem; scrollbar-color: rgba(143, 200, 255, .44) rgba(7, 13, 28, .45); }
+.combat-arsenal__layout { min-height: 0; }
+.combat-arsenal__main { min-width: 0; }
+.combat-arsenal__footer { flex-shrink: 0; background: linear-gradient(180deg, rgba(7,13,28,.7), rgba(7,13,28,.96)); border-top: 1px solid rgba(143,200,255,.14); }
+.combat-action-card__actions { padding-bottom: .15rem; }
+
+@media (max-width: 1100px) {
+  .combat-arsenal-modal .modal-content,
+  .combat-arsenal { max-height: 100dvh; }
+  .combat-arsenal__body { padding-bottom: calc(46vh + 1.5rem); -webkit-overflow-scrolling: touch; }
+  .combat-arsenal__footer { padding-bottom: max(1rem, env(safe-area-inset-bottom)); }
+}
+
+@media (max-width: 720px) {
+  .combat-arsenal-modal { padding: 0 !important; }
+  .combat-arsenal-modal .modal-dialog { height: 100dvh; min-height: 100dvh; }
+  .combat-arsenal-modal .modal-content,
+  .combat-arsenal { height: 100dvh; max-height: 100dvh; }
+  .combat-arsenal__body { overflow-y: auto; padding-bottom: calc(46vh + 5rem); }
+  .combat-arsenal__sidebar { margin-bottom: .5rem; }
+}
+
+/* Combat Arsenal independent column scrolling */
+@media (min-width: 1101px) {
+  .combat-arsenal__body { overflow: hidden; }
+  .combat-arsenal__layout { height: 100%; overflow: hidden; align-items: start; }
+  .combat-arsenal__sidebar,
+  .combat-inspector { position: sticky; top: 0; align-self: start; max-height: calc(100dvh - 235px); overflow-y: auto; scrollbar-color: rgba(143, 200, 255, .44) rgba(7, 13, 28, .45); }
+  .combat-arsenal__main { max-height: calc(100dvh - 235px); overflow-y: auto; padding-right: .35rem; scrollbar-color: rgba(143, 200, 255, .44) rgba(7, 13, 28, .45); }
+}
+
+@media (max-width: 1100px) {
+  .combat-arsenal__body { overflow-y: auto; }
+  .combat-arsenal__main { overflow: visible; max-height: none; }
+}
+
+/* Combat Arsenal inspector dismiss control */
+.combat-inspector__close { position: absolute; top: .75rem; right: .75rem; z-index: 2; width: 38px; height: 38px; display: grid; place-items: center; border: 1px solid rgba(143,200,255,.28); border-radius: 999px; color: #fff; background: rgba(7,13,28,.72); box-shadow: 0 0 18px rgba(91,169,255,.12); font-size: 1.45rem; line-height: 1; }
+.combat-inspector__close:hover, .combat-inspector__close:focus { border-color: rgba(215,180,106,.62); color: #ffe39a; outline: none; }
+@media (min-width: 1101px) { .combat-inspector__close { opacity: .74; } }
+@media (max-width: 1100px) { .combat-inspector__close { top: .6rem; right: .6rem; width: 42px; height: 42px; background: rgba(13,20,39,.92); } }

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -6,8 +6,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
-import { Button, Modal, Card, OverlayTrigger, Popover, Form } from "react-bootstrap";
-import { Swords } from 'lucide-react';
+import { Button, Modal, Card, Form } from "react-bootstrap";
 import spellsData from '../../../data/spells';
 import UpcastModal from './UpcastModal';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -458,6 +457,13 @@ const PlayerTurnActions = React.forwardRef(
   ) => {
   // -----------------------------------------------------------Modal for attacks------------------------------------------------------------------------
   const [showAttack, setShowAttack] = useState(false);
+  const [attackSearch, setAttackSearch] = useState('');
+  const [activeAttackCategory, setActiveAttackCategory] = useState('all');
+  const [activeAttackFilters, setActiveAttackFilters] = useState(() => new Set());
+  const [attackSort, setAttackSort] = useState('favorites');
+  const [selectedAttackId, setSelectedAttackId] = useState('');
+  const [favoriteAttackIds, setFavoriteAttackIds] = useState(() => new Set());
+  const [recentAttackIds, setRecentAttackIds] = useState([]);
   const [showDiceRoller, setShowDiceRoller] = useState(false);
   const handleCloseAttack = () => setShowAttack(false);
   const handleShowAttack = useCallback(() => setShowAttack(true), []);
@@ -501,7 +507,7 @@ const PlayerTurnActions = React.forwardRef(
     setShowDiceRoller(false);
   };
 
-  const [footerHeight, setFooterHeight] = useState(0);
+  const [, setFooterHeight] = useState(0);
   // -----------------------------------------Dice roller for damage-------------------------------------------------------------------
   const [damageValue, setDamageValue] = useState(0);
   const [hasDamageRoll, setHasDamageRoll] = useState(false);
@@ -1389,6 +1395,45 @@ const manualCriticalRef = useRef(false);
 
     return 'Attack';
   };
+
+
+  const getAttackIcon = useCallback((attack = {}) => {
+    const haystack = `${attack.name || ''} ${attack.damageText || ''} ${attack.damageType || ''} ${attack.weaponType || ''} ${attack.school || ''}`.toLowerCase();
+    if (/fire|flame|burn/.test(haystack)) return '🔥';
+    if (/cold|ice|frost/.test(haystack)) return '❄️';
+    if (/lightning|thunder|storm/.test(haystack)) return '⚡';
+    if (/radiant|holy|divine|heal/.test(haystack)) return '☀️';
+    if (/necrotic|shadow|death/.test(haystack)) return '☠️';
+    if (/poison|acid|toxin/.test(haystack)) return '☣️';
+    if (/force|arcane|magic missile/.test(haystack)) return '✦';
+    if (/bow|crossbow|arrow|ranged/.test(haystack)) return '🏹';
+    if (/dagger|knife/.test(haystack)) return '🗡️';
+    if (/hammer|mace|maul|club/.test(haystack)) return '🔨';
+    if (/breath|dragon/.test(haystack)) return '🐉';
+    if (attack.kind === 'spell' || attack.kind === 'cantrip') return '🔮';
+    if (attack.kind === 'feature') return '🌟';
+    return '⚔️';
+  }, []);
+
+  const extractDamageTypeText = useCallback((damage = '') => {
+    if (typeof damage !== 'string') return '';
+    const types = damage.match(/\b(acid|bludgeoning|cold|fire|force|lightning|necrotic|piercing|poison|psychic|radiant|slashing|thunder)\b/gi);
+    return types ? [...new Set(types.map(toTitleCase))].join(', ') : '';
+  }, []);
+
+  const makeRecent = useCallback((id) => {
+    setRecentAttackIds((prev) => [id, ...prev.filter((value) => value !== id)].slice(0, 5));
+  }, []);
+
+  const toggleAttackFavorite = useCallback((id) => {
+    setFavoriteAttackIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
 
   const diceFaceColor = useMemo(
     () => normalizeDiceColor(form?.diceColor) || DEFAULT_DICE_COLOR,
@@ -2493,6 +2538,34 @@ const damageAmountStyle = {
 };
 const isDamageRollSurfaceVisible = hasDamageRoll || isDiceRollPending;
 const isDamageRollResultVisible = hasDamageRoll && !isDiceRollPending;
+
+const attackArsenalItems = useMemo(() => {
+  const weaponItems = equippedWeapons.map(({ slot, weapon }) => {
+    const damageString = getDamageStringForHandSelection(slot, weapon) || 'Unknown';
+    const details = getWeaponPropertyDetails(weapon);
+    const mastery = getWeaponMasteryDetails(weapon);
+    const id = getWeaponAttackRollId(slot, weapon);
+    return { id, kind: isUnarmedAttack(weapon) ? 'unarmed' : 'weapon', category: isUnarmedAttack(weapon) ? 'unarmed' : 'weapons', name: getWeaponDisplayName(slot, weapon), source: getWeaponTypeLabel(weapon), actionType: 'Attack', range: weapon?.range || weapon?.normalRange || weapon?.longRange || (isRangedWeapon(weapon) ? 'Ranged' : '5 ft'), damageText: damageString, damageNode: getDamageString(slot, weapon), damageType: extractDamageTypeText(damageString), attackBonus: formatModifier(getAttackBonus(slot, weapon)), sortAccuracy: Number(getAttackBonus(slot, weapon)) || 0, sortDamage: parseInt((damageString.match(/\d+d(\d+)/i) || [])[1] || '0', 10), tags: [getWeaponTypeLabel(weapon), ...(isRangedWeapon(weapon) ? ['Ranged'] : ['Melee']), ...details.map(({ label }) => label), mastery?.label].filter(Boolean), properties: details, mastery, slot, weapon, canAttackRoll: true, canDamageRoll: true };
+  });
+  const breathItems = breathWeaponDetails ? [{ id: 'feature:breath-weapon', kind: 'feature', category: 'racial', name: breathWeaponDetails.label, source: 'Racial Ability', actionType: breathWeaponDetails.save ? `${breathWeaponDetails.save} Save` : 'Action', range: breathWeaponDetails.shape || 'Area', damageText: breathWeaponDetails.damageString, damageNode: formatDamageSegments(breathWeaponDetails.damageString), damageType: extractDamageTypeText(breathWeaponDetails.damageString), attackBonus: `DC ${breathWeaponDetails.saveDC}`, sortAccuracy: Number(breathWeaponDetails.saveDC) || 0, sortDamage: parseInt((breathWeaponDetails.damageString.match(/\d+d(\d+)/i) || [])[1] || '0', 10), tags: ['Breath', breathWeaponDetails.shape, breathWeaponDetails.save].filter(Boolean), properties: [], canDamageRoll: true }] : [];
+  const spellItems = [...(Array.isArray(form.spells) ? sortedSpells.filter((spell) => spell && spell.damage) : []), ...fiendishLegacySpells].map((spell, idx) => { const details = getSpellAttackDetails(spell); const levelNumber = Number(spell.level) || 0; const id = `${getSpellAttackRollId(spell)}:${idx}`; return { id, kind: levelNumber === 0 ? 'cantrip' : 'spell', category: levelNumber === 0 ? 'cantrips' : 'spells', name: spell.name || 'Spell', source: spell.casterType || spell.caster || (fiendishLegacySpells.includes(spell) ? 'Fiendish Legacy' : 'Spell'), actionType: spell.castingTime || 'Cast', range: spell.range || '—', damageText: spell.damage || 'Unknown', damageNode: formatDamageSegments(spell.damage || ''), damageType: extractDamageTypeText(spell.damage || ''), attackBonus: details ? formatModifier(details.total) : 'Save / Effect', sortAccuracy: details ? Number(details.total) || 0 : 0, sortDamage: parseInt(((spell.damage || '').match(/\d+d(\d+)/i) || [])[1] || '0', 10), spellLevel: levelNumber, school: spell.school, tags: [levelNumber === 0 ? 'Cantrip' : `Level ${levelNumber}`, spell.school, spell.duration, spell.components].filter(Boolean), spell, canAttackRoll: Boolean(details), canDamageRoll: true }; });
+  return [...weaponItems, ...breathItems, ...spellItems].map((item) => ({ ...item, icon: getAttackIcon(item), isFavorite: favoriteAttackIds.has(item.id), isRecent: recentAttackIds.includes(item.id) }));
+}, [equippedWeapons, breathWeaponDetails, form.spells, sortedSpells, fiendishLegacySpells, getAttackIcon, favoriteAttackIds, recentAttackIds, extractDamageTypeText, getSpellAttackDetails]);
+
+const visibleAttackItems = useMemo(() => {
+  const search = attackSearch.trim().toLowerCase();
+  const filters = Array.from(activeAttackFilters);
+  return attackArsenalItems.filter((item) => {
+    if (activeAttackCategory !== 'all' && item.category !== activeAttackCategory) return false;
+    if (search && !`${item.name} ${item.source} ${item.damageText} ${item.tags?.join(' ')}`.toLowerCase().includes(search)) return false;
+    return filters.every((filter) => filter === 'favorites' ? item.isFavorite : filter === 'equipped' ? ['weapon', 'unarmed'].includes(item.kind) : filter === 'weapons' ? ['weapon', 'unarmed'].includes(item.kind) : filter === 'spells' ? item.kind === 'spell' : filter === 'cantrips' ? item.kind === 'cantrip' : filter === 'melee' ? /melee|5 ft/i.test(`${item.range} ${item.tags?.join(' ')}`) : filter === 'ranged' ? /ranged|ft|mile/i.test(`${item.range} ${item.tags?.join(' ')}`) && !/5 ft$/.test(item.range) : filter === 'bonus' ? /bonus/i.test(item.actionType) : filter === 'reaction' ? /reaction/i.test(item.actionType) : true);
+  }).sort((a, b) => { if (a.isFavorite !== b.isFavorite) return a.isFavorite ? -1 : 1; if (a.isRecent !== b.isRecent) return a.isRecent ? -1 : 1; if (attackSort === 'damage') return b.sortDamage - a.sortDamage || a.name.localeCompare(b.name); if (attackSort === 'accuracy') return b.sortAccuracy - a.sortAccuracy || a.name.localeCompare(b.name); if (attackSort === 'spellLevel') return (a.spellLevel || 0) - (b.spellLevel || 0) || a.name.localeCompare(b.name); if (attackSort === 'weaponType') return (a.source || '').localeCompare(b.source || '') || a.name.localeCompare(b.name); return a.name.localeCompare(b.name); });
+}, [activeAttackCategory, activeAttackFilters, attackArsenalItems, attackSearch, attackSort]);
+
+const selectedAttack = useMemo(() => attackArsenalItems.find((item) => item.id === selectedAttackId) || null, [attackArsenalItems, selectedAttackId]);
+
+const runAttackRoll = useCallback((item) => { if (!item) return; makeRecent(item.id); if (item.kind === 'weapon' || item.kind === 'unarmed') handleWeaponAttackRoll(item.slot, item.weapon); else if (item.spell) handleSpellAttackRoll(item.spell); handleCloseAttack(); }, [handleSpellAttackRoll, makeRecent]);
+const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item.id); if (item.kind === 'weapon' || item.kind === 'unarmed') handleWeaponAttack(item.slot, item.weapon); else if (item.id === 'feature:breath-weapon') handleBreathWeaponAttack(); else if (item.spell) handleSpellsButtonClick(item.spell); handleCloseAttack(); }, [handleBreathWeaponAttack, handleSpellsButtonClick, makeRecent]);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div
@@ -2720,450 +2793,157 @@ const isDamageRollResultVisible = hasDamageRoll && !isDiceRollPending;
 {/* Attack Modal */}
 
       <Modal
-        size="lg"
-        className="dnd-modal modern-modal"
+        size="xl"
+        className="dnd-modal modern-modal combat-arsenal-modal"
         centered
         scrollable
         show={showAttack}
         onHide={handleCloseAttack}
       >
-        <Card className="modern-card">
-          <Card.Header className="modal-header">
-            <Card.Title className="modal-title">Attacks</Card.Title>
-          </Card.Header>
-          <Card.Body className="modal-body attack-modal__body">
-            <Card.Title className="modal-title">Weapons</Card.Title>
-            <div className="attack-card-grid">
-              {equippedWeapons.length === 0 ? (
-                <div className="attack-card attack-card--empty">
-                  <p className="text-muted mb-0">No weapons equipped.</p>
-                </div>
-              ) : (
-                equippedWeapons.map(({ slot, weapon }) => {
-                  const weaponTypeLabel = getWeaponTypeLabel(weapon);
-                  const propertyDetails = getWeaponPropertyDetails(weapon);
-                  const propertyLabels = propertyDetails.map(({ label }) => label);
-                  const popoverId = `weapon-properties-${slot}`;
-                  const masteryDetail = getWeaponMasteryDetails(weapon);
-                  const masteryPopoverId = `weapon-mastery-${slot}`;
-                  const propertiesDisplay =
-                    propertyLabels.length > 0
-                      ? propertyLabels.join(', ')
-                      : 'None';
-                  const versatileDice = getVersatileDamageDice(weapon);
-                  const isVersatile = Boolean(versatileDice);
-                  const weaponAttackRollId = getWeaponAttackRollId(slot, weapon);
-                  const weaponHasPendingCritical = Boolean(pendingCriticalAttack?.isCriticalHit && pendingCriticalAttack?.attackId === weaponAttackRollId);
-                  const handSelection = getHandSelectionForWeapon(slot, weapon);
-                  const oneHandedDamage = getDamageStringForHandSelection(
-                    slot,
-                    weapon,
-                    HAND_SELECTIONS.ONE_HANDED
-                  );
-                  const twoHandedDamage = isVersatile
-                    ? getDamageStringForHandSelection(
-                        slot,
-                        weapon,
-                        HAND_SELECTIONS.TWO_HANDED
-                      )
-                    : '';
-
-                  const propertiesPopover = (
-                    <Popover id={popoverId}>
-                      <Popover.Header as="h3">Weapon Properties</Popover.Header>
-                      <Popover.Body>
-                        {propertyDetails.map(({ label, description }) => (
-                          <div className="weapon-property" key={`${popoverId}-${label}`}>
-                            <div className="weapon-property__name">{label}</div>
-                            <div className="weapon-property__description">{description}</div>
-                          </div>
-                        ))}
-                      </Popover.Body>
-                    </Popover>
-                  );
-
-                  const masteryPopover = masteryDetail
-                    ? (
-                        <Popover id={masteryPopoverId}>
-                          <Popover.Header as="h3">Weapon Mastery</Popover.Header>
-                          <Popover.Body>
-                            <div className="weapon-mastery">
-                              <div className="weapon-mastery__name">{masteryDetail.label}</div>
-                              <div className="weapon-mastery__description">
-                                {masteryDetail.description}
-                              </div>
-                            </div>
-                          </Popover.Body>
-                        </Popover>
-                      )
-                    : null;
-
-                  return (
-                    <div
-                      className="attack-card"
-                      key={`${slot}-${weapon.name || slot}`}
-                    >
-                      <div className="attack-card__title text-capitalize">
-                        {weapon.name || 'Unknown'}
-                      </div>
-                      <div className="attack-card__meta">
-                        <div className="attack-card__meta-item">
-                          <span className="attack-card__meta-label">Weapon Type:</span>
-                          <span className="attack-card__meta-value">{weaponTypeLabel}</span>
-                        </div>
-                      </div>
-                      <div className="attack-card__details">
-                        <div className="attack-card__row">
-                          <span className="attack-card__label">Attack Bonus</span>
-                          <span className="attack-card__value">
-                            {getAttackBonus(slot, weapon)}
-                          </span>
-                        </div>
-                        {isFinesseWeapon(weapon) && (
-                          <div className="attack-card__row">
-                            <span className="attack-card__label">Ability</span>
-                            <span className="attack-card__value">
-                              <Form.Select
-                                id={`weapon-ability-${slot}`}
-                                aria-label={`Select ability for ${weapon.name || slot}`}
-                                value={getAbilityKeyForWeapon(slot, weapon)}
-                                onChange={(event) => {
-                                  const selected = event.target.value === 'dex' ? 'dex' : 'str';
-                                  setWeaponAbilitySelections((prev) => ({
-                                    ...prev,
-                                    [slot]: selected,
-                                  }));
-                                }}
-                                size="sm"
-                              >
-                                <option value="str">
-                                  Strength ({formatModifier(numericStrMod)})
-                                </option>
-                                <option value="dex">
-                                  Dexterity ({formatModifier(numericDexMod)})
-                                </option>
-                              </Form.Select>
-                            </span>
-                          </div>
-                        )}
-                        {isVersatile && (
-                          <div className="attack-card__row">
-                            <span className="attack-card__label">Grip</span>
-                            <span className="attack-card__value">
-                              <Form.Select
-                                id={`weapon-grip-${slot}`}
-                                aria-label={`Select grip for ${weapon.name || slot}`}
-                                value={handSelection}
-                                onChange={(event) => {
-                                  const selectedHand =
-                                    event.target.value === HAND_SELECTIONS.TWO_HANDED
-                                      ? HAND_SELECTIONS.TWO_HANDED
-                                      : HAND_SELECTIONS.ONE_HANDED;
-                                  setWeaponHandSelections((prev) => ({
-                                    ...prev,
-                                    [slot]: selectedHand,
-                                  }));
-                                }}
-                                size="sm"
-                              >
-                                <option value={HAND_SELECTIONS.ONE_HANDED}>
-                                  One-Handed ({oneHandedDamage || 'Unknown'})
-                                </option>
-                                <option value={HAND_SELECTIONS.TWO_HANDED}>
-                                  Two-Handed ({twoHandedDamage || 'Unknown'})
-                                </option>
-                              </Form.Select>
-                            </span>
-                          </div>
-                        )}
-                        <div className="attack-card__row">
-                          <span className="attack-card__label">Damage</span>
-                          <span className="attack-card__value">
-                            {getDamageString(slot, weapon)}
-                          </span>
-                        </div>
-                        <div className="attack-card__row attack-card__row--properties">
-                          <span className="attack-card__label">Properties</span>
-                          <span className="attack-card__value attack-card__properties">
-                            {propertiesDisplay}
-                            {propertyDetails.length > 0 && (
-                              <OverlayTrigger
-                                trigger="click"
-                                placement="auto"
-                                overlay={propertiesPopover}
-                                rootClose
-                              >
-                                <Button
-                                  type="button"
-                                  variant="link"
-                                  className="attack-card__properties-button"
-                                  aria-label="View weapon property descriptions"
-                                >
-                                  <i className="fa-solid fa-eye" aria-hidden="true"></i>
-                                </Button>
-                              </OverlayTrigger>
-                            )}
-                          </span>
-                        </div>
-                      </div>
-                      <div className="attack-card__actions">
-                        {masteryDetail && masteryPopover && (
-                          <OverlayTrigger
-                            trigger="click"
-                            placement="auto"
-                            overlay={masteryPopover}
-                            rootClose
-                          >
-                            <Button
-                              type="button"
-                              variant="link"
-                              className="attack-card__roll attack-card__mastery"
-                              aria-label={`View ${masteryDetail.label} mastery description`}
-                            >
-                              <i className="fa-solid fa-crown" aria-hidden="true"></i>
-                            </Button>
-                          </OverlayTrigger>
-                        )}
-                        <Button
-                          onClick={() => {
-                            handleWeaponAttackRoll(slot, weapon);
-                            handleCloseAttack();
-                          }}
-                          variant="link"
-                          aria-label="Roll to hit"
-                          className="attack-card__roll"
-                        >
-                          <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
-                        </Button>
-                        <Button
-                          onClick={() => {
-                            handleWeaponAttack(slot, weapon);
-                            handleCloseAttack();
-                          }}
-                          variant="link"
-                          aria-label={weaponHasPendingCritical ? 'Roll critical damage' : 'Roll damage'}
-                          title={weaponHasPendingCritical ? 'Roll Critical Damage' : 'Roll damage'}
-                          className={`attack-card__roll ${weaponHasPendingCritical ? 'critical-active' : ''}`}
-                        >
-                          <Swords size={18} aria-hidden="true" />
-                        </Button>
-                      </div>
-                    </div>
-                  );
-                })
-              )}
+        <Card className="modern-card combat-arsenal">
+          <Card.Header className="combat-arsenal__header">
+            <div>
+              <span className="combat-arsenal__eyebrow">Combat Arsenal</span>
+              <Card.Title className="combat-arsenal__title">Attacks</Card.Title>
+              <p className="combat-arsenal__subtitle">Choose, inspect, favorite, and roll without leaving the fight.</p>
             </div>
-            {breathWeaponDetails && (
-              <>
-                <Card.Title className="modal-title mt-4">Breath Attack</Card.Title>
-                <div className="attack-card-grid">
-                  <div className="attack-card">
-                    <div className="attack-card__title">
-                      {breathWeaponDetails.label}
-                    </div>
-                    <div className="attack-card__details">
-                      <div className="attack-card__row">
-                        <span className="attack-card__label">Save DC</span>
-                        <span className="attack-card__value">
-                          {breathWeaponDetails.saveDC}
-                        </span>
-                      </div>
-                      <div className="attack-card__row">
-                        <span className="attack-card__label">Damage</span>
-                        <span className="attack-card__value">
-                          {formatDamageSegments(breathWeaponDetails.damageString)}
-                        </span>
-                      </div>
-                      {(breathWeaponDetails.shape || breathWeaponDetails.save) && (
-                        <div className="attack-card__row">
-                          <span className="attack-card__label">Shape</span>
-                          <span className="attack-card__value">
-                            {breathWeaponDetails.shape}
-                            {breathWeaponDetails.shape && breathWeaponDetails.save
-                              ? ' • '
-                              : ''}
-                            {breathWeaponDetails.save
-                              ? `${breathWeaponDetails.save} Save`
-                              : ''}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                    <div className="attack-card__actions">
-                      <Button
-                        onClick={() => {
-                          handleBreathWeaponAttack();
-                          handleCloseAttack();
-                        }}
-                        variant="link"
-                        aria-label="Roll damage"
-                        className="attack-card__roll"
-                      >
-                        <i className="fa-solid fa-dice-d20"></i>
-                      </Button>
-                    </div>
-                  </div>
+            <div className="combat-arsenal__search-wrap">
+              <i className="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+              <input
+                className="combat-arsenal__search"
+                type="search"
+                value={attackSearch}
+                onChange={(event) => setAttackSearch(event.target.value)}
+                placeholder="Search attacks..."
+                aria-label="Search attacks"
+              />
+            </div>
+          </Card.Header>
+          <Card.Body className="combat-arsenal__body">
+            <div className="combat-arsenal__layout">
+              <aside className="combat-arsenal__sidebar" aria-label="Attack categories">
+                {[
+                  ['all', 'All Attacks', '✦'], ['weapons', 'Weapons', '⚔️'], ['spells', 'Spells', '🔮'],
+                  ['cantrips', 'Cantrips', '✨'], ['class', 'Class Abilities', '🌟'], ['racial', 'Racial Abilities', '🐉'],
+                  ['unarmed', 'Unarmed', '👊'], ['improvised', 'Improvised', '🪨'], ['magic-items', 'Magic Items', '💎'],
+                  ['favorites', 'Favorites', '⭐'],
+                ].map(([key, label, icon]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    className={`combat-category ${activeAttackCategory === key ? 'is-active' : ''}`}
+                    onClick={() => {
+                      setActiveAttackCategory(key);
+                      if (key === 'favorites') setActiveAttackFilters((prev) => new Set([...prev, 'favorites']));
+                    }}
+                  >
+                    <span>{icon}</span>{label}
+                  </button>
+                ))}
+              </aside>
+              <main className="combat-arsenal__main">
+                <div className="combat-arsenal__toolbar">
+                  <span>{visibleAttackItems.length} available actions</span>
+                  <Form.Select
+                    value={attackSort}
+                    onChange={(event) => setAttackSort(event.target.value)}
+                    aria-label="Sort attacks"
+                    size="sm"
+                  >
+                    <option value="favorites">Favorites / Recent</option>
+                    <option value="alpha">Alphabetical</option>
+                    <option value="damage">Highest Damage</option>
+                    <option value="accuracy">Most Accurate</option>
+                    <option value="spellLevel">Spell Level</option>
+                    <option value="weaponType">Weapon Type</option>
+                  </Form.Select>
                 </div>
-              </>
-            )}
-            {Array.isArray(form.spells) && form.spells.some((s) => s?.damage) && (
-              <>
-                <Card.Title className="modal-title mt-4">Spells</Card.Title>
-                <div className="attack-card-grid">
-                  {sortedSpells
-                    .filter((s) => s && s.damage)
-                    .map((spell, idx) => {
-                      const details = getSpellAttackDetails(spell);
-                      const showAttack = Boolean(details);
-                      const spellHasPendingCritical = Boolean(pendingCriticalAttack?.isCriticalHit && pendingCriticalAttack?.attackId === getSpellAttackRollId(spell));
-                      return (
-                        <div className="attack-card" key={idx}>
-                          <div className="attack-card__title">{spell.name}</div>
-                          <div className="attack-card__meta">
-                            <span>{spell.casterType || spell.caster || 'Unknown'}</span>
-                            <span>• Level {spell.level}</span>
-                          </div>
-                          <div className="attack-card__details">
-                            {showAttack && details && (
-                              <div className="attack-card__row">
-                                <span className="attack-card__label">Attack Bonus</span>
-                                <span className="attack-card__value">
-                                  {formatModifier(details.total)}
-                                </span>
-                              </div>
-                            )}
-                            <div className="attack-card__row">
-                              <span className="attack-card__label">Damage</span>
-                              <span className="attack-card__value">
-                                {formatDamageSegments(spell.damage)}
-                              </span>
-                            </div>
-                            <div className="attack-card__row">
-                              <span className="attack-card__label">Casting Time</span>
-                              <span className="attack-card__value">{spell.castingTime}</span>
-                            </div>
-                            <div className="attack-card__row">
-                              <span className="attack-card__label">Range</span>
-                              <span className="attack-card__value">{spell.range}</span>
-                            </div>
-                            <div className="attack-card__row">
-                              <span className="attack-card__label">Duration</span>
-                              <span className="attack-card__value">{spell.duration}</span>
-                            </div>
-                          </div>
-                          <div className="attack-card__actions">
-                            {showAttack && (
-                              <Button
-                                onClick={() => {
-                                  handleSpellAttackRoll(spell);
-                                  handleCloseAttack();
-                                }}
-                                variant="link"
-                                aria-label="Roll spell attack"
-                                className="attack-card__roll"
-                              >
-                                <i className="fa-solid fa-bullseye"></i>
-                              </Button>
-                            )}
-                            <Button
-                              onClick={() => {
-                                handleSpellsButtonClick(spell);
-                                handleCloseAttack();
-                              }}
-                              variant="link"
-                              aria-label={spellHasPendingCritical ? 'Roll critical damage' : 'Roll damage'}
-                              title={spellHasPendingCritical ? 'Roll Critical Damage' : 'Roll damage'}
-                              className={`attack-card__roll ${spellHasPendingCritical ? 'critical-active' : ''}`}
-                            >
-                              <i className="fa-solid fa-dice-d20"></i>
-                            </Button>
-                          </div>
-                        </div>
-                      );
-                    })}
-                </div>
-              </>
-            )}
-            {fiendishLegacySpells.length > 0 && (
-              <>
-                <Card.Title className="modal-title mt-4">Fiendish Legacy</Card.Title>
-                <div className="attack-card-grid">
-                  {fiendishLegacySpells.map((spell, idx) => {
-                    const details = getSpellAttackDetails(spell);
-                    const showAttack = Boolean(details);
+                <div className="attack-card-grid combat-attack-grid">
+                  {visibleAttackItems.length === 0 ? (
+                    <div className="attack-card attack-card--empty combat-action-card">No attacks match your filters.</div>
+                  ) : visibleAttackItems.map((item) => {
+                    const pendingId = item.kind === 'weapon' || item.kind === 'unarmed' ? getWeaponAttackRollId(item.slot, item.weapon) : item.spell ? getSpellAttackRollId(item.spell) : item.id;
+                    const hasPendingCritical = Boolean(pendingCriticalAttack?.isCriticalHit && pendingCriticalAttack?.attackId === pendingId);
                     return (
-                      <div className="attack-card" key={`fiendish-${idx}`}>
-                        <div className="attack-card__title">{spell.name}</div>
-                        <div className="attack-card__meta">
-                          <span>{spell.casterType || 'Fiendish Legacy'}</span>
-                          <span>• Level {spell.level}</span>
-                        </div>
-                        <div className="attack-card__details">
-                          {showAttack && details && (
-                            <div className="attack-card__row">
-                              <span className="attack-card__label">Attack Bonus</span>
-                              <span className="attack-card__value">
-                                {formatModifier(details.total)}
-                              </span>
-                            </div>
-                          )}
-                          <div className="attack-card__row">
-                            <span className="attack-card__label">Damage</span>
-                            <span className="attack-card__value">
-                              {formatDamageSegments(spell.damage)}
-                            </span>
-                          </div>
-                          <div className="attack-card__row">
-                            <span className="attack-card__label">Casting Time</span>
-                            <span className="attack-card__value">{spell.castingTime}</span>
-                          </div>
-                          <div className="attack-card__row">
-                            <span className="attack-card__label">Range</span>
-                            <span className="attack-card__value">{spell.range}</span>
-                          </div>
-                          <div className="attack-card__row">
-                            <span className="attack-card__label">Duration</span>
-                            <span className="attack-card__value">{spell.duration}</span>
+                      <article
+                        key={item.id}
+                        className={`attack-card combat-action-card combat-action-card--${item.kind} ${selectedAttack?.id === item.id ? 'is-selected' : ''} ${item.isFavorite ? 'is-favorite' : ''}`}
+                        onClick={() => setSelectedAttackId(item.id)}
+                      >
+                        <div className="combat-action-card__topline"><span>{item.source}</span><span>{item.actionType}</span></div>
+                        <div className="combat-action-card__hero">
+                          <div className="combat-action-card__icon" aria-hidden="true">{item.icon}</div>
+                          <div>
+                            <h3>{item.name}</h3>
+                            <p>{item.kind === 'spell' || item.kind === 'cantrip' ? item.school || 'Arcane attack' : item.damageType || 'Martial attack'}</p>
                           </div>
                         </div>
-                        <div className="attack-card__actions">
-                          {showAttack && (
-                            <Button
-                              onClick={() => {
-                                handleSpellAttackRoll(spell);
-                                handleCloseAttack();
-                              }}
-                              variant="link"
-                              aria-label="Roll spell attack"
-                              className="attack-card__roll"
-                            >
-                              <i className="fa-solid fa-bullseye"></i>
-                            </Button>
-                          )}
-                          <Button
-                            onClick={() => {
-                              handleSpellsButtonClick(spell);
-                              handleCloseAttack();
-                            }}
-                            variant="link"
-                            aria-label="Roll damage"
-                            className="attack-card__roll"
-                          >
-                            <i className="fa-solid fa-dice-d20"></i>
-                          </Button>
+                        <div className="combat-action-card__stats">
+                          <div><strong>{item.damageNode}</strong><span>Damage</span></div>
+                          <div><strong>{item.attackBonus}</strong><span>Hit / DC</span></div>
+                          <div><strong>{item.range}</strong><span>Range</span></div>
                         </div>
-                      </div>
+                        <div className="attack-card__details visually-hidden">
+                          <div className="attack-card__row"><span className="attack-card__label">{item.kind === 'feature' ? 'Save DC' : 'Attack Bonus'}</span><span className="attack-card__value">{item.kind === 'feature' ? String(item.attackBonus).replace(/^DC\s*/, '') : item.attackBonus}</span></div>
+                          {(item.kind === 'weapon' || item.kind === 'unarmed') && <div className="attack-card__meta-item"><span className="attack-card__meta-label">Weapon Type:</span><span className="attack-card__meta-value">{item.source}</span></div>}
+                        </div>
+                        <div className="combat-action-card__tags">
+                          {(item.tags || []).slice(0, 5).map((tag, tagIndex) => <span key={`${item.id}-${tag}-${tagIndex}`}>{tag}</span>)}
+                        </div>
+                        <div className="combat-action-card__actions" onClick={(event) => event.stopPropagation()}>
+                          <Button type="button" variant="link" className={`combat-icon-button ${item.isFavorite ? 'is-active' : ''}`} onClick={() => toggleAttackFavorite(item.id)} aria-label={`Favorite ${item.name}`}>⭐</Button>
+                          <Button type="button" variant="link" className="combat-icon-button" onClick={() => setSelectedAttackId(item.id)} aria-label={`Inspect ${item.name}`}>📖</Button>
+                          {item.canAttackRoll && <Button type="button" aria-label={item.spell ? 'Roll spell attack' : 'Roll to hit'} className="combat-roll-button combat-roll-button--attack" onClick={() => runAttackRoll(item)}>🎲 Roll Attack</Button>}
+                          {item.canDamageRoll && <Button type="button" aria-label={hasPendingCritical ? 'Roll critical damage' : 'Roll damage'} className={`combat-roll-button ${hasPendingCritical ? 'critical-active' : ''}`} onClick={() => runDamageRoll(item)}>💥 {hasPendingCritical ? 'Roll Critical' : 'Roll Damage'}</Button>}
+                        </div>
+                      </article>
                     );
                   })}
                 </div>
-              </>
-            )}
+              </main>
+              <aside className="combat-inspector" aria-live="polite">
+                {selectedAttack ? (
+                  <>
+                    <button
+                      type="button"
+                      className="combat-inspector__close"
+                      onClick={() => setSelectedAttackId('')}
+                      aria-label="Close attack preview"
+                    >
+                      <span aria-hidden="true">×</span>
+                    </button>
+                    <div className={`combat-inspector__art combat-inspector__art--${selectedAttack.kind}`}><span>{selectedAttack.icon}</span></div>
+                    <div className="combat-inspector__preview">
+                      <h3>{selectedAttack.name}</h3>
+                      <div><span>{selectedAttack.attackBonus}</span><small>to Hit / DC</small></div>
+                      <div><span>{selectedAttack.damageNode}</span><small>Damage</small></div>
+                      <div><span>{selectedAttack.range}</span><small>Reach</small></div>
+                    </div>
+                    <p className="combat-inspector__description">{selectedAttack.source} • {selectedAttack.actionType}{selectedAttack.damageType ? ` • ${selectedAttack.damageType}` : ''}</p>
+                    {(selectedAttack.kind === 'weapon' || selectedAttack.kind === 'unarmed') && isFinesseWeapon(selectedAttack.weapon) && (
+                      <Form.Select size="sm" value={getAbilityKeyForWeapon(selectedAttack.slot, selectedAttack.weapon)} onChange={(event) => setWeaponAbilitySelections((prev) => ({ ...prev, [selectedAttack.slot]: event.target.value === 'dex' ? 'dex' : 'str' }))} aria-label={`Select ability for ${selectedAttack.name}`}>
+                        <option value="str">Strength ({formatModifier(numericStrMod)})</option>
+                        <option value="dex">Dexterity ({formatModifier(numericDexMod)})</option>
+                      </Form.Select>
+                    )}
+                    <div className="combat-inspector__properties">
+                      {(selectedAttack.properties || []).map(({ label, description }) => <div key={`${selectedAttack.id}-${label}`}><strong>{label}</strong><span>{description}</span></div>)}
+                      {selectedAttack.mastery && <div><strong>Mastery: {selectedAttack.mastery.label}</strong><span>{selectedAttack.mastery.description}</span></div>}
+                      {(selectedAttack.tags || []).length === 0 && <div><strong>Properties</strong><span>No special properties listed.</span></div>}
+                    </div>
+                    <div className="combat-inspector__buttons">
+                      {selectedAttack.canAttackRoll && <Button type="button" aria-label={selectedAttack.spell ? 'Roll spell attack' : 'Roll to hit'} className="combat-roll-button combat-roll-button--attack" onClick={() => runAttackRoll(selectedAttack)}>🎲 Roll Attack</Button>}
+                      {selectedAttack.canDamageRoll && <Button type="button" aria-label="Roll damage" className="combat-roll-button" onClick={() => runDamageRoll(selectedAttack)}>💥 Roll Damage</Button>}
+                      <Button type="button" variant="link" className={`combat-favorite-button ${selectedAttack.isFavorite ? 'is-active' : ''}`} onClick={() => toggleAttackFavorite(selectedAttack.id)}>⭐ Favorite</Button>
+                    </div>
+                  </>
+                ) : <p className="text-muted">Select an attack to inspect its combat profile.</p>}
+              </aside>
+            </div>
           </Card.Body>
-            <Card.Footer className="modal-footer">
-              <Button className="close-btn" variant="secondary" onClick={handleCloseAttack}>
-                Close
-              </Button>
-            </Card.Footer>
+          <Card.Footer className="modal-footer combat-arsenal__footer">
+            <Button className="close-btn" variant="secondary" onClick={handleCloseAttack}>Close Arsenal</Button>
+          </Card.Footer>
         </Card>
       </Modal>
       <UpcastModal


### PR DESCRIPTION
### Motivation
- Introduce an integrated "Combat Arsenal" attack browser so players can search, inspect, favorite, and roll attacks without leaving the turn UI.
- Improve mobile and desktop ergonomics for attack selection with an inspector panel, independent column scrolling, and responsive modal sizing.

### Description
- Add comprehensive combat arsenal styling to `client/src/App.scss` including modal layout, responsive behavior, inspector, cards, filters, and scroll refinements for desktop and mobile.
- Replace the previous simple attack modal in `client/src/components/Zombies/attributes/PlayerTurnActions.js` with a full-featured arsenal UI and change the modal size/class to `size="xl"` and `className="... combat-arsenal-modal"`.
- Add state and behavior for searching, category selection, filters, sorting, favorites, and recent items, plus helpers `getAttackIcon`, `extractDamageTypeText`, `makeRecent`, `toggleAttackFavorite`, and computed lists `attackArsenalItems` and `visibleAttackItems` to drive the UI.
- Wire action buttons in the grid and inspector to existing handlers (`handleWeaponAttackRoll`, `handleWeaponAttack`, `handleSpellAttackRoll`, `handleSpellsButtonClick`, `handleBreathWeaponAttack`) and persist recent/favorite interactions in component state; remove unused UI imports (`OverlayTrigger`, `Popover`, `Swords`) and tidy unused state usage.

### Testing
- Performed a frontend build with `npm run build`, which completed successfully.
- Ran the frontend test suite with `npm test`, and unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a43537700832eaee7046a3e46df04)