### PR TITLE
Fix level-up modal: remove duplicate header close & improve mobile scrolling

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -11827,6 +11827,7 @@ body.character-creation-modal-open {
 /* Premium character management modals */
 .character-info-modal .modal-dialog { max-width: min(1180px, calc(100vw - 32px)); }
 .progression-modal .modal-dialog { max-width: min(920px, calc(100vw - 32px)); }
+.progression-modal .modal-content { height: min(88dvh, 980px); max-height: min(88dvh, 980px); }
 .character-info-shell,
 .progression-shell {
   display: grid;
@@ -11836,6 +11837,7 @@ body.character-creation-modal-open {
   border: 0;
   background: transparent;
 }
+.progression-shell { height: 100%; max-height: none; }
 .character-info-shell .realm-modal-header,
 .progression-shell .realm-modal-header {
   min-height: 88px;
@@ -11860,7 +11862,14 @@ body.character-creation-modal-open {
 .character-summary-header__copy p, .character-summary-header__copy span, .character-summary-header__copy small { margin: 0; color: rgba(238,246,255,.78); }
 .character-summary-header__copy span { white-space: normal; overflow-wrap: anywhere; }
 .character-info-body,
-.progression-body { min-height: 0; overflow-y: auto; padding: 22px !important; }
+.progression-body {
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: 22px !important;
+}
 .character-info-layout { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(280px, .8fr); gap: 16px; align-items: start; }
 .character-info-panel { padding: 18px; background: linear-gradient(145deg, rgba(15,29,52,.82), rgba(5,10,22,.88)); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
 .character-info-panel--progression { grid-row: span 2; }
@@ -11907,6 +11916,9 @@ body.character-creation-modal-open {
 @media (max-width: 768px) {
   .character-info-modal .modal-dialog, .progression-modal .modal-dialog { max-width: 100%; }
   .character-info-shell, .progression-shell { max-height: 92vh; }
+  .progression-modal .modal-dialog { height: 92dvh; max-height: 92dvh; }
+  .progression-modal .modal-content { height: 92dvh; max-height: 92dvh; }
+  .progression-shell { height: 100%; max-height: none; }
   .character-info-shell .realm-modal-header, .progression-shell .realm-modal-header { padding: 14px 60px 14px 16px; align-items: flex-start; flex-direction: column; }
   .realm-modal-header__actions { order: 0; }
   .character-summary-header__portrait { width: 52px; height: 52px; border-radius: 16px; }

--- a/client/src/components/Zombies/attributes/LevelUp.js
+++ b/client/src/components/Zombies/attributes/LevelUp.js
@@ -136,12 +136,11 @@ export default function LevelUp({ show, handleClose, form }) {
   const availablePrimalSkills = BARBARIAN_LEVEL_1_SKILLS.filter((skill) => !alreadyProficient.has(skill));
 
   return (
-    <Modal className="dnd-modal modern-modal progression-modal" show={show} onHide={close} centered size="lg" scrollable restoreFocus>
+    <Modal className="dnd-modal modern-modal progression-modal" show={show} onHide={close} centered size="lg" restoreFocus>
       <ModalShell className="progression-shell">
         <ModalHeader
           title={step === 'add-class' ? 'Add a Class' : 'Level Up'}
           subtitle={step === 'add-class' ? `Choose a new class for ${form.name || 'this character'}.` : `Choose how ${form.name || 'this character'} advances to level ${totalLevel + 1}.`}
-          onClose={close}
           actions={step === 'add-class' ? <Button variant="ghost" onClick={() => { setStep('choose-progression'); setSelectedNewClassId(''); }}>← Back</Button> : null}
         />
         <ModalBody className="progression-body">

--- a/client/src/components/Zombies/attributes/LevelUp.test.js
+++ b/client/src/components/Zombies/attributes/LevelUp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import LevelUp from './LevelUp';
 
 jest.mock('../../../utils/apiFetch');
@@ -21,4 +21,13 @@ test('fetches classes on mount', async () => {
   render(<LevelUp show={true} handleClose={() => {}} form={{ occupation: [] }} />);
 
   await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/classes'));
+});
+
+test('uses the footer cancel control instead of a duplicate header close button', () => {
+  useUser.mockReturnValue(null);
+
+  render(<LevelUp show={true} handleClose={() => {}} form={{ occupation: [] }} />);
+
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
 });


### PR DESCRIPTION
### Motivation
- The Level Up modal showed a redundant header close control and exhibited glitchy disappearing items on mobile due to competing scroll containers, so the intent is to provide a single, touch-friendly dismissal affordance and a stable mobile scrolling region.

### Description
- Remove the header close control by not rendering the header `onClose` prop and remove the `scrollable` prop on the `Modal` so the dialog uses a single, dedicated scroll region (`client/src/components/Zombies/attributes/LevelUp.js`).
- Constrain the progression modal viewport and enable a touch-friendly scroll area by adding height and mobile rules and making the progression body the scroll container with `-webkit-overflow-scrolling: touch` and `overscroll-behavior: contain` (`client/src/App.scss`).
- Add/adjust unit test imports and a regression test asserting the footer `Cancel` button is present and the duplicate header `Close` control is not rendered (`client/src/components/Zombies/attributes/LevelUp.test.js`).

### Testing
- Ran `CI=true npm test -- --runInBand client/src/components/Zombies/attributes/LevelUp.test.js` and the suite passed (2 tests), though the run emitted an existing React `act(...)` warning from the asynchronous class-catalogue mock. 
- Attempted `npm run build` in this environment, but the optimized production build did not complete here (the build process stalled and a full artifact was not produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60068fb440832ea35923c88ae0a611)