### PR TITLE
Fix remaining Brutal Strike rule validation

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -1947,6 +1947,13 @@ const manualCriticalRef = useRef(false);
       isUnarmedStrike: isUnarmedAttack(weapon),
     };
     const rollModeResult = resolveAttackRollMode(form, attackContext, targetRollMode);
+    if (targetRollMode.brutalStrike && !isBrutalStrikeEligibleAttack({
+      attack: attackContext,
+      ability: abilityKey,
+      rollMode: rollModeResult.mode,
+    })) {
+      throw new Error('Brutal Strike requires a Strength-based attack that does not have Disadvantage.');
+    }
     await prepareDiceRollSurface('Roll');
     const { result, d20, rolledD20s, keptD20, rollMode } = await rollSkillWithDiceBox(bonus, {
       diceColor: diceFaceColor,
@@ -2609,7 +2616,10 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
       if (!attack) throw new Error('The selected attack is no longer available.');
       const ability = attack.kind === 'weapon' || attack.kind === 'unarmed' ? getAbilityKeyForWeapon(attack.slot, attack.weapon) : '';
       const pendingBrutalStrike = getBrutalStrikePendingEffect(combatState, characterId);
-      const usesBrutalStrike = Boolean(pendingBrutalStrike && isBrutalStrikeEligibleAttack({ attack, ability, rollMode: 'normal' }));
+      const usesBrutalStrike = Boolean(pendingBrutalStrike);
+      if (usesBrutalStrike && (!isActiveTurn || !isBrutalStrikeEligibleAttack({ attack, ability, rollMode: 'normal' }))) {
+        throw new Error('Brutal Strike requires a Strength-based attack that does not have Disadvantage.');
+      }
       return resolveAttack({
         attackerId: characterId, targetId, attack, target,
         combatState,
@@ -2652,7 +2662,7 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
         onAttackResolved,
       });
     },
-  }), [abilityForWeapon, attackArsenalItems, characterId, form, getAbilityKeyForWeapon, getDamageStringForHandSelection, getSpellAttackDetails, handleShowAttack, isActiveTurn, onApplyTargetDamage, onAttackResolved, onCharacterChange, rollDamageExpression]);
+  }), [abilityForWeapon, attackArsenalItems, characterId, combatState, form, getAbilityKeyForWeapon, getDamageStringForHandSelection, getSpellAttackDetails, handleShowAttack, isActiveTurn, onApplyTargetDamage, onAttackResolved, onCharacterChange, rollDamageExpression]);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -6087,7 +6087,6 @@ export default function ZombiesCharacterSheet() {
                 onApplyTargetDamage={handleApplyTargetDamage}
                 onCancelTargeting={() => {
                   setCombatTargeting(INACTIVE_COMBAT_TARGETING);
-                  setCombatState((state) => consumeBrutalStrikeOnAttackResolution(state, resolvedCharacterId || characterId));
                 }}
                 onAttackResolved={(result) => {
                   if (result.brutalStrike) setCombatState((state) => consumeBrutalStrikeOnAttackResolution(state, resolvedCharacterId || characterId));

--- a/client/src/components/Zombies/utils/attackResolution.js
+++ b/client/src/components/Zombies/utils/attackResolution.js
@@ -12,6 +12,10 @@ export const getAttackRollMode = ({ targetId, combatState, advantageSources = []
     mode: resolvedAdvantages.length && !disadvantages.length ? 'advantage' : disadvantages.length && !resolvedAdvantages.length ? 'disadvantage' : 'normal',
     advantageSources: resolvedAdvantages,
     disadvantageSources: disadvantages,
+    // Preserve source-level suppressions for the attack producer, which adds
+    // attacker-specific sources (such as Reckless Attack) immediately before
+    // the dice are rolled.
+    suppressedAdvantageSources: [...suppressedAdvantageSources],
   };
 };
 
@@ -44,7 +48,8 @@ export async function resolveAttack({
   if (validation?.valid === false) throw new Error(validation.reason || 'That target is not valid.');
 
   const rollMode = getAttackRollMode({ targetId, combatState, advantageSources, disadvantageSources, suppressedAdvantageSources });
-  if (brutalStrike && rollMode.mode === 'disadvantage') throw new Error('Brutal Strike cannot be used on an attack with Disadvantage.');
+  if (brutalStrike) rollMode.brutalStrike = true;
+  if (brutalStrike && rollMode.mode === 'disadvantage') throw new Error('Brutal Strike requires a Strength-based attack that does not have Disadvantage.');
   const rolledAttack = await rollAttack(attack, rollMode);
   const naturalRoll = Number(rolledAttack?.naturalRoll);
   const attackTotal = Number(rolledAttack?.total);

--- a/client/src/components/Zombies/utils/attackResolution.test.js
+++ b/client/src/components/Zombies/utils/attackResolution.test.js
@@ -49,3 +49,28 @@ it('passes the shared target roll mode to every attack producer', async () => {
   await resolveAttack(input);
   expect(input.rollAttack).toHaveBeenCalledWith(input.attack, expect.objectContaining({ mode: 'advantage' }));
 });
+
+it('forwards offensive source suppression to the attack producer without hiding Reckless defense', async () => {
+  const input = base(10, 15);
+  input.combatState = { activeEffects: [{ definitionId: 'reckless-attack', targetCombatantId: 'troll' }] };
+  input.suppressedAdvantageSources = ['Reckless Attack'];
+  input.brutalStrike = true;
+  await resolveAttack(input);
+  expect(input.rollAttack).toHaveBeenCalledWith(input.attack, expect.objectContaining({
+    mode: 'advantage',
+    advantageSources: ['Target used Reckless Attack'],
+    suppressedAdvantageSources: ['Reckless Attack'],
+    brutalStrike: true,
+  }));
+  expect(input.rollDamage).toHaveBeenCalledWith(input.attack, { critical: false, brutalStrike: true });
+});
+
+it('does not roll or consume a queued Brutal Strike when final Disadvantage remains', async () => {
+  const input = base(10, 15);
+  input.brutalStrike = true;
+  input.disadvantageSources = ['Prone'];
+  input.onAttackResolved = jest.fn();
+  await expect(resolveAttack(input)).rejects.toThrow('Brutal Strike requires a Strength-based attack that does not have Disadvantage.');
+  expect(input.rollAttack).not.toHaveBeenCalled();
+  expect(input.onAttackResolved).not.toHaveBeenCalled();
+});

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -65,8 +65,18 @@ describe('Brutal Strike rules', () => {
     expect(pending.activeEffects.some((effect) => effect.definitionId === 'reckless-attack')).toBe(true);
     expect(() => activateBrutalStrike({ character: character(), combatState: pending, combatantId: 'barbarian' })).toThrow('already ready');
     expect(resolveAttackRollMode(character(), attack, { advantageSources: ['Hidden'], suppressedAdvantageSources: ['Reckless Attack'] })).toMatchObject({ mode: 'advantage', advantageSources: ['Hidden'] });
+    expect(resolveAttackRollMode(character(), attack, { suppressedAdvantageSources: ['Reckless Attack'] })).toMatchObject({ mode: 'normal', advantageSources: [] });
+    expect(resolveAttackRollMode(character(), attack, { disadvantageSources: ['Prone'], suppressedAdvantageSources: ['Reckless Attack'] })).toMatchObject({ mode: 'disadvantage' });
+    expect(resolveAttackRollMode(character(), attack, { advantageSources: ['Hidden'], disadvantageSources: ['Prone'], suppressedAdvantageSources: ['Reckless Attack'] })).toMatchObject({ mode: 'normal' });
     expect(consumeBrutalStrikeOnAttackResolution(pending, 'barbarian').activeEffects.some((effect) => effect.definitionId === 'brutal-strike-pending')).toBe(false);
     expect(character().classState.barbarian.recklessAttack.active).toBe(true);
+  });
+
+  it('rejects direct activation after Reckless Attack expires', () => {
+    const expired = advanceTurn(advanceTurn(combat));
+    expect(expired.activeEffects.some((effect) => effect.definitionId === 'reckless-attack')).toBe(false);
+    expect(() => activateBrutalStrike({ character: character(), combatState: expired, combatantId: 'barbarian', currentTurnCombatantId: 'barbarian' }))
+      .toThrow('Brutal Strike requires Reckless Attack to be active.');
   });
 
   it('clears an unused pending strike at turn end and combat end', () => {


### PR DESCRIPTION
### Motivation

- Ensure `Brutal Strike` can only be queued and consumed under the same authoritative Reckless Attack preconditions and that the queued attack validation happens at roll time. 
- Suppress only the offensive Advantage contributed by Reckless Attack for the chosen attack while preserving Reckless Attack as a visible/defensive effect.

### Description

- Passthrough: `getAttackRollMode` now returns `suppressedAdvantageSources` so attacker-side callers can request source-level suppression without hiding target-side Reckless defense, preserving the shared roll-mode resolver behavior in `client/src/components/Zombies/utils/attackResolution.js`.
- Brutal-mark + error: `resolveAttack` marks `rollMode.brutalStrike` and enforces the specific pre-roll validation error message `Brutal Strike requires a Strength-based attack that does not have Disadvantage.` when final roll mode is `disadvantage`.
- Pre-roll validation: added final validation before rolling in `handleWeaponAttackRoll` and in `resolveTargetedAttack` to reject Brutal Strike uses that are not Strength-based, are not on the Barbarian's turn, or would end with Disadvantage; these raise the same error and prevent consuming the pending effect (`client/src/components/Zombies/attributes/PlayerTurnActions.js`).
- Lifecycle: stopped consuming a pending Brutal Strike when targeting is canceled so the effect remains queued until a valid eligible attack resolves or the turn/combat expires (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Tests: extended and added assertions in `client/src/components/Zombies/utils/barbarian.test.js` and `client/src/components/Zombies/utils/attackResolution.test.js` to cover activation prerequisites, suppression of only Reckless attack Advantage, expiry behavior, and non-consumption on invalid attacks.

### Testing

- Ran targeted unit tests: `CI=true npm --prefix client test -- --runInBand --watchAll=false src/components/Zombies/utils/barbarian.test.js src/components/Zombies/utils/attackResolution.test.js` — both suites passed.
- Built production bundle: `npm --prefix client run build` — build completed successfully (existing lint/Browserslist/Autoprefixer warnings remained and are unrelated to this change).
- Ran a broader UI test suite including `PlayerTurnActions.test.js`: the two utility suites passed but the larger `PlayerTurnActions` suite reported multiple pre-existing UI expectation failures (20 failing expectations); those failures appear unrelated to the Brutal Strike logic changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6254ed13948323b4e6a9c694a9323a)