### PR TITLE
Fix blank skills modal panel on mobile

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13504,6 +13504,10 @@ ul.spellbook-tabs.nav-tabs {
 
 /* On touch screens, open the skill inspector above the library instead of after it. */
 @media (max-width: 850px) {
+  .skill-codex-inspector:not(.is-open) {
+    display: none;
+  }
+
   .skill-codex-inspector.is-open {
     position: fixed;
     z-index: 1065;


### PR DESCRIPTION
### Motivation
- On narrow screens the skills modal showed an inert purple inspector panel even when no skill was selected, creating a confusing blank area.

### Description
- Add a CSS rule in `client/src/App.scss` to hide `.skill-codex-inspector` when it does not have the `.is-open` class inside the `@media (max-width: 850px)` block.
- Preserve the existing fixed overlay and animation behavior for `.skill-codex-inspector.is-open` so the inspector still appears correctly when a skill is selected.
- Only one file was modified: `client/src/App.scss`.

### Testing
- Built the client to verify styles and bundling with `CI=true npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a600591eb14832e865e38cab5634797)