### PR TITLE
Add mobile close control to Character Features modal

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13283,3 +13283,57 @@ ul.spellbook-tabs.nav-tabs {
     z-index: 5;
   }
 }
+
+/* Keep a close affordance visible in the Character Features modal header on small screens. */
+.abilities-codex-card .modal-header {
+  padding-right: 128px !important;
+}
+
+.abilities-codex-card .dock-control--right {
+  right: 72px;
+}
+
+.abilities-modal-close.btn {
+  position: absolute;
+  right: 18px;
+  top: 0.75rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border-color: var(--realm-border-strong);
+  background: rgba(9, 18, 34, .82);
+  color: var(--realm-text);
+  font-size: 1.6rem;
+  line-height: 1;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, .35);
+  z-index: 11;
+}
+
+.abilities-modal-close.btn:hover,
+.abilities-modal-close.btn:focus-visible {
+  background: rgba(34, 52, 86, .96);
+  color: #fff;
+}
+
+@media (max-width: 575px) {
+  .abilities-codex-card .modal-header {
+    padding-left: 64px !important;
+    padding-right: 116px !important;
+  }
+
+  .abilities-codex-card .dock-control--left {
+    left: 12px;
+  }
+
+  .abilities-codex-card .dock-control--right {
+    right: 64px;
+  }
+
+  .abilities-modal-close.btn {
+    right: 12px;
+  }
+}

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1763,6 +1763,16 @@ export default function Features({
                 isDocked={isDocked}
               />
               <Card.Title className="modal-title">Character Features</Card.Title>
+              <Button
+                type="button"
+                variant="outline-light"
+                className="abilities-modal-close"
+                aria-label="Close character features"
+                title="Close character features"
+                onClick={handleModalHide}
+              >
+                <span aria-hidden="true">×</span>
+              </Button>
             </Card.Header>
             <Card.Body className="abilities-codex-body">
               {error && (


### PR DESCRIPTION
### Motivation
- Ensure mobile users have a persistent, visible close affordance for the Character Features modal where the default close control was not easily reachable on small screens.
- Prevent the new close affordance from overlapping the existing docking controls when the modal is displayed in narrow viewports.

### Description
- Add a header close `Button` to the Character Features modal and wire it to the existing `handleModalHide` handler in `client/src/components/Zombies/attributes/Features.js`.
- Add scoped styles to `client/src/App.scss` to reserve header space and position the new `.abilities-modal-close` button, and adjust `.dock-control--right` and related mobile paddings to avoid overlap.
- Keep existing modal behavior intact by reusing the existing close handler and docking controls rather than changing modal wiring.

### Testing
- Ran the component unit tests with `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js`, and the suite passed (`Tests: 59 passed, 59 total`).
- Built a production bundle with `npm --prefix client run build`, which completed successfully though the output included pre-existing lint and autoprefixer warnings; the build finished and produced the `build/` artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a8009d0bc832ebe767b7fc0a9e7dd)