### PR TITLE
Keep combat map grid lines sharp at every zoom level

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -239,15 +239,15 @@
     linear-gradient(
       to right,
       rgba(255, 255, 255, 0.42) 0,
-      rgba(255, 255, 255, 0.42) var(--campaign-map-grid-line-width, 0.75px),
-      transparent var(--campaign-map-grid-line-width, 0.75px),
+      rgba(255, 255, 255, 0.42) 1px,
+      transparent 1px,
       transparent 100%
     ),
     linear-gradient(
       to bottom,
       rgba(255, 255, 255, 0.42) 0,
-      rgba(255, 255, 255, 0.42) var(--campaign-map-grid-line-width, 0.75px),
-      transparent var(--campaign-map-grid-line-width, 0.75px),
+      rgba(255, 255, 255, 0.42) 1px,
+      transparent 1px,
       transparent 100%
     );
   background-size:
@@ -5318,12 +5318,16 @@ h1 {
   }
 
   &__grid-overlay {
-    transform: translate(
-        var(--campaign-map-pan-x, 0),
-        var(--campaign-map-pan-y, 0)
-      )
-      scale(var(--campaign-map-zoom, 1));
-    will-change: transform;
+    // Keep the gradient in screen space so its one-CSS-pixel lines are never
+    // reduced to fractional physical pixels by map zoom. Only the spacing and
+    // origin follow the map transform; tokens and map coordinates are unchanged.
+    inset: auto;
+    top: calc(var(--campaign-map-grid-origin, 0%) + var(--campaign-map-pan-y, 0px));
+    left: calc(var(--campaign-map-grid-origin, 0%) + var(--campaign-map-pan-x, 0px));
+    width: var(--campaign-map-grid-extent, 100%);
+    height: var(--campaign-map-grid-extent, 100%);
+    transform: none;
+    will-change: top, left, width, height;
   }
 
   &__image {
@@ -10843,7 +10847,6 @@ body.character-select-scroll-enabled {
   border-radius: 0;
 }
 
-.zombies-dm-page__map-board .campaign-map-board__grid-overlay,
 .zombies-dm-page__map-board .campaign-map-board__tokens-layer {
   inset: 0;
 }

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -4,7 +4,7 @@ import classNames from '../../../utils/classNames';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { resolveFigurineImageData } from '../utils/figurineAssets';
 import resolveMapImageSource from '../utils/mapImages';
-import clampMapZoom, { MAP_ZOOM_DEFAULT, MAP_ZOOM_MIN, MAP_ZOOM_MAX } from '../utils/mapZoom';
+import clampMapZoom, { MAP_ZOOM_DEFAULT } from '../utils/mapZoom';
 import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
 import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
 
@@ -849,21 +849,16 @@ const CampaignMapBoard = ({
 
   const boardStyle = useMemo(() => {
     const zoomValue = Number.isFinite(resolvedMapZoom) ? resolvedMapZoom : MAP_ZOOM_DEFAULT;
-    const normalizedZoom = Math.max(MAP_ZOOM_MIN, Math.min(MAP_ZOOM_MAX, zoomValue));
-    const gridLineWidth = Math.max(0.35, Math.min(0.75, 0.75 / normalizedZoom));
-
-    const baseStyle = {
-      '--campaign-map-grid-line-width': `${gridLineWidth}px`,
-    };
 
     if (!allowWheelZoom) {
-      return baseStyle;
+      return {};
     }
 
     return {
-      ...baseStyle,
       '--campaign-map-zoom': `${zoomValue}`,
       '--map-modal-background-scale': `${zoomValue}`,
+      '--campaign-map-grid-extent': `${zoomValue * 100}%`,
+      '--campaign-map-grid-origin': `${(1 - zoomValue) * 50}%`,
     };
   }, [allowWheelZoom, resolvedMapZoom]);
 

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -773,12 +773,20 @@ describe('CampaignMapBoard pointer interactions', () => {
     }
 
     expect(boardElement.style.getPropertyValue('--campaign-map-zoom')).toBe('1');
+    expect(boardElement.style.getPropertyValue('--campaign-map-grid-extent')).toBe('100%');
+    expect(boardElement.style.getPropertyValue('--campaign-map-grid-origin')).toBe('0%');
 
     fireEvent.wheel(boardElement, { deltaY: -240 });
 
     await waitFor(() => {
       const zoomValue = boardElement.style.getPropertyValue('--campaign-map-zoom');
       expect(parseFloat(zoomValue)).toBeGreaterThan(1);
+      expect(parseFloat(boardElement.style.getPropertyValue('--campaign-map-grid-extent'))).toBeCloseTo(
+        parseFloat(zoomValue) * 100
+      );
+      expect(parseFloat(boardElement.style.getPropertyValue('--campaign-map-grid-origin'))).toBeCloseTo(
+        (1 - parseFloat(zoomValue)) * 50
+      );
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Grid lines on 1080p sometimes faded or disappeared while zooming due to CSS-gradient stroke scaling into fractional physical pixels and transform-based scaling. 
- The fix must keep existing spacing, appearance, and map coordinate behavior while ensuring one-pixel strokes remain visible across DPRs and zoom levels.

### Description
- Stabilized the gradient stroke by making the gradient stops use a fixed one-CSS-pixel stroke (`1px`) instead of a zoom-scaled CSS variable, preventing sub-pixel thinning; change in `client/src/App.scss`.
- Decoupled the grid rendering from the scaled map layer so the grid strokes remain screen-space while spacing/origin follow map pan/zoom via new CSS properties, implemented with `--campaign-map-grid-extent` and `--campaign-map-grid-origin` set from the component; changes in `client/src/App.scss` and `client/src/components/Zombies/attributes/CampaignMapBoard.js`.
- Removed the previous grid line-width adjustment that attempted to scale stroke width with zoom and instead let the grid overlay remain one CSS pixel thick while the overlay bounds/centering are adjusted to match map zoom, preserving token snapping and coordinates.
- Added assertions to `CampaignMapBoard` unit tests to cover the new grid extent/origin variables and their behavior during wheel zoom; test updates in `client/src/components/Zombies/attributes/CampaignMapBoard.test.js`.

### Testing
- Ran unit tests: `CI=true npm test -- --watchAll=false --runInBand src/components/Zombies/attributes/CampaignMapBoard.test.js`, result: all tests passed (15/15).
- Built production bundle: `npm run build`, result: production build completed successfully (tooling warnings unrelated to this change were reported). 
- Ran static checks: `git diff --check` returned clean results for the patch.
- Note: visual screenshots across multiple DPRs/resolutions could not be captured here because no browser binary / automation tool is available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a622e9b67048323931ca04dc08f5a27)