### PR TITLE
Add Abilities Codex UI: searchable, filterable feature browser with inspector and favorites

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12612,3 +12612,355 @@ ul.spellbook-tabs.nav-tabs {
 .combat-inspector__close:hover, .combat-inspector__close:focus { border-color: rgba(215,180,106,.62); color: #ffe39a; outline: none; }
 @media (min-width: 1101px) { .combat-inspector__close { opacity: .74; } }
 @media (max-width: 1100px) { .combat-inspector__close { top: .6rem; right: .6rem; width: 42px; height: 42px; background: rgba(13,20,39,.92); } }
+
+/* Character Abilities Codex */
+.abilities-codex-body {
+  max-height: 78vh;
+  overflow: hidden;
+  padding: 0 !important;
+  background:
+    radial-gradient(circle at top left, rgba(83, 139, 255, 0.18), transparent 32rem),
+    radial-gradient(circle at bottom right, rgba(162, 91, 255, 0.16), transparent 34rem),
+    linear-gradient(135deg, rgba(5, 12, 28, 0.96), rgba(13, 18, 39, 0.94));
+}
+
+.abilities-codex-shell {
+  color: #edf6ff;
+  text-align: left;
+  padding: 1rem;
+}
+
+.abilities-codex-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  padding: 1rem;
+  border: 1px solid rgba(139, 190, 255, 0.18);
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(7, 19, 43, 0.94), rgba(22, 18, 50, 0.9));
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px);
+}
+
+.abilities-codex-kicker {
+  color: #8fc8ff;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.abilities-codex-title-row,
+.abilities-codex-controls,
+.abilities-codex-layout,
+.ability-card-title-block,
+.ability-card-tags,
+.ability-resource-strip,
+.ability-inspector-meta,
+.ability-inspector-actions {
+  display: flex;
+  gap: 0.85rem;
+}
+
+.abilities-codex-title-row {
+  align-items: end;
+  justify-content: space-between;
+  margin-top: 0.35rem;
+}
+
+.abilities-codex-title-row h2 {
+  margin: 0;
+  font-family: 'Cinzel', serif;
+  color: #fff7d6;
+  text-shadow: 0 0 20px rgba(105, 171, 255, 0.25);
+}
+
+.abilities-codex-title-row p {
+  margin: 0.25rem 0 0;
+  color: rgba(224, 238, 255, 0.74);
+  max-width: 44rem;
+}
+
+.abilities-codex-count {
+  min-width: 8rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 215, 128, 0.22);
+}
+
+.abilities-codex-count strong { display: block; color: #ffd982; font-size: 1.6rem; line-height: 1; }
+.abilities-codex-count span { color: rgba(255,255,255,.72); font-size: .78rem; }
+
+.abilities-codex-controls { margin-top: 1rem; }
+.abilities-codex-controls .form-control,
+.abilities-codex-controls .form-select {
+  min-height: 44px;
+  color: #f7fbff;
+  border-color: rgba(139, 190, 255, 0.26);
+  background-color: rgba(2, 11, 27, 0.72);
+}
+.abilities-codex-search { flex: 1 1 auto; }
+.abilities-codex-controls .form-select { flex: 0 0 13rem; }
+
+.abilities-codex-layout {
+  align-items: flex-start;
+  margin-top: 1rem;
+  overflow: auto;
+  max-height: calc(78vh - 11rem);
+}
+
+.abilities-codex-sidebar,
+.ability-inspector {
+  position: sticky;
+  top: 0;
+  flex: 0 0 13.5rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(139, 190, 255, 0.16);
+  border-radius: 1.1rem;
+  background: rgba(3, 13, 32, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+}
+
+.abilities-filter-pill {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  margin-bottom: .45rem;
+  padding: .65rem .75rem;
+  color: rgba(238,246,255,.82);
+  border: 1px solid transparent;
+  border-radius: .85rem;
+  background: rgba(255,255,255,.04);
+  transition: transform .18s ease, border-color .18s ease, background .18s ease;
+}
+.abilities-filter-pill:hover,
+.abilities-filter-pill:focus-visible,
+.abilities-filter-pill.is-active {
+  transform: translateX(2px);
+  border-color: rgba(126, 189, 255, .45);
+  background: linear-gradient(135deg, rgba(42, 105, 180, .32), rgba(108, 70, 180, .24));
+  outline: none;
+}
+
+.abilities-grid { flex: 1 1 auto; grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr)); align-items: stretch; }
+
+.feature-card.ability-card {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 14rem;
+  border-color: rgba(126, 189, 255, .2);
+  background: linear-gradient(145deg, rgba(9, 23, 50, .88), rgba(15, 18, 43, .78));
+  box-shadow: 0 14px 35px rgba(0,0,0,.28), inset 0 1px 0 rgba(255,255,255,.08);
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+  cursor: pointer;
+}
+.feature-card.ability-card:hover,
+.feature-card.ability-card:focus-visible,
+.feature-card.ability-card.is-selected {
+  transform: translateY(-3px);
+  border-color: rgba(255, 218, 137, .5);
+  box-shadow: 0 22px 48px rgba(0,0,0,.38), 0 0 0 1px rgba(139,190,255,.18), inset 0 0 38px rgba(91, 151, 255, .1);
+  outline: none;
+}
+.ability-card--signature { grid-column: span 2; }
+.ability-card-accent { position: absolute; inset: 0 auto 0 0; width: 5px; background: #7fc8ff; box-shadow: 0 0 24px #7fc8ff; }
+.ability-card--combat .ability-card-accent { background: #ff9a4f; box-shadow: 0 0 24px #ff7a45; }
+.ability-card--passive .ability-card-accent { background: #70b7ff; }
+.ability-card--racial .ability-card-accent { background: #65e6a5; }
+.ability-card--subclass .ability-card-accent { background: #ffd36a; }
+
+.ability-card-title-block { align-items: center; min-width: 0; }
+.ability-card-icon {
+  display: grid;
+  place-items: center;
+  flex: 0 0 3.15rem;
+  height: 3.15rem;
+  border-radius: 1rem;
+  font-size: 1.55rem;
+  background: radial-gradient(circle, rgba(255,255,255,.16), rgba(255,255,255,.04));
+  border: 1px solid rgba(255,255,255,.14);
+}
+.ability-card-tags { flex-wrap: wrap; margin-top: auto; }
+.ability-card-tags span,
+.ability-resource-strip span,
+.ability-inspector-meta span {
+  padding: .28rem .55rem;
+  border-radius: 999px;
+  font-size: .75rem;
+  color: rgba(238,246,255,.86);
+  background: rgba(255,255,255,.07);
+  border: 1px solid rgba(255,255,255,.1);
+}
+.ability-resource-strip { align-items: center; justify-content: space-between; margin-top: .25rem; }
+.ability-status-passive { color: #9fe6ff !important; }
+.ability-status-ready { color: #ffe09a !important; }
+.ability-favorite-btn { color: #ffd36a !important; }
+
+.ability-inspector { flex-basis: 18rem; color: rgba(238,246,255,.86); }
+.ability-inspector-art {
+  display: grid;
+  place-items: center;
+  height: 9rem;
+  margin-bottom: .85rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255,255,255,.12);
+  background: radial-gradient(circle at 50% 35%, rgba(130, 188, 255, .32), rgba(64, 38, 119, .24) 45%, rgba(2, 9, 24, .72));
+}
+.ability-inspector-art span { font-size: 3rem; filter: drop-shadow(0 0 24px rgba(143, 200, 255, .55)); }
+.ability-inspector h3 { margin: .25rem 0; color: #fff7d6; font-family: 'Cinzel', serif; }
+.ability-inspector-meta { flex-wrap: wrap; margin-bottom: .8rem; }
+.ability-inspector p { max-height: 11rem; overflow: auto; line-height: 1.5; color: rgba(238,246,255,.78); }
+.ability-inspector dl div { display: flex; justify-content: space-between; gap: 1rem; border-top: 1px solid rgba(255,255,255,.08); padding: .45rem 0; }
+.ability-inspector dt { color: #8fc8ff; }
+.ability-inspector dd { margin: 0; color: #fff7d6; text-transform: capitalize; }
+
+@media (max-width: 991px) {
+  .abilities-codex-body { max-height: 82vh; }
+  .abilities-codex-title-row,
+  .abilities-codex-controls,
+  .abilities-codex-layout { flex-direction: column; }
+  .abilities-codex-layout { max-height: calc(82vh - 13rem); }
+  .abilities-codex-sidebar,
+  .ability-inspector { position: static; flex: 1 1 auto; width: 100%; }
+  .abilities-codex-sidebar { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .45rem; }
+  .abilities-filter-pill { margin: 0; }
+  .abilities-codex-controls .form-select { flex-basis: auto; }
+  .ability-card--signature { grid-column: auto; }
+}
+
+@media (max-width: 575px) {
+  .abilities-codex-shell { padding: .65rem; }
+  .abilities-codex-toolbar { padding: .8rem; }
+  .abilities-codex-sidebar { grid-template-columns: 1fr; }
+  .abilities-grid { grid-template-columns: 1fr; }
+  .feature-card-header { flex-direction: column; }
+  .feature-card-actions { justify-content: flex-start; }
+  .ability-inspector { border-radius: 1.1rem 1.1rem 0 0; }
+}
+
+/* Character Abilities Codex refinements */
+.abilities-codex-body {
+  max-height: calc(100vh - 12rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-bottom: 1rem !important;
+}
+
+.abilities-codex-layout {
+  max-height: none;
+  overflow: visible;
+  align-items: stretch;
+}
+
+.abilities-grid {
+  justify-items: center;
+  align-content: start;
+}
+
+.feature-card.ability-card {
+  width: min(100%, 38rem);
+}
+
+.ability-card .feature-card-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+
+.ability-card .feature-card-name {
+  overflow-wrap: anywhere;
+  line-height: 1.22;
+}
+
+.ability-card .feature-card-meta {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.ability-card .feature-card-actions {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  padding-left: 4rem;
+  margin-top: -0.25rem;
+}
+
+.ability-card .feature-card-actions .btn {
+  min-width: 2.45rem;
+  min-height: 2.45rem;
+}
+
+.abilities-codex-footer {
+  justify-content: flex-end !important;
+  padding: 0.85rem 1.5rem !important;
+}
+
+.abilities-codex-footer .close-btn {
+  width: auto !important;
+  min-width: 8.5rem;
+  margin-left: auto;
+  padding-inline: 1.75rem;
+}
+
+@media (max-width: 991px) {
+  .abilities-codex-body {
+    max-height: calc(100vh - 11rem);
+  }
+
+  .abilities-codex-layout {
+    max-height: none;
+    overflow: visible;
+  }
+
+  .feature-card.ability-card {
+    width: min(100%, 36rem);
+  }
+}
+
+@media (max-width: 575px) {
+  .abilities-codex-body {
+    max-height: calc(100vh - 10rem);
+  }
+
+  .abilities-codex-shell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .abilities-codex-toolbar,
+  .abilities-codex-layout,
+  .abilities-grid,
+  .abilities-codex-sidebar,
+  .ability-inspector {
+    width: 100%;
+  }
+
+  .abilities-grid {
+    justify-items: center;
+    padding-inline: 0.25rem;
+  }
+
+  .feature-card.ability-card {
+    width: min(100%, 32rem);
+    margin-inline: auto;
+  }
+
+  .ability-card .feature-card-actions {
+    justify-content: center;
+    padding-left: 0;
+    margin-top: 0.15rem;
+  }
+
+  .abilities-codex-footer {
+    justify-content: flex-end !important;
+  }
+
+  .abilities-codex-footer .close-btn {
+    min-width: 7.5rem;
+  }
+}

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
-import { Modal, Card, Button, Spinner, Form } from 'react-bootstrap';
+import { Modal, Card, Button, Spinner, Form, Badge } from 'react-bootstrap';
 import apiFetch from '../../../utils/apiFetch';
 import FeatureModal from './FeatureModal';
 import UpcastModal from './UpcastModal';
@@ -155,6 +155,12 @@ export default function Features({
   const [showUpcast, setShowUpcast] = useState(false);
   const [pendingSpell, setPendingSpell] = useState(null);
   const [weaponData, setWeaponData] = useState({});
+  const [abilitySearch, setAbilitySearch] = useState('');
+  const [activeAbilityFilter, setActiveAbilityFilter] = useState('all');
+  const [abilitySort, setAbilitySort] = useState('class');
+  const [selectedAbilityKey, setSelectedAbilityKey] = useState(null);
+  const [favoriteAbilityKeys, setFavoriteAbilityKeys] = useState(() => new Set());
+  const [recentAbilityKeys, setRecentAbilityKeys] = useState([]);
   const hasInitializedRestRef = useRef(false);
   const speakWithAnimalsUsesRef = useRef(speakWithAnimalsUses);
   const lineageSpellUsesRef = useRef(lineageSpellUses);
@@ -1622,6 +1628,108 @@ export default function Features({
     return classes.join(' ');
   }, [isDocked]);
 
+
+  const abilityCodexItems = useMemo(() => {
+    const signatureNames = new Set([
+      'rage', 'action surge', 'second wind', 'lay on hands', 'wild shape',
+      'channel divinity', 'ki', 'sorcery points', 'sneak attack',
+      'reckless attack', 'adrenaline rush', 'large form', 'draconic flight'
+    ]);
+
+    const normalize = (value) => String(value || '').toLowerCase();
+    const inferType = (feat) => {
+      const text = `${feat?.name || ''} ${feat?.meta || ''} ${feat?.description || feat?.desc || ''} ${feat?.type || ''}`.toLowerCase();
+      if (feat?.subclass || text.includes('subclass')) return 'subclass';
+      if (feat?.id?.includes('race') || ['dwarf', 'orc', 'elf', 'gnome', 'tiefling', 'dragonborn', 'goliath', 'halfling'].some((race) => feat?.id?.startsWith(race) || normalize(feat?.meta).includes(race))) return 'racial';
+      if (feat?.hideUseButton || feat?.type === 'passive' || /advantage|resistance|proficiency|increases|you know|always/.test(text)) return 'passive';
+      if (/reaction|bonus action|action|attack|combat|surge|rage|dash|cast/.test(text)) return 'combat';
+      return 'utility';
+    };
+    const inferAction = (feat) => {
+      const text = `${feat?.name || ''} ${feat?.description || feat?.desc || ''}`.toLowerCase();
+      if (text.includes('reaction')) return 'Reaction';
+      if (text.includes('bonus action')) return 'Bonus Action';
+      if (text.includes('action')) return 'Action';
+      return feat?.hideUseButton || feat?.type === 'passive' ? 'Passive' : 'Active';
+    };
+    const inferRecharge = (feat) => {
+      const text = `${feat?.description || feat?.desc || ''} ${feat?.meta || ''}`.toLowerCase();
+      if (text.includes('short rest')) return 'Short Rest';
+      if (text.includes('long rest')) return 'Long Rest';
+      if (feat?.hideUseButton || feat?.type === 'passive') return 'Always Active';
+      return 'At Will';
+    };
+    const getUses = (feat) => {
+      if (feat?.name?.includes('Action Surge')) return surgeUsed ? 'Spent' : 'Ready';
+      if (feat?.id === 'orc-adrenaline-rush') return `${adrenalineRushUses} / ${adrenalineRushMaxUses}`;
+      if (feat?.id === 'gnome-forest-speak-with-animals') return `${speakWithAnimalsUses} / ${speakWithAnimalsMaxUses}`;
+      if (LIMITED_USE_LINEAGE_SPELL_IDS_SET.has(feat?.id)) return `${lineageSpellUses[feat.id] ?? 0} / ${LINEAGE_SPELLS[feat.id]?.maxUses ?? 1}`;
+      if (feat?.id === 'goliath-large-form') return largeFormUsed ? 'Spent' : 'Ready';
+      if (feat?.id === 'dragonborn-draconic-flight') return draconicFlightUsed ? 'Spent' : 'Ready';
+      if (feat?.isWeaponMasteryConfig) return `${displayedWeaponMasteryState.selections.length} / ${displayedWeaponMasteryState.count}`;
+      return feat?.hideUseButton || feat?.type === 'passive' ? 'Always On' : 'Available';
+    };
+
+    return displayFeatures.map((feat, idx) => {
+      const key = feat.id || `${feat.name}-${idx}`;
+      const type = inferType(feat);
+      const source = feat.class || (feat.meta ? String(feat.meta).split('•')[0].trim() : 'Character');
+      const name = feat.name || 'Feature';
+      const searchText = `${name} ${source} ${feat.meta || ''} ${feat.description || feat.desc || ''} ${type}`.toLowerCase();
+      const isFavorite = favoriteAbilityKeys.has(key);
+      const recentlyUsedIndex = recentAbilityKeys.indexOf(key);
+      return {
+        feat, key, idx, type, source, name, searchText, isFavorite,
+        recentlyUsedIndex,
+        actionType: inferAction(feat),
+        recharge: inferRecharge(feat),
+        usesLabel: getUses(feat),
+        isSignature: signatureNames.has(name.toLowerCase().replace(/ \(.*\)$/, '')),
+        icon: type === 'combat' ? '⚔️' : type === 'passive' ? '🛡️' : type === 'racial' ? '🍃' : type === 'subclass' ? '✦' : '✧',
+      };
+    });
+  }, [displayFeatures, favoriteAbilityKeys, recentAbilityKeys, surgeUsed, adrenalineRushUses, adrenalineRushMaxUses, speakWithAnimalsUses, speakWithAnimalsMaxUses, lineageSpellUses, largeFormUsed, draconicFlightUsed, displayedWeaponMasteryState]);
+
+  const visibleAbilityItems = useMemo(() => {
+    const query = abilitySearch.trim().toLowerCase();
+    const filtered = abilityCodexItems.filter((item) => {
+      const matchesSearch = !query || item.searchText.includes(query);
+      const matchesFilter = activeAbilityFilter === 'all' ||
+        (activeAbilityFilter === 'active' && item.actionType !== 'Passive') ||
+        (activeAbilityFilter === 'passive' && item.actionType === 'Passive') ||
+        (activeAbilityFilter === 'favorites' && item.isFavorite) ||
+        (activeAbilityFilter === 'recent' && item.recentlyUsedIndex !== -1) ||
+        (activeAbilityFilter === 'class' && Boolean(item.feat.class)) ||
+        item.type === activeAbilityFilter;
+      return matchesSearch && matchesFilter;
+    });
+    return [...filtered].sort((a, b) => {
+      if (abilitySort === 'alphabetical') return a.name.localeCompare(b.name);
+      if (abilitySort === 'level') return (a.feat.level || 0) - (b.feat.level || 0) || a.name.localeCompare(b.name);
+      if (abilitySort === 'favorites') return Number(b.isFavorite) - Number(a.isFavorite) || a.name.localeCompare(b.name);
+      if (abilitySort === 'combat') return Number(b.type === 'combat') - Number(a.type === 'combat') || a.name.localeCompare(b.name);
+      if (abilitySort === 'recent') return (a.recentlyUsedIndex === -1 ? 999 : a.recentlyUsedIndex) - (b.recentlyUsedIndex === -1 ? 999 : b.recentlyUsedIndex);
+      return a.source.localeCompare(b.source) || (a.feat.level || 0) - (b.feat.level || 0) || a.name.localeCompare(b.name);
+    });
+  }, [abilityCodexItems, abilitySearch, activeAbilityFilter, abilitySort]);
+
+  const selectedAbility = useMemo(() => {
+    return abilityCodexItems.find((item) => item.key === selectedAbilityKey) || null;
+  }, [abilityCodexItems, selectedAbilityKey]);
+
+  const toggleFavorite = useCallback((key) => {
+    setFavoriteAbilityKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const markRecentlyUsed = useCallback((key) => {
+    setRecentAbilityKeys((prev) => [key, ...prev.filter((item) => item !== key)].slice(0, 8));
+  }, []);
+
   const handleModalHide = useCallback(() => {
     if (isDocked) {
       if (typeof onDockClose === 'function') {
@@ -1639,7 +1747,7 @@ export default function Features({
         className={modalClassName}
         show={showFeatures}
         onHide={handleModalHide}
-        size="lg"
+        size="xl"
         centered={!isDocked}
         backdrop={isDocked ? false : true}
         enforceFocus={!isDocked}
@@ -1654,9 +1762,9 @@ export default function Features({
                 onDockChange={onDockChange}
                 isDocked={isDocked}
               />
-              <Card.Title className="modal-title">Features</Card.Title>
+              <Card.Title className="modal-title">Character Features</Card.Title>
             </Card.Header>
-            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
+            <Card.Body className="abilities-codex-body">
               {error && (
                 <div className="text-danger mb-2">{error}</div>
               )}
@@ -1664,10 +1772,60 @@ export default function Features({
                 <div className="d-flex justify-content-center py-4">
                   <Spinner animation="border" role="status" />
                 </div>
-              ) : displayFeatures.length > 0 ? (
-                <div className="feature-card-grid">
-                  {displayFeatures.map((feat, idx) => {
-                    const featKey = feat.id || `${feat.name}-${idx}`;
+              ) : abilityCodexItems.length > 0 ? (
+                <div className="abilities-codex-shell">
+                  <div className="abilities-codex-toolbar">
+                    <div className="abilities-codex-kicker">Hero Ability Codex</div>
+                    <div className="abilities-codex-title-row">
+                      <div>
+                        <h2>Character Features</h2>
+                        <p>Scan active powers, passive traits, class resources, and lineage gifts without losing any rules detail.</p>
+                      </div>
+                      <div className="abilities-codex-count" aria-label={`${visibleAbilityItems.length} abilities shown out of ${abilityCodexItems.length}`}>
+                        <strong>{visibleAbilityItems.length}</strong>
+                        <span>/ {abilityCodexItems.length} Abilities</span>
+                      </div>
+                    </div>
+                    <div className="abilities-codex-controls">
+                      <Form.Control
+                        aria-label="Search character abilities"
+                        className="abilities-codex-search"
+                        placeholder="Search abilities, class, type, or rules text..."
+                        value={abilitySearch}
+                        onChange={(event) => setAbilitySearch(event.target.value)}
+                      />
+                      <Form.Select aria-label="Sort abilities" value={abilitySort} onChange={(event) => setAbilitySort(event.target.value)}>
+                        <option value="class">Class</option>
+                        <option value="level">Level</option>
+                        <option value="recent">Recently Used</option>
+                        <option value="alphabetical">Alphabetical</option>
+                        <option value="favorites">Favorites</option>
+                        <option value="combat">Combat</option>
+                      </Form.Select>
+                    </div>
+                  </div>
+                  <div className="abilities-codex-layout">
+                    <aside className="abilities-codex-sidebar" aria-label="Ability filters">
+                      {[
+                        ['all', 'All Features'], ['combat', 'Combat'], ['passive', 'Passive'], ['active', 'Active'],
+                        ['utility', 'Utility'], ['class', 'Class Features'], ['racial', 'Racial Features'],
+                        ['subclass', 'Subclass Features'], ['recent', 'Recently Used'], ['favorites', 'Favorites'],
+                      ].map(([filter, label]) => (
+                        <button
+                          type="button"
+                          key={filter}
+                          className={`abilities-filter-pill ${activeAbilityFilter === filter ? 'is-active' : ''}`}
+                          onClick={() => setActiveAbilityFilter(filter)}
+                        >
+                          <span>{label}</span>
+                          <Badge bg="dark">{filter === 'all' ? abilityCodexItems.length : abilityCodexItems.filter((item) => filter === 'active' ? item.actionType !== 'Passive' : filter === 'favorites' ? item.isFavorite : filter === 'recent' ? item.recentlyUsedIndex !== -1 : filter === 'class' ? Boolean(item.feat.class) : item.type === filter).length}</Badge>
+                        </button>
+                      ))}
+                    </aside>
+                    <div className="feature-card-grid abilities-grid">
+                  {visibleAbilityItems.map((item, idx) => {
+                    const feat = item.feat;
+                    const featKey = item.key;
                     const isActionSurge = feat.name?.includes('Action Surge');
                     const isLargeForm = feat.id === 'goliath-large-form';
                     const isDraconicFlight =
@@ -1707,9 +1865,12 @@ export default function Features({
                     const isTieflingLineageSpell =
                       isLineageSpell && feat.id?.startsWith('tiefling-');
                     return (
-                      <div className="feature-card" key={featKey}>
+                      <div className={`feature-card ability-card ability-card--${item.type} ${item.isSignature ? 'ability-card--signature' : ''} ${selectedAbility?.key === featKey ? 'is-selected' : ''}`} key={featKey} role="button" tabIndex={0} onClick={(event) => { if (!event.target.closest('button, input, select, a')) setSelectedAbilityKey(featKey); }} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') setSelectedAbilityKey(featKey); }}>
+                        <div className="ability-card-accent" aria-hidden="true" />
                         <div className="feature-card-header">
-                          <div>
+                          <div className="ability-card-title-block">
+                            <div className="ability-card-icon" aria-hidden="true">{item.icon}</div>
+                            <div>
                             <div className="feature-card-name">{feat.name}</div>
                             <div className="feature-card-meta">
                               {feat.meta ? (
@@ -1727,6 +1888,7 @@ export default function Features({
                               )}
                             </div>
                           </div>
+                          </div>
                           <div className="feature-card-actions">
                             {isActionSurge ? (
                               <Button
@@ -1737,6 +1899,7 @@ export default function Features({
                                   if (!surgeUsed) {
                                     onActionSurge?.();
                                     setSurgeUsed(true);
+                                    markRecentlyUsed(featKey);
                                   }
                                 }}
                                 disabled={surgeUsed}
@@ -1758,6 +1921,7 @@ export default function Features({
                                 onClick={() => {
                                   if (adrenalineRushUses > 0) {
                                     onAdrenalineRush?.();
+                                    markRecentlyUsed(featKey);
                                     setAdrenalineRushUses((prev) =>
                                       Math.max(0, prev - 1)
                                     );
@@ -1781,6 +1945,7 @@ export default function Features({
                                   if (!largeFormUsed) {
                                     onLargeForm?.();
                                     setLargeFormUsed(true);
+                                    markRecentlyUsed(featKey);
                                   }
                                 }}
                                 disabled={largeFormUsed}
@@ -1803,6 +1968,7 @@ export default function Features({
                                   if (!draconicFlightUsed) {
                                     onDraconicFlight?.();
                                     setDraconicFlightUsed(true);
+                                    markRecentlyUsed(featKey);
                                   }
                                 }}
                                 disabled={draconicFlightUsed}
@@ -2021,16 +2187,26 @@ export default function Features({
                                 <span className={`combat-hud-resource-tile__icon ${form?.classState?.barbarian?.recklessAttack?.active ? 'opacity-100' : 'opacity-50'}`}><Swords size={36} /></span>
                               </Button>
                             ) : !feat.hideUseButton ? (
-                              <Button aria-label="use feature" variant="outline-light" size="sm">
+                              <Button aria-label="use feature" variant="outline-light" size="sm" onClick={() => markRecentlyUsed(featKey)}>
                                 Use
                               </Button>
                             ) : null}
+                            <Button
+                              aria-label={item.isFavorite ? "remove favorite" : "favorite feature"}
+                              variant="link"
+                              size="sm"
+                              className="view-link-btn ability-favorite-btn"
+                              onClick={(event) => { event.stopPropagation(); toggleFavorite(featKey); }}
+                            >
+                              <i className={`${item.isFavorite ? 'fa-solid' : 'fa-regular'} fa-star`}></i>
+                            </Button>
                             <Button
                               aria-label="view feature"
                               variant="link"
                               size="sm"
                               className="view-link-btn"
-                              onClick={() => {
+                              onClick={(event) => {
+                                event.stopPropagation();
                                 setModalFeature(
                                   isWeaponMasteryConfig
                                     ? { ...feat, renderDetails: renderWeaponMasteryDetails }
@@ -2042,6 +2218,14 @@ export default function Features({
                               <i className="fa-solid fa-eye"></i>
                             </Button>
                           </div>
+                        </div>
+                        <div className="ability-card-tags">
+                          <span>{item.actionType}</span>
+                          <span>{item.recharge}</span>
+                        </div>
+                        <div className="ability-resource-strip">
+                          <span>{item.usesLabel}</span>
+                          <span className={item.actionType === 'Passive' ? 'ability-status-passive' : 'ability-status-ready'}>{item.actionType === 'Passive' ? 'Always Active' : 'Can Activate'}</span>
                         </div>
                         {isWeaponMasteryConfig && (
                           <div className="feature-card-uses text-muted small mt-2">
@@ -2072,11 +2256,39 @@ export default function Features({
                     );
                   })}
                 </div>
+                    <aside className="ability-inspector" aria-label="Selected ability inspector">
+                      {selectedAbility && (
+                        <>
+                          <div className={`ability-inspector-art ability-inspector-art--${selectedAbility.type}`}>
+                            <span>{selectedAbility.icon}</span>
+                          </div>
+                          <div className="abilities-codex-kicker">Ability Inspector</div>
+                          <h3>{selectedAbility.name}</h3>
+                          <div className="ability-inspector-meta">
+                            <span>{selectedAbility.source}</span>
+                            {selectedAbility.feat.level != null && <span>Level {selectedAbility.feat.level}</span>}
+                            <span>{selectedAbility.actionType}</span>
+                          </div>
+                          <p>{selectedAbility.feat.description || selectedAbility.feat.desc || 'No description available.'}</p>
+                          <dl>
+                            <div><dt>Uses</dt><dd>{selectedAbility.usesLabel}</dd></div>
+                            <div><dt>Recharge</dt><dd>{selectedAbility.recharge}</dd></div>
+                            <div><dt>Type</dt><dd>{selectedAbility.type}</dd></div>
+                          </dl>
+                          <div className="ability-inspector-actions">
+                            <Button size="sm" variant="outline-light" onClick={() => toggleFavorite(selectedAbility.key)}>{selectedAbility.isFavorite ? 'Unfavorite' : 'Favorite'}</Button>
+                            <Button size="sm" className="action-btn" onClick={() => { setModalFeature(selectedAbility.feat.isWeaponMasteryConfig ? { ...selectedAbility.feat, renderDetails: renderWeaponMasteryDetails } : selectedAbility.feat); setShowModal(true); }}>Details</Button>
+                          </div>
+                        </>
+                      )}
+                    </aside>
+                  </div>
+                </div>
               ) : !error ? (
                 <div className="text-center text-muted">No features found</div>
               ) : null}
             </Card.Body>
-            <Card.Footer className="modal-footer">
+            <Card.Footer className="modal-footer abilities-codex-footer">
               <Button
                 className="action-btn close-btn"
                 onClick={handleModalHide}


### PR DESCRIPTION
### Motivation
- Replace the flat features list with an interactive Abilities Codex to make character features easier to scan, filter, and inspect while preserving rules detail.
- Surface usage state (limited uses, class resources, toggles) and provide quick actions such as Use, View, Favorite, and mark-as-recent for better UX during play.

### Description
- Added a large set of styles for the Abilities Codex in `client/src/App.scss` under the `.abilities-codex-*`, `.ability-card-*`, and `.ability-inspector-*` classes to style toolbar, grid, sidebar filters, cards, and the inspector panel. 
- Reworked `client/src/components/Zombies/attributes/Features.js` to implement the codex UI by importing `Badge`, adding new state (`abilitySearch`, `activeAbilityFilter`, `abilitySort`, `selectedAbilityKey`, `favoriteAbilityKeys`, `recentAbilityKeys`), and deriving `abilityCodexItems` and `visibleAbilityItems` via `useMemo` with heuristics to infer type/action/recharge/uses. 
- Updated the modal to `size="xl"`, renamed the modal title to `Character Features`, and replaced the previous feature grid with a toolbar (search + sort), a filter sidebar, an abilities grid with richer cards (icons, tags, resource strip, favorite button), and a right-side inspector that shows details for the selected ability. 
- Added interaction helpers: `toggleFavorite`, `markRecentlyUsed`, and integrated recent/favorite marking when abilities are used or inspected, and preserved special-case handling for action surge, large form, draconic flight, adrenaline rush, lineage spells, and weapon mastery UI integration. 

### Testing
- Ran the frontend linting with `npm run lint` in the client and it completed successfully. 
- Executed the client unit test suite with `npm test` and all tests passed. 
- Built the client bundle with `npm run build` to validate the new styles and UI changes and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a6352f730832e9dbd6e9c3aa52294)