### PR TITLE
Persist targeted monster damage and resolve Berserker Frenzy

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -431,7 +431,7 @@ export function calculateDamage(
     diceRolls,
     modifiers: [
       ...(rageBonus > 0 ? [{ label: 'Rage', value: rageBonus }] : []),
-      ...(frenzyApplied ? [{ label: 'Reckless Attack', value: results[results.length - 1].value }] : []),
+      ...(frenzyApplied ? [{ label: 'Frenzy', value: results[results.length - 1].value }] : []),
     ],
     frenzyApplied,
   };
@@ -453,6 +453,7 @@ const PlayerTurnActions = React.forwardRef(
       longRestCount = 0,
       shortRestCount = 0,
       characterId = null,
+      isActiveTurn = false,
       onBeginTargeting = () => {},
       onApplyTargetDamage = async () => {},
       onCancelTargeting = () => {},
@@ -1895,10 +1896,6 @@ const manualCriticalRef = useRef(false);
         ],
       };
 
-      if (result.frenzyApplied) {
-        onCharacterChange?.((previous) => markFrenzyUsed(previous || form));
-      }
-
       updateDamageValueWithAnimation(
         result.total,
         result.breakdown,
@@ -2592,7 +2589,21 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
             const result = await rollDamageExpression({
               damageString: getDamageStringForHandSelection(selected.slot, selected.weapon),
               ability: abilityForWeapon(selected.weapon, selected.slot), crit: critical,
+              options: {
+                character: form,
+                attack: {
+                  ability: getAbilityKeyForWeapon(selected.slot, selected.weapon),
+                  kind: selected.kind,
+                  isWeaponAttack: selected.kind === 'weapon',
+                  isUnarmedStrike: selected.kind === 'unarmed',
+                  dealsDamage: true,
+                  hit: true,
+                  isOwnTurn: isActiveTurn,
+                  damageType: selected.damageType,
+                },
+              },
             });
+            if (result?.frenzyApplied) onCharacterChange?.((previous) => markFrenzyUsed(previous || form));
             if (result) updateDamageValueWithAnimation(result.total, result.breakdown, selected.name, { diceRolls: result.diceRolls });
             return result?.total;
           }
@@ -2605,7 +2616,7 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
         writeLog: async (entry) => setDamageLog((previous) => [...previous, entry]),
       });
     },
-  }), [abilityForWeapon, attackArsenalItems, characterId, getDamageStringForHandSelection, getSpellAttackDetails, handleShowAttack, onApplyTargetDamage, rollDamageExpression]);
+  }), [abilityForWeapon, attackArsenalItems, characterId, form, getAbilityKeyForWeapon, getDamageStringForHandSelection, getSpellAttackDetails, handleShowAttack, isActiveTurn, onApplyTargetDamage, onCharacterChange, rollDamageExpression]);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div

--- a/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.test.js
@@ -153,12 +153,12 @@ describe('calculateDamage parser', () => {
     const attack = { ability: 'str', kind: 'weapon', isWeaponAttack: true, dealsDamage: true };
     expect(calculateDamage('1d12 Slashing', 3, false, fixedRoll, undefined, 0, { character: berserker, attack })).toMatchObject({
       total: 8,
-      breakdown: '4 Slashing + 2 Rage + 2 Reckless Attack Slashing',
+      breakdown: '4 Slashing + 2 Rage + 2 Frenzy Slashing',
       frenzyApplied: true,
     });
     expect(calculateDamage('1d12 Slashing', 3, true, fixedRoll, undefined, 0, { character: berserker, attack })).toMatchObject({
       total: 11,
-      breakdown: '5 Slashing + 2 Rage + 4 Reckless Attack Slashing',
+      breakdown: '5 Slashing + 2 Rage + 4 Frenzy Slashing',
       frenzyApplied: true,
     });
     expect(calculateDamage('1d12 Slashing', 3, false, fixedRoll, undefined, 0, { character: { ...berserker, classState: { barbarian: { ...berserker.classState.barbarian, frenzy: { usedThisTurn: true } } } }, attack }).frenzyApplied).toBe(false);

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1658,17 +1658,34 @@ export default function ZombiesCharacterSheet() {
     [activeCharacterIds]
   );
 
-  const handleApplyTargetDamage = useCallback(async ({ targetId, hpAfter }) => {
-    setEnemies((previous) => previous.map((enemy) => {
-      const id = enemy?.enemyId || enemy?._id;
-      return id === targetId ? { ...enemy, currentHp: hpAfter } : enemy;
-    }));
+  const handleApplyTargetDamage = useCallback(async ({ targetId, hpBefore, damageApplied }) => {
+    const enemy = enemies.find((candidate) => (candidate?.enemyId || candidate?._id) === targetId);
+    if (enemy) {
+      if (!encodedCampaignId) throw new Error('Campaign is unavailable; damage was not applied.');
+      const previousHp = Number(enemy.currentHp ?? enemy.maxHp ?? enemy.hitPoints);
+      const requestedHp = Math.max(0, previousHp - Math.max(0, Number(damageApplied) || 0));
+      const response = await apiFetch(`/campaigns/${encodedCampaignId}/enemies/${encodeURIComponent(targetId)}/health`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentHp: requestedHp }),
+      });
+      if (!response.ok) throw new Error(response.statusText || 'Failed to persist monster damage.');
+      const payload = await response.json();
+      const updatedEnemy = payload?.enemy;
+      if (!updatedEnemy) throw new Error('The monster health update was not confirmed.');
+      setEnemies((previous) => previous.map((candidate) =>
+        (candidate?.enemyId || candidate?._id) === targetId ? { ...candidate, ...updatedEnemy } : candidate));
+      if (payload?.combat) setCombatState(normalizeCombatState(payload.combat));
+      const currentHp = Number(updatedEnemy.currentHp);
+      return { previousHp, currentHp, appliedDamage: Math.max(0, previousHp - currentHp) };
+    }
+    const hpAfter = Math.max(0, Number(hpBefore) - (Number(damageApplied) || 0));
     setCampaignCharacters((previous) => {
       if (!previous?.[targetId]) return previous;
       return { ...previous, [targetId]: { ...previous[targetId], currentHp: hpAfter, tempHealth: hpAfter } };
     });
     if (targetId === resolvedCharacterId) handleHealthChange(hpAfter);
-  }, [handleHealthChange, resolvedCharacterId]);
+    return { previousHp: Number(hpBefore), currentHp: hpAfter, appliedDamage: Number(damageApplied) || 0 };
+  }, [encodedCampaignId, enemies, handleHealthChange, resolvedCharacterId]);
 
   const handleTargetTokenClick = useCallback(async (targetId) => {
     if (combatTargeting.status !== 'selecting-target' || targetingLockRef.current) return;
@@ -6017,6 +6034,7 @@ export default function ZombiesCharacterSheet() {
                 spellAbilityMod={spellAbilityMod}
                 spellAbilityKey={spellAbilityKey}
                 characterId={characterId}
+                isActiveTurn={isPlayersTurn}
                 ref={playerTurnActionsRef}
                 onCastSpell={handleCastSpell}
                 onDamageSummaryChange={handleDamageSummaryChange}

--- a/client/src/components/Zombies/utils/attackResolution.js
+++ b/client/src/components/Zombies/utils/attackResolution.js
@@ -35,7 +35,7 @@ export async function resolveAttack({
     if (!Number.isFinite(rawDamage)) throw new Error('The damage roll could not be completed.');
     damageApplied = Math.max(0, Number(calculateAppliedDamage({ rawDamage, damageType: attack.damageType, target })) || 0);
   }
-  const hpAfter = Math.max(0, hpBefore - damageApplied);
+  let hpAfter = Math.max(0, hpBefore - damageApplied);
   const result = {
     type: 'attack-resolution', attackerId, targetId, attackId: attack.id,
     naturalRoll, attackTotal, targetArmorClass: armorClass,
@@ -43,7 +43,17 @@ export async function resolveAttack({
     damage: rawDamage, damageApplied, damageType: attack.damageType || '',
     hpBefore, hpAfter, timestamp: Date.now(),
   };
-  if (hit) await applyDamage({ targetId, hpBefore, hpAfter, damageApplied, result });
+  if (hit) {
+    // The HP writer owns the authoritative before/after values.  In particular,
+    // callers must not log an optimistic token-only prediction as persisted HP.
+    const applied = await applyDamage({ targetId, hpBefore, hpAfter, damageApplied, result });
+    if (applied) {
+      if (Number.isFinite(Number(applied.previousHp))) result.hpBefore = Number(applied.previousHp);
+      if (Number.isFinite(Number(applied.currentHp))) result.hpAfter = Number(applied.currentHp);
+      if (Number.isFinite(Number(applied.appliedDamage))) result.damageApplied = Number(applied.appliedDamage);
+      hpAfter = result.hpAfter;
+    }
+  }
   await writeLog(result);
   return result;
 }

--- a/client/src/components/Zombies/utils/attackResolution.test.js
+++ b/client/src/components/Zombies/utils/attackResolution.test.js
@@ -25,3 +25,11 @@ it('hits when total equals AC', async () => {
   const result = await resolveAttack(base(10, 15));
   expect(result.outcome).toBe('hit'); expect(result.damageApplied).toBe(7);
 });
+
+it('logs HP returned by the canonical damage writer', async () => {
+  const input = base(10, 15);
+  input.applyDamage.mockResolvedValue({ previousHp: 12, currentHp: 4, appliedDamage: 8 });
+  const result = await resolveAttack(input);
+  expect(result).toMatchObject({ hpBefore: 12, hpAfter: 4, damageApplied: 8 });
+  expect(input.writeLog).toHaveBeenCalledWith(expect.objectContaining({ hpBefore: 12, hpAfter: 4 }));
+});

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -638,7 +638,8 @@ export const getFrenzyDamageDice = (character, attack = {}) => {
   if (getBarbarianLevel(character) < 3 || !isPathOfTheBerserker(character)) return null;
   if (!isRageActive(character) || !getRecklessAttackState(character).active) return null;
   if (getFrenzyState(character).usedThisTurn) return null;
+  if (attack.isOwnTurn === false) return null;
   if (attack.hit === false || attack.dealsDamage === false) return null;
   if (getRageDamageBonus(character, attack) <= 0) return null;
-  return { label: "Reckless Attack", count: getRageDamageBonus(character, attack), sides: 6 };
+  return { label: "Frenzy", count: getRageDamageBonus(character, attack), sides: 6 };
 };

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -326,7 +326,8 @@ describe("barbarian level 3 features", () => {
 
   it("resolves Frenzy eligibility and per-turn reset", () => {
     const ragingReckless = declareRecklessAttack(activateRage(barbarian3()));
-    expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "weapon attack", dealsDamage: true })).toMatchObject({ label: "Reckless Attack", count: 2, sides: 6 });
+    expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "weapon attack", dealsDamage: true })).toMatchObject({ label: "Frenzy", count: 2, sides: 6 });
+    expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "weapon attack", dealsDamage: true, isOwnTurn: false })).toBeNull();
     expect(getFrenzyDamageDice(ragingReckless, { ability: "dex", type: "weapon attack", dealsDamage: true })).toBeNull();
     expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "spell attack", isSpellAttack: true })).toBeNull();
     expect(getFrenzyDamageDice(ragingReckless, { ability: "str", type: "weapon attack", hit: false, dealsDamage: true })).toBeNull();


### PR DESCRIPTION
### Motivation
- Fix a bug where map token HP updated visually but the DM/canonical encounter monster HP was not persisted, and ensure Frenzy damage is included only when the Berserker’s conditions are met.  
- Preserve existing architecture and reuse the canonical encounter/health update and damage pipeline instead of adding token-local or duplicated state.  

### Description
- Route targeted monster damage through the existing campaign enemy health endpoint so the server-authoritative `enemy` record and normalized `combat` state are reconciled and propagated to the encounter and UI consumers.  
- Use the `applyDamage` writer result inside `resolveAttack` to replace optimistic hp/damage values in the combat log with the canonical `previousHp`, `currentHp`, and `appliedDamage` returned by the HP writer.  
- Pass full attack context (ability, `isWeaponAttack`/`isUnarmedStrike`, `damageType`, `hit`, and `isOwnTurn`) into the centralized damage pipeline so `Rage` and `Frenzy` eligibility and dice are calculated in one place.  
- Restrict Berserker `Frenzy` to the barbarian subclass with active Rage and Reckless Attack, only on the barbarian’s own turn, calculate Frenzy as `N d6` where `N` is the rage damage bonus, double Frenzy dice on a critical, and label Frenzy damage explicitly in logs.  

### Testing
- Ran focused unit tests: `CI=true npm test -- --runInBand src/components/Zombies/utils/attackResolution.test.js src/components/Zombies/utils/barbarian.test.js --testNamePattern='canonical|Frenzy eligibility|natural|hits when|critical'` and they passed.  
- Ran the targeted Frenzy UI test: `CI=true npm test -- --runInBand src/components/Zombies/attributes/PlayerTurnActions.test.js --testNamePattern='Berserker Frenzy'` and it passed.  
- Added a regression test asserting that `resolveAttack` logs HP values returned by the canonical damage writer and validated it passes.  
- Note: running the entire `PlayerTurnActions` suite revealed pre-existing unrelated UI assertion failures in many tests; the focused HP/Frenzy tests above passed, and `npm run build` completed with standard environment warnings about outdated Browserslist/baseline data (non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61a381108c83239d2d77b5e9ff618d)