### PR TITLE
Align Character Features modal close control

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13284,56 +13284,12 @@ ul.spellbook-tabs.nav-tabs {
   }
 }
 
-/* Keep a close affordance visible in the Character Features modal header on small screens. */
-.abilities-codex-card .modal-header {
-  padding-right: 128px !important;
-}
-
-.abilities-codex-card .dock-control--right {
-  right: 72px;
-}
-
-.abilities-modal-close.btn {
-  position: absolute;
-  right: 18px;
-  top: 0.75rem;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 12px;
-  border-color: var(--realm-border-strong);
-  background: rgba(9, 18, 34, .82);
-  color: var(--realm-text);
-  font-size: 1.6rem;
-  line-height: 1;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, .35);
-  z-index: 11;
-}
-
-.abilities-modal-close.btn:hover,
-.abilities-modal-close.btn:focus-visible {
-  background: rgba(34, 52, 86, .96);
-  color: #fff;
-}
-
 @media (max-width: 575px) {
   .abilities-codex-card .modal-header {
     padding-left: 64px !important;
-    padding-right: 116px !important;
   }
 
   .abilities-codex-card .dock-control--left {
     left: 12px;
-  }
-
-  .abilities-codex-card .dock-control--right {
-    right: 64px;
-  }
-
-  .abilities-modal-close.btn {
-    right: 12px;
   }
 }

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1763,16 +1763,6 @@ export default function Features({
                 isDocked={isDocked}
               />
               <Card.Title className="modal-title">Character Features</Card.Title>
-              <Button
-                type="button"
-                variant="outline-light"
-                className="abilities-modal-close"
-                aria-label="Close character features"
-                title="Close character features"
-                onClick={handleModalHide}
-              >
-                <span aria-hidden="true">×</span>
-              </Button>
             </Card.Header>
             <Card.Body className="abilities-codex-body">
               {error && (
@@ -2300,7 +2290,7 @@ export default function Features({
             </Card.Body>
             <Card.Footer className="modal-footer abilities-codex-footer">
               <Button
-                className="action-btn close-btn abilities-codex-close-button"
+                className="spellbook-modal-close-btn"
                 onClick={handleModalHide}
               >
                 Close

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -76,6 +76,30 @@ test('renders features and opens modal with description', async () => {
   ).toBeInTheDocument();
 });
 
+test('uses the spellbook-style footer close button without a header close icon', async () => {
+  const handleCloseFeatures = jest.fn();
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  render(
+    <Features
+      form={{ occupation: [{ Name: 'Fighter', Level: 1 }] }}
+      showFeatures={true}
+      handleCloseFeatures={handleCloseFeatures}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const closeButton = await screen.findByRole('button', { name: 'Close' });
+  expect(closeButton).toHaveClass('spellbook-modal-close-btn');
+  expect(screen.queryByRole('button', { name: /close character features/i })).not.toBeInTheDocument();
+
+  await userEvent.click(closeButton);
+  expect(handleCloseFeatures).toHaveBeenCalledTimes(1);
+});
+
 test('dragonborn always has damage resistance and gains draconic flight at level 5', async () => {
   apiFetch.mockResolvedValue({
     ok: true,


### PR DESCRIPTION
### Motivation
- Make the Character Features modal use the same footer-styled `Close` control as the Spells modal and remove the redundant header close icon to provide a consistent UX across modals.
- Remove now-unused header-close positioning/styles that were only required for the removed header control.

### Description
- Remove the header “×” close `Button` from `client/src/components/Zombies/attributes/Features.js` and rely on the footer close control instead.
- Replace the footer close button classes on the features modal with the shared `spellbook-modal-close-btn` class (previously used by the Spells modal) in `client/src/components/Zombies/attributes/Features.js`.
- Delete obsolete header-close CSS and associated spacing overrides from `client/src/App.scss` that were only used to position the removed header control.
- Add a test in `client/src/components/Zombies/attributes/Features.test.js` that asserts the footer `Close` button uses the `spellbook-modal-close-btn` class, that the header close icon is absent, and that clicking the footer `Close` invokes the `handleCloseFeatures` callback.

### Testing
- Ran the features unit tests with `CI=true npm test -- --runInBand client/src/components/Zombies/attributes/Features.test.js` and all tests in that suite passed (24 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e19c8e7a0832eb8c1af679b1ea82a)