### PR TITLE
Add turn-based temporary effect lifecycle

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { io } from "socket.io-client";
 import apiFetch from '../../../utils/apiFetch';
+import { createCombatState as normalizeTimelineState, advanceTurn } from '../utils/combatTimeline';
 import { useParams } from "react-router-dom";
 import { Navbar, Container, Modal, Card, Button as BootstrapButton } from 'react-bootstrap';
 import '../../../App.scss';
@@ -123,7 +124,7 @@ const DOCKABLE_MODAL_DEFINITIONS = {
   shop: { label: 'Shop', component: ShopModal },
   help: { label: 'Help', component: Help },
 };
-const createEmptyCombatState = () => ({ participants: [], activeTurn: null });
+const createEmptyCombatState = () => normalizeTimelineState();
 export const formatSignedBonus = (value) => {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return '—';
@@ -240,7 +241,7 @@ const normalizeCombatState = (state) => {
       ? activeTurnCandidate
       : null;
 
-  return { participants, activeTurn };
+  return normalizeTimelineState({ ...state, participants, activeTurn });
 };
 
 const collectCharacterIdentifiers = (entity) => {
@@ -1951,7 +1952,8 @@ export default function ZombiesCharacterSheet() {
       return;
     }
 
-    const nextIndex = (activeIndex + 1) % participants.length;
+    const advancedState = advanceTurn(combatState);
+    const nextIndex = advancedState.activeTurn;
 
     const payload = {
       participants: participants.map((participant) => ({
@@ -1959,6 +1961,10 @@ export default function ZombiesCharacterSheet() {
         initiative: participant.initiative,
       })),
       activeTurn: nextIndex,
+      round: advancedState.round,
+      turnSequence: advancedState.turnSequence,
+      activeEffects: advancedState.activeEffects,
+      eventLog: advancedState.eventLog,
     };
 
     try {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -24,6 +24,7 @@ import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative, calculatePassivePerception } from '../utils/derivedStats';
 import { resolveInitiativeRollMode } from '../utils/barbarian';
 import { calculateCharacterHitPoints, calculateCharacterMovementSpeed } from '../utils/characterMetrics';
+import { createCombatState as normalizeTimelineState, advanceTurn, undoTurn } from '../utils/combatTimeline';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import DamageDiceCanvas from '../attributes/DamageDiceCanvas';
@@ -1166,7 +1167,7 @@ const normalizeCombatState = (state) => {
     }
   }
 
-  return { participants: sortedParticipants, activeTurn };
+  return normalizeTimelineState({ ...state, participants: sortedParticipants, activeTurn });
 };
 
 export const createActiveMapEnemySummaries = ({
@@ -4067,10 +4068,7 @@ export default function ZombiesDM() {
           return;
         }
 
-        const nextState = normalizeCombatState({
-          participants,
-          activeTurn: index,
-        });
+        const nextState = normalizeCombatState(advanceTurn({ ...combatState, participants }, { nextCombatantId: characterId }));
 
         setCombatState(nextState);
         persistCombatState(nextState);
@@ -4204,10 +4202,7 @@ export default function ZombiesDM() {
           nextIndex = direction > 0 ? 0 : total - 1;
         }
 
-        const nextState = normalizeCombatState({
-          participants,
-          activeTurn: nextIndex,
-        });
+        const nextState = normalizeCombatState(direction === 1 ? advanceTurn(combatState) : undoTurn(combatState));
 
         setCombatState(nextState);
         persistCombatState(nextState);

--- a/client/src/components/Zombies/utils/combatTimeline.js
+++ b/client/src/components/Zombies/utils/combatTimeline.js
@@ -1,0 +1,146 @@
+const BOUNDARIES = new Set(['start', 'end']);
+const STACK_POLICIES = new Set(['replace', 'refresh', 'stack', 'ignore']);
+
+export const createCombatState = (state = {}) => ({
+  participants: Array.isArray(state.participants) ? state.participants : [],
+  activeTurn: Number.isInteger(state.activeTurn) ? state.activeTurn : null,
+  round: Math.max(1, Number.isInteger(state.round) ? state.round : 1),
+  turnSequence: Math.max(0, Number.isInteger(state.turnSequence) ? state.turnSequence : 0),
+  activeEffects: Array.isArray(state.activeEffects) ? state.activeEffects : [],
+  eventLog: Array.isArray(state.eventLog) ? state.eventLog : [],
+  undoStack: Array.isArray(state.undoStack) ? state.undoStack : [],
+});
+
+const eventFor = (type, state, combatantId) => ({
+  type,
+  ...(combatantId ? { combatantId } : {}),
+  ...(!['combatEnded'].includes(type) ? { round: state.round } : {}),
+  ...(type === 'turnStarted' || type === 'turnEnded'
+    ? { turnSequence: state.turnSequence }
+    : {}),
+});
+
+export const durationToExpiration = (duration, { sourceCombatantId, targetCombatantId, round = 1 } = {}) => {
+  switch (duration?.type) {
+    case 'untilSourceTurn':
+    case 'sourceTurns':
+      return { type: 'sourceTurn', combatantId: sourceCombatantId, boundary: duration.boundary, remainingOccurrences: duration.count || 1 };
+    case 'untilTargetTurn':
+    case 'targetTurns':
+      return { type: 'targetTurn', combatantId: targetCombatantId, boundary: duration.boundary, remainingOccurrences: duration.count || 1 };
+    case 'rounds':
+      return { type: 'rounds', expiresAtRound: round + Math.max(1, duration.count || 1), boundary: duration.boundary };
+    case 'combat': return { type: 'combatEnd' };
+    case 'concentration': return { type: 'concentration', concentrationId: duration.concentrationId };
+    case 'permanent': return { type: 'manual' };
+    default: throw new Error(`Unsupported effect duration: ${duration?.type || 'missing'}`);
+  }
+};
+
+const expirationMatches = (effect, event) => {
+  const expiration = effect.expiration || {};
+  if (expiration.type === 'combatEnd') return event.type === 'combatEnded';
+  if (expiration.type === 'rounds') {
+    const type = expiration.boundary === 'end' ? 'roundEnded' : 'roundStarted';
+    return event.type === type && event.round >= expiration.expiresAtRound;
+  }
+  if (expiration.type !== 'sourceTurn' && expiration.type !== 'targetTurn') return false;
+  const type = expiration.boundary === 'end' ? 'turnEnded' : 'turnStarted';
+  return event.type === type && event.combatantId === expiration.combatantId &&
+    event.turnSequence > (effect.appliedAtTurnSequence ?? -1);
+};
+
+/** Resolve all effects as a batch; ids make simultaneous expiration deterministic. */
+export const resolveCombatEvent = (effects, event) => {
+  const expiredEffectIds = [];
+  const activeEffects = [...(effects || [])].sort((a, b) => String(a.id).localeCompare(String(b.id))).flatMap((effect) => {
+    if (!expirationMatches(effect, event)) return [effect];
+    const expiration = effect.expiration;
+    if (expiration.type === 'sourceTurn' || expiration.type === 'targetTurn') {
+      const remaining = Math.max(0, (expiration.remainingOccurrences || 1) - 1);
+      if (remaining > 0) return [{ ...effect, expiration: { ...expiration, remainingOccurrences: remaining } }];
+    }
+    expiredEffectIds.push(effect.id);
+    return [];
+  });
+  return { activeEffects, expiredEffectIds };
+};
+
+const emit = (state, event) => {
+  const resolved = resolveCombatEvent(state.activeEffects, event);
+  return { ...state, activeEffects: resolved.activeEffects, eventLog: [...state.eventLog, event], lastExpiredEffectIds: resolved.expiredEffectIds };
+};
+
+export const applyActiveEffect = (inputState, effect) => {
+  const state = createCombatState(inputState);
+  if (!effect?.id || !effect.targetCombatantId || !effect.expiration) throw new Error('Active effects require id, targetCombatantId, and expiration');
+  if ((effect.expiration.type === 'sourceTurn' || effect.expiration.type === 'targetTurn') && (!BOUNDARIES.has(effect.expiration.boundary) || !effect.expiration.combatantId)) throw new Error('Turn expiration requires a combatant and boundary');
+  const normalized = { ...effect, appliedAtTurnSequence: state.turnSequence, stackPolicy: STACK_POLICIES.has(effect.stackPolicy) ? effect.stackPolicy : 'refresh' };
+  const match = normalized.stackKey && state.activeEffects.findIndex((item) => item.stackKey === normalized.stackKey);
+  if (match >= 0 && normalized.stackPolicy !== 'stack') {
+    if (normalized.stackPolicy === 'ignore') return state;
+    const next = [...state.activeEffects];
+    next[match] = normalized.stackPolicy === 'refresh' ? { ...next[match], ...normalized, id: next[match].id } : normalized;
+    return { ...state, activeEffects: next };
+  }
+  return { ...state, activeEffects: [...state.activeEffects, normalized] };
+};
+
+export const removeActiveEffect = (inputState, effectId) => {
+  const state = createCombatState(inputState);
+  return { ...state, activeEffects: state.activeEffects.filter((effect) => effect.id !== effectId) };
+};
+
+export const removeCombatant = (inputState, combatantId) => {
+  const state = createCombatState(inputState);
+  const activeId = state.participants[state.activeTurn]?.characterId;
+  const participants = state.participants.filter((item) => item.characterId !== combatantId);
+  const activeTurn = activeId === combatantId ? null : participants.findIndex((item) => item.characterId === activeId);
+  return { ...state, participants, activeTurn: activeTurn < 0 ? null : activeTurn, activeEffects: state.activeEffects.filter((effect) => effect.targetCombatantId !== combatantId && effect.sourceCombatantId !== combatantId && effect.expiration?.combatantId !== combatantId) };
+};
+
+export const advanceTurn = (inputState, { nextCombatantId } = {}) => {
+  let state = createCombatState(inputState);
+  if (!state.participants.length) return state;
+  const snapshot = { ...state, undoStack: undefined };
+  state = { ...state, undoStack: [...state.undoStack, snapshot].slice(-20) };
+  const current = state.participants[state.activeTurn];
+  if (current) state = emit(state, eventFor('turnEnded', state, current.characterId));
+  else state = emit(state, eventFor('roundStarted', state));
+  let nextIndex = nextCombatantId ? state.participants.findIndex((item) => item.characterId === nextCombatantId) : (state.activeTurn === null ? 0 : (state.activeTurn + 1) % state.participants.length);
+  if (nextIndex < 0) throw new Error('Next combatant is not in combat');
+  const wrapped = Boolean(current) && !nextCombatantId && nextIndex <= state.activeTurn;
+  if (wrapped) {
+    state = emit(state, eventFor('roundEnded', state));
+    state = { ...state, round: state.round + 1 };
+    state = emit(state, eventFor('roundStarted', state));
+  }
+  state = { ...state, activeTurn: nextIndex, turnSequence: state.turnSequence + 1 };
+  return emit(state, eventFor('turnStarted', state, state.participants[nextIndex].characterId));
+};
+
+export const undoTurn = (inputState) => {
+  const state = createCombatState(inputState);
+  if (!state.undoStack.length) return state;
+  const snapshot = state.undoStack[state.undoStack.length - 1];
+  return createCombatState({ ...snapshot, undoStack: state.undoStack.slice(0, -1) });
+};
+
+export const endCombat = (inputState) => {
+  let state = createCombatState(inputState);
+  state = emit(state, eventFor('combatEnded', state));
+  return { ...state, activeTurn: null };
+};
+
+export const endConcentration = (inputState, concentrationId) => {
+  const state = createCombatState(inputState);
+  return {
+    ...state,
+    activeEffects: state.activeEffects.filter((effect) => effect.expiration?.type !== 'concentration' ||
+      (concentrationId && effect.expiration.concentrationId !== concentrationId)),
+  };
+};
+
+export const getEffectiveSpeed = (baseSpeed, effects, targetCombatantId) => Math.max(0,
+  (Number(baseSpeed) || 0) + (effects || []).filter((effect) => effect.targetCombatantId === targetCombatantId).flatMap((effect) => effect.modifiers || []).filter((modifier) => modifier.type === 'speed' && modifier.operation === 'add').reduce((sum, modifier) => sum + (Number(modifier.value) || 0), 0)
+);

--- a/client/src/components/Zombies/utils/combatTimeline.test.js
+++ b/client/src/components/Zombies/utils/combatTimeline.test.js
@@ -1,0 +1,136 @@
+import {
+  advanceTurn, applyActiveEffect, createCombatState, durationToExpiration,
+  endCombat, endConcentration, getEffectiveSpeed, removeCombatant, resolveCombatEvent, undoTurn,
+} from './combatTimeline';
+
+const participants = ['source', 'other', 'target'].map((characterId, index) => ({ characterId, initiative: 20 - index }));
+const stateAtSource = () => advanceTurn(createCombatState({ participants }));
+const effect = (overrides = {}) => ({
+  id: overrides.id || 'slow', definitionId: 'slow', sourceCombatantId: 'source', targetCombatantId: 'target',
+  expiration: { type: 'sourceTurn', combatantId: 'source', boundary: 'start', remainingOccurrences: 1 },
+  modifiers: [{ type: 'speed', operation: 'add', value: -15 }], stackKey: 'slow:source:target', stackPolicy: 'refresh', ...overrides,
+});
+
+describe('combat timeline effects', () => {
+  test('source start effects survive application and other turns, then expire next source turn', () => {
+    let state = applyActiveEffect(stateAtSource(), effect());
+    expect(state.activeEffects).toHaveLength(1);
+    state = advanceTurn(state); expect(state.activeEffects).toHaveLength(1);
+    state = advanceTurn(state); expect(state.activeEffects).toHaveLength(1);
+    state = advanceTurn(state); expect(state.activeEffects).toHaveLength(0);
+    expect(state.round).toBe(2);
+  });
+
+  test('an effect applied before the source acts expires later in the same round', () => {
+    let state = advanceTurn(createCombatState({ participants, activeTurn: 1, turnSequence: 4 })); // target
+    state = applyActiveEffect(state, effect());
+    state = advanceTurn(state); // wraps to source
+    expect(state.round).toBe(2);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test.each([['sourceTurn', 'source'], ['targetTurn', 'target']])('%s end boundary tracks its creature id', (type, combatantId) => {
+    let state = applyActiveEffect(stateAtSource(), effect({ expiration: { type, combatantId, boundary: 'end', remainingOccurrences: 1 } }));
+    if (combatantId === 'source') state = advanceTurn(state);
+    while (state.participants[state.activeTurn].characterId !== combatantId) state = advanceTurn(state);
+    state = advanceTurn(state);
+    expect(state.activeEffects).toHaveLength(0);
+    expect(state.eventLog.some((event) => event.type === 'turnEnded' && event.combatantId === combatantId)).toBe(true);
+  });
+
+  test('multiple creature turns count occurrences, including a true extra turn', () => {
+    let state = applyActiveEffect(stateAtSource(), effect({ expiration: { type: 'sourceTurn', combatantId: 'source', boundary: 'start', remainingOccurrences: 2 } }));
+    state = advanceTurn(state, { nextCombatantId: 'source' });
+    expect(state.activeEffects[0].expiration.remainingOccurrences).toBe(1);
+    state = advanceTurn(state, { nextCombatantId: 'source' });
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('initiative reordering and unrelated additions do not affect id-based expiration', () => {
+    let state = applyActiveEffect(stateAtSource(), effect());
+    state = { ...state, participants: [participants[2], { characterId: 'new', initiative: 15 }, participants[1], participants[0]], activeTurn: 2 };
+    state = advanceTurn(state);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('removing source or target cleans related effects, while unrelated removal does not', () => {
+    const state = applyActiveEffect(stateAtSource(), effect());
+    expect(removeCombatant(state, 'other').activeEffects).toHaveLength(1);
+    expect(removeCombatant(state, 'source').activeEffects).toHaveLength(0);
+    expect(removeCombatant(state, 'target').activeEffects).toHaveLength(0);
+  });
+
+  test('refresh replaces duration without stacking and stack explicitly stacks', () => {
+    let state = applyActiveEffect(stateAtSource(), effect());
+    state = advanceTurn(state);
+    state = applyActiveEffect(state, effect({ id: 'new' }));
+    expect(state.activeEffects).toHaveLength(1);
+    expect(state.activeEffects[0].id).toBe('slow');
+    state = applyActiveEffect(state, effect({ id: 'stacked', stackPolicy: 'stack' }));
+    expect(state.activeEffects).toHaveLength(2);
+  });
+
+  test('speed modifiers are derived, additive, clamped, and never mutate base speed', () => {
+    const base = 30;
+    let state = applyActiveEffect(stateAtSource(), effect());
+    state = applyActiveEffect(state, effect({ id: 'other-slow', stackKey: 'other', stackPolicy: 'stack', modifiers: [{ type: 'speed', operation: 'add', value: -20 }] }));
+    expect(getEffectiveSpeed(base, state.activeEffects, 'target')).toBe(0);
+    expect(base).toBe(30);
+    state = { ...state, activeEffects: [] };
+    expect(getEffectiveSpeed(base, state.activeEffects, 'target')).toBe(30);
+  });
+
+  test('skipped actions still process boundaries, while an extra action does not', () => {
+    let state = applyActiveEffect(stateAtSource(), effect({ expiration: { type: 'targetTurn', combatantId: 'target', boundary: 'start', remainingOccurrences: 1 } }));
+    const sequence = state.turnSequence; // an action has no timeline API call
+    expect(state.turnSequence).toBe(sequence);
+    state = advanceTurn(state); state = advanceTurn(state);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('undo atomically restores turn position, sequence, round, events, and expired effects', () => {
+    let state = applyActiveEffect(stateAtSource(), effect());
+    state = advanceTurn(advanceTurn(state));
+    const before = state;
+    state = advanceTurn(state);
+    expect(state.activeEffects).toHaveLength(0);
+    state = undoTurn(state);
+    expect(state).toMatchObject({ activeTurn: before.activeTurn, round: before.round, turnSequence: before.turnSequence, activeEffects: before.activeEffects });
+  });
+
+  test('JSON persistence retains expiration behavior and defaults migrate old saves', () => {
+    let state = applyActiveEffect(stateAtSource(), effect());
+    state = createCombatState(JSON.parse(JSON.stringify(state)));
+    state = advanceTurn(advanceTurn(advanceTurn(state)));
+    expect(state.activeEffects).toHaveLength(0);
+    expect(createCombatState({ participants: [] })).toMatchObject({ round: 1, turnSequence: 0, activeEffects: [] });
+  });
+
+  test('simultaneous expiration is deterministic by effect id', () => {
+    const event = { type: 'turnStarted', combatantId: 'source', round: 2, turnSequence: 2 };
+    const result = resolveCombatEvent([effect({ id: 'z' }), effect({ id: 'a', stackKey: 'a' })], event);
+    expect(result.expiredEffectIds).toEqual(['a', 'z']);
+  });
+
+  test('combat and round durations expire on their declared lifecycle boundaries', () => {
+    let state = applyActiveEffect(stateAtSource(), effect({ expiration: { type: 'combatEnd' } }));
+    expect(endCombat(state).activeEffects).toHaveLength(0);
+    state = applyActiveEffect(stateAtSource(), effect({ expiration: durationToExpiration({ type: 'rounds', count: 1, boundary: 'start' }, { round: 1 }) }));
+    state = advanceTurn(advanceTurn(advanceTurn(state)));
+    expect(state.round).toBe(2);
+    expect(state.activeEffects).toHaveLength(0);
+  });
+
+  test('duration definitions cover required declarative variants and manual effects remain', () => {
+    expect(durationToExpiration({ type: 'untilSourceTurn', boundary: 'start' }, { sourceCombatantId: 's' })).toMatchObject({ type: 'sourceTurn', remainingOccurrences: 1 });
+    expect(durationToExpiration({ type: 'targetTurns', count: 3, boundary: 'end' }, { targetCombatantId: 't' })).toMatchObject({ type: 'targetTurn', remainingOccurrences: 3 });
+    const manual = applyActiveEffect(stateAtSource(), effect({ expiration: { type: 'manual' } }));
+    expect(endCombat(manual).activeEffects).toHaveLength(1);
+  });
+
+  test('ending concentration removes only matching concentration effects', () => {
+    let state = applyActiveEffect(stateAtSource(), effect({ expiration: { type: 'concentration', concentrationId: 'spell-a' } }));
+    state = applyActiveEffect(state, effect({ id: 'b', stackKey: 'b', expiration: { type: 'concentration', concentrationId: 'spell-b' } }));
+    expect(endConcentration(state, 'spell-a').activeEffects.map((item) => item.id)).toEqual(['b']);
+  });
+});

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -32,6 +32,7 @@ const resetActiveDeathSaveRoll = async (db, combatState) => {
   if (activeTurn === null || activeTurn < 0 || activeTurn >= participants.length) return;
   const characterId = typeof participants[activeTurn]?.characterId === 'string' ? participants[activeTurn].characterId.trim() : '';
   if (!characterId) return;
+  if (typeof db.collection('Characters')?.updateOne !== 'function') return;
   const filters = [{ characterId }];
   if (ObjectId.isValid(characterId)) filters.push({ _id: new ObjectId(characterId) });
   await db.collection('Characters').updateOne(
@@ -387,6 +388,25 @@ module.exports = (router) => {
     activeTurn: null,
   });
 
+  // Combat timeline data is already declarative JSON. Limit its shape and size while
+  // retaining the complete expiration marker needed by save/restore and undo.
+  const sanitizeTimelineArray = (value, limit) => Array.isArray(value)
+    ? value.filter((item) => item && typeof item === 'object' && !Array.isArray(item)).slice(-limit)
+    : [];
+
+  const timelineMetadata = (combat = {}) => {
+    const hasTimeline = ['round', 'turnSequence', 'activeEffects', 'eventLog', 'undoStack']
+      .some((key) => Object.prototype.hasOwnProperty.call(combat || {}, key));
+    if (!hasTimeline) return {};
+    return ({
+    round: Math.max(1, Number.isInteger(Number(combat.round)) ? Number(combat.round) : 1),
+    turnSequence: Math.max(0, Number.isInteger(Number(combat.turnSequence)) ? Number(combat.turnSequence) : 0),
+    activeEffects: sanitizeTimelineArray(combat.activeEffects, 500),
+    eventLog: sanitizeTimelineArray(combat.eventLog, 1000),
+    undoStack: sanitizeTimelineArray(combat.undoStack, 20),
+    });
+  };
+
   const generateEnemyId = () => {
     if (typeof randomUUID === 'function') {
       return randomUUID();
@@ -546,6 +566,7 @@ module.exports = (router) => {
       combat: {
         participants,
         activeTurn,
+        ...timelineMetadata(campaign.combat),
       },
       enemies: Array.isArray(campaign.enemies) ? campaign.enemies : [],
     };
@@ -1800,7 +1821,10 @@ module.exports = (router) => {
             activeTurn = participants.length > 0 ? Math.min(activeTurn, participants.length - 1) : null;
           }
 
-          const combatState = { participants, activeTurn };
+          const metadata = timelineMetadata(campaign.combat);
+          const combatState = { participants, activeTurn, ...metadata,
+            ...(metadata.activeEffects ? { activeEffects: metadata.activeEffects.filter((effect) => effect.sourceCombatantId !== enemyId && effect.targetCombatantId !== enemyId && effect.expiration?.combatantId !== enemyId) } : {}),
+          };
 
           await collection.updateOne(
             { campaignName },
@@ -1902,7 +1926,7 @@ module.exports = (router) => {
             activeTurn = participants.length > 0 ? Math.min(activeTurn, participants.length - 1) : null;
           }
 
-          const combatState = { participants, activeTurn };
+          const combatState = { participants, activeTurn, ...timelineMetadata(campaign.combat) };
 
           await collection.updateOne(
             { campaignName },
@@ -2139,6 +2163,7 @@ module.exports = (router) => {
           const combatState = {
             participants,
             activeTurn,
+            ...timelineMetadata(req.body),
           };
 
           await db_connect

--- a/server/routes/characters/base.js
+++ b/server/routes/characters/base.js
@@ -505,7 +505,10 @@ module.exports = (router) => {
             }
           }
 
-          const combatState = { participants, activeTurn };
+          const activeEffects = Array.isArray(normalizedCampaign.combat?.activeEffects)
+            ? normalizedCampaign.combat.activeEffects.filter((effect) => effect && !deletedIds.has(effect.sourceCombatantId) && !deletedIds.has(effect.targetCombatantId) && !deletedIds.has(effect.expiration?.combatantId))
+            : [];
+          const combatState = { ...normalizedCampaign.combat, participants, activeTurn, activeEffects };
 
           await campaignsCollection.updateOne(
             { campaignName },
@@ -1110,4 +1113,3 @@ module.exports = (router) => {
 
   router.use('/characters', characterRouter);
 };
-


### PR DESCRIPTION
### Motivation

- The existing combat model could not deterministically expire effects that last "until the source/target’s next turn" or for a number of turns/rounds, so turn-bound durations (e.g. Barbarian speed reduction) could not be implemented generically. 
- Add a small, focused timeline surface that emits turn/round/combat lifecycle events and a monotonic `turnSequence` so effect expirations can be resolved reliably across initiative changes, persistence, undo, and combatant removal.

### Description

- Introduce a centralized timeline utility `client/src/components/Zombies/utils/combatTimeline.js` that normalizes legacy combat state and tracks `round`, `turnSequence`, `activeEffects`, `eventLog`, and a bounded `undoStack`, and exposes `applyActiveEffect`, `removeActiveEffect`, `removeCombatant`, `advanceTurn`, `undoTurn`, `endCombat`, `endConcentration`, and `getEffectiveSpeed`.
- Implement declarative duration -> expiration conversion and deterministic expiration resolution that: matches by combatant ID, respects `start`/`end` boundaries, ignores events that occurred before effect application by checking `appliedAtTurnSequence`, supports remaining-occurrence decrementing, and orders simultaneous expirations by effect id.
- Integrate the timeline into the existing flow by routing DM and player turn advancement through the timeline from `client/src/components/Zombies/pages/ZombiesDM.js` and `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`, and persist timeline metadata in the combat payload so saved state retains `round`, `turnSequence`, effects, and undo history.
- Extend server endpoints (`server/routes/campaigns.js` and `server/routes/characters/base.js`) to sanitize and retain timeline metadata when present while preserving backward compatibility for older saved combat records, and clean up effects tied to removed combatants.
- Add focused unit tests `client/src/components/Zombies/utils/combatTimeline.test.js` covering source/target start/end semantics, same-round and multi-turn behavior, extra turns, initiative changes, removals, stacking/refresh policies, non-mutating speed modifiers, undo, persistence migration, deterministic simultaneous expiration, round/combat durations, and concentration cleanup.

### Testing

- Ran the new client unit tests with `CI=true npm --prefix client test -- --runInBand client/src/components/Zombies/utils/combatTimeline.test.js` and they passed (`16 tests` in the focused suite).
- Ran targeted client+DM tests with `CI=true npm --prefix client test -- --runInBand client/src/components/Zombies/utils/combatTimeline.test.js client/src/components/Zombies/pages/ZombiesDM.test.js -t 'combat timeline effects|allows the DM to manage combat participants'` and those suites passed.
- Ran server tests with `npm --prefix server test -- --runInBand __tests__/campaigns.test.js` and the campaign test suite passed (`55 tests`).
- Performed static checks `node --check server/routes/campaigns.js` and `node --check server/routes/characters/base.js` and ran `git diff --check`; no syntax issues were reported, and persisted timeline metadata is bounded to avoid unbounded DB growth.
- Note: a full CRA `npm --prefix client run build` was attempted in the environment but the environment-run build was terminated; no compilation error was reported by the tool before termination.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6114b62b8c8323b1f692b1771a33ee)