### PR TITLE
Align character select cards across grid rows

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -10253,18 +10253,18 @@ h1 {
 .character-select-library__header { display: flex; justify-content: space-between; gap: 1rem; align-items: end; margin-bottom: 1rem; }
 .character-select-library h2, .character-select-create h2, .character-select-empty h2 { font-weight: 900; margin: 0; }
 .character-select-tools { display: flex; flex-wrap: wrap; gap: .5rem; justify-content: flex-end; }
-.character-select-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(285px, calc((100% - 2rem) / 3))); justify-content: center; gap: 1rem; }
-.character-select-card { position: relative; border-radius: 26px; padding: 1rem; overflow: hidden; transition: transform .24s ease, border-color .24s ease, box-shadow .24s ease; animation: characterSelectFadeIn .45s ease both; }
+.character-select-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(285px, calc((100% - 2rem) / 3))); align-items: stretch; justify-content: center; gap: 1rem; }
+.character-select-card { position: relative; display: flex; flex-direction: column; height: 100%; border-radius: 26px; padding: 1rem; overflow: hidden; transition: transform .24s ease, border-color .24s ease, box-shadow .24s ease; animation: characterSelectFadeIn .45s ease both; }
 .character-select-card:hover { transform: translateY(-7px); border-color: rgba(142, 183, 255, .58); box-shadow: 0 2rem 4.5rem rgba(0,0,0,.48), 0 0 2rem rgba(109, 134, 255, .2); }
 .character-select-card__favorite { position: absolute; right: 1rem; top: 1rem; color: rgba(244, 221, 154, .82); font-size: .75rem; z-index: 2; }
 .character-select-portrait { width: 145px; aspect-ratio: 1; margin: 1.6rem auto 1rem; border-radius: 34px; display: grid; place-items: center; background: radial-gradient(circle at 45% 30%, rgba(255,255,255,.72), rgba(115, 143, 255, .5) 28%, rgba(67, 45, 116, .78) 62%, rgba(6, 11, 27, .95)); border: 2px solid rgba(196, 222, 255, .42); box-shadow: 0 0 2.5rem rgba(104, 139, 255, .35), inset 0 0 2rem rgba(255,255,255,.12); overflow: hidden; }
 .character-select-portrait img { width: 100%; height: 100%; object-fit: cover; }
 .character-select-portrait span { font-size: 2.7rem; font-weight: 900; color: #fff; }
-.character-select-card__body { text-align: center; }
+.character-select-card__body { display: flex; flex: 1; flex-direction: column; text-align: center; }
 .character-select-card__eyebrow, .character-select-card__lineage { color: #9dbfff; margin-bottom: .25rem; font-weight: 800; }
 .character-select-card h3 { font-size: 1.75rem; font-weight: 900; margin: 0; }
 .character-select-card__chips, .character-select-card__meta { display: flex; flex-wrap: wrap; justify-content: center; gap: .45rem; margin-top: .8rem; }
-.character-select-card__stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: .5rem; margin-top: 1rem; }
+.character-select-card__stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: .5rem; margin-top: auto; padding-top: 1rem; }
 .character-select-card__stats span { border-radius: 16px; padding: .65rem .4rem; background: rgba(255,255,255,.06); color: #91b7ff; font-size: .72rem; }
 .character-select-card__stats strong { display: block; color: #fff; font-size: 1.25rem; }
 .character-select-card__meta span { color: rgba(230,237,255,.7); font-size: .78rem; }


### PR DESCRIPTION
### Motivation
- Ensure every `.character-select-card` in the same responsive grid row stretches to the same height so stats, status and action areas align regardless of name length or variable content.
- Preserve existing visual styling, component structure, and responsive breakpoints while avoiding fixed pixel heights or truncation.
- Use modern layout techniques (CSS Grid + Flexbox) so cards naturally distribute space and anchor footers consistently at the bottom.

### Description
- Updated `client/src/App.scss` to make the grid cells stretch by adding `align-items: stretch` to `.character-select-grid` so each cell gets equal height.
- Converted `.character-select-card` into a vertical flex container with `display: flex`, `flex-direction: column`, and `height: 100%` so the card fills its grid cell and can layout children vertically.
- Made `.character-select-card__body` a flexible column (`display: flex; flex: 1; flex-direction: column`) and set `.character-select-card__stats` to `margin-top: auto` with `padding-top: 1rem` so stats/meta/actions are anchored toward the bottom without fixed heights.
- Made only layout changes in the existing selectors and did not alter component APIs, data structures, or visual styling beyond layout behavior.

### Testing
- Ran `git diff --check` to verify no style errors from the patch and it passed.
- Built the project with `npm run build` which completed and produced the optimized build; the build reported unrelated warnings (lint, Browserslist/autoprefixer) but no failures.
- Confirmed the change was committed and the working tree is clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a621fccb52c832385a7a0168a7957ee)