### PR TITLE
Lock combat map during attack target selection

### DIFF
--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -1198,6 +1198,15 @@ const CampaignMapBoard = ({
 
   const handlePointerDown = useCallback(
     (event, token) => {
+      // Target selection takes precedence over every map editing interaction. The
+      // subsequent click owns target selection, while pointer down must never
+      // initialize a drag (including for DM-controlled movable tokens).
+      if (targeting) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
       if (interactionDisabled || !token || token.isMovable === false) {
         return;
       }
@@ -1240,7 +1249,7 @@ const CampaignMapBoard = ({
         }
       }
     },
-    [interactionDisabled, onTokenDragStart]
+    [interactionDisabled, onTokenDragStart, targeting]
   );
 
   const updateDragPosition = useCallback((tokenId, nextPosition) => {
@@ -1351,6 +1360,11 @@ const CampaignMapBoard = ({
       setActiveLabelTokenId(null);
       setLastDraggedTokenId(null);
       setHoveredTokenId(null);
+      if (targeting) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       if (interactionDisabled) {
         return;
       }
@@ -1398,7 +1412,7 @@ const CampaignMapBoard = ({
       event.preventDefault();
       event.stopPropagation();
     },
-    [getNormalizedCoordinates, interactionDisabled, onBackgroundClick]
+    [getNormalizedCoordinates, interactionDisabled, onBackgroundClick, targeting]
   );
 
   const handleLayerPointerMove = useCallback((event) => {
@@ -2235,7 +2249,7 @@ const CampaignMapBoard = ({
                   isActiveTurn,
                   size,
                 } = token;
-                const draggable = !interactionDisabled && token.isMovable !== false;
+                const draggable = !targeting && !interactionDisabled && token.isMovable !== false;
                 const normalizedLabel = normalizeText(label);
                 const displayLabel = normalizedLabel || normalizeText(characterId) || characterId;
                 const isLabelActive = activeLabelTokenId === characterId;
@@ -2339,6 +2353,14 @@ const CampaignMapBoard = ({
                     }}
                     title={displayLabel || undefined}
                     onClick={(event) => {
+                      if (targeting) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        if (onTokenClick) {
+                          onTokenClick(characterId, token);
+                        }
+                        return;
+                      }
                       if (onTokenClick) {
                         event.stopPropagation();
                         onTokenClick(characterId, token);

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -29,11 +29,72 @@ describe('CampaignMapBoard pointer interactions', () => {
         onTokenPositionChange={overrides.onTokenPositionChange}
         onBackgroundClick={overrides.onBackgroundClick}
         onTokenRemove={overrides.onTokenRemove}
+        onTokenClick={overrides.onTokenClick}
+        targeting={overrides.targeting}
       />
     );
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('prioritizes target selection over dragging and restores dragging afterward', () => {
+    const onTokenClick = jest.fn();
+    const onTokenDragStart = jest.fn();
+    const { container, rerender } = renderBoard({
+      targeting: true,
+      onTokenClick,
+      onTokenDragStart,
+    });
+    let tokenElement = container.querySelector('[data-token-id="char-1"]');
+    const pointerDownEvent = createEvent.pointerDown(tokenElement, {
+      button: 0,
+      pointerId: 1,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    fireEvent(tokenElement, pointerDownEvent);
+    fireEvent.click(tokenElement);
+
+    expect(pointerDownEvent.defaultPrevented).toBe(true);
+    expect(onTokenDragStart).not.toHaveBeenCalled();
+    expect(onTokenClick).toHaveBeenCalledWith(
+      'char-1',
+      expect.objectContaining({ characterId: 'char-1' })
+    );
+
+    rerender(
+      <CampaignMapBoard
+        map={baseMap}
+        tokens={[baseToken]}
+        onTokenClick={onTokenClick}
+        onTokenDragStart={onTokenDragStart}
+        targeting={false}
+      />
+    );
+    tokenElement = container.querySelector('[data-token-id="char-1"]');
+    fireEvent.pointerDown(tokenElement, { button: 0, pointerId: 2 });
+
+    expect(onTokenDragStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initiate repositioning from the map background while targeting', () => {
+    const onBackgroundClick = jest.fn();
+    const { container } = renderBoard({ targeting: true, onBackgroundClick });
+    const layer = container.querySelector('.campaign-map-board__tokens-layer');
+    const pointerDownEvent = createEvent.pointerDown(layer, {
+      button: 0,
+      pointerId: 4,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    fireEvent(layer, pointerDownEvent);
+    fireEvent.pointerUp(layer, { button: 0, pointerId: 4 });
+
+    expect(pointerDownEvent.defaultPrevented).toBe(true);
+    expect(onBackgroundClick).not.toHaveBeenCalled();
   });
 
   it('ignores non-primary pointer input and does not start a drag', () => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -6671,6 +6671,9 @@ const [form2, setForm2] = useState({
   const handleCloseResourceTab = useCallback(
     (key) => {
       switch (key) {
+        case 'enemies':
+          setCombatTargeting(INACTIVE_COMBAT_TARGETING);
+          break;
         case 'weapons':
           setIsCreatingWeapon(false);
           break;
@@ -6695,7 +6698,7 @@ const [form2, setForm2] = useState({
       }
       setActiveResourceTab((current) => (current === key ? null : current));
     },
-    [setActiveResourceTab, setPlayersSearch, setGeneratedMap, setMapPrompt]
+    [setActiveResourceTab, setPlayersSearch, setGeneratedMap, setMapPrompt, setCombatTargeting]
   );
 
   const updateAccessoryForm = (value) => {
@@ -7008,6 +7011,16 @@ const resolveIcon = (category, iconMap, fallback) => {
         <div className="combat-targeting-instruction" role="status" aria-live="polite">
           <strong>{combatTargeting.status === 'resolving' ? 'Rolling attack…' : 'Select a target'}</strong>
           <span>{combatTargeting.status === 'resolving' ? 'Resolving hit and damage.' : 'Click a living combatant to attack. Esc to cancel.'}</span>
+          {combatTargeting.status === 'selecting-target' && (
+            <Button
+              type="button"
+              variant="outline-light"
+              size="sm"
+              onClick={() => setCombatTargeting(INACTIVE_COMBAT_TARGETING)}
+            >
+              Cancel
+            </Button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
### Motivation
- Prevent token dragging, map panning, or repositioning from interfering while the DM (or player) is selecting an attack target. 
- Reuse the shared `combatTargeting` state so monster/DM attacks use the same targeting flow as player attacks.

### Description
- In `CampaignMapBoard.js` prioritize targeting by preventing pointer-down from starting drags when `targeting` is true and by skipping layer pan start while targeting. 
- Make tokens non-draggable while `targeting` and route token `onClick` to the existing `onTokenClick` callback immediately when targeting, using `event.preventDefault()`/`event.stopPropagation()` to avoid triggering drag/reposition handlers. 
- Add tests to `CampaignMapBoard.test.js` that verify pointer-down is blocked during targeting, clicks still select targets, background repositioning is prevented while targeting, and normal dragging is restored after targeting ends. 
- In `ZombiesDM.js` clear `combatTargeting` when the Enemies resource tab closes and add a small DM UI `Cancel` button while a target is being selected, ensuring targeting can be cancelled and normal interactions resume.

### Testing
- Ran `CI=true npm --prefix client test -- --runInBand --watchAll=false CampaignMapBoard.test.js` and all `CampaignMapBoard` tests passed (15/15). 
- Ran `CI=true npm --prefix client test -- --runInBand --watchAll=false ZombiesDM.test.js`; tests completed but the run produced pre-existing React `act(...)` console warnings (tests exercised large component lifecycle code). 
- Built the app with `npm run build` which completed successfully (with pre-existing ESLint/Browserslist/autoprefixer warnings). 
- Ran `git diff --check` with no new problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6229a3feec8323ad3622fa9c1c7b16)