### PR TITLE
Fix mobile character features modal scrolling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13308,6 +13308,25 @@ ul.spellbook-tabs.nav-tabs {
     bottom: 0;
     z-index: 5;
   }
+
+  /* Keep the controls with the content on small screens so they scroll out of
+     view, leaving room to reach the footer close button. */
+  .abilities-codex-card .abilities-codex-toolbar {
+    position: static;
+    padding: 0.75rem;
+  }
+
+  .abilities-codex-card .abilities-codex-title-row h2 {
+    font-size: 1.35rem;
+  }
+
+  .abilities-codex-card .abilities-codex-title-row p {
+    display: none;
+  }
+
+  .abilities-codex-card .abilities-codex-controls {
+    margin-top: 0.65rem;
+  }
 }
 
 @media (max-width: 575px) {

--- a/client/src/components/Zombies/attributes/Features.js
+++ b/client/src/components/Zombies/attributes/Features.js
@@ -1754,8 +1754,7 @@ export default function Features({
         restoreFocus={!isDocked}
         dialogClassName={dialogClassName}
       >
-        <div className="text-center">
-          <Card className="modern-card abilities-codex-card">
+        <Card className="modern-card abilities-codex-card">
             <Card.Header className="modal-header">
               <DockControls
                 dockedSide={dockedSide}
@@ -2296,8 +2295,7 @@ export default function Features({
                 Close
               </Button>
             </Card.Footer>
-          </Card>
-        </div>
+        </Card>
       </Modal>
       <FeatureModal
         show={showModal}


### PR DESCRIPTION
### Motivation
- On small screens the Character Features modal kept the toolbar/header pinned and the card wrapper prevented the modal from reserving room for its footer, which caused the footer Close button to be clipped and the close control to be unreachable.
- The intent is to make the features modal behave like the spell modal on mobile by allowing the header/search controls to scroll away and ensuring the footer remains reachable.

### Description
- Place the features `Card` directly inside the `Modal` by removing the extra wrapper so the modal's flex layout can reserve space for the footer; change in `client/src/components/Zombies/attributes/Features.js`.
- Make the abilities toolbar flow with the content on small screens by setting `.abilities-codex-card .abilities-codex-toolbar { position: static; }` and compact the toolbar (padding, smaller title, hide subtitle) to free vertical space; changes in `client/src/App.scss`.
- Tweak the toolbar controls spacing so the search/sort controls scroll with the list and do not remain sticky, improving reachability of the footer Close button on mobile.

### Testing
- Ran the feature unit tests with `CI=true npm test -- --runInBand src/components/Zombies/attributes/Features.test.js` and the suite passed (all tests in the file passed).
- Built the client bundle with `CI=true npm run build` which completed successfully (build emitted existing browserslist/baseline warnings but exited successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a600371ef64832e85027c6ef0785209)