### PR TITLE
Move Features modal close control to footer; adjust mobile layout and tests

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13262,12 +13262,13 @@ ul.spellbook-tabs.nav-tabs {
   .abilities-codex-card {
     display: flex !important;
     flex-direction: column !important;
-    height: calc(100vh - 1rem) !important;
-    max-height: calc(100vh - 1rem) !important;
+    /* Keep the card within the modal-content viewport so its footer is not clipped. */
+    height: 92vh !important;
+    max-height: 92vh !important;
   }
 
   .abilities-codex-card .abilities-codex-body {
-    flex: 1 1 auto !important;
+    flex: 1 1 0 !important;
     min-height: 0 !important;
     max-height: none !important;
     overflow-y: auto !important;
@@ -13277,63 +13278,21 @@ ul.spellbook-tabs.nav-tabs {
 
   .abilities-codex-card .abilities-codex-footer {
     display: flex !important;
-    flex: 0 0 auto !important;
+    flex: 0 0 76px !important;
+    min-height: 76px;
+    box-sizing: border-box;
     position: sticky;
     bottom: 0;
     z-index: 5;
   }
 }
 
-/* Keep a close affordance visible in the Character Features modal header on small screens. */
-.abilities-codex-card .modal-header {
-  padding-right: 128px !important;
-}
-
-.abilities-codex-card .dock-control--right {
-  right: 72px;
-}
-
-.abilities-modal-close.btn {
-  position: absolute;
-  right: 18px;
-  top: 0.75rem;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 12px;
-  border-color: var(--realm-border-strong);
-  background: rgba(9, 18, 34, .82);
-  color: var(--realm-text);
-  font-size: 1.6rem;
-  line-height: 1;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, .35);
-  z-index: 11;
-}
-
-.abilities-modal-close.btn:hover,
-.abilities-modal-close.btn:focus-visible {
-  background: rgba(34, 52, 86, .96);
-  color: #fff;
-}
-
 @media (max-width: 575px) {
   .abilities-codex-card .modal-header {
     padding-left: 64px !important;
-    padding-right: 116px !important;
   }
 
   .abilities-codex-card .dock-control--left {
     left: 12px;
-  }
-
-  .abilities-codex-card .dock-control--right {
-    right: 64px;
-  }
-
-  .abilities-modal-close.btn {
-    right: 12px;
   }
 }

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1763,16 +1763,6 @@ export default function Features({
                 isDocked={isDocked}
               />
               <Card.Title className="modal-title">Character Features</Card.Title>
-              <Button
-                type="button"
-                variant="outline-light"
-                className="abilities-modal-close"
-                aria-label="Close character features"
-                title="Close character features"
-                onClick={handleModalHide}
-              >
-                <span aria-hidden="true">×</span>
-              </Button>
             </Card.Header>
             <Card.Body className="abilities-codex-body">
               {error && (
@@ -2300,7 +2290,7 @@ export default function Features({
             </Card.Body>
             <Card.Footer className="modal-footer abilities-codex-footer">
               <Button
-                className="action-btn close-btn abilities-codex-close-button"
+                className="spellbook-modal-close-btn"
                 onClick={handleModalHide}
               >
                 Close

--- a/client/src/components/Zombies/attributes/Features.test.js
+++ b/client/src/components/Zombies/attributes/Features.test.js
@@ -76,6 +76,30 @@ test('renders features and opens modal with description', async () => {
   ).toBeInTheDocument();
 });
 
+test('uses the spellbook-style footer close button without a header close icon', async () => {
+  const handleCloseFeatures = jest.fn();
+  apiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  });
+
+  render(
+    <Features
+      form={{ occupation: [{ Name: 'Fighter', Level: 1 }] }}
+      showFeatures={true}
+      handleCloseFeatures={handleCloseFeatures}
+      characterId={TEST_CHARACTER_ID}
+    />
+  );
+
+  const closeButton = await screen.findByRole('button', { name: 'Close' });
+  expect(closeButton).toHaveClass('spellbook-modal-close-btn');
+  expect(screen.queryByRole('button', { name: /close character features/i })).not.toBeInTheDocument();
+
+  await userEvent.click(closeButton);
+  expect(handleCloseFeatures).toHaveBeenCalledTimes(1);
+});
+
 test('dragonborn always has damage resistance and gains draconic flight at level 5', async () => {
   apiFetch.mockResolvedValue({
     ok: true,


### PR DESCRIPTION
### Motivation
- Keep the Features (Character Features) modal footer visible on small screens and consolidate the close control into the footer for a consistent spellbook-style UI.
- Prevent the header close icon from overlapping dock controls and reduce clipped footer issues inside the modal viewport.

### Description
- Replace header close `Button` in `Features.js` with a footer-only close control and update the footer button class to `spellbook-modal-close-btn`.
- Update mobile layout rules in `App.scss` to set the card height to `92vh`, change body flex to `flex: 1 1 0`, and make the footer a fixed `76px` height with `position: sticky` to ensure the footer is visible and not clipped.
- Remove obsolete header close styling and related dock-position adjustments from `App.scss` that targeted the removed header close control.
- Add a unit test in `Features.test.js` named `uses the spellbook-style footer close button without a header close icon` to assert the footer close button class, absence of the header close icon, and that clicking it calls the provided `handleCloseFeatures` handler.

### Testing
- Ran the component test suite with the updated `Features.test.js` and the new test `uses the spellbook-style footer close button without a header close icon` passed.
- Verified existing feature rendering tests (e.g. `renders features and opens modal with description`) remained passing after the changes.
- Confirmed the updated tests exercise the click path to `handleCloseFeatures` and that it was called once when the footer close button was clicked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e19c8e7a0832eb8c1af679b1ea82a)