### PR TITLE
Fix monster attacks resolving combatant armor class

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -36,6 +36,7 @@ import {
 } from "../utils/derivedStats";
 import {
   calculateCharacterArmorClass,
+  resolveCombatantArmorClass,
   calculateCharacterHitPoints,
   calculateCharacterMovementSpeed,
 } from "../utils/characterMetrics";
@@ -4668,7 +4669,7 @@ export default function ZombiesCharacterSheet() {
           entityType,
           currentHp: Number.isFinite(currentHp) ? currentHp : null,
           maxHp: Number.isFinite(maxHp) ? maxHp : null,
-          armorClass: toFiniteNumberOrNull(value?.armorClass ?? value?.ac ?? value?.armorClassTotal),
+          armorClass: resolveCombatantArmorClass({ ...value, entityType }),
           ...(recordSize ? { size: recordSize } : {}),
           ...(figurineImageUrl ? { figurineImageUrl } : {}),
           ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
@@ -4718,7 +4719,7 @@ export default function ZombiesCharacterSheet() {
           entityType: 'enemy',
           currentHp: enemyCurrentHp !== null ? enemyCurrentHp : null,
           maxHp: enemyMaxHp !== null ? enemyMaxHp : null,
-          armorClass: toFiniteNumberOrNull(Array.isArray(enemy.armorClass) ? enemy.armorClass[0]?.value : (enemy.armorClass ?? enemy.ac)),
+          armorClass: resolveCombatantArmorClass({ ...enemy, entityType: 'enemy' }),
           ...(enemySize ? { size: enemySize } : {}),
           ...(figurineImageUrl ? { figurineImageUrl } : {}),
           ...(figurineImagePublicId ? { figurineImagePublicId } : {}),
@@ -4762,7 +4763,7 @@ export default function ZombiesCharacterSheet() {
           entityType: 'character',
           currentHp: Number.isFinite(currentHp) ? currentHp : null,
           maxHp: Number.isFinite(maxHp) ? maxHp : null,
-          armorClass: toFiniteNumberOrNull(form?.armorClass ?? form?.ac) ?? 10,
+          armorClass: resolveCombatantArmorClass({ ...form, entityType: 'character' }),
           ...(fallbackSize ? { size: fallbackSize } : {}),
           ...(figurineImageUrl ? { figurineImageUrl } : {}),
           ...(figurineImagePublicId ? { figurineImagePublicId } : {}),

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -23,7 +23,7 @@ import { STATS } from '../statSchema';
 import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative, calculatePassivePerception } from '../utils/derivedStats';
 import { resolveInitiativeRollMode } from '../utils/barbarian';
-import { calculateCharacterHitPoints, calculateCharacterMovementSpeed } from '../utils/characterMetrics';
+import { calculateCharacterHitPoints, calculateCharacterMovementSpeed, resolveCombatantArmorClass } from '../utils/characterMetrics';
 import { createCombatState as normalizeTimelineState, advanceTurn, undoTurn } from '../utils/combatTimeline';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
@@ -3779,9 +3779,13 @@ export default function ZombiesDM() {
       if (combatTargeting.status !== 'selecting-target' || targetingLockRef.current) return;
       if (!targetId || targetId === combatTargeting.sourceCombatantId) return;
       const target = characterLookup.get(targetId);
+      if (!target) {
+        setStatus({ type: 'warning', message: 'That map object is not a valid combat target.' });
+        return;
+      }
       const currentHp = toFiniteNumberOrNull(target?.currentHp ?? target?.tempHealth ?? target?.health ?? target?.maxHp ?? target?.hitPoints);
-      if (!target || currentHp === null || currentHp <= 0) return;
-      const armorClass = toFiniteNumberOrNull(target?.armorClass ?? target?.ac);
+      if (currentHp === null || currentHp <= 0) return;
+      const armorClass = resolveCombatantArmorClass(target);
       if (armorClass === null) {
         setStatus({ type: 'warning', message: 'That target does not have an armor class.' });
         return;

--- a/client/src/components/Zombies/utils/characterMetrics.js
+++ b/client/src/components/Zombies/utils/characterMetrics.js
@@ -482,6 +482,30 @@ export const calculateCharacterArmorClass = (character, overrides = {}) => {
   return Number.isFinite(normalized) ? normalized : null;
 };
 
+// Keep map/combat targeting on the same AC path as the character sheet. Monster
+// API records use either a number or an array of AC entries, while characters
+// must include all of the equipment, feat, and unarmored-defense calculations
+// above rather than relying on a stale persisted summary field.
+export const resolveCombatantArmorClass = (combatant, overrides = {}) => {
+  if (!combatant || typeof combatant !== 'object') {
+    return null;
+  }
+
+  const entityType = String(combatant.entityType ?? '').trim().toLowerCase();
+  const isMonster = entityType === 'enemy' || entityType === 'monster';
+  if (!isMonster) {
+    return calculateCharacterArmorClass(combatant, overrides);
+  }
+
+  const armorClass = Array.isArray(combatant.armorClass)
+    ? combatant.armorClass
+        .map((entry) => Number(entry?.value ?? entry))
+        .find((value) => Number.isFinite(value))
+    : Number(combatant.armorClass ?? combatant.ac ?? combatant.armorClassTotal);
+
+  return Number.isFinite(armorClass) ? armorClass : null;
+};
+
 export const calculateCharacterHitPoints = (character, overrides = {}) => {
   if (!character || typeof character !== 'object') {
     return { currentHp: null, maxHp: null };

--- a/client/src/components/Zombies/utils/characterMetrics.test.js
+++ b/client/src/components/Zombies/utils/characterMetrics.test.js
@@ -1,4 +1,4 @@
-import { calculateCharacterArmorClass, calculateCharacterHitPoints, calculateCharacterMovementSpeed } from './characterMetrics';
+import { calculateCharacterArmorClass, calculateCharacterHitPoints, calculateCharacterMovementSpeed, resolveCombatantArmorClass } from './characterMetrics';
 
 describe('calculateCharacterHitPoints', () => {
   it('calculates current and max hp using con and level', () => {
@@ -198,6 +198,29 @@ describe('calculateCharacterArmorClass barbarian unarmored defense', () => {
     const equipped = { ...requestedBase, armor: [leather], equipment: { chest: leather } };
     expect(calculateCharacterArmorClass(equipped)).toBe(14);
     expect(calculateCharacterArmorClass({ ...equipped, equipment: { chest: null } })).toBe(16);
+  });
+});
+
+describe('resolveCombatantArmorClass', () => {
+  it('uses the canonical character calculation instead of a persisted AC summary', () => {
+    const barbarian = {
+      entityType: 'character',
+      armorClass: 10,
+      dex: 14,
+      con: 16,
+      occupation: [{ Name: 'Barbarian', Level: 1 }],
+    };
+
+    expect(resolveCombatantArmorClass(barbarian)).toBe(15);
+  });
+
+  it('normalizes monster AC records used by map combatants', () => {
+    expect(resolveCombatantArmorClass({ entityType: 'enemy', armorClass: [{ value: 13 }] })).toBe(13);
+    expect(resolveCombatantArmorClass({ entityType: 'monster', ac: 17 })).toBe(17);
+  });
+
+  it('returns null when a monster genuinely has no AC', () => {
+    expect(resolveCombatantArmorClass({ entityType: 'enemy', name: 'Illusion' })).toBeNull();
   });
 });
 


### PR DESCRIPTION
### Motivation

- Monster attacks were resolving the selected target's Armor Class differently than player attacks, producing spurious "That target does not have an armor class." warnings for valid player characters. 
- The goal is to reuse the canonical character AC calculation for all combat targeting so monsters, players, and monsters-versus-monsters share the same lookup and hit/miss logic.

### Description

- Added `resolveCombatantArmorClass` to `client/src/components/Zombies/utils/characterMetrics.js` to centralize AC lookup by using the canonical `calculateCharacterArmorClass` for characters and normalizing monster AC records (number or array formats). 
- Updated the DM monster targeting flow in `client/src/components/Zombies/pages/ZombiesDM.js` to use `resolveCombatantArmorClass` and to emit a distinct warning for decorative/non-combat map objects. 
- Updated the player-side `characterLookup` population in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` to use `resolveCombatantArmorClass` so map metadata and player attacks share the same AC source. 
- Added unit tests in `client/src/components/Zombies/utils/characterMetrics.test.js` to cover Barbarian calculated AC, monster AC normalization, and the case where a monster genuinely has no AC; no changes were made to existing centralized damage or attack resolution logic (`resolveAttack`).

### Testing

- Ran unit tests with `CI=true npm test -- --runInBand --watchAll=false src/components/Zombies/utils/characterMetrics.test.js src/components/Zombies/utils/attackResolution.test.js`, and both test suites passed. 
- Performed a production build with `CI=true npm run build`, which reached lint validation but failed due to existing repository lint warnings being treated as errors; these failures are unrelated to the AC resolution logic changes. 
- Verified interactive behavior locally by ensuring the AC used when resolving monster attacks is the same canonical value used elsewhere (player attacks, character sheet calculations, and AC badges).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a622b9b06448323ba1733accf10e92b)