### PR TITLE
Use spellbook-style footer close button in Features modal and adjust mobile layout CSS

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13267,7 +13267,7 @@ ul.spellbook-tabs.nav-tabs {
   }
 
   .abilities-codex-card .abilities-codex-body {
-    flex: 1 1 auto !important;
+    flex: 1 1 0 !important;
     min-height: 0 !important;
     max-height: none !important;
     overflow-y: auto !important;
@@ -13277,63 +13277,21 @@ ul.spellbook-tabs.nav-tabs {
 
   .abilities-codex-card .abilities-codex-footer {
     display: flex !important;
-    flex: 0 0 auto !important;
+    flex: 0 0 76px !important;
+    min-height: 76px;
+    box-sizing: border-box;
     position: sticky;
     bottom: 0;
     z-index: 5;
   }
 }
 
-/* Keep a close affordance visible in the Character Features modal header on small screens. */
-.abilities-codex-card .modal-header {
-  padding-right: 128px !important;
-}
-
-.abilities-codex-card .dock-control--right {
-  right: 72px;
-}
-
-.abilities-modal-close.btn {
-  position: absolute;
-  right: 18px;
-  top: 0.75rem;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 12px;
-  border-color: var(--realm-border-strong);
-  background: rgba(9, 18, 34, .82);
-  color: var(--realm-text);
-  font-size: 1.6rem;
-  line-height: 1;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, .35);
-  z-index: 11;
-}
-
-.abilities-modal-close.btn:hover,
-.abilities-modal-close.btn:focus-visible {
-  background: rgba(34, 52, 86, .96);
-  color: #fff;
-}
-
 @media (max-width: 575px) {
   .abilities-codex-card .modal-header {
     padding-left: 64px !important;
-    padding-right: 116px !important;
   }
 
   .abilities-codex-card .dock-control--left {
     left: 12px;
-  }
-
-  .abilities-codex-card .dock-control--right {
-    right: 64px;
-  }
-
-  .abilities-modal-close.btn {
-    right: 12px;
   }
 }

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1763,16 +1763,6 @@ export default function Features({
                 isDocked={isDocked}
               />
               <Card.Title className="modal-title">Character Features</Card.Title>
-              <Button
-                type="button"
-                variant="outline-light"
-                className="abilities-modal-close"
-                aria-label="Close character features"
-                title="Close character features"
-                onClick={handleModalHide}
-              >
-                <span aria-hidden="true">×</span>
-              </Button>
             </Card.Header>
             <Card.Body className="abilities-codex-body">
               {error && (
@@ -2300,7 +2290,7 @@ export default function Features({
             </Card.Body>
             <Card.Footer className="modal-footer abilities-codex-footer">
               <Button
-                className="action-btn close-btn abilities-codex-close-button"
+                className="spellbook-modal-close-btn"
                 onClick={handleModalHide}
               >
                 Close

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -76,6 +76,30 @@ test('renders features and opens modal with description', async () => {
   ).toBeInTheDocument();
 });
 
+test('uses the spellbook-style footer close button without a header close icon', async () => {
+  const handleCloseFeatures = jest.fn();
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  render(
+    <Features
+      form={{ occupation: [{ Name: 'Fighter', Level: 1 }] }}
+      showFeatures={true}
+      handleCloseFeatures={handleCloseFeatures}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const closeButton = await screen.findByRole('button', { name: 'Close' });
+  expect(closeButton).toHaveClass('spellbook-modal-close-btn');
+  expect(screen.queryByRole('button', { name: /close character features/i })).not.toBeInTheDocument();
+
+  await userEvent.click(closeButton);
+  expect(handleCloseFeatures).toHaveBeenCalledTimes(1);
+});
+
 test('dragonborn always has damage resistance and gains draconic flight at level 5', async () => {
   apiFetch.mockResolvedValue({
     ok: true,


### PR DESCRIPTION
### Motivation
- Standardize the Features modal close affordance to a single footer button and remove the duplicate header close control for a cleaner mobile UX.
- Ensure the abilities codex body and footer size/behavior are stable on small screens so the footer remains visible and content scrolls correctly.

### Description
- Removed the header close `Button` from `Features.js` and changed the footer close button class from `action-btn close-btn abilities-codex-close-button` to `spellbook-modal-close-btn` so the modal uses the spellbook-style footer affordance.
- Updated `App.scss` to set `.abilities-codex-card .abilities-codex-body` to `flex: 1 1 0` and tightened the footer with `flex: 0 0 76px`, `min-height: 76px`, and `box-sizing: border-box` for consistent footer sizing on small screens.
- Deleted redundant header-close related CSS rules (header padding/right dock control offsets and `.abilities-modal-close.btn` styles) and removed conflicting mobile padding overrides.
- Added a unit test to `Features.test.js` that asserts the header close icon is absent, the footer close button has the new `spellbook-modal-close-btn` class, and that clicking it invokes `handleCloseFeatures`.

### Testing
- Ran the component unit tests with Jest, including the updated `Features.test.js`, and the test suite passed successfully.
- Verified the new `uses the spellbook-style footer close button without a header close icon` test specifically passes and exercises the close handler invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e19c8e7a0832eb8c1af679b1ea82a)