### PR TITLE
Remove character info header close control

### DIFF
--- a/client/src/components/Zombies/attributes/CharacterInfo.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.js
@@ -225,7 +225,6 @@ export default function CharacterInfo({
         <ModalHeader
           title="Character Overview"
           subtitle={`${primaryClass} dossier`}
-          onClose={handleModalHide}
           actions={
             <DockControls
               dockedSide={dockedSide}

--- a/client/src/components/Zombies/attributes/CharacterInfo.test.js
+++ b/client/src/components/Zombies/attributes/CharacterInfo.test.js
@@ -72,6 +72,13 @@ test('calls rest handlers when buttons clicked', () => {
   expect(onShortRest).toHaveBeenCalled();
 });
 
+test('does not render a header close button', () => {
+  renderCharacterInfo();
+
+  expect(screen.queryByRole('button', { name: 'Close' })).toBeInTheDocument();
+  expect(document.querySelector('.realm-modal-header__close')).not.toBeInTheDocument();
+});
+
 test('renders goliath subrace within race card when ancestry selected', () => {
   renderCharacterInfo({
     form: {


### PR DESCRIPTION
### Motivation
- Remove the redundant top-right close (“X”) control from the Character Overview modal header so the modal is closed only via dock controls or the footer action.

### Description
- Deleted the `onClose={handleModalHide}` prop from the modal header in `client/src/components/Zombies/attributes/CharacterInfo.js` to prevent rendering the header close control, and added a unit test in `client/src/components/Zombies/attributes/CharacterInfo.test.js` verifying the header close element is not present while the footer Close action remains available.

### Testing
- Ran `CI=true npm test -- --runInBand --watch=false src/components/Zombies/attributes/CharacterInfo.test.js` and the test file passed (9 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e4349be18832eb1e65b763a0ec3dd)