### PR TITLE
Fix mobile Settings & Help modal clipping

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -12119,9 +12119,10 @@ body.character-creation-modal-open {
 .delete-character-confirmation__portrait { width: 76px; height: 76px; margin: 0 auto; border-radius: 24px; display: inline-flex; align-items: center; justify-content: center; background: linear-gradient(135deg, rgba(248,113,113,.26), rgba(216,183,106,.16)); border: 1px solid rgba(248,113,113,.42); color: #fff8df; font: 900 2rem 'Cinzel', serif; }
 .delete-character-footer { justify-content: flex-end !important; }
 @media (max-width: 767px) {
-  .settings-help-dialog { max-width: 100vw; margin: 0; min-height: 100%; }
-  .settings-help-dialog .modal-content { height: 100vh; min-height: 100vh; border-radius: 0 !important; }
-  .settings-help-shell { display: flex; flex-direction: column; height: 100vh; min-height: 0; border-radius: 0 !important; }
+  /* Use the visible viewport so the full-screen sheet is not hidden by mobile browser chrome. */
+  .settings-help-dialog { max-width: 100vw; margin: 0; min-height: 100vh; min-height: 100dvh; }
+  .settings-help-dialog .modal-content { height: 100vh; height: 100dvh; min-height: 100vh; min-height: 100dvh; border-radius: 0 !important; }
+  .settings-help-shell { display: flex; flex-direction: column; height: 100vh; height: 100dvh; min-height: 0; border-radius: 0 !important; }
   .settings-help-header { min-height: 76px; padding: calc(12px + env(safe-area-inset-top)) 60px 12px 16px !important; justify-content: flex-start; }
   .settings-help-title-block { text-align: left; }
   .settings-help-title-block p { display: none; }


### PR DESCRIPTION
### Motivation
- Prevent the Settings & Help full-screen sheet from being obscured by mobile browser chrome by sizing it to the visible viewport.

### Description
- Update `client/src/App.scss` to use `100dvh` (with `100vh` fallback) for the Settings & Help dialog, modal content, and shell so the modal tracks the dynamic viewport on mobile devices.

### Testing
- Ran `npm --prefix client run build` which completed successfully.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6000608a88832e9c0f5622301704bc)