### PR TITLE
Move help modal close action to footer

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12041,8 +12041,9 @@ body.character-creation-modal-open {
 .settings-help-header { display: flex; gap: 16px; }
 .settings-help-title-block { text-align: center; }
 .settings-help-title-block p { margin: 4px 0 0; color: var(--realm-muted, rgba(226,232,240,.72)); font-family: var(--realm-font-ui, system-ui, sans-serif); font-size: .92rem; }
-.settings-help-close { position: absolute; right: 18px; top: 16px; min-width: 44px; min-height: 44px; padding: 0 !important; font-size: 1.5rem; line-height: 1; }
 .settings-help-body { overflow: hidden !important; padding: 0 !important; }
+.settings-help-footer { justify-content: flex-end !important; }
+.settings-help-footer .close-btn { flex: 0 0 auto; }
 .settings-help-layout { display: grid; grid-template-columns: 230px minmax(0, 1fr); min-height: 0; height: min(650px, calc(100vh - 150px)); background: radial-gradient(circle at 20% 0%, rgba(78,161,255,.12), transparent 34%), rgba(3,7,16,.38); }
 .settings-help-sidebar { position: sticky; top: 0; display: flex; flex-direction: column; gap: 10px; padding: 18px; border-right: 1px solid var(--realm-border, rgba(151,190,255,.22)); background: linear-gradient(180deg, rgba(5,13,28,.92), rgba(4,8,18,.72)); overflow-y: auto; }
 .settings-help-nav-item { min-height: 58px; display: grid; grid-template-columns: 34px 1fr; gap: 10px; align-items: center; border: 1px solid rgba(151,190,255,.18); border-radius: 16px; padding: 10px; color: var(--realm-text, #eaf2ff); background: rgba(255,255,255,.035); text-align: left; }

--- a/client/src/components/Zombies/attributes/Help.js
+++ b/client/src/components/Zombies/attributes/Help.js
@@ -364,7 +364,6 @@ export default function Help({
               <Card.Title id="settings-help-title" className="modal-title">Settings & Help</Card.Title>
               <p>Player preferences, guidance, campaigns, account, and character safety.</p>
             </div>
-            <Button className="settings-help-close" variant="outline-light" onClick={handleModalHide} aria-label="Close Settings & Help">×</Button>
           </Card.Header>
           <Card.Body className="settings-help-body">
             {campaignNotification && <Alert variant="danger" dismissible onClose={clearNotification} className="mb-3">{campaignNotification}</Alert>}
@@ -386,6 +385,9 @@ export default function Help({
               </main>
             </div>
           </Card.Body>
+          <Card.Footer className="modal-footer settings-help-footer">
+            <Button className="action-btn close-btn" onClick={handleModalHide}>Close</Button>
+          </Card.Footer>
         </Card>
       </Modal>
       <Modal className="dnd-modal modern-modal delete-character-modal" size="md" aria-labelledby="delete-character-title" centered show={showDeleteCharacter} onHide={() => setShowDeleteCharacter(false)}>


### PR DESCRIPTION
### Motivation
- Replace the header "X" close control in the Settings & Help modal with the standard bottom-right `Close` button so the help modal matches the other modals.

### Description
- Removed the header close `Button` from `client/src/components/Zombies/attributes/Help.js`.
- Added a `Card.Footer` containing a `Close` `Button` wired to the existing `handleModalHide` handler in `Help.js`.
- Updated `client/src/App.scss` to remove the header close positioning rule and to add `.settings-help-footer` styles that right-align and size the footer `Close` button.

### Testing
- Ran `CI=true npm test -- --watch=false --runInBand`; the test runner executed and key suites began passing but the run emitted existing React `act(...)` warnings during execution.
- Ran `npm run build` and verified the client build produced artifacts (public assets were present) despite standard Browserslist freshness warnings.
- Ran `git diff --check` to ensure there are no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e3ca99eec832e96465a247770d3e1)