### PR TITLE
Fix Barbarian Brutal Strike activation

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -610,13 +610,16 @@ export const getFooterConditionSummary = (conditions) => {
   };
 };
 
-export const buildFooterConditions = (character, normalizeCollection) => {
+export const buildFooterConditions = (character, normalizeCollection, combatState, combatantId) => {
   const normalize = typeof normalizeCollection === 'function' ? normalizeCollection : (value) => value || [];
   const conditions = normalize(character?.conditions || character?.statusConditions);
   const recklessActive = getRecklessAttackState(character).active;
-  const withReckless = recklessActive && !conditions.some((condition) => String(condition?.name || condition?.label || condition?.id || '').toLowerCase() === 'reckless attack')
+  let withReckless = recklessActive && !conditions.some((condition) => String(condition?.name || condition?.label || condition?.id || '').toLowerCase() === 'reckless attack')
     ? [{ id: 'reckless-attack-effect', icon: '⚔️', name: 'Reckless Attack', displayLines: ['Reckless', 'Attack'], color: '#f59e0b' }, ...conditions]
     : conditions;
+  if (getBrutalStrikePendingEffect(combatState, combatantId)) {
+    withReckless = [{ id: 'brutal-strike-pending', icon: '👊', name: 'Brutal Strike', duration: 'Until end of turn', color: '#dc6047' }, ...withReckless];
+  }
   if (!getRageState(character).active) {
     return withReckless;
   }
@@ -3103,14 +3106,13 @@ export default function ZombiesCharacterSheet() {
       setCombatState((state) => consumeBrutalStrikeOnAttackResolution(state, combatantId));
       return;
     }
-    const context = playerTurnActionsRef.current?.getAttackContext?.(combatTargeting.attackId);
     const currentTurnCombatantId = combatState.participants?.[combatState.activeTurn]?.characterId;
     try {
-      setCombatState(activateBrutalStrike({ character: form, combatState, combatantId, currentTurnCombatantId, ...context }));
+      setCombatState(activateBrutalStrike({ character: form, combatState, combatantId, currentTurnCombatantId }));
     } catch (error) {
       window.alert(error.message);
     }
-  }, [characterId, combatState, combatTargeting.attackId, form, resolvedCharacterId]);
+  }, [characterId, combatState, form, resolvedCharacterId]);
 
   const rollSpellDamage = useCallback(
     async (damageString, extraDice, levelsAbove = 0) => {
@@ -5548,8 +5550,8 @@ export default function ZombiesCharacterSheet() {
     [form?.activeBonuses, form?.bonuses, form?.activeEffects, normalizeFooterCollection]
   );
   const footerConditions = useMemo(
-    () => buildFooterConditions(form, normalizeFooterCollection),
-    [form, normalizeFooterCollection]
+    () => buildFooterConditions(form, normalizeFooterCollection, combatState, resolvedCharacterId || characterId),
+    [characterId, combatState, form, normalizeFooterCollection, resolvedCharacterId]
   );
   const footerConditionSummary = useMemo(
     () => getFooterConditionSummary(footerConditions),
@@ -6169,8 +6171,7 @@ export default function ZombiesCharacterSheet() {
                         const isRageResource = resource.id === 'rage';
                         const isRecklessAttackResource = resource.id === 'reckless-attack';
                         const isBrutalStrikeResource = resource.id === 'brutal-strike';
-                        const brutalContext = playerTurnActionsRef.current?.getAttackContext?.(combatTargeting.attackId);
-                        const brutalEligibility = canActivateBrutalStrike({ character: form, combatState, combatantId: resolvedCharacterId || characterId, currentTurnCombatantId: combatState.participants?.[combatState.activeTurn]?.characterId, ...brutalContext });
+                        const brutalEligibility = canActivateBrutalStrike({ character: form, combatState, combatantId: resolvedCharacterId || characterId });
                         const resourceMax = Number(resource.max);
                         const handleResourceActivate = (event, action = 'spend') => {
                           if (isRageResource) {
@@ -6205,7 +6206,7 @@ export default function ZombiesCharacterSheet() {
                             type="button"
                             className="combat-hud-resource-tile"
                             style={{ '--hud-resource-accent': resource.color }}
-                            title={isBrutalStrikeResource ? (resource.active ? 'Brutal Strike is ready. Your next eligible Strength-based attack this turn forgoes Reckless Attack Advantage. On a hit, it deals an extra 1d10 damage and triggers a Brutal Strike effect.' : brutalEligibility.reason || 'Ready Brutal Strike for the selected attack.') : isRecklessAttackResource ? (resource.active ? 'Reckless Attack active. Attack rolls against this character have Advantage until the start of their next turn.' : canActivateRecklessAttack(form).reason || 'Activate Reckless Attack. Attacks against you have Advantage until the start of your next turn.') : isRageResource ? (resource.active ? `End Rage: ${resource.current ?? '—'}/${resource.max ?? '—'} uses remaining` : hasHeavyArmorEquipped(form) ? 'Cannot rage while wearing Heavy Armor' : Number(resource.current) <= 0 ? 'No Rage uses remaining' : `Activate Rage: ${resource.current ?? '—'}/${resource.max ?? '—'} uses remaining`) : isFocusResource ? `${resource.name}: click to spend, right-click to restore, double-click to reset` : `${resource.name}: ${resource.current ?? '—'}/${resource.max ?? '—'}`}
+                            title={isBrutalStrikeResource ? (resource.active ? 'Brutal Strike is ready. Your next eligible Strength-based attack this turn forgoes Reckless Attack Advantage. On a hit, it deals an extra 1d10 damage and triggers a Brutal Strike effect.' : brutalEligibility.reason || 'Ready Brutal Strike for your next eligible attack this turn.') : isRecklessAttackResource ? (resource.active ? 'Reckless Attack active. Attack rolls against this character have Advantage until the start of their next turn.' : canActivateRecklessAttack(form).reason || 'Activate Reckless Attack. Attacks against you have Advantage until the start of your next turn.') : isRageResource ? (resource.active ? `End Rage: ${resource.current ?? '—'}/${resource.max ?? '—'} uses remaining` : hasHeavyArmorEquipped(form) ? 'Cannot rage while wearing Heavy Armor' : Number(resource.current) <= 0 ? 'No Rage uses remaining' : `Activate Rage: ${resource.current ?? '—'}/${resource.max ?? '—'} uses remaining`) : isFocusResource ? `${resource.name}: click to spend, right-click to restore, double-click to reset` : `${resource.name}: ${resource.current ?? '—'}/${resource.max ?? '—'}`}
                             aria-label={`${resource.name}: ${resource.current ?? '—'} of ${resource.max ?? '—'}`}
                             onClick={(event) => handleResourceActivate(event, event.shiftKey ? 'restore' : 'spend')}
                             onContextMenu={(event) => handleResourceActivate(event, 'restore')}

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -1,4 +1,4 @@
-import { applyActiveEffect, removeActiveEffect } from './combatTimeline';
+import { applyActiveEffect, hasActiveEffect, removeActiveEffect } from './combatTimeline';
 
 export const BARBARIAN_PROGRESSION = [
   { level: 1, rageUses: 2, rageDamage: 2, weaponMasteryCount: 2 },
@@ -648,7 +648,7 @@ export const resolveAttackRollMode = (character, attack = {}, options = {}) => {
   };
 };
 
-export const BRUTAL_STRIKE_ERROR = "Brutal Strike requires an active Reckless Attack and a Strength-based attack without Disadvantage.";
+export const BRUTAL_STRIKE_ERROR = "Brutal Strike requires Reckless Attack to be active.";
 
 export const getBrutalStrikePendingEffect = (combatState, combatantId) =>
   (combatState?.activeEffects || []).find((effect) =>
@@ -661,13 +661,14 @@ export const isBrutalStrikeEligibleAttack = ({ attack = {}, ability, rollMode } 
   return (actualAbility === 'str' || actualAbility === 'strength') && qualifyingKind && !attack.isSpellAttack && rollMode !== 'disadvantage';
 };
 
-export const canActivateBrutalStrike = ({ character, combatState, combatantId, currentTurnCombatantId, attack, ability, rollMode } = {}) => {
+export const canActivateBrutalStrike = ({ character, combatState, combatant, combatantId, currentTurnCombatantId } = {}) => {
+  const barbarianCombatantId = combatantId ?? combatant?.characterId ?? combatant?.id;
+  const activeCombatantId = currentTurnCombatantId ?? combatState?.participants?.[combatState?.activeTurn]?.characterId;
   let reason = null;
   if (getBarbarianLevel(character) < 9) reason = 'Brutal Strike requires Barbarian level 9.';
-  else if (!combatantId || combatantId !== currentTurnCombatantId) reason = "Brutal Strike can be activated only on the Barbarian's turn.";
-  else if (!getRecklessAttackState(character).active) reason = BRUTAL_STRIKE_ERROR;
-  else if (getBrutalStrikePendingEffect(combatState, combatantId)) reason = 'Brutal Strike is already ready.';
-  else if (!isBrutalStrikeEligibleAttack({ attack, ability, rollMode })) reason = BRUTAL_STRIKE_ERROR;
+  else if (!barbarianCombatantId || barbarianCombatantId !== activeCombatantId) reason = "Brutal Strike can be activated only on the Barbarian's turn.";
+  else if (!hasActiveEffect(combatState, barbarianCombatantId, 'reckless-attack')) reason = BRUTAL_STRIKE_ERROR;
+  else if (hasActiveEffect(combatState, barbarianCombatantId, 'brutal-strike-pending')) reason = 'Brutal Strike is already ready.';
   return { allowed: !reason, reason };
 };
 
@@ -677,8 +678,8 @@ export const createBrutalStrikePendingEffect = (combatantId, attackId) => ({
   name: 'Brutal Strike',
   sourceCombatantId: combatantId,
   targetCombatantId: combatantId,
-  attackId,
-  expiration: { type: 'sourceTurn', combatantId, boundary: 'end', remainingOccurrences: 1 },
+  ...(attackId ? { attackId } : {}),
+  expiration: { type: 'sourceTurn', combatantId, boundary: 'end', remainingOccurrences: 1, expireOnCurrentTurn: true },
   stackKey: `brutal-strike-pending:${combatantId}`,
   stackPolicy: 'ignore',
 });

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -31,8 +31,10 @@ import {
   activateBrutalStrike,
   applyHamstringBlow,
   canActivateBrutalStrike,
+  createRecklessAttackEffect,
   consumeBrutalStrikeOnAttackResolution,
 } from "./barbarian";
+import { advanceTurn, applyActiveEffect, endCombat } from './combatTimeline';
 
 const barbarian = (extra = {}) => ({
   occupation: [{ Name: "Barbarian", Level: 1 }],
@@ -42,25 +44,39 @@ const barbarian = (extra = {}) => ({
 describe('Brutal Strike rules', () => {
   const character = () => ({ occupation: [{ Name: 'Barbarian', Level: 9 }], classState: { barbarian: { recklessAttack: { active: true } } } });
   const attack = { id: 'greataxe', kind: 'weapon', attackAbility: 'str', isWeaponAttack: true };
-  const combat = { participants: [{ characterId: 'barbarian' }], activeTurn: 0, turnSequence: 3, activeEffects: [] };
+  const combat = applyActiveEffect(
+    { participants: [{ characterId: 'barbarian' }, { characterId: 'other' }], activeTurn: 0, turnSequence: 3, activeEffects: [] },
+    createRecklessAttackEffect('barbarian')
+  );
 
-  it('requires level, current turn, Reckless Attack, and an eligible attack', () => {
-    expect(canActivateBrutalStrike({ character: barbarian(), combatState: combat, combatantId: 'barbarian', currentTurnCombatantId: 'barbarian', attack }).allowed).toBe(false);
-    expect(canActivateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian', currentTurnCombatantId: 'other', attack }).allowed).toBe(false);
-    expect(canActivateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian', currentTurnCombatantId: 'barbarian', attack: { ...attack, attackAbility: 'dex' } }).allowed).toBe(false);
-    expect(canActivateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian', currentTurnCombatantId: 'barbarian', attack, rollMode: 'disadvantage' }).allowed).toBe(false);
+  it('requires level, current turn, and the combat Reckless Attack effect, but not a selected attack', () => {
+    expect(canActivateBrutalStrike({ character: barbarian(), combatState: combat, combatantId: 'barbarian' }).allowed).toBe(false);
+    expect(canActivateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian', currentTurnCombatantId: 'other' }).allowed).toBe(false);
+    expect(canActivateBrutalStrike({ character: character(), combatState: { ...combat, activeEffects: [] }, combatantId: 'barbarian' })).toMatchObject({
+      allowed: false,
+      reason: 'Brutal Strike requires Reckless Attack to be active.',
+    });
+    expect(canActivateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian' }).allowed).toBe(true);
   });
 
-  it('queues once, suppresses only Reckless Attack, and consumes independently', () => {
-    const pending = activateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian', currentTurnCombatantId: 'barbarian', attack });
-    expect(() => activateBrutalStrike({ character: character(), combatState: pending, combatantId: 'barbarian', currentTurnCombatantId: 'barbarian', attack })).toThrow('already ready');
+  it('queues once without removing Reckless Attack, suppresses only its attack Advantage, and consumes independently', () => {
+    const pending = activateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian' });
+    expect(pending.activeEffects.filter((effect) => effect.definitionId === 'brutal-strike-pending')).toHaveLength(1);
+    expect(pending.activeEffects.some((effect) => effect.definitionId === 'reckless-attack')).toBe(true);
+    expect(() => activateBrutalStrike({ character: character(), combatState: pending, combatantId: 'barbarian' })).toThrow('already ready');
     expect(resolveAttackRollMode(character(), attack, { advantageSources: ['Hidden'], suppressedAdvantageSources: ['Reckless Attack'] })).toMatchObject({ mode: 'advantage', advantageSources: ['Hidden'] });
-    expect(consumeBrutalStrikeOnAttackResolution(pending, 'barbarian').activeEffects).toHaveLength(0);
+    expect(consumeBrutalStrikeOnAttackResolution(pending, 'barbarian').activeEffects.some((effect) => effect.definitionId === 'brutal-strike-pending')).toBe(false);
     expect(character().classState.barbarian.recklessAttack.active).toBe(true);
   });
 
+  it('clears an unused pending strike at turn end and combat end', () => {
+    const pending = activateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian' });
+    expect(advanceTurn(pending).activeEffects.some((effect) => effect.definitionId === 'brutal-strike-pending')).toBe(false);
+    expect(endCombat(pending).activeEffects.some((effect) => effect.definitionId === 'brutal-strike-pending')).toBe(false);
+  });
+
   it('replaces Hamstring Blow by target and reduces effective speed', () => {
-    const first = applyHamstringBlow(combat, { sourceCombatantId: 'one', targetCombatantId: 'target' });
+    const first = applyHamstringBlow({ ...combat, activeEffects: [] }, { sourceCombatantId: 'one', targetCombatantId: 'target' });
     const second = applyHamstringBlow(first, { sourceCombatantId: 'two', targetCombatantId: 'target' });
     expect(second.activeEffects).toHaveLength(1);
     expect(second.activeEffects[0]).toMatchObject({ sourceCombatantId: 'two', modifiers: [{ type: 'speed', value: -15 }] });

--- a/client/src/components/Zombies/utils/combatTimeline.js
+++ b/client/src/components/Zombies/utils/combatTimeline.js
@@ -47,7 +47,9 @@ const expirationMatches = (effect, event) => {
   if (expiration.type !== 'sourceTurn' && expiration.type !== 'targetTurn') return false;
   const type = expiration.boundary === 'end' ? 'turnEnded' : 'turnStarted';
   return event.type === type && event.combatantId === expiration.combatantId &&
-    event.turnSequence > (effect.appliedAtTurnSequence ?? -1);
+    (expiration.expireOnCurrentTurn
+      ? event.turnSequence >= (effect.appliedAtTurnSequence ?? -1)
+      : event.turnSequence > (effect.appliedAtTurnSequence ?? -1));
 };
 
 /** Resolve all effects as a batch; ids make simultaneous expiration deterministic. */
@@ -133,7 +135,11 @@ export const undoTurn = (inputState) => {
 export const endCombat = (inputState) => {
   let state = createCombatState(inputState);
   state = emit(state, eventFor('combatEnded', state));
-  return { ...state, activeTurn: null };
+  return {
+    ...state,
+    activeTurn: null,
+    activeEffects: state.activeEffects.filter((effect) => effect.definitionId !== 'brutal-strike-pending'),
+  };
 };
 
 export const endConcentration = (inputState, concentrationId) => {

--- a/server/data/classFeatures.js
+++ b/server/data/classFeatures.js
@@ -231,11 +231,6 @@ A Rage can last for up to 10 minutes.`
     {
       name: 'Brutal Strike',
       description: 'If you use Reckless Attack, you can forgo its Advantage on one eligible Strength-based attack. On a hit, the attack deals an extra 1d10 damage and you choose Forceful Blow or Hamstring Blow.'
-    },
-    {
-      name: 'Brutal Critical (1 die)',
-      description:
-        'You can roll one additional weapon damage die when determining the extra damage for a critical hit.'
     }
   ],
  10: [


### PR DESCRIPTION
### Motivation
- Remove an invalid Barbarian feature (the spurious “Brutal Critical (1 die)”) from the rules data so it no longer appears in feature lists or is granted at level 9.
- Restore and centralize the Brutal Strike combat activation flow so the combat HUD pill can queue the effect when its prerequisites are met without requiring a selected attack.

### Description
- Removed the `Brutal Critical (1 die)` entry from the Barbarian level 9 progression so level 9 only contains `Brutal Strike` (`server/data/classFeatures.js`).
- Reworked Brutal Strike eligibility to use combat timeline state (combat turn and active effects) rather than a selected-attack context by changing `canActivateBrutalStrike` to validate Barbarian class level, current turn, presence of the `reckless-attack` effect, and duplicate pending prevention (`client/src/components/Zombies/utils/barbarian.js`).
- Make activation create a single `brutal-strike-pending` active effect (with end-of-current-turn expiration) and keep Reckless Attack active while the pending effect exists, deferring Strength/Disadvantage validation to attack resolution (`client/src/components/Zombies/utils/barbarian.js`).
- Adjusted combat timeline expiration logic to allow end-of-current-turn expiration semantics and added combat-end cleanup for pending Brutal Strike effects (`client/src/components/Zombies/utils/combatTimeline.js`).
- Updated the character-sheet resource/pill handling and active-conditions presentation to use the centralized eligibility and show queued Brutal Strike state without a selected attack (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Added and adjusted unit tests to cover activation without an attack selection, duplicate prevention, Reckless Attack preservation, consumption on resolution, and cleanup on turn end and combat end (`client/src/components/Zombies/utils/barbarian.test.js` and timeline tests).

### Testing
- Ran unit tests with `CI=true npm --prefix client test -- --runInBand --watchAll=false src/components/Zombies/utils/barbarian.test.js src/components/Zombies/utils/combatTimeline.test.js` and the suites passed (`46 tests passed`).
- Ran a broader test invocation including the character sheet tests with `CI=true npm --prefix client test -- --runInBand --watchAll=false src/components/Zombies/utils/barbarian.test.js src/components/Zombies/utils/combatTimeline.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js` and the suites completed (tests passed; React `act(...)` console warnings are existing pre-existing warnings, not introduced by this change).
- Verified the server data via a `node` assertion that Barbarian level 9 registry now contains only `Brutal Strike` and no `Brutal Critical (1 die)` entry.
- Performed a production build with `npm run build` which completed (build emitted unrelated lint/browser-data warnings already present in the project).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a623cbe1f04832386387e10f9402f49)