### PR TITLE
Add Skill Codex UI and styles; refactor Skills modal into searchable, filterable codex

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13425,3 +13425,76 @@ ul.spellbook-tabs.nav-tabs {
     max-height: calc(100dvh - 4rem);
   }
 }
+
+/* Skill Codex library */
+.skill-codex-body{background:radial-gradient(circle at 8% 0%,rgba(75,128,226,.14),transparent 30%),#060d1a!important}.skill-codex-summary{display:grid;grid-template-columns:minmax(210px,.8fr) 2fr;gap:18px;padding:18px;margin-bottom:16px;border:1px solid rgba(132,183,255,.2);border-radius:18px;background:linear-gradient(135deg,rgba(18,42,76,.9),rgba(13,17,43,.92))}.skill-codex-kicker{color:#d8b76a;font-size:.7rem;letter-spacing:.15em;font-weight:800;text-transform:uppercase}.skill-codex-summary h2{margin:3px 0;font-size:1.55rem}.skill-codex-summary p{margin:0;color:var(--realm-muted);font-size:.88rem}.skill-codex-stats{display:grid;grid-template-columns:repeat(3,minmax(100px,1fr));gap:8px}.skill-codex-stat{min-width:0;padding:10px;border:1px solid rgba(165,194,255,.12);border-radius:12px;background:rgba(3,10,23,.44)}.skill-codex-stat span{display:block;color:var(--realm-muted);font-size:.67rem;letter-spacing:.06em;text-transform:uppercase}.skill-codex-stat strong{display:block;margin-top:4px;overflow:hidden;color:#f4f8ff;font-size:.94rem;text-overflow:ellipsis;white-space:nowrap}.skill-codex-stat.is-complete strong{color:#72ddb0}
+.skill-codex-toolbar{display:grid;grid-template-columns:minmax(220px,1fr) auto auto;align-items:center;gap:10px;margin-bottom:16px}.skill-codex-search{display:flex;align-items:center;gap:9px;min-width:0;padding:0 12px;border:1px solid var(--realm-border);border-radius:12px;background:rgba(6,16,33,.82);color:var(--realm-muted)}.skill-codex-search:focus-within{border-color:var(--realm-blue);box-shadow:0 0 0 3px rgba(78,161,255,.14)}.skill-codex-search input{width:100%;min-width:0;padding:10px 0;border:0;outline:0;color:var(--realm-text);background:transparent}.skill-codex-filter-row,.skill-codex-card__actions,.skill-codex-card__training{display:flex;align-items:center;gap:6px}.skill-codex-filter-row{flex-wrap:wrap;gap:5px}.skill-filter-chip,.skill-training-chip{border:1px solid rgba(153,184,235,.22);border-radius:999px;padding:6px 9px;color:#b9c7df;background:rgba(255,255,255,.035);font-size:.74rem;font-weight:700;transition:.18s ease}.skill-filter-chip:hover,.skill-filter-chip:focus-visible,.skill-training-chip:focus-visible{border-color:#77b8ff;outline:none}.skill-filter-chip.is-active{color:#fff;border-color:rgba(93,171,255,.7);background:rgba(54,133,226,.27)}.skill-codex-sort{display:flex;align-items:center;gap:7px;color:var(--realm-muted);font-size:.75rem;white-space:nowrap}.skill-codex-sort select{padding:7px;border:1px solid var(--realm-border);border-radius:9px;color:var(--realm-text);background:#0b1930}
+.skill-codex-layout{display:grid;grid-template-columns:minmax(0,1fr) minmax(245px,310px);gap:16px;align-items:start}.skill-ability-group{--skill-accent:#75aaff;margin-bottom:14px;border:1px solid rgba(143,177,226,.14);border-left:3px solid var(--skill-accent);border-radius:14px;overflow:hidden;background:rgba(8,17,34,.62)}.skill-ability-group--str{--skill-accent:#e67878}.skill-ability-group--dex{--skill-accent:#73c48c}.skill-ability-group--con{--skill-accent:#e89b55}.skill-ability-group--int{--skill-accent:#6faeff}.skill-ability-group--wis{--skill-accent:#55c7a3}.skill-ability-group--cha{--skill-accent:#bc8cff}.skill-ability-heading{display:flex;width:100%;align-items:center;gap:9px;padding:11px 13px;border:0;color:var(--realm-text);text-align:left;background:rgba(255,255,255,.02)}.skill-ability-heading:focus-visible{outline:2px solid var(--skill-accent);outline-offset:-3px}.skill-ability-icon{display:grid;width:31px;height:31px;place-items:center;border:1px solid var(--skill-accent);border-radius:9px;color:var(--skill-accent);font-size:1.1rem}.skill-ability-heading small{display:block;color:var(--realm-muted);font-size:.68rem;text-transform:uppercase;letter-spacing:.12em}.skill-ability-heading strong{font-size:.87rem}.skill-ability-count{margin-left:auto;color:var(--realm-muted);font-size:.75rem}.skill-codex-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;padding:9px}
+.skill-codex-card{display:grid;grid-template-columns:auto minmax(0,1fr);gap:8px;padding:11px;border:1px solid rgba(157,186,232,.14);border-radius:12px;background:linear-gradient(145deg,rgba(25,42,72,.72),rgba(8,14,28,.86));transition:transform .18s ease,border-color .18s ease,box-shadow .18s ease}.skill-codex-card:hover,.skill-codex-card.is-selected{transform:translateY(-2px);border-color:var(--skill-accent);box-shadow:0 10px 22px rgba(0,0,0,.22)}.skill-codex-card__main{display:contents;color:inherit;text-align:left;background:none;border:0}.skill-codex-card__main:focus-visible{outline:2px solid var(--skill-accent);outline-offset:3px;border-radius:5px}.skill-codex-card__bonus{align-self:center;color:#f6d779;font-weight:900;font-size:1.55rem;line-height:1}.skill-codex-card__identity{min-width:0}.skill-codex-card__identity strong,.skill-codex-card__identity small{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.skill-codex-card__identity strong{font-size:.9rem}.skill-codex-card__identity small{margin-top:3px;color:var(--realm-muted);font-size:.69rem}.skill-codex-card__actions{grid-column:1/-1;justify-content:space-between}.skill-codex-card__training{grid-column:1/-1}.skill-status-chip{display:inline-flex;width:max-content;padding:4px 7px;border:1px solid rgba(170,185,208,.2);border-radius:999px;color:#aeb9ca;background:rgba(255,255,255,.04);font-size:.64rem;font-weight:800;letter-spacing:.04em;text-transform:uppercase}.skill-status-chip.is-proficient{color:#89c7ff;border-color:rgba(91,168,255,.45);background:rgba(48,119,216,.15)}.skill-status-chip.is-expertise{color:#ffdc7a;border-color:rgba(238,188,71,.48);background:rgba(202,148,34,.14)}.skill-icon-button{display:grid;width:30px;height:30px;place-items:center;border:1px solid rgba(146,179,230,.2);border-radius:9px;color:#a8d5ff;background:rgba(8,21,42,.75)}.skill-icon-button:hover,.skill-icon-button:focus-visible{color:#fff;border-color:#65b0ff;outline:none}.skill-training-chip{padding:5px 8px}.skill-training-chip.is-active{color:#b7ddff;border-color:rgba(91,168,255,.56);background:rgba(48,119,216,.2)}.skill-training-chip--expertise.is-active{color:#ffdc7a;border-color:rgba(238,188,71,.55);background:rgba(202,148,34,.16)}.skill-training-chip:disabled{cursor:not-allowed;opacity:.42}
+.skill-codex-inspector{position:sticky;top:0;min-height:280px;padding:16px;border:1px solid rgba(161,132,255,.24);border-radius:16px;background:linear-gradient(155deg,rgba(31,26,62,.91),rgba(8,17,35,.94));box-shadow:inset 0 1px rgba(255,255,255,.06),0 16px 35px rgba(0,0,0,.22)}.skill-codex-inspector__heading{display:flex;justify-content:space-between}.skill-codex-inspector__ability{display:block;margin-top:16px;color:#c6a8ff;font-size:.78rem;text-transform:uppercase;letter-spacing:.09em}.skill-codex-inspector h3{display:flex;justify-content:space-between;align-items:center;margin:5px 0 10px;font-size:1.35rem}.skill-codex-inspector h3 strong{color:#f6d779}.skill-codex-inspector p{color:#c2cce0;font-size:.87rem;line-height:1.55}.skill-codex-inspector h4{margin:20px 0 7px;color:#d8b76a;font-size:.72rem;letter-spacing:.12em;text-transform:uppercase}.skill-breakdown{display:grid;gap:5px;margin:0}.skill-breakdown div{display:flex;justify-content:space-between;gap:8px;padding:7px 0;border-bottom:1px solid rgba(166,185,224,.1)}.skill-breakdown dt{color:var(--realm-muted);font-size:.78rem;font-weight:500}.skill-breakdown dd{margin:0;color:#f4f8ff;font-weight:800}.skill-inspector-roll{width:100%;margin-top:16px}.skill-codex-inspector__empty{display:grid;min-height:240px;place-items:center;align-content:center;text-align:center;color:var(--realm-muted)}.skill-codex-inspector__empty i{color:#c6a8ff;font-size:1.5rem}.skill-codex-inspector__empty strong{margin-top:10px;color:var(--realm-text)}.skill-codex-empty{padding:35px;border:1px dashed var(--realm-border);border-radius:14px;color:var(--realm-muted);text-align:center}
+@media(max-width:850px){.skill-codex-summary{grid-template-columns:1fr}.skill-codex-toolbar{grid-template-columns:1fr}.skill-codex-layout{grid-template-columns:1fr}.skill-codex-inspector{position:static}.skill-codex-inspector__empty{display:none}}@media(max-width:575px){.skill-codex-body{padding:12px!important}.skill-codex-summary{padding:13px;margin:0 -2px 12px}.skill-codex-stats{grid-template-columns:repeat(2,minmax(0,1fr))}.skill-codex-stat:last-child{grid-column:span 2}.skill-codex-filter-row{flex-wrap:nowrap;overflow-x:auto;padding-bottom:3px}.skill-filter-chip{white-space:nowrap}.skill-codex-grid{grid-template-columns:1fr}.skill-codex-inspector{margin-top:6px}.skill-ability-heading{padding:10px}}@media(prefers-reduced-motion:reduce){.skill-codex-card,.skill-filter-chip,.skill-training-chip{transition:none}}
+
+/* Keep the Codex library in its own scroll region as ability sections expand. */
+.skill-codex-card-shell {
+  height: calc(100dvh - 2rem);
+  max-height: calc(100dvh - 2rem);
+  min-height: 0;
+}
+
+.skill-codex-card-shell .skill-codex-body {
+  min-height: 0;
+  overflow-y: auto !important;
+  overscroll-behavior: contain;
+}
+
+.skill-codex-footer {
+  justify-content: flex-start;
+}
+
+.skill-codex-close-button {
+  flex: 0 0 auto;
+  min-width: 8rem;
+}
+
+@media (max-width: 768px) {
+  .skill-codex-card-shell {
+    height: 92dvh;
+    max-height: 92dvh;
+  }
+}
+
+/* On touch screens, open the skill inspector above the library instead of after it. */
+@media (max-width: 850px) {
+  .skill-codex-inspector.is-open {
+    position: fixed;
+    z-index: 1065;
+    right: 1rem;
+    bottom: calc(5.75rem + env(safe-area-inset-bottom));
+    left: 1rem;
+    width: min(calc(100vw - 2rem), 38rem);
+    max-height: min(68dvh, 42rem);
+    min-height: 0;
+    margin: 0 auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    animation: skill-codex-inspector-in .2s ease-out;
+  }
+
+  .skill-codex-inspector.is-open::before {
+    position: fixed;
+    z-index: -1;
+    inset: 0;
+    content: '';
+    background: rgba(2, 7, 17, .42);
+    pointer-events: none;
+  }
+}
+
+@keyframes skill-codex-inspector-in {
+  from { opacity: 0; transform: translateY(1rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skill-codex-inspector.is-open { animation: none; }
+}

--- a/client/src/components/Zombies/attributes/Skills.js
+++ b/client/src/components/Zombies/attributes/Skills.js
@@ -5,7 +5,6 @@ import { useParams } from 'react-router-dom';
 
 import { SKILLS } from '../skillSchema';
 import proficiencyBonus from '../../../utils/proficiencyBonus';
-import SkillInfoModal from './SkillInfoModal';
 import { normalizeEquipmentMap } from './equipmentNormalization';
 import DockControls from '../components/DockControls';
 import {
@@ -29,6 +28,14 @@ const ABILITY_LABELS = {
   wis: 'Wisdom',
   cha: 'Charisma',
 };
+
+const ABILITY_ICONS = {
+  str: '✦', dex: '↟', con: '⬡', int: '✧', wis: '◉', cha: '❖',
+};
+
+const ABILITY_ORDER = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
+const formatBonus = (value) => `${Number(value) >= 0 ? '+' : ''}${Number(value)}`;
 
 const formatAdjustmentSegment = (value, label) => {
   if (!value) return null;
@@ -184,8 +191,11 @@ export default function Skills({
   const formExpertisePoints = safeForm.expertisePoints || 0;
   const [skills, setSkills] = useState(formSkills);
   const [error, setError] = useState('');
-  const [showSkillInfo, setShowSkillInfo] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [skillFilter, setSkillFilter] = useState('all');
+  const [sortOrder, setSortOrder] = useState('ability');
+  const [collapsedAbilities, setCollapsedAbilities] = useState({});
   const [modifierPrompt, setModifierPrompt] = useState(null);
   const [selectedModifierAbility, setSelectedModifierAbility] = useState('');
   const [isRollingSkill, setIsRollingSkill] = useState(false);
@@ -335,6 +345,60 @@ export default function Skills({
 
   const selectableSkills = new Set(safeForm.allowedSkills || []);
   const selectableExpertise = new Set(safeForm.allowedExpertise || []);
+
+  const skillRecords = useMemo(() => SKILLS.map((skill) => {
+    const { key, ability, armorPenalty = 0 } = skill;
+    const current = skills[key] || {};
+    const isProficient = Boolean(current.proficient || lockedProficiencies.has(key));
+    const expertise = Boolean(current.expertise || lockedExpertise.has(key));
+    const armorPenaltyValue = armorPenalty ? armorPenalty * totalCheckPenalty : 0;
+    const proficiencyValue = profBonus * (expertise ? 2 : isProficient ? 1 : 0);
+    return {
+      ...skill,
+      proficient: isProficient,
+      expertise,
+      armorPenaltyValue,
+      proficiencyValue,
+      itemBonus: itemTotals[key],
+      featBonus: featTotals[key],
+      raceBonus: raceTotals[key],
+      total: modMap[ability] + proficiencyValue + armorPenaltyValue + itemTotals[key] + featTotals[key] + raceTotals[key],
+    };
+  }), [skills, lockedProficiencies, lockedExpertise, totalCheckPenalty, profBonus, itemTotals, featTotals, raceTotals, strMod, dexMod, conMod, intMod, wisMod, chaMod]);
+
+  const visibleSkillGroups = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    const filtered = skillRecords.filter((skill) => {
+      const matchesQuery = !query || [skill.label, ABILITY_LABELS[skill.ability], skill.description]
+        .some((value) => value.toLowerCase().includes(query));
+      const matchesFilter = skillFilter === 'all'
+        || (skillFilter === 'proficient' && skill.proficient)
+        || (skillFilter === 'expertise' && skill.expertise)
+        || (skillFilter === 'untrained' && !skill.proficient)
+        || skillFilter === skill.ability;
+      return matchesQuery && matchesFilter;
+    });
+    const byAbility = ABILITY_ORDER.map((ability) => ({
+      ability,
+      skills: filtered.filter((skill) => skill.ability === ability).sort((a, b) => {
+        if (sortOrder === 'highest') return b.total - a.total || a.label.localeCompare(b.label);
+        if (sortOrder === 'alphabetical') return a.label.localeCompare(b.label);
+        if (sortOrder === 'proficient') return Number(b.proficient) - Number(a.proficient) || b.total - a.total;
+        if (sortOrder === 'expertise') return Number(b.expertise) - Number(a.expertise) || b.total - a.total;
+        return 0;
+      }),
+    }));
+    return sortOrder === 'highest' || sortOrder === 'alphabetical' || sortOrder === 'proficient' || sortOrder === 'expertise'
+      ? byAbility.filter((group) => group.skills.length)
+      : byAbility.filter((group) => group.skills.length);
+  }, [skillRecords, searchQuery, skillFilter, sortOrder]);
+
+  const strongestSkill = useMemo(
+    () => skillRecords.reduce((best, skill) => (!best || skill.total > best.total ? skill : best), null),
+    [skillRecords],
+  );
+  const passivePerception = (skillRecords.find((skill) => skill.key === 'perception')?.total || 0) + 10;
+  const activeSkill = skillRecords.find((skill) => skill.key === selectedSkill) || null;
 
   const dialogClassName = useMemo(() => {
     if (!isDocked) {
@@ -555,12 +619,8 @@ export default function Skills({
 
   const handleView = (skill) => {
     setSelectedSkill(skill);
-    setShowSkillInfo(true);
   };
 
-  const handleCloseSkillInfo = () => {
-    setShowSkillInfo(false);
-  };
 
   return (
     <>
@@ -576,7 +636,7 @@ export default function Skills({
         restoreFocus={!isDocked}
         dialogClassName={dialogClassName}
       >
-        <Card className="modern-card text-center">
+        <Card className="modern-card text-center skill-codex-card-shell">
           <Card.Header className="modal-header">
             <DockControls
               dockedSide={dockedSide}
@@ -585,120 +645,105 @@ export default function Skills({
             />
             <Card.Title className="modal-title">Skills</Card.Title>
           </Card.Header>
-          <Card.Body style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+          <Card.Body className="skill-codex-body">
             {error && (
               <Alert variant="danger" onClose={() => setError('')} dismissible>
                 {error}
               </Alert>
             )}
-            <div className="points-container" style={{ display: 'flex' }}>
-              <span className="points-label text-light">Proficiencies Left:</span>
-              <span className="points-value">{proficiencyPointsLeft}</span>
-            </div>
-            <div className="points-container" style={{ display: 'flex' }}>
-              <span className="points-label text-light">Expertise Left:</span>
-              <span className="points-value">{expertisePointsLeft}</span>
-            </div>
-            <div className="skills-card-grid">
-              {SKILLS.map(({
-                key,
-                label,
-                ability,
-                armorPenalty = 0,
-              }) => {
-                const { proficient = false, expertise = false } =
-                  skills[key] || {};
-                const penalty = armorPenalty
-                  ? armorPenalty * totalCheckPenalty
-                  : 0;
-                const isProficient = proficient || lockedProficiencies.has(key);
-                const multiplier = expertise ? 2 : isProficient ? 1 : 0;
-                const total =
-                  modMap[ability] +
-                  profBonus * multiplier +
-                  penalty +
-                  itemTotals[key] +
-                  featTotals[key] +
-                  raceTotals[key];
-                const isSelectable = selectableSkills.has(key);
-                const isRaceSkill = raceProficiencies.has(key);
-                const isBackgroundSkill = backgroundProficiencies.has(key);
-                const abilityLabel = ability?.toUpperCase();
-                const proficiencyId = `skill-${key}-proficiency`;
-                const expertiseId = `skill-${key}-expertise`;
+            <section className="skill-codex-summary" aria-label="Skill summary">
+              <div className="skill-codex-summary__title">
+                <span className="skill-codex-kicker">Adventurer's reference</span>
+                <h2>Skill Codex</h2>
+                <p>Master your strengths, chart your training, and roll with confidence.</p>
+              </div>
+              <div className="skill-codex-stats">
+                <div className={`skill-codex-stat ${proficiencyPointsLeft === 0 ? 'is-complete' : ''}`}>
+                  <span>Proficiencies remaining</span><strong>{proficiencyPointsLeft === 0 ? '✓ Complete' : proficiencyPointsLeft}</strong>
+                </div>
+                <div className={`skill-codex-stat ${expertisePointsLeft === 0 ? 'is-complete' : ''}`}>
+                  <span>Expertise remaining</span><strong>{expertisePointsLeft === 0 ? '✓ Complete' : expertisePointsLeft}</strong>
+                </div>
+                <div className="skill-codex-stat"><span>Highest skill</span><strong>{strongestSkill ? `${strongestSkill.label} ${formatBonus(strongestSkill.total)}` : '—'}</strong></div>
+                <div className="skill-codex-stat"><span>Passive perception</span><strong>{passivePerception}</strong></div>
+                <div className="skill-codex-stat"><span>Proficiency bonus</span><strong>{formatBonus(profBonus)}</strong></div>
+              </div>
+            </section>
 
-                return (
-                  <div key={key} className="skill-card">
-                    <div className="skill-card-header">
-                      <div className="skill-card-title">
-                        <span className="skill-card-name">{label}</span>
-                        <span className="skill-card-ability">{abilityLabel}</span>
-                      </div>
-                      <div className="skill-card-actions">
-                        <Button
-                          onClick={() => handleView(key)}
-                          variant="link"
-                          aria-label={`view ${label}`}
-                        >
-                          <i className="fa-solid fa-eye"></i>
-                        </Button>
-                        <Button
-                          onClick={() =>
-                            handleRoll(key, ability, isProficient, expertise)
-                          }
-                          variant="link"
-                          aria-label={`roll ${label}`}
-                        >
-                          <i className="fa-solid fa-dice-d20"></i>
-                        </Button>
-                      </div>
-                    </div>
-                    <div className="skill-card-metrics">
-                      <div className="skill-card-metric">
-                        <span className="skill-card-metric-label">Total</span>
-                        <span className="skill-card-metric-value">{total}</span>
-                      </div>
-                      <div className="skill-card-metric">
-                        <span className="skill-card-metric-label">Mod</span>
-                        <span className="skill-card-metric-value">
-                          {modMap[ability]}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="skill-card-toggles">
-                      <Form.Check
-                        id={proficiencyId}
-                        className="skill-checkbox"
-                        type="checkbox"
-                        label="Proficient"
-                        checked={proficient}
-                        disabled={!isSelectable || isRaceSkill || isBackgroundSkill}
-                        onChange={() => toggleProficient(key)}
-                      />
-                      <Form.Check
-                        id={expertiseId}
-                        className="skill-checkbox"
-                        type="checkbox"
-                        label="Expertise"
-                        checked={expertise}
-                        disabled={
-                          !isProficient ||
-                          !selectableExpertise.has(key) ||
-                          lockedExpertise.has(key) ||
-                          (!expertise && expertisePointsLeft <= 0)
-                        }
-                        onChange={() => toggleExpertise(key)}
-                      />
-                    </div>
-                  </div>
-                );
-              })}
+            <section className="skill-codex-toolbar" aria-label="Search and filter skills">
+              <label className="skill-codex-search">
+                <i className="fa-solid fa-magnifying-glass" aria-hidden="true" />
+                <span className="visually-hidden">Search skills</span>
+                <input value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Search skills, abilities, or lore" />
+              </label>
+              <div className="skill-codex-filter-row" role="group" aria-label="Skill status filters">
+                {[
+                  ['all', 'All'], ['proficient', 'Proficient'], ['expertise', 'Expertise'], ['untrained', 'Untrained'],
+                ].map(([value, label]) => <button key={value} type="button" className={`skill-filter-chip ${skillFilter === value ? 'is-active' : ''}`} onClick={() => setSkillFilter(value)} aria-pressed={skillFilter === value}>{label}</button>)}
+              </div>
+              <label className="skill-codex-sort">Sort
+                <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value)} aria-label="Sort skills">
+                  <option value="ability">Ability</option><option value="highest">Highest bonus</option><option value="alphabetical">Alphabetical</option><option value="proficient">Proficient</option><option value="expertise">Expertise</option>
+                </select>
+              </label>
+            </section>
+
+            <div className="skill-codex-layout">
+              <main className="skill-codex-library" aria-live="polite">
+                {visibleSkillGroups.length ? visibleSkillGroups.map(({ ability, skills: abilitySkills }) => (
+                  <section key={ability} className={`skill-ability-group skill-ability-group--${ability}`}>
+                    <button type="button" className="skill-ability-heading" onClick={() => setCollapsedAbilities((previous) => ({ ...previous, [ability]: !previous[ability] }))} aria-expanded={!collapsedAbilities[ability]}>
+                      <span className="skill-ability-icon" aria-hidden="true">{ABILITY_ICONS[ability]}</span>
+                      <span><small>{ABILITY_LABELS[ability]}</small><strong>{formatBonus(modMap[ability])} modifier</strong></span>
+                      <span className="skill-ability-count">{abilitySkills.length} skills <i className={`fa-solid fa-chevron-${collapsedAbilities[ability] ? 'down' : 'up'}`} aria-hidden="true" /></span>
+                    </button>
+                    {!collapsedAbilities[ability] && <div className="skill-codex-grid">
+                      {abilitySkills.map((skill) => {
+                        const isSelectable = selectableSkills.has(skill.key);
+                        const isRaceSkill = raceProficiencies.has(skill.key);
+                        const isBackgroundSkill = backgroundProficiencies.has(skill.key);
+                        const canToggleProficiency = isSelectable && !isRaceSkill && !isBackgroundSkill && (skill.proficient || proficiencyPointsLeft > 0);
+                        const canToggleExpertise = skill.proficient && selectableExpertise.has(skill.key) && !lockedExpertise.has(skill.key) && (skill.expertise || expertisePointsLeft > 0);
+                        const status = skill.expertise ? 'Expertise' : skill.proficient ? 'Proficient' : 'Not trained';
+                        return <article key={skill.key} className={`skill-codex-card ${selectedSkill === skill.key ? 'is-selected' : ''}`}>
+                          <button type="button" className="skill-codex-card__main" onClick={() => handleView(skill.key)} aria-label={`View ${skill.label} details`}>
+                            <span className="skill-codex-card__bonus">{formatBonus(skill.total)}</span>
+                            <span className="skill-codex-card__identity"><strong>{skill.label}</strong><small>{ABILITY_LABELS[skill.ability]} · {skill.ability.toUpperCase()} {formatBonus(modMap[skill.ability])}</small></span>
+                          </button>
+                          <div className="skill-codex-card__actions">
+                            <span className={`skill-status-chip is-${status.toLowerCase().replace(' ', '-')}`}>{status}</span>
+                            <button type="button" className="skill-icon-button" onClick={() => handleRoll(skill.key, skill.ability, skill.proficient, skill.expertise)} aria-label={`roll ${skill.label}`} title="Roll skill check"><i className="fa-solid fa-dice-d20" aria-hidden="true" /></button>
+                          </div>
+                          <div className="skill-codex-card__training" role="group" aria-label={`${skill.label} training`}>
+                            <button type="button" className={`skill-training-chip ${skill.proficient ? 'is-active' : ''}`} disabled={!canToggleProficiency} onClick={() => toggleProficient(skill.key)} aria-pressed={skill.proficient}>Proficient</button>
+                            <button type="button" className={`skill-training-chip skill-training-chip--expertise ${skill.expertise ? 'is-active' : ''}`} disabled={!canToggleExpertise} onClick={() => toggleExpertise(skill.key)} aria-pressed={skill.expertise}>Expertise</button>
+                          </div>
+                        </article>;
+                      })}
+                    </div>}
+                  </section>
+                )) : <div className="skill-codex-empty">No skills match this search. Clear a filter to reveal your full codex.</div>}
+              </main>
+              <aside
+                className={`skill-codex-inspector ${activeSkill ? 'is-open' : ''}`}
+                aria-label="Skill details"
+                aria-modal={activeSkill ? 'true' : undefined}
+                role={activeSkill ? 'dialog' : undefined}
+              >
+                {activeSkill ? <>
+                  <div className="skill-codex-inspector__heading"><span className={`skill-status-chip is-${(activeSkill.expertise ? 'expertise' : activeSkill.proficient ? 'proficient' : 'not-trained')}`}>{activeSkill.expertise ? 'Expertise' : activeSkill.proficient ? 'Proficient' : 'Not trained'}</span><button type="button" className="skill-icon-button" onClick={() => setSelectedSkill(null)} aria-label="Close skill details"><i className="fa-solid fa-xmark" /></button></div>
+                  <span className="skill-codex-inspector__ability">{ABILITY_ICONS[activeSkill.ability]} {ABILITY_LABELS[activeSkill.ability]}</span><h3>{activeSkill.label} <strong>{formatBonus(activeSkill.total)}</strong></h3><p>{activeSkill.description}</p>
+                  <h4>Bonus breakdown</h4>
+                  <dl className="skill-breakdown"><div><dt>Ability modifier</dt><dd>{formatBonus(modMap[activeSkill.ability])}</dd></div><div><dt>{activeSkill.expertise ? 'Expertise bonus' : 'Proficiency bonus'}</dt><dd>{formatBonus(activeSkill.proficiencyValue)}</dd></div><div><dt>Equipment & features</dt><dd>{formatBonus(activeSkill.itemBonus + activeSkill.featBonus + activeSkill.raceBonus)}</dd></div>{activeSkill.armorPenaltyValue !== 0 && <div><dt>Armor penalty</dt><dd>{formatBonus(activeSkill.armorPenaltyValue)}</dd></div>}</dl>
+                  <Button className="skill-inspector-roll" onClick={() => handleRoll(activeSkill.key, activeSkill.ability, activeSkill.proficient, activeSkill.expertise)} aria-label={`roll ${activeSkill.label}`}>Roll {activeSkill.label}</Button>
+                </> : <div className="skill-codex-inspector__empty"><i className="fa-solid fa-book-open" aria-hidden="true" /><strong>Skill inspector</strong><p>Select a skill to view its lore, current bonus, and training details.</p></div>}
+              </aside>
             </div>
           </Card.Body>
-          <Card.Footer className="modal-footer d-flex">
+          <Card.Footer className="modal-footer d-flex skill-codex-footer">
             <Button
               onClick={() => handleCloseSkill()}
-              className="action-btn close-btn flex-fill"
+              className="action-btn close-btn skill-codex-close-button"
             >Close</Button>
           </Card.Footer>
         </Card>
@@ -743,12 +788,6 @@ export default function Skills({
           </Card.Footer>
         </Card>
       </Modal>
-      <SkillInfoModal
-        show={showSkillInfo}
-        onHide={handleCloseSkillInfo}
-        skillKey={selectedSkill}
-      />
     </>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Replace the old flat skills list with a richer, searchable and filterable "Skill Codex" experience to make skill information, training toggles, and rolling more discoverable and usable.
- Provide a persistent inspector panel and mobile-friendly behavior so skill details can be viewed and rolled without losing context.

### Description
- Added a large set of new styles in `client/src/App.scss` to support the Skill Codex visual design, responsive layouts, animations, and a separate scroll region for the codex library.
- Refactored `client/src/components/Zombies/attributes/Skills.js` to compute `skillRecords`, `visibleSkillGroups`, `strongestSkill`, and `passivePerception`, and to introduce search, filter, sort, grouping by ability, collapse state, and an inspector pane instead of the previous `SkillInfoModal`.
- Introduced UI states and helpers: `ABILITY_ICONS`, `ABILITY_ORDER`, `formatBonus`, and new React state hooks for `searchQuery`, `skillFilter`, `sortOrder`, and `collapsedAbilities`, plus updates to markup and ARIA attributes for accessibility and keyboard focus.
- Kept existing actions intact (toggle proficiency/expertise, roll skill checks, close/dock behaviors) while updating class names and layout (`skill-codex-card-shell`, `skill-codex-body`, `skill-codex-footer`, `skill-codex-close-button`).

### Testing
- Performed a local development build with `npm run build` to ensure the frontend compiles and bundling succeeded.
- Ran the test suite with `npm test` and verified unit tests and linting for the modified files passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f6c4dcd20832e9ea0bd5421384ec3)