### PR TITLE
Feat Library: new UI, search/filters, inspector, responsive styling, and test updates

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13296,3 +13296,114 @@ ul.spellbook-tabs.nav-tabs {
     left: 12px;
   }
 }
+
+/* Legendary Feat Library */
+.feats-library { overflow: hidden; background: linear-gradient(145deg, rgba(5,17,43,.98), rgba(18,13,48,.98)); }.feats-library__body { padding: 1rem !important; overflow: hidden; }.feats-library__hero { display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:.9rem; }.feats-library__hero h2 { margin:.12rem 0; color:#fff3d1; font-family:'Cinzel',serif; font-size:1.4rem; }.feats-library__hero p { margin:0; color:rgba(213,232,255,.7); font-size:.83rem; }.feats-library__eyebrow { color:#96c9ff; font-size:.69rem; font-weight:700; letter-spacing:.12em; text-transform:uppercase; }.feats-library__points { display:flex; align-items:center; gap:.45rem; padding:.6rem .75rem; color:#ffe1a0; border:1px solid rgba(255,211,122,.3); border-radius:.8rem; background:rgba(194,140,46,.11); }.feats-library__points strong { font-size:1.25rem; }.feats-library__toolbar { margin-bottom:.8rem; }.feats-search { display:flex; align-items:center; gap:.5rem; padding:.65rem .75rem; color:#9dccff; border:1px solid rgba(136,187,255,.2); border-radius:.75rem; background:rgba(3,12,34,.55); }.feats-search input { width:100%; color:#f4f8ff; border:0; outline:0; background:transparent; }.feats-search input::placeholder { color:rgba(217,232,255,.52); }.feats-library__layout { display:grid; grid-template-columns:10.5rem minmax(0,1fr) 18.5rem; gap:.85rem; min-height:31rem; }.feats-sidebar,.feat-inspector { border:1px solid rgba(138,187,255,.16); border-radius:1rem; background:rgba(3,12,34,.54); }.feats-sidebar { padding:.6rem; }.feats-sidebar__label { display:block; padding:.45rem .5rem; color:rgba(197,219,255,.57); font-size:.68rem; font-weight:700; letter-spacing:.1em; text-transform:uppercase; }.feats-sidebar button { width:100%; padding:.55rem .6rem; text-align:left; color:rgba(230,242,255,.78); border:1px solid transparent; border-radius:.65rem; background:transparent; }.feats-sidebar button:hover,.feats-sidebar button.is-active { color:#fff4d1; border-color:rgba(129,190,255,.28); background:linear-gradient(90deg,rgba(42,102,175,.38),rgba(88,58,165,.26)); }.feats-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(13rem,1fr)); align-content:start; gap:.75rem; overflow-y:auto; max-height:38rem; padding:.1rem .25rem .5rem; }.feat-library-card { display:flex; flex-direction:column; min-height:16rem; padding:.85rem; text-align:left; color:#eef6ff; border:1px solid rgba(133,185,255,.2); border-radius:1rem; background:radial-gradient(circle at 85% 0%,rgba(97,146,233,.2),transparent 34%),linear-gradient(145deg,rgba(12,31,68,.92),rgba(20,16,51,.88)); box-shadow:inset 0 1px rgba(255,255,255,.08),0 10px 22px rgba(0,0,0,.16); transition:transform .18s ease,border-color .18s ease,box-shadow .18s ease; }.feat-library-card:hover,.feat-library-card:focus-visible,.feat-library-card.is-selected { transform:translateY(-3px); border-color:rgba(255,214,129,.68); box-shadow:0 16px 30px rgba(0,0,0,.34),0 0 18px rgba(119,179,255,.18); outline:none; }.feat-library-card--owned { border-color:rgba(95,226,163,.6); }.feat-library-card--locked,.feat-library-card--unavailable { opacity:.64; filter:saturate(.6); }.feat-library-card__art { display:grid; place-items:center; width:3rem; height:3rem; margin-bottom:.6rem; color:#d9b772; border:1px solid rgba(255,224,154,.25); border-radius:.85rem; background:radial-gradient(circle,rgba(255,217,130,.22),rgba(85,70,171,.08)); }.feat-library-card__topline,.feat-library-card__badges { display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:.3rem; color:#9ccaff; font-size:.67rem; font-weight:700; letter-spacing:.07em; text-transform:uppercase; }.feat-library-card strong { margin:.45rem 0; font-family:'Cinzel',serif; font-size:1rem; color:#fff3d1; }.feat-library-card__description { display:-webkit-box; overflow:hidden; color:rgba(226,239,255,.76); font-size:.79rem; line-height:1.45; -webkit-line-clamp:3; -webkit-box-orient:vertical; }.feat-library-card__badges { justify-content:flex-start; margin-top:auto; padding-top:.65rem; }.feat-status,.ability-chip,.requirement-chip { display:inline-flex; align-items:center; gap:.22rem; padding:.22rem .38rem; border-radius:99px; font-size:.63rem; letter-spacing:.03em; }.feat-status--owned { color:#9ff0bf; background:rgba(59,170,103,.17); }.feat-status--available { color:#b7dcff; background:rgba(69,140,226,.18); }.feat-status--locked,.feat-status--unavailable,.requirement-chip { color:#ffd1ce; background:rgba(177,66,77,.2); }.ability-chip { color:#fff; background:rgba(100,135,215,.25); }.ability-chip--str {background:rgba(191,73,73,.35)}.ability-chip--dex{background:rgba(56,160,118,.33)}.ability-chip--con{background:rgba(202,135,57,.34)}.ability-chip--int{background:rgba(70,130,207,.35)}.ability-chip--wis{background:rgba(126,94,185,.36)}.ability-chip--cha{background:rgba(191,75,151,.35)}.feats-empty { grid-column:1/-1; padding:2rem; text-align:center; color:#aac8ec; border:1px dashed rgba(138,187,255,.26); border-radius:1rem; }.feat-inspector { position:relative; padding:.85rem; overflow-y:auto; color:#e9f3ff; }.feat-inspector__close { position:absolute; top:.65rem; right:.65rem; color:#d6eaff; border:0; background:transparent; }.feat-inspector__art { display:grid; place-items:center; height:6.5rem; margin-bottom:.7rem; color:#ffdc92; border:1px solid rgba(255,224,154,.17); border-radius:.85rem; background:radial-gradient(circle at 50% 30%,rgba(117,172,255,.36),rgba(80,49,146,.27) 50%,rgba(4,15,40,.5)); }.feat-inspector h3 { margin:.2rem 0 .5rem; font-family:'Cinzel',serif; color:#fff2ce; }.feat-inspector p { color:rgba(222,237,255,.76); font-size:.87rem; line-height:1.5; }.feat-inspector__section { display:flex; flex-direction:column; gap:.4rem; margin:.8rem 0; padding-top:.7rem; border-top:1px solid rgba(148,193,255,.13); }.feat-inspector__section>div { display:flex; flex-wrap:wrap; gap:.3rem; }.requirement-row { display:flex; align-items:center; gap:.35rem; color:#a9ecc2; font-size:.8rem; }.feat-inspector__reason { padding:.45rem; font-size:.76rem; border-radius:.55rem; }.feat-inspector__reason--locked,.feat-inspector__reason--unavailable { color:#ffd2cf; background:rgba(167,55,67,.19); }.feat-inspector__reason--owned { color:#a8f1c5; background:rgba(46,145,90,.16); }.feat-choice { margin:.7rem 0; }.feat-choice .form-label { color:#cfe4ff; font-size:.78rem; }.feat-choice .form-select { color:#edf7ff; border-color:rgba(145,192,255,.28); background-color:rgba(9,23,54,.86); }.feat-choice select[multiple] { min-height:8rem; }.feat-inspector__action { width:100%; margin-top:.25rem; }.feat-inspector__placeholder { display:grid; place-items:center; gap:.55rem; height:100%; min-height:14rem; text-align:center; color:#acc9ed; }.feat-inspector__placeholder b {color:#fff0c6}.muted {color:rgba(213,231,255,.58);font-size:.8rem}@media(max-width:991px){.feats-library__layout{grid-template-columns:9rem minmax(0,1fr)}.feat-inspector{grid-column:1/-1;max-height:25rem}.feats-grid{max-height:29rem}}@media(max-width:575px){.feats-library__body{padding:.65rem!important}.feats-library__hero{align-items:flex-start;flex-direction:column}.feats-library__layout{display:block}.feats-sidebar{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.2rem;margin-bottom:.65rem}.feats-sidebar__label{grid-column:1/-1}.feats-grid{grid-template-columns:1fr;max-height:none;overflow:visible}.feat-library-card{min-height:12.5rem}.feat-inspector{margin-top:.7rem;max-height:none}.modal-footer{display:none}}
+@media (max-width: 575px) { .feat-inspector { position: fixed; z-index: 1080; right: 0; bottom: 0; left: 0; max-height: 78vh; margin: 0; border-radius: 1.25rem 1.25rem 0 0; background: #0b1e45; box-shadow: 0 -12px 42px rgba(0,0,0,.52); } }
+
+/* Keep the library's final actions visible without making the whole modal scroll. */
+.feats-library__footer {
+  display: flex !important;
+  justify-content: flex-end !important;
+  padding: 0.75rem 1.5rem !important;
+}
+
+.feats-library__footer .close-btn {
+  width: auto !important;
+  min-width: 8rem;
+  margin-left: auto;
+  padding-inline: 1.5rem;
+}
+
+.feat-inspector {
+  height: 38rem;
+  max-height: 38rem;
+  overscroll-behavior: contain;
+  scrollbar-color: rgba(135, 191, 255, 0.55) rgba(5, 17, 43, 0.45);
+}
+
+.feat-inspector__action {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  box-shadow: 0 -0.75rem 1rem rgba(3, 12, 34, 0.92);
+}
+
+@media (max-width: 991px) {
+  .feat-inspector { height: auto; max-height: 25rem; }
+}
+
+@media (max-width: 575px) {
+  .feats-library__footer.modal-footer { display: flex !important; }
+  .feat-inspector { max-height: 78vh; }
+  .feats-library__footer .close-btn { min-width: 7.5rem; }
+}
+
+/* Feat Library footer/inspector safeguards. The shared .action-btn defaults to flex: 1. */
+.feats-library__footer .close-btn.action-btn {
+  flex: 0 0 auto !important;
+  width: auto !important;
+}
+
+.feat-inspector {
+  box-sizing: border-box;
+  padding-bottom: 5.5rem;
+  scroll-padding-bottom: 5.5rem;
+}
+
+.feat-inspector__action {
+  bottom: 0.75rem;
+}
+
+@media (max-width: 575px) {
+  .feat-inspector {
+    padding-bottom: 5rem;
+    scroll-padding-bottom: 5rem;
+  }
+}
+
+/* Reserve the same footer clearance for the independently scrolling feat grid. */
+.feats-grid {
+  box-sizing: border-box;
+  padding-bottom: 5.5rem;
+  scroll-padding-bottom: 5.5rem;
+}
+
+@media (max-width: 575px) {
+  .feats-grid {
+    padding-bottom: 5rem;
+    scroll-padding-bottom: 5rem;
+  }
+}
+
+/* Mobile Feat Library: cards remain the primary surface until a card opens the inspector sheet. */
+@media (max-width: 575px) {
+  .modern-card:has(.feats-library) {
+    display: flex;
+    flex-direction: column;
+    height: calc(100dvh - 2rem);
+    max-height: calc(100dvh - 2rem);
+  }
+
+  .modern-card:has(.feats-library) .feats-library__body {
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
+    overflow-y: auto !important;
+    overscroll-behavior: contain;
+  }
+
+  .modern-card:has(.feats-library) .feats-library__footer {
+    display: flex !important;
+    flex: 0 0 auto;
+  }
+
+  .feats-library .feat-inspector:not(.is-selected) {
+    display: none;
+  }
+
+  .feats-library .feat-inspector.is-selected {
+    display: block;
+    overflow-y: auto;
+  }
+}

--- a/client/src/components/Zombies/attributes/Feats.js
+++ b/client/src/components/Zombies/attributes/Feats.js
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { SKILLS } from "../skillSchema";
 import { calculateFeatPointsLeft } from '../../../utils/featUtils';
 import DockControls from '../components/DockControls';
+import { Check, Lock, Search, Shield, Sparkles, Sword, WandSparkles, X } from 'lucide-react';
 
 // Tools and musical instruments that can be selected for proficiency.
 // This list is not exhaustive to every possible item in the game but
@@ -55,6 +56,24 @@ const ALL_SKILLS = [...SKILLS, ...TOOL_OPTIONS];
 
 // Maximum number of selectable proficiencies a feat may grant.
 const SKILL_SELECT_LIMIT = 3;
+const ABILITIES = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+const categoryFor = (feat) => {
+  if (feat.category) return feat.category;
+  const text = `${feat.featName || ''} ${feat.notes || ''}`.toLowerCase();
+  if (/spell|magic|caster|ritual|arcana/.test(text)) return 'Magic';
+  if (/armor|shield|tough|resilien|defen/.test(text)) return 'Defensive';
+  if (/weapon|battle|fighter|attack|martial/.test(text)) return 'Combat';
+  return 'General';
+};
+const requirementsFor = (feat) => {
+  const value = feat?.prerequisites || feat?.prerequisite || feat?.requirements;
+  if (Array.isArray(value)) return value.map(String);
+  if (value) return [String(value)];
+  if (feat?.minLevel || feat?.requiredLevel) return [`Requires level ${feat.minLevel || feat.requiredLevel}`];
+  return [];
+};
+const bonusesFor = (feat) => ABILITIES.filter((ability) => Number(feat?.[ability])).map((ability) => ({ ability, value: Number(feat[ability]) }));
+const descriptionFor = (notes) => String(notes || 'A defining talent that broadens your hero’s legend.').replace(/\s+/g, ' ').trim();
 
 export default function Feats({
   form,
@@ -80,6 +99,8 @@ export default function Feats({
   const [abilitySelections, setAbilitySelections] = useState({});
   const [skillSelections, setSkillSelections] = useState([]);
   const [notification, setNotification] = useState(null);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState('All Feats');
 
   const skillChoiceFields = [
     'skillChoiceCount',
@@ -202,6 +223,19 @@ export default function Feats({
   // ---------------------------------------Feats left-----------------------------------------------------
   const featPointsLeft = calculateFeatPointsLeft(form.occupation, form.feat);
   const showFeatBtn = featPointsLeft > 0 ? "" : "none";
+  const characterLevel = Math.max(0, ...(form.occupation || []).map((entry) => Number(entry.Level) || 0));
+  const featStatus = useCallback((item) => {
+    if (form.feat.some((owned) => owned.featName === item.featName)) return { key: 'owned', label: 'Owned', reason: 'Already part of your legend.' };
+    const requiredLevel = Number(item.minLevel || item.requiredLevel || 0);
+    if (requiredLevel > characterLevel) return { key: 'locked', label: 'Locked', reason: `Requires Level ${requiredLevel}` };
+    if (featPointsLeft <= 0) return { key: 'unavailable', label: 'Unavailable', reason: 'No feat selections remaining.' };
+    return { key: 'available', label: 'Available', reason: requirementsFor(item).join(' • ') || 'Ready to unlock.' };
+  }, [characterLevel, featPointsLeft, form.feat]);
+  const filteredFeats = useMemo(() => feat.feat.filter((item) => {
+    const status = featStatus(item);
+    const query = `${item.featName} ${item.notes || ''} ${categoryFor(item)} ${requirementsFor(item).join(' ')}`.toLowerCase();
+    return query.includes(search.toLowerCase()) && (filter === 'All Feats' || filter === categoryFor(item) || (filter === 'Ability Score Increase' && (bonusesFor(item).length || item.abilityIncreaseOptions)) || (filter === 'Owned' && status.key === 'owned') || (filter === 'Available' && status.key === 'available') || (filter === 'Locked' && status.key === 'locked'));
+  }).sort((a, b) => a.featName.localeCompare(b.featName)), [feat.feat, featStatus, filter, search]);
 
   // ----------------------------------------Fetch Feats-----------------------------------
   useEffect(() => {
@@ -356,220 +390,21 @@ export default function Feats({
           />
           <Card.Title className="modal-title">Feats</Card.Title>
         </Card.Header>
-            <Card.Body style={{ overflowY: 'auto', maxHeight: '70vh' }}>
-              <div className="points-container" style={{ display: showFeatBtn }}>
-                <span className="points-label text-light">Points Left:</span>
-                <span className="points-value" id="featPointLeft">{featPointsLeft}</span>
+            <Card.Body className="feats-library__body">
+              <section className="feats-library__hero">
+                <div><span className="feats-library__eyebrow">Heroic progression</span><h2>Feat Library</h2><p>Choose a legend-defining talent for your next milestone.</p></div>
+                <div className="feats-library__points"><Sparkles size={18} /><strong id="featPointLeft">{featPointsLeft}</strong><span>{featPointsLeft === 1 ? 'selection remaining' : 'selections remaining'}</span></div>
+              </section>
+              <div className="feats-library__toolbar">
+                <label className="feats-search"><Search size={18} /><span className="visually-hidden">Search feats</span><input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search feats, benefits, and requirements…" /></label>
               </div>
-              <div className="feat-card-grid">
-                {form.feat.map((el, index) => {
-                  const skillValues = [];
-                  if (el.skills) {
-                    Object.keys(el.skills).forEach((key) => {
-                      const skill = ALL_SKILLS.find((s) => s.key === key);
-                      const label = skill ? skill.label : key;
-                      skillValues.push(`${label}: proficient`);
-                    });
-                  }
-                  SKILLS.forEach(({ label, key }) => {
-                    const val = el[key];
-                    if (val && val !== "0" && val !== "") {
-                      skillValues.push(`${label}: ${val}`);
-                    }
-                  });
-
-                  const abilityValues = [];
-                  abilityLabels.forEach((label) => {
-                    const prop = label.toLowerCase();
-                    const val = el[prop];
-                    if (val && val !== "0" && val !== "") {
-                      abilityValues.push(`${label}: ${val}`);
-                    }
-                  });
-                  extraAbilityLabels.forEach(({ label, key }) => {
-                    const val = el[key];
-                    if (val && val !== "0" && val !== "") {
-                      abilityValues.push(`${label}: ${val}`);
-                    }
-                  });
-
-                  return (
-                    <div className="feat-card" key={`${el.featName}-${index}`}>
-                      <div className="feat-card-header">
-                        <div className="feat-card-name">{el.featName}</div>
-                        <div
-                          className="feat-card-actions"
-                          style={{ display: showDeleteFeatBtn }}
-                        >
-                          <Button
-                            variant="link"
-                            size="sm"
-                            className="view-link-btn"
-                            onClick={() => {
-                              handleShowFeatNotes();
-                              setModalFeatData(el);
-                            }}
-                          >
-                            <i className="fa-solid fa-eye" aria-hidden="true"></i>
-                            <span className="visually-hidden">View notes</span>
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="danger"
-                            className="action-btn"
-                            onClick={() => {
-                              deleteFeats(index);
-                            }}
-                          >
-                            <i className="fa-solid fa-trash" aria-hidden="true"></i>
-                            <span className="visually-hidden">Delete feat</span>
-                          </Button>
-                        </div>
-                      </div>
-                      <div className="feat-card-body">
-                        {skillValues.length > 0 && (
-                          <div
-                            className="feat-card-section"
-                            style={{ display: showDeleteFeatBtn }}
-                          >
-                            <div className="feat-card-section-title">Skills &amp; Tools</div>
-                            <ul className="feat-card-list">
-                              {skillValues.map((skill) => (
-                                <li key={skill}>{skill}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        )}
-                        {abilityValues.length > 0 && (
-                          <div
-                            className="feat-card-section"
-                            style={{ display: showDeleteFeatBtn }}
-                          >
-                            <div className="feat-card-section-title">Ability Bonuses</div>
-                            <ul className="feat-card-list">
-                              {abilityValues.map((ab) => (
-                                <li key={ab}>{ab}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
+              <div className="feats-library__layout">
+                <aside className="feats-sidebar" aria-label="Feat filters"><span className="feats-sidebar__label">Browse collection</span>{['All Feats', 'Combat', 'Magic', 'Defensive', 'Ability Score Increase', 'Available', 'Locked', 'Owned'].map((item) => <button type="button" key={item} className={filter === item ? 'is-active' : ''} onClick={() => setFilter(item)}>{item}</button>)}</aside>
+                <section className="feats-grid" aria-live="polite">{filteredFeats.map((item) => { const status = featStatus(item); const category = categoryFor(item); const Icon = category === 'Combat' ? Sword : category === 'Magic' ? WandSparkles : category === 'Defensive' ? Shield : Sparkles; const selected = selectedFeatData?.featName === item.featName; return <button type="button" key={item.featName} className={`feat-library-card feat-library-card--${status.key}${selected ? ' is-selected' : ''}`} onClick={() => handleSelectFeat({ target: { value: item.featName } })} aria-pressed={selected}><span className="feat-library-card__art"><Icon size={30} /></span><span className="feat-library-card__topline"><span>{category}</span><span className={`feat-status feat-status--${status.key}`}>{status.key === 'owned' ? <Check size={13} /> : status.key !== 'available' ? <Lock size={13} /> : <Sparkles size={13} />}{status.label}</span></span><strong>{item.featName}</strong><span className="feat-library-card__description">{descriptionFor(item.notes)}</span><span className="feat-library-card__badges">{bonusesFor(item).map(({ ability, value }) => <span key={ability} className={`ability-chip ability-chip--${ability}`}>+{value} {ability.toUpperCase()}</span>)}{requirementsFor(item).slice(0, 1).map((requirement) => <span key={requirement} className="requirement-chip">{requirement}</span>)}</span></button>; })}{!filteredFeats.length && <div className="feats-empty">No feats match this search. Try a different term or filter.</div>}</section>
+                <aside className={`feat-inspector${selectedFeatData ? ' is-selected' : ''}`} aria-label="Feat inspector">{selectedFeatData ? <><button type="button" className="feat-inspector__close" onClick={() => { setSelectedFeatData(null); setChosenFeat(''); }} aria-label="Close feat inspector"><X size={18} /></button><div className="feat-inspector__art"><Sparkles size={40} /></div><span className="feats-library__eyebrow">{categoryFor(selectedFeatData)} feat</span><h3>{selectedFeatData.featName}</h3><p>{descriptionFor(selectedFeatData.notes)}</p><div className="feat-inspector__section"><b>Ability bonuses</b><div>{bonusesFor(addFeat || selectedFeatData).length ? bonusesFor(addFeat || selectedFeatData).map(({ ability, value }) => <span key={ability} className={`ability-chip ability-chip--${ability}`}>+{value} {ability.toUpperCase()}</span>) : <span className="muted">No direct ability increase.</span>}</div></div><div className="feat-inspector__section"><b>Requirements</b>{requirementsFor(selectedFeatData).length ? requirementsFor(selectedFeatData).map((requirement) => <span key={requirement} className="requirement-row"><Check size={15} /> {requirement}</span>) : <span className="requirement-row"><Check size={15} /> No prerequisites</span>}<span className={`feat-inspector__reason feat-inspector__reason--${featStatus(selectedFeatData).key}`}>{featStatus(selectedFeatData).reason}</span></div><Form onSubmit={addFeatToDb}>{featStatus(selectedFeatData).key === 'owned' && <Button type="button" className="action-btn feat-inspector__remove" onClick={() => deleteFeats(form.feat.findIndex((item) => item.featName === selectedFeatData.featName))}>Remove feat</Button>}{selectedFeatData.abilityIncreaseOptions?.map((option, idx) => { const abilities = Array.isArray(option) ? option : option.abilities || []; return <Form.Group className="feat-choice" key={idx}><Form.Label>Choose an ability increase</Form.Label><Form.Select value={abilitySelections[idx] || ''} onChange={(event) => handleAbilityChoice(idx, event.target.value)}><option value="" disabled>Select ability</option>{abilities.map((opt) => <option key={opt} value={opt}>{opt.toUpperCase()}</option>)}</Form.Select></Form.Group>; })}{hasSkillChoice && <Form.Group className="feat-choice"><Form.Label>Skill/Tool Proficiencies (choose up to {skillLimit})</Form.Label><Form.Select multiple value={skillSelections} onChange={handleSkillChoice}>{ALL_SKILLS.map(({ key, label }) => { const selected = skillSelections.includes(key); return <option key={key} value={key} disabled={!selected && (skillSelections.length >= skillLimit || existingProficiencies.has(key))}>{label}</option>; })}</Form.Select></Form.Group>}<Button disabled={featStatus(selectedFeatData).key !== 'available' || (selectedFeatData.abilityIncreaseOptions && Object.keys(abilitySelections).length !== selectedFeatData.abilityIncreaseOptions.length) || (hasSkillChoice && skillSelections.length === 0)} className="action-btn feat-inspector__action" type="submit">{featStatus(selectedFeatData).key === 'locked' ? 'Requirement not met' : featStatus(selectedFeatData).key === 'unavailable' ? 'No selections remaining' : 'Select feat'}</Button></Form></> : <div className="feat-inspector__placeholder"><Sparkles size={32} /><b>Choose a feat</b><span>Explore the library, then inspect a feat to make it part of your story.</span></div>}</aside>
               </div>
-              <Row>
-                <Col style={{ display: showFeatBtn }}>
-                  <Form onSubmit={addFeatToDb}>
-                    <Form.Group className="mb-3 mx-5">
-                      <Form.Label className="text-light">Select Feat</Form.Label>
-                      <div className="d-flex">
-                        <Form.Select
-                          onChange={handleSelectFeat}
-                          defaultValue=""
-                          type="text"
-                          style={{ maxHeight: '200px', overflowY: 'auto' }}
-                        >
-                          <option value="" disabled>
-                            Select your feat
-                          </option>
-                          {feat.feat.map((el) => (
-                            <option key={el.featName} value={el.featName}>
-                              {el.featName}
-                            </option>
-                          ))}
-                        </Form.Select>
-                        <Button
-                          variant="link"
-                          className="view-link-btn"
-                          disabled={!selectedFeatData}
-                          onClick={() => {
-                            setModalFeatData(selectedFeatData);
-                            handleShowFeatNotes();
-                          }}
-                        >
-                          <i className="fa-solid fa-eye"></i>
-                        </Button>
-                      </div>
-                    </Form.Group>
-
-                    {selectedFeatData?.abilityIncreaseOptions &&
-                      selectedFeatData.abilityIncreaseOptions.map((option, idx) => {
-                        const abilities = Array.isArray(option)
-                          ? option
-                          : option.abilities || [];
-                        return (
-                          <Form.Group className="mb-3 mx-5" key={idx}>
-                            <Form.Label className="text-light">Ability Increase</Form.Label>
-                            <Form.Select
-                              value={abilitySelections[idx] || ""}
-                              onChange={(e) => handleAbilityChoice(idx, e.target.value)}
-                              defaultValue=""
-                            >
-                              <option value="" disabled>
-                                Select ability
-                              </option>
-                              {abilities.map((opt) => (
-                                <option key={opt} value={opt}>
-                                  {opt.toUpperCase()}
-                                </option>
-                              ))}
-                            </Form.Select>
-                          </Form.Group>
-                        );
-                      })}
-
-                    {hasSkillChoice && (
-                      <Form.Group className="mb-3 mx-5">
-                        <Form.Label className="text-light">
-                          Skill/Tool Proficiencies
-                        </Form.Label>
-                        <Form.Select
-                          multiple
-                          value={skillSelections}
-                          onChange={handleSkillChoice}
-                        >
-                          {ALL_SKILLS.map(({ key, label }) => {
-                            const selected = skillSelections.includes(key);
-                            const alreadyProficient = existingProficiencies.has(key);
-                            const disabled =
-                              (!selected && skillSelections.length >= skillLimit) ||
-                              (!selected && alreadyProficient);
-                            return (
-                              <option key={key} value={key} disabled={disabled}>
-                                {label}
-                              </option>
-                            );
-                          })}
-                        </Form.Select>
-                        <Form.Text className="text-light">
-                          Select up to {skillLimit}
-                        </Form.Text>
-                        {skillSelections.length >= skillLimit && (
-                          <Form.Text className="text-danger">
-                            Maximum skill selections reached
-                          </Form.Text>
-                        )}
-                      </Form.Group>
-                    )}
-
-                    <Button
-                      disabled={
-                        !chosenFeat ||
-                        (selectedFeatData?.abilityIncreaseOptions &&
-                          Object.keys(abilitySelections).length !==
-                            selectedFeatData.abilityIncreaseOptions.length) ||
-                        (hasSkillChoice && skillSelections.length === 0)
-                      }
-                      className="action-btn" type="submit"
-                    >
-                      Add
-                    </Button>
-                  </Form>
-                </Col>
-              </Row>
             </Card.Body>
-            <Card.Footer className="modal-footer">
+            <Card.Footer className="modal-footer feats-library__footer">
               <Button className="action-btn close-btn" onClick={handleModalHide}>
                 Close
               </Button>

--- a/client/src/components/Zombies/attributes/Feats.test.js
+++ b/client/src/components/Zombies/attributes/Feats.test.js
@@ -29,32 +29,28 @@ async function renderWithFeat(featData, formOverrides = {}) {
       handleCloseFeats={() => {}}
     />
   );
-  await screen.findByRole('option', { name: featData.featName });
-  await userEvent.selectOptions(
-    screen.getByRole('combobox'),
-    featData.featName
-  );
+  await userEvent.click(await screen.findByRole('button', { name: new RegExp(featData.featName) }));
 }
 
 describe('Feats skill selection', () => {
   test('renders for skill choices', async () => {
     await renderWithFeat({ featName: 'SkillFeat', skillChoiceCount: 1 });
     expect(
-      await screen.findByText('Skill/Tool Proficiencies')
+      await screen.findByText(/Skill\/Tool Proficiencies/)
     ).toBeInTheDocument();
   });
 
   test('renders for tool proficiencies', async () => {
     await renderWithFeat({ featName: 'ToolFeat', toolProficiencies: ['smithsTools'] });
     expect(
-      await screen.findByText('Skill/Tool Proficiencies')
+      await screen.findByText(/Skill\/Tool Proficiencies/)
     ).toBeInTheDocument();
   });
 
   test('renders for Skilled feat', async () => {
     await renderWithFeat({ featName: 'Skilled' });
     expect(
-      await screen.findByText('Skill/Tool Proficiencies')
+      await screen.findByText(/Skill\/Tool Proficiencies/)
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- Replace the legacy select-based feat picker with a browsable, searchable library to make feat discovery and inspection easier. 
- Surface prerequisites, ability bonuses, and ownership/availability status so users understand why a feat is selectable or locked. 
- Improve mobile behavior by providing an inspector sheet and keeping action buttons visible while content scrolls.

### Description
- Add a complete `feats-library` stylesheet in `client/src/App.scss` providing grid layout, card styles, filters, inspector sheet, sticky footer/controls, responsive/mobile rules, and scroll-padding safeguards. 
- Rework `client/src/components/Zombies/attributes/Feats.js` to implement a library UI: add `search` and `filter` state, helper functions (`categoryFor`, `requirementsFor`, `bonusesFor`, `descriptionFor`), compute `characterLevel` and `featStatus`, build `filteredFeats`, and render a sidebar, searchable grid of feat cards with icons (using `lucide-react`) and a detail inspector with selection actions; remove the old select/dropdown UI. 
- Update interaction handling and selection logic to support ability choice fields, skill/tool proficiencies, and existing-proficiency checks while keeping previous persistence behavior. 
- Adjust tests in `client/src/components/Zombies/attributes/Feats.test.js` to exercise the new card-based UI by clicking feat cards and use relaxed regex matching for labels.

### Testing
- Ran component unit tests for `Feats` via the test suite; updated `Feats.test.js` to match the new UI and those tests passed. 
- Executed the full test run with `npm test` and observed no regressions in the updated test set. 
- Manual storybook/dev verification of the responsive inspector and footer behavior was performed during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2635bf2c832e8047cf37bcb05986)