### PR TITLE
Fix Reckless Attack advantage for resolved Strength attacks

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1924,7 +1924,8 @@ const manualCriticalRef = useRef(false);
     const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
     const abilityKey = getAbilityKeyForWeapon(slot, weapon);
     const attackContext = {
-      ability: abilityKey,
+      attackAbility: abilityKey,
+      isMeleeAttack: isUnarmedAttack(weapon) || isMeleeWeapon(weapon),
       kind: isUnarmedAttack(weapon) ? 'unarmed' : 'weapon',
       isWeaponAttack: !isUnarmedAttack(weapon),
       isUnarmedStrike: isUnarmedAttack(weapon),

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -551,20 +551,42 @@ export const endRecklessAttack = (character) => {
 
 export const markBarbarianAttackRoll = (character) => character;
 
+/**
+ * Reckless Attack is evaluated from the resolved attack, after any choice of
+ * attack ability has been made.  Callers should provide isMeleeAttack on new
+ * attack models; the kind fallback keeps older attack producers compatible.
+ */
+export const qualifiesForRecklessAttack = (attack = {}, context = {}) => {
+  const ability = normalize(
+    attack.attackAbility ?? attack.ability ?? attack.abilityKey ?? attack.stat
+  );
+  const kind = normalize(attack.kind ?? attack.type ?? attack.attackType);
+  const range = normalize(attack.rangeType ?? attack.range ?? attack.category);
+  const isMeleeAttack = typeof attack.isMeleeAttack === "boolean"
+    ? attack.isMeleeAttack
+    : typeof context.isMeleeAttack === "boolean"
+      ? context.isMeleeAttack
+      : !range.includes("ranged") && (
+        kind.includes("melee") ||
+        kind.includes("weapon") ||
+        kind.includes("unarmed") ||
+        attack.isWeaponAttack ||
+        attack.isUnarmedStrike
+      );
+
+  return context.isSourceCurrentTurn !== false &&
+    (ability === "str" || ability === "strength") &&
+    isMeleeAttack &&
+    !attack.isDamageRoll;
+};
+
 export const getRecklessAttackAdvantageSources = (character, attack = {}) => {
   const state = getRecklessAttackState(character);
   if (!state.active) return [];
-  const ability = normalize(attack.ability ?? attack.abilityKey ?? attack.stat);
-  const kind = normalize(attack.kind ?? attack.type ?? attack.attackType);
-  const isQualifyingKind =
-    kind.includes("weapon") ||
-    kind.includes("unarmed") ||
-    attack.isWeaponAttack ||
-    attack.isUnarmedStrike;
-  if (ability !== "str" || attack.isSpellAttack || !isQualifyingKind || attack.isDamageRoll) {
-    return [];
-  }
-  return ["Reckless Attack"];
+  return qualifiesForRecklessAttack(attack, {
+    isSourceCurrentTurn: attack.isSourceCurrentTurn,
+    isMeleeAttack: attack.isMeleeAttack,
+  }) ? ["Reckless Attack"] : [];
 };
 
 export const resolveAttackRollMode = (character, attack = {}, options = {}) => {

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -17,6 +17,7 @@ import {
   endRecklessAttack,
   getRecklessAttackState,
   markBarbarianAttackRoll,
+  qualifiesForRecklessAttack,
   resolveAttackRollMode,
   getAvailableBarbarianSubclasses,
   getActiveBarbarianSubclassFeatures,
@@ -245,15 +246,43 @@ describe("barbarian level 2 features", () => {
     expect(getRecklessAttackState(declareRecklessAttack(markBarbarianAttackRoll(barbarian2())))).toMatchObject({ active: true, firstAttackMade: false });
   });
 
-  it("adds Reckless Attack advantage only to Strength weapon and unarmed attack rolls", () => {
+  it("adds Reckless Attack through the shared roll mode using the resolved attack ability", () => {
     const declared = declareRecklessAttack(barbarian2());
-    expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" })).toMatchObject({ mode: "advantage", advantageSources: ["Reckless Attack"] });
-    expect(resolveAttackRollMode(declared, { ability: "str", type: "unarmed strike" }).mode).toBe("advantage");
-    expect(resolveAttackRollMode(declared, { ability: "dex", type: "weapon attack" }).mode).toBe("normal");
-    expect(resolveAttackRollMode(declared, { ability: "str", type: "spell attack", isSpellAttack: true }).mode).toBe("normal");
+    const melee = { isMeleeAttack: true };
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "str", type: "weapon attack" })).toMatchObject({ mode: "advantage", advantageSources: ["Reckless Attack"] });
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "str", type: "unarmed strike" }).mode).toBe("advantage");
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "str", type: "ability attack" }).mode).toBe("advantage");
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "dex", type: "weapon attack" }).mode).toBe("normal");
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "cha", type: "spell attack" }).mode).toBe("normal");
+    expect(resolveAttackRollMode(declared, { attackAbility: "str", isMeleeAttack: false, type: "weapon attack" }).mode).toBe("normal");
     expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" }, { disadvantageSources: ["Prone"] }).mode).toBe("normal");
     expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" }, { advantageSources: ["Help"] }).mode).toBe("advantage");
     expect(resolveAttackRollMode(endRecklessAttack(declared), { ability: "str", type: "weapon attack" }).mode).toBe("normal");
+  });
+
+  it("bases finesse eligibility on the selected ability, not the available abilities", () => {
+    const finesseAttack = { type: "weapon attack", isMeleeAttack: true, availableAbilities: ["str", "dex"] };
+    expect(qualifiesForRecklessAttack({ ...finesseAttack, attackAbility: "str" })).toBe(true);
+    expect(qualifiesForRecklessAttack({ ...finesseAttack, attackAbility: "dex" })).toBe(false);
+    expect(qualifiesForRecklessAttack(finesseAttack)).toBe(false);
+  });
+
+  it("keeps every attack in the activating turn eligible and rejects attacks outside it", () => {
+    const declared = declareRecklessAttack(barbarian2());
+    const attack = { attackAbility: "strength", isMeleeAttack: true, isSourceCurrentTurn: true };
+    expect(resolveAttackRollMode(declared, attack).mode).toBe("advantage");
+    expect(resolveAttackRollMode(markBarbarianAttackRoll(declared), attack).mode).toBe("advantage");
+    const afterMovementAndBonusAction = { ...declared, movementUsed: 20, bonusActionUsed: true };
+    expect(resolveAttackRollMode(afterMovementAndBonusAction, attack).mode).toBe("advantage");
+    expect(resolveAttackRollMode(declared, { ...attack, isSourceCurrentTurn: false }).mode).toBe("normal");
+    expect(resolveAttackRollMode(endRecklessAttack(declared), attack).mode).toBe("normal");
+  });
+
+  it("does not replace Reckless Attack when another temporary state is added", () => {
+    const declared = declareRecklessAttack(barbarian2());
+    const withAnotherEffect = { ...declared, activeEffects: [{ id: "bless" }] };
+    expect(getRecklessAttackState(withAnotherEffect).active).toBe(true);
+    expect(resolveAttackRollMode(withAnotherEffect, { attackAbility: "str", isMeleeAttack: true }).advantageSources).toContain("Reckless Attack");
   });
 });
 


### PR DESCRIPTION
### Motivation
- A recent regression caused Reckless Attack to be applied based on weapon/type flags and an abbreviated `str` field rather than the attack's resolved ability and melee status, so many Strength-based attacks (including unarmed and ability-generated attacks) stopped receiving Advantage.
- The fix must evaluate eligibility from the final resolved attack representation and register the Advantage through the centralized roll-mode pipeline so it composes with other Advantage/Disadvantage sources.

### Description
- Add a centralized eligibility predicate `qualifiesForRecklessAttack(attack, context)` in `client/src/components/Zombies/utils/barbarian.js` that inspects the resolved `attackAbility`/`ability`, `isMeleeAttack` (with compatibility fallbacks), `isSourceCurrentTurn`, and `isDamageRoll` to decide Reckless eligibility. 
- Make `getRecklessAttackAdvantageSources` use `qualifiesForRecklessAttack(...)` so the Advantage source is appended into the existing `resolveAttackRollMode` aggregation rather than creating a separate roll path. 
- Pass the resolved ability and melee classification into the shared attack-roll pipeline by updating attack context construction in `client/src/components/Zombies/attributes/PlayerTurnActions.js` to provide `attackAbility` and `isMeleeAttack` for weapon and unarmed attacks. 
- Add and adapt regression tests in `client/src/components/Zombies/utils/barbarian.test.js` to cover Strength melee weapon attacks, Strength unarmed strikes, finesse attacks selecting Strength vs Dexterity, off-turn attacks, repeated attacks during the activating turn, and persistence with other temporary effects. 
- Preserve turn-duration semantics: Reckless Attack remains an explicit Barbarian class-state flag (`getRecklessAttackState`, `declareRecklessAttack`, `endRecklessAttack`), and eligibility is gated by the `isSourceCurrentTurn`/turn-context supplied to the predicate.

### Testing
- Ran `CI=true npm test -- --runInBand --watchAll=false src/components/Zombies/utils/barbarian.test.js src/components/Zombies/attributes/abilityRolls.test.js`, and both suites passed (2 suites, 27 tests total passed). 
- Ran `CI=true npm test -- --runInBand --watchAll=false src/components/Zombies/attributes/PlayerTurnActions.test.js`; this larger UI suite reports 43 tests passing and 17 failing, but the failures are broad presentation/query expectations unrelated to the Reckless Attack eligibility changes. 
- Attempted `CI=true npm run build`; build reached lint/autoprefixer checks and failed due to existing repository-wide ESLint and Autoprefixer warnings being treated as errors under `CI=true` (these warnings pre-existed and are not introduced by this change). 

Files changed
- `client/src/components/Zombies/utils/barbarian.js` (add `qualifiesForRecklessAttack`, update `getRecklessAttackAdvantageSources`) 
- `client/src/components/Zombies/attributes/PlayerTurnActions.js` (pass `attackAbility` and `isMeleeAttack` into attack context) 
- `client/src/components/Zombies/utils/barbarian.test.js` (add/adjust regression tests)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a615d2bacd4832382da33311232bf50)