### PR TITLE
Respect resolved attack ability and melee context for Reckless Attack; add qualification helper and tests

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1924,7 +1924,8 @@ const manualCriticalRef = useRef(false);
     const bonus = Number.isFinite(rawBonus) ? rawBonus : 0;
     const abilityKey = getAbilityKeyForWeapon(slot, weapon);
     const attackContext = {
-      ability: abilityKey,
+      attackAbility: abilityKey,
+      isMeleeAttack: isUnarmedAttack(weapon) || isMeleeWeapon(weapon),
       kind: isUnarmedAttack(weapon) ? 'unarmed' : 'weapon',
       isWeaponAttack: !isUnarmedAttack(weapon),
       isUnarmedStrike: isUnarmedAttack(weapon),
@@ -2569,7 +2570,7 @@ const visibleAttackItems = useMemo(() => {
 
 const selectedAttack = useMemo(() => attackArsenalItems.find((item) => item.id === selectedAttackId) || null, [attackArsenalItems, selectedAttackId]);
 
-const runAttackRoll = useCallback((item) => { if (!item) return; makeRecent(item.id); if (item.kind === 'weapon' || item.kind === 'unarmed') handleWeaponAttackRoll(item.slot, item.weapon); else if (item.spell) handleSpellAttackRoll(item.spell); handleCloseAttack(); }, [handleSpellAttackRoll, makeRecent]);
+const runAttackRoll = useCallback((item) => { if (!item) return; makeRecent(item.id); if (item.kind === 'weapon' || item.kind === 'unarmed') handleWeaponAttackRoll(item.slot, item.weapon); else if (item.spell) handleSpellAttackRoll(item.spell); handleCloseAttack(); }, [handleSpellAttackRoll, handleWeaponAttackRoll, makeRecent]);
 const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item.id); if (item.kind === 'weapon' || item.kind === 'unarmed') handleWeaponAttack(item.slot, item.weapon); else if (item.id === 'feature:breath-weapon') handleBreathWeaponAttack(); else if (item.spell) handleSpellsButtonClick(item.spell); handleCloseAttack(); }, [handleBreathWeaponAttack, handleSpellsButtonClick, makeRecent]);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -853,6 +853,64 @@ describe('PlayerTurnActions weapon damage display', () => {
     }
   });
 
+  test('active Reckless Attack rolls a resolved Strength melee attack with advantage', async () => {
+    const weapon = {
+      name: 'Greatsword',
+      damage: '2d6 slashing',
+      category: 'Martial Melee Weapon',
+      source: 'weapon',
+      properties: ['Heavy', 'Two-Handed'],
+    };
+    const onRoll = jest.fn();
+    window.addEventListener('damage-roll', onRoll);
+    const baseForm = {
+      diceColor: '#000000',
+      equipment: { mainHand: weapon },
+      spells: [],
+      occupation: [{ Name: 'Barbarian', Level: 5 }],
+      classState: { barbarian: { recklessAttack: { active: false } } },
+    };
+    const { actionsRef, rerender } = render(
+      <PlayerTurnActions
+        form={baseForm}
+        strMod={4}
+        dexMod={1}
+      />
+    );
+
+    // Reproduce activating Reckless Attack after this attack UI mounted. The
+    // regression retained the initial form in runAttackRoll's callback.
+    rerender(
+      <PlayerTurnActions
+        ref={actionsRef}
+        form={{
+          ...baseForm,
+          classState: { barbarian: { recklessAttack: { active: true, declared: true } } },
+        }}
+        strMod={4}
+        dexMod={1}
+      />
+    );
+
+    openAttackModal(actionsRef);
+    const card = screen.getByText('Greatsword').closest('.attack-card');
+    expect(card).not.toBeNull();
+    rollDiceWithBox.mockResolvedValueOnce({ rolls: [[7, 16]] });
+    await act(async () => {
+      fireEvent.click(within(card).getByLabelText(/Roll to hit/i));
+    });
+
+    await waitFor(() => {
+      expect(rollDiceWithBox).toHaveBeenCalledWith([{ count: 2, sides: 20 }]);
+    });
+    const detail = onRoll.mock.calls.at(-1)?.[0]?.detail;
+    expect(detail).toMatchObject({
+      rollMode: 'advantage',
+      advantageSources: ['Reckless Attack'],
+    });
+    window.removeEventListener('damage-roll', onRoll);
+  });
+
   test('ranged spell attack roll uses spell ability and proficiency bonus', async () => {
     const spell = {
       name: 'Fire Bolt',

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -551,20 +551,42 @@ export const endRecklessAttack = (character) => {
 
 export const markBarbarianAttackRoll = (character) => character;
 
+/**
+ * Reckless Attack is evaluated from the resolved attack, after any choice of
+ * attack ability has been made.  Callers should provide isMeleeAttack on new
+ * attack models; the kind fallback keeps older attack producers compatible.
+ */
+export const qualifiesForRecklessAttack = (attack = {}, context = {}) => {
+  const ability = normalize(
+    attack.attackAbility ?? attack.ability ?? attack.abilityKey ?? attack.stat
+  );
+  const kind = normalize(attack.kind ?? attack.type ?? attack.attackType);
+  const range = normalize(attack.rangeType ?? attack.range ?? attack.category);
+  const isMeleeAttack = typeof attack.isMeleeAttack === "boolean"
+    ? attack.isMeleeAttack
+    : typeof context.isMeleeAttack === "boolean"
+      ? context.isMeleeAttack
+      : !range.includes("ranged") && (
+        kind.includes("melee") ||
+        kind.includes("weapon") ||
+        kind.includes("unarmed") ||
+        attack.isWeaponAttack ||
+        attack.isUnarmedStrike
+      );
+
+  return context.isSourceCurrentTurn !== false &&
+    (ability === "str" || ability === "strength") &&
+    isMeleeAttack &&
+    !attack.isDamageRoll;
+};
+
 export const getRecklessAttackAdvantageSources = (character, attack = {}) => {
   const state = getRecklessAttackState(character);
   if (!state.active) return [];
-  const ability = normalize(attack.ability ?? attack.abilityKey ?? attack.stat);
-  const kind = normalize(attack.kind ?? attack.type ?? attack.attackType);
-  const isQualifyingKind =
-    kind.includes("weapon") ||
-    kind.includes("unarmed") ||
-    attack.isWeaponAttack ||
-    attack.isUnarmedStrike;
-  if (ability !== "str" || attack.isSpellAttack || !isQualifyingKind || attack.isDamageRoll) {
-    return [];
-  }
-  return ["Reckless Attack"];
+  return qualifiesForRecklessAttack(attack, {
+    isSourceCurrentTurn: attack.isSourceCurrentTurn,
+    isMeleeAttack: attack.isMeleeAttack,
+  }) ? ["Reckless Attack"] : [];
 };
 
 export const resolveAttackRollMode = (character, attack = {}, options = {}) => {

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -17,6 +17,7 @@ import {
   endRecklessAttack,
   getRecklessAttackState,
   markBarbarianAttackRoll,
+  qualifiesForRecklessAttack,
   resolveAttackRollMode,
   getAvailableBarbarianSubclasses,
   getActiveBarbarianSubclassFeatures,
@@ -245,15 +246,43 @@ describe("barbarian level 2 features", () => {
     expect(getRecklessAttackState(declareRecklessAttack(markBarbarianAttackRoll(barbarian2())))).toMatchObject({ active: true, firstAttackMade: false });
   });
 
-  it("adds Reckless Attack advantage only to Strength weapon and unarmed attack rolls", () => {
+  it("adds Reckless Attack through the shared roll mode using the resolved attack ability", () => {
     const declared = declareRecklessAttack(barbarian2());
-    expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" })).toMatchObject({ mode: "advantage", advantageSources: ["Reckless Attack"] });
-    expect(resolveAttackRollMode(declared, { ability: "str", type: "unarmed strike" }).mode).toBe("advantage");
-    expect(resolveAttackRollMode(declared, { ability: "dex", type: "weapon attack" }).mode).toBe("normal");
-    expect(resolveAttackRollMode(declared, { ability: "str", type: "spell attack", isSpellAttack: true }).mode).toBe("normal");
+    const melee = { isMeleeAttack: true };
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "str", type: "weapon attack" })).toMatchObject({ mode: "advantage", advantageSources: ["Reckless Attack"] });
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "str", type: "unarmed strike" }).mode).toBe("advantage");
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "str", type: "ability attack" }).mode).toBe("advantage");
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "dex", type: "weapon attack" }).mode).toBe("normal");
+    expect(resolveAttackRollMode(declared, { ...melee, attackAbility: "cha", type: "spell attack" }).mode).toBe("normal");
+    expect(resolveAttackRollMode(declared, { attackAbility: "str", isMeleeAttack: false, type: "weapon attack" }).mode).toBe("normal");
     expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" }, { disadvantageSources: ["Prone"] }).mode).toBe("normal");
     expect(resolveAttackRollMode(declared, { ability: "str", type: "weapon attack" }, { advantageSources: ["Help"] }).mode).toBe("advantage");
     expect(resolveAttackRollMode(endRecklessAttack(declared), { ability: "str", type: "weapon attack" }).mode).toBe("normal");
+  });
+
+  it("bases finesse eligibility on the selected ability, not the available abilities", () => {
+    const finesseAttack = { type: "weapon attack", isMeleeAttack: true, availableAbilities: ["str", "dex"] };
+    expect(qualifiesForRecklessAttack({ ...finesseAttack, attackAbility: "str" })).toBe(true);
+    expect(qualifiesForRecklessAttack({ ...finesseAttack, attackAbility: "dex" })).toBe(false);
+    expect(qualifiesForRecklessAttack(finesseAttack)).toBe(false);
+  });
+
+  it("keeps every attack in the activating turn eligible and rejects attacks outside it", () => {
+    const declared = declareRecklessAttack(barbarian2());
+    const attack = { attackAbility: "strength", isMeleeAttack: true, isSourceCurrentTurn: true };
+    expect(resolveAttackRollMode(declared, attack).mode).toBe("advantage");
+    expect(resolveAttackRollMode(markBarbarianAttackRoll(declared), attack).mode).toBe("advantage");
+    const afterMovementAndBonusAction = { ...declared, movementUsed: 20, bonusActionUsed: true };
+    expect(resolveAttackRollMode(afterMovementAndBonusAction, attack).mode).toBe("advantage");
+    expect(resolveAttackRollMode(declared, { ...attack, isSourceCurrentTurn: false }).mode).toBe("normal");
+    expect(resolveAttackRollMode(endRecklessAttack(declared), attack).mode).toBe("normal");
+  });
+
+  it("does not replace Reckless Attack when another temporary state is added", () => {
+    const declared = declareRecklessAttack(barbarian2());
+    const withAnotherEffect = { ...declared, activeEffects: [{ id: "bless" }] };
+    expect(getRecklessAttackState(withAnotherEffect).active).toBe(true);
+    expect(resolveAttackRollMode(withAnotherEffect, { attackAbility: "str", isMeleeAttack: true }).advantageSources).toContain("Reckless Attack");
   });
 });
 


### PR DESCRIPTION
### Motivation
- Fix Reckless Attack evaluation so it uses the resolved attack model (selected ability and explicit melee flag) instead of stale or inferred fields.
- Centralize Reckless Attack eligibility logic to avoid regressions when UI updates the attack form after mount.

### Description
- Add `qualifiesForRecklessAttack(attack, context)` to `utils/barbarian.js` to centralize eligibility checks and prefer `attack.attackAbility` and explicit `isMeleeAttack` flags. 
- Change `getRecklessAttackAdvantageSources` to call `qualifiesForRecklessAttack` and preserve previous turn checks via `isSourceCurrentTurn`.
- Update `resolveAttackRollMode` usage to include advantage sources from the new qualification logic.
- Update `PlayerTurnActions` to include `attackAbility` and `isMeleeAttack` in the constructed attack context when rolling, and add `handleWeaponAttackRoll` to the `runAttackRoll` callback dependencies to avoid stale closures.
- Add and update unit tests in `PlayerTurnActions.test.js` and `barbarian.test.js` to cover: resolved-ability Reckless Attack behavior, finesse/ability selection edge cases, turn-scoped eligibility, and a UI timing regression for activating Reckless Attack after mount.

### Testing
- Ran unit tests for `PlayerTurnActions.test.js` including the new "active Reckless Attack rolls a resolved Strength melee attack with advantage" test, which passed.
- Ran unit tests for `barbarian.test.js` covering `qualifiesForRecklessAttack`, edge cases, and existing barbarian behavior, which passed.
- All modified and added Jest tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a615d2bacd4832382da33311232bf50)