### PR TITLE
Extend shared combat targeting to DM monster attacks

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -347,8 +347,7 @@ function EnemyQuickAttacksModal({
                   </div>
                   <div className="attack-card__actions">
                     <Button
-                      variant="link"
-                      className="attack-card__roll"
+                      className="combat-roll-button combat-roll-button--attack"
                       onClick={() => {
                         onHide();
                         if (normalizedEnemyId && onEnemyAttackRoll) {
@@ -358,11 +357,10 @@ function EnemyQuickAttacksModal({
                       disabled={!onEnemyAttackRoll || !normalizedEnemyId}
                       aria-label={`Roll attack for ${actionLabel}`}
                     >
-                      <i className="fa-solid fa-bullseye" aria-hidden="true"></i>
+                      🎲 Roll Attack
                     </Button>
                     <Button
-                      variant="link"
-                      className="attack-card__roll"
+                      className="combat-roll-button"
                       onClick={() => {
                         onHide();
                         if (normalizedEnemyId && onEnemyDamageRoll) {
@@ -372,12 +370,13 @@ function EnemyQuickAttacksModal({
                       disabled={!onEnemyDamageRoll || !normalizedEnemyId}
                       aria-label={`Roll damage for ${actionLabel}`}
                     >
-                      <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
+                      💥 Roll Damage
                     </Button>
                   </div>
                   {isLatestRoll && latestEnemyRoll?.breakdown && (
-                    <div className="mt-2 small fw-semibold text-primary">
-                      {`${latestEnemyRoll.rollType === 'attack' ? 'Attack' : 'Damage'}: ${latestEnemyRoll.total} (${latestEnemyRoll.breakdown})`}
+                    <div className="mt-2 small fw-semibold text-primary" role="status">
+                      <div>{`${latestEnemyRoll.rollType === 'attack' ? 'Attack' : 'Damage'}: ${latestEnemyRoll.total} (${latestEnemyRoll.breakdown})`}</div>
+                      {latestEnemyRoll.targetName && <div>{`Target: ${latestEnemyRoll.targetName} • AC ${latestEnemyRoll.targetArmorClass} • ${latestEnemyRoll.outcome === 'critical-hit' ? 'Critical Hit' : latestEnemyRoll.outcome === 'hit' ? 'Hit' : 'Miss'}`}</div>}
                     </div>
                   )}
                 </div>

--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.test.js
@@ -171,6 +171,7 @@ describe('ActiveEnemyQuickList', () => {
       action?.name === 'Scimitar' ? '1d6 slashing' : null
     );
     const onEnemyDamageRoll = jest.fn();
+    const onEnemyAttackRoll = jest.fn();
     const latestEnemyRoll = {
       enemyId: 'enemy-1',
       actionName: 'Scimitar',
@@ -182,6 +183,7 @@ describe('ActiveEnemyQuickList', () => {
       formatAttackBonus,
       getEnemyActionDamageString,
       onEnemyDamageRoll,
+      onEnemyAttackRoll,
       latestEnemyRoll,
       summaries: [
         {
@@ -205,10 +207,13 @@ describe('ActiveEnemyQuickList', () => {
     const dialog = await screen.findByRole('dialog', { name: /Goblin Attacks/i });
     expect(within(dialog).getByText('Attacks')).toBeInTheDocument();
     expect(within(dialog).getByText('Scimitar')).toBeInTheDocument();
-    expect(within(dialog).getByText('Attack Bonus: +4')).toBeInTheDocument();
-    expect(within(dialog).getByText('Damage: 1d6 slashing')).toBeInTheDocument();
+    expect(within(dialog).getByText('Attack Bonus')).toBeInTheDocument();
+    expect(within(dialog).getByText('+4')).toBeInTheDocument();
+    expect(within(dialog).getByText('Damage')).toBeInTheDocument();
+    expect(within(dialog).getByText('1d6 slashing')).toBeInTheDocument();
 
-    const rollButton = within(dialog).getByRole('button', { name: /^Roll$/i });
+    expect(within(dialog).getByRole('button', { name: /Roll attack for Scimitar/i })).toHaveTextContent('🎲 Roll Attack');
+    const rollButton = within(dialog).getByRole('button', { name: /Roll damage for Scimitar/i });
     await act(async () => {
       await userEvent.click(rollButton);
     });
@@ -217,6 +222,7 @@ describe('ActiveEnemyQuickList', () => {
       expect.objectContaining({ enemyId: 'enemy-1' }),
       expect.objectContaining({ name: 'Scimitar' })
     );
-    expect(within(dialog).getByText('Result: 11 damage (1d6 (8) + 3)')).toBeInTheDocument();
+    await userEvent.click(attacksButton);
+    expect(await screen.findByText('Damage: 11 (1d6 (8) + 3)')).toBeInTheDocument();
   });
 });

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -29,6 +29,7 @@ import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import DamageDiceCanvas from '../attributes/DamageDiceCanvas';
 import { calculateDamage, createCriticalDamageFormula, isCriticalAttackRoll } from '../attributes/PlayerTurnActions';
+import { INACTIVE_COMBAT_TARGETING, resolveAttack } from '../utils/attackResolution';
 import { rollSkillWithDiceBox } from '../attributes/Skills';
 import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
 import { bindCriticalRollTransport } from '../../../utils/criticalRolls';
@@ -942,25 +943,24 @@ function EnemyCard({
                     </div>
                     <div className="attack-card__actions">
                       <Button
-                        variant="link"
-                        className="attack-card__roll"
+                        className="combat-roll-button combat-roll-button--attack"
                         onClick={() => onEnemyAttackRoll(enemy, action)}
                         aria-label={`Roll attack for ${actionLabel}`}
                       >
-                        <i className="fa-solid fa-bullseye" aria-hidden="true"></i>
+                        🎲 Roll Attack
                       </Button>
                       <Button
-                        variant="link"
-                        className="attack-card__roll"
+                        className="combat-roll-button"
                         onClick={() => onEnemyDamageRoll(enemy, action)}
                         aria-label={`Roll damage for ${actionLabel}`}
                       >
-                        <i className="fa-solid fa-dice-d20" aria-hidden="true"></i>
+                        💥 Roll Damage
                       </Button>
                     </div>
                     {isLatestRoll && latestEnemyRoll?.breakdown && (
-                      <div className="mt-2 small fw-semibold text-primary">
-                        {`${latestEnemyRoll.rollType === 'attack' ? 'Attack' : 'Damage'}: ${latestEnemyRoll.total} (${latestEnemyRoll.breakdown})`}
+                      <div className="mt-2 small fw-semibold text-primary" role="status">
+                        <div>{`${latestEnemyRoll.rollType === 'attack' ? 'Attack' : 'Damage'}: ${latestEnemyRoll.total} (${latestEnemyRoll.breakdown})`}</div>
+                        {latestEnemyRoll.targetName && <div>{`Target: ${latestEnemyRoll.targetName} • AC ${latestEnemyRoll.targetArmorClass} • ${latestEnemyRoll.outcome === 'critical-hit' ? 'Critical Hit' : latestEnemyRoll.outcome === 'hit' ? 'Hit' : 'Miss'}`}</div>}
                       </div>
                     )}
                   </div>
@@ -1776,6 +1776,8 @@ export default function ZombiesDM() {
     const [enemyHealthSaving, setEnemyHealthSaving] = useState({});
     const [latestEnemyRoll, setLatestEnemyRoll] = useState(null);
     const [pendingEnemyCriticalAttack, setPendingEnemyCriticalAttack] = useState(null);
+    const [combatTargeting, setCombatTargeting] = useState(INACTIVE_COMBAT_TARGETING);
+    const targetingLockRef = useRef(false);
     const [showEnemyTokenPicker, setShowEnemyTokenPicker] = useState(false);
     const [enemyTokenSelection, setEnemyTokenSelection] = useState({
       figurineImageUrl: null,
@@ -3026,6 +3028,7 @@ export default function ZombiesDM() {
           naturalRoll,
           total: result,
         });
+        return { naturalRoll, total: result };
       },
       [displayEnemyDiceResults, showEnemyDiceOverlay]
     );
@@ -3152,10 +3155,22 @@ export default function ZombiesDM() {
         if (pendingEnemyCriticalAttack?.enemyId === enemy.enemyId && pendingEnemyCriticalAttack?.actionName === actionName) {
           setPendingEnemyCriticalAttack(null);
         }
-
+        return result.total;
       },
       [displayEnemyDiceResults, getEnemyActionDamageString, pendingEnemyCriticalAttack, setStatus, showEnemyDiceOverlay]
     );
+
+    const beginEnemyTargeting = useCallback((enemy, action) => {
+      const attackerId = enemy?.enemyId || enemy?._id;
+      if (!attackerId || !action) return;
+      setCombatTargeting({
+        status: 'selecting-target',
+        sourceCombatantId: attackerId,
+        attackId: `${attackerId}:${action.name || 'action'}`,
+        attacker: enemy,
+        action,
+      });
+    }, []);
 
     const challengeRatingOptions = useMemo(() => {
       if (!Array.isArray(monsterCatalog) || monsterCatalog.length === 0) {
@@ -3759,6 +3774,85 @@ export default function ZombiesDM() {
       }
       return map;
     }, [combinedRecords, getEntityId]);
+
+    const handleEnemyTargetClick = useCallback(async (targetId) => {
+      if (combatTargeting.status !== 'selecting-target' || targetingLockRef.current) return;
+      if (!targetId || targetId === combatTargeting.sourceCombatantId) return;
+      const target = characterLookup.get(targetId);
+      const currentHp = toFiniteNumberOrNull(target?.currentHp ?? target?.tempHealth ?? target?.health ?? target?.maxHp ?? target?.hitPoints);
+      if (!target || currentHp === null || currentHp <= 0) return;
+      const armorClass = toFiniteNumberOrNull(target?.armorClass ?? target?.ac);
+      if (armorClass === null) {
+        setStatus({ type: 'warning', message: 'That target does not have an armor class.' });
+        return;
+      }
+
+      targetingLockRef.current = true;
+      setCombatTargeting((previous) => ({ ...previous, status: 'resolving', targetCombatantId: targetId }));
+      try {
+        const { attacker, action, attackId } = combatTargeting;
+        const attack = {
+          id: attackId,
+          name: action?.name || 'Action',
+          damageType: action?.damage_type?.name || action?.damage_type || '',
+        };
+        const result = await resolveAttack({
+          attackerId: combatTargeting.sourceCombatantId,
+          targetId,
+          attack,
+          target: { ...target, currentHp, armorClass },
+          rollAttack: () => handleEnemyAttackRoll(attacker, action),
+          rollDamage: () => handleEnemyDamageRoll(attacker, action),
+          applyDamage: async ({ damageApplied }) => {
+            const nextHp = Math.max(0, currentHp - damageApplied);
+            if (target.entityType === 'enemy') {
+              await updateEnemyHealth(targetId, nextHp);
+            } else {
+              const response = await apiFetch(`/characters/update-temphealth/${encodeURIComponent(targetId)}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ tempHealth: nextHp }),
+              });
+              if (!response.ok) throw new Error(response.statusText || 'Failed to update character health.');
+              setRecords((previous) => previous.map((record) =>
+                getEntityId(record) === targetId ? { ...record, tempHealth: nextHp } : record));
+            }
+            return { previousHp: currentHp, currentHp: nextHp, appliedDamage: damageApplied };
+          },
+          writeLog: async () => {},
+        });
+        const targetName = target.characterName || target.name || targetId;
+        setLatestEnemyRoll({
+          enemyId: attacker?.enemyId || attacker?._id,
+          enemyName: attacker?.name || attacker?.displayType || 'Enemy',
+          actionName: action?.name || 'Action',
+          total: result.attackTotal,
+          naturalRoll: result.naturalRoll,
+          attackBonus: Number(action?.attack_bonus) || 0,
+          breakdown: `${result.naturalRoll} (d20) ${Number(action?.attack_bonus) >= 0 ? '+' : '-'} ${Math.abs(Number(action?.attack_bonus) || 0)} Attack Bonus`,
+          rollType: 'attack',
+          targetId,
+          targetName,
+          targetArmorClass: result.targetArmorClass,
+          outcome: result.outcome,
+          damage: result.damageApplied,
+        });
+      } catch (error) {
+        setStatus({ type: 'danger', message: error?.message || 'The attack could not be resolved.' });
+      } finally {
+        targetingLockRef.current = false;
+        setCombatTargeting(INACTIVE_COMBAT_TARGETING);
+      }
+    }, [characterLookup, combatTargeting, getEntityId, handleEnemyAttackRoll, handleEnemyDamageRoll, updateEnemyHealth]);
+
+    useEffect(() => {
+      if (combatTargeting.status === 'inactive') return undefined;
+      const cancelTargeting = (event) => {
+        if (event.key === 'Escape') setCombatTargeting(INACTIVE_COMBAT_TARGETING);
+      };
+      window.addEventListener('keydown', cancelTargeting);
+      return () => window.removeEventListener('keydown', cancelTargeting);
+    }, [combatTargeting.status]);
 
     const resolveDisplayName = useCallback(
       (characterId) => {
@@ -6890,6 +6984,8 @@ const resolveIcon = (category, iconMap, fallback) => {
             tokens={boardTokens}
             disabled={!shouldShowCampaignTokens || mapPlacementSaving}
             allowWheelZoom
+            targeting={combatTargeting.status !== 'inactive'}
+            onTokenClick={handleEnemyTargetClick}
             onTokenPositionChange={
               shouldShowCampaignTokens && !mapPlacementSaving
                 ? handleTokenPositionChange
@@ -6908,6 +7004,12 @@ const resolveIcon = (category, iconMap, fallback) => {
           </div>
         )}
       </div>
+      {combatTargeting.status !== 'inactive' && (
+        <div className="combat-targeting-instruction" role="status" aria-live="polite">
+          <strong>{combatTargeting.status === 'resolving' ? 'Rolling attack…' : 'Select a target'}</strong>
+          <span>{combatTargeting.status === 'resolving' ? 'Resolving hit and damage.' : 'Click a living combatant to attack. Esc to cancel.'}</span>
+        </div>
+      )}
 
       <div className="zombies-dm-page__chrome">
         {status && (
@@ -7034,7 +7136,7 @@ const resolveIcon = (category, iconMap, fallback) => {
           onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
           onResetEnemyHealth={handleResetEnemyHealth}
           onEnemyDamageRoll={handleEnemyDamageRoll}
-          onEnemyAttackRoll={handleEnemyAttackRoll}
+          onEnemyAttackRoll={beginEnemyTargeting}
           formatAttackBonus={formatAttackBonus}
           getEnemyActionDamageString={getEnemyActionDamageString}
           latestEnemyRoll={latestEnemyRoll}
@@ -8242,7 +8344,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                       legendaryActionsList={legendaryActionsList}
                       latestEnemyRoll={latestEnemyRoll}
                       onEnemyDamageRoll={handleEnemyDamageRoll}
-                      onEnemyAttackRoll={handleEnemyAttackRoll}
+                      onEnemyAttackRoll={beginEnemyTargeting}
                       onEnemyAdjustmentInputChange={handleEnemyAdjustmentInputChange}
                       onApplyEnemyHealthAdjustment={handleApplyEnemyHealthAdjustment}
                       onResetEnemyHealth={handleResetEnemyHealth}


### PR DESCRIPTION
### Motivation
- Allow DM-controlled monsters to target and attack using the same targeting/attack resolution used by player actions instead of duplicating logic. 
- Replace ambiguous icon-only monster attack controls with clear labeled `🎲 Roll Attack` and `💥 Roll Damage` buttons that match the player UI and workflows. 
- Ensure HP mutation and damage processing remain centralized through existing resolution and health endpoints so resistances, immunities, temp HP, and critical handling are preserved.

### Description
- Reused the shared resolver by wiring DM attacks through `resolveAttack` and the existing roll/apply hooks so attack rolls, AC comparison, natural 1/20, critical damage, and damage application follow the same rules as player attacks; key logic added in `client/src/components/Zombies/pages/ZombiesDM.js`. 
- Added DM targeting state and handlers (`combatTargeting`, `beginEnemyTargeting`, `handleEnemyTargetClick`, and a targeting lock) to enter/select/resolve targets and to clear or cancel targeting with Escape. 
- Updated the DM attack UI to use labeled buttons and the same styles as player actions by replacing icon-only controls with `🎲 Roll Attack` and `💥 Roll Damage` in `ActiveEnemyQuickList` and the enemy card attack list (`client/src/components/Zombies/components/ActiveEnemyQuickList.js` and `client/src/components/Zombies/pages/ZombiesDM.js`). 
- Integrated map targeting presentation by passing `targeting` and `onTokenClick` into the map board so tokens are highlighted and selectable while DM targeting is active, and surface-level result details (target name, AC, outcome, damage) are surfaced in `latestEnemyRoll` displays. 

### Testing
- Ran unit tests with `CI=true npm --prefix client test -- --runInBand --watchAll=false client/src/components/Zombies/components/ActiveEnemyQuickList.test.js client/src/components/Zombies/utils/attackResolution.test.js` and both suites passed. 
- Built the client with `npm run build`; production build completed successfully with pre-existing lint and browserslist warnings only. 
- Performed quick verification that `git diff --check` produced no errors after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62256512f08323bdcc038ace29ce8b)