### PR TITLE
Complete Brutal Strike effect selection flow

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -446,6 +446,7 @@ export function calculateDamage(
     ],
     frenzyApplied,
     brutalStrikeApplied,
+    brutalStrikeDamage: brutalStrikeApplied ? (results.find((entry) => entry.type.startsWith('Brutal Strike'))?.value || 0) : 0,
   };
 }
 
@@ -2650,7 +2651,7 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
             });
             if (result?.frenzyApplied) onCharacterChange?.((previous) => markFrenzyUsed(previous || form));
             if (result) updateDamageValueWithAnimation(result.total, result.breakdown, selected.name, { diceRolls: result.diceRolls });
-            return result?.total;
+            return result;
           }
           const details = getSpellAttackDetails(selected.spell);
           const result = await rollDamageExpression({ damageString: selected.damageText, ability: details?.abilityBonus || 0, crit: critical });

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -47,7 +47,7 @@ import Features from "../attributes/Features";
 import SpellSlots from "../attributes/SpellSlots";
 import { fullCasterSlots, pactMagic } from '../../../utils/spellSlots';
 import { getMonkFocusPoints } from '../../../utils/monk';
-import { activateBrutalStrike, activateRage, activateRecklessAttack, applyRageRest, canActivateBrutalStrike, canActivateRecklessAttack, consumeBrutalStrikeOnAttackResolution, endRage, endRecklessAttack, getBarbarianLevel, getBrutalStrikePendingEffect, getRageBenefits, getRageState, getRecklessAttackState, hasHeavyArmorEquipped } from '../utils/barbarian';
+import { activateBrutalStrike, activateRage, activateRecklessAttack, applyBrutalStrikeChoice, applyRageRest, canActivateBrutalStrike, canActivateRecklessAttack, consumeBrutalStrikeOnAttackResolution, endRage, endRecklessAttack, getBarbarianLevel, getBrutalStrikeChoice, getBrutalStrikePendingEffect, getRageBenefits, getRageState, getRecklessAttackState, hasHeavyArmorEquipped, resolveBrutalStrikeAttack } from '../utils/barbarian';
 import { FaDiceD20 } from "react-icons/fa";
 import { Backpack, BookOpen, CircleHelp, Dice5, Dumbbell, Gem, HeartPulse, Package, Settings, Shield, Sparkles, Swords, UserRound } from "lucide-react";
 import { Button as HudButton, Dock, IconButton, Panel, Toolbar } from "../common/HudPrimitives";
@@ -688,6 +688,8 @@ export default function ZombiesCharacterSheet() {
   const [form, setForm] = useState(null);
   const [campaignId, setCampaignId] = useState(null);
   const [combatState, setCombatState] = useState(createEmptyCombatState());
+  const [brutalStrikeSelection, setBrutalStrikeSelection] = useState('');
+  const brutalStrikeSubmittingRef = useRef(false);
   const [campaignCharacters, setCampaignCharacters] = useState({});
   const [enemies, setEnemies] = useState([]);
   const [campaignMaps, setCampaignMaps] = useState([]);
@@ -5566,6 +5568,43 @@ export default function ZombiesCharacterSheet() {
   const handleCloseActiveConditionsModal = useCallback(() => {
     setShowActiveConditionsModal(false);
   }, []);
+  const brutalStrikeChoice = getBrutalStrikeChoice(combatState, resolvedCharacterId || characterId);
+  const brutalStrikeTarget = brutalStrikeChoice ? (targetingTokenLookupRef.current[brutalStrikeChoice.targetCombatantId]
+    || enemies.find((enemy) => (enemy.enemyId || enemy._id) === brutalStrikeChoice.targetCombatantId)
+    || campaignCharacters?.[brutalStrikeChoice.targetCombatantId]) : null;
+  const brutalStrikeTargetName = brutalStrikeTarget?.name || brutalStrikeTarget?.characterName || 'the target';
+  const barbarianName = form?.name || form?.characterName || 'The Barbarian';
+
+  const persistCombatState = useCallback(async (nextState) => {
+    setCombatState(nextState);
+    if (!encodedCampaignId) return;
+    const response = await apiFetch(`/campaigns/${encodedCampaignId}/combat`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(nextState),
+    });
+    if (!response.ok) throw new Error(response.statusText || 'Failed to save the Brutal Strike choice.');
+    setCombatState(normalizeCombatState(await response.json()));
+  }, [encodedCampaignId]);
+
+  const confirmBrutalStrikeChoice = useCallback(async () => {
+    if (!brutalStrikeChoice || !brutalStrikeSelection || brutalStrikeSubmittingRef.current) return;
+    brutalStrikeSubmittingRef.current = true;
+    try {
+      const next = applyBrutalStrikeChoice(combatState, { resolutionId: brutalStrikeChoice.resolutionId, choice: brutalStrikeSelection });
+      if (brutalStrikeSelection === 'forceful') {
+        next.eventLog[next.eventLog.length - 1] = {
+          ...next.eventLog[next.eventLog.length - 1],
+          message: `Brutal Strike — Forceful Blow: ${brutalStrikeTargetName} is pushed 15 feet directly away from ${barbarianName}. ${barbarianName} may then move up to half their Speed directly toward the target without provoking Opportunity Attacks.`,
+        };
+      }
+      await persistCombatState(next);
+      if (brutalStrikeSelection === 'forceful') notify(next.eventLog[next.eventLog.length - 1].message, 'info');
+      setBrutalStrikeSelection('');
+    } catch (error) {
+      notify(error?.message || 'The Brutal Strike effect could not be applied.', 'danger');
+    } finally {
+      brutalStrikeSubmittingRef.current = false;
+    }
+  }, [barbarianName, brutalStrikeChoice, brutalStrikeSelection, brutalStrikeTargetName, combatState, persistCombatState]);
 
   const hasFooterSpellSlots = hasSpellcasting || (form?.occupation || []).some((cls) => {
     const name = (cls.Name || cls.Occupation || '').toLowerCase();
@@ -6088,8 +6127,13 @@ export default function ZombiesCharacterSheet() {
                 onCancelTargeting={() => {
                   setCombatTargeting(INACTIVE_COMBAT_TARGETING);
                 }}
-                onAttackResolved={(result) => {
-                  if (result.brutalStrike) setCombatState((state) => consumeBrutalStrikeOnAttackResolution(state, resolvedCharacterId || characterId));
+                onAttackResolved={async (result) => {
+                  if (result.brutalStrike) {
+                    const sourceCombatantId = resolvedCharacterId || characterId;
+                    await persistCombatState(resolveBrutalStrikeAttack(combatState, {
+                      ...result, sourceCombatantId, targetCombatantId: result.targetId,
+                    }));
+                  }
                 }}
                 combatState={combatState}
               />
@@ -6450,6 +6494,29 @@ export default function ZombiesCharacterSheet() {
       errorMessage={tokenPickerError}
       filterScope={tokenPickerFilterScope}
     />
+    <Modal className="dnd-modal" centered show={Boolean(brutalStrikeChoice)} onHide={() => {}} backdrop="static" keyboard={false}>
+      <Modal.Header>
+        <Modal.Title>Choose a Brutal Strike Effect</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>Your Brutal Strike hit. Choose one effect to apply to {brutalStrikeTargetName}.</p>
+        <div role="radiogroup" aria-label="Brutal Strike effects" className="d-grid gap-3">
+          {[
+            ['forceful', 'Forceful Blow', 'The target is pushed 15 feet straight away from you. You can then move up to half your Speed straight toward the target without provoking Opportunity Attacks.'],
+            ['hamstring', 'Hamstring Blow', 'The target’s Speed is reduced by 15 feet until the start of your next turn. A target can be affected by only one Hamstring Blow at a time; the most recent one replaces the previous effect.'],
+          ].map(([value, title, description]) => (
+            <Card key={value} as="button" type="button" role="radio" aria-checked={brutalStrikeSelection === value}
+              className={`text-start selectable-card${brutalStrikeSelection === value ? ' border-primary' : ''}`}
+              onClick={() => setBrutalStrikeSelection(value)}>
+              <Card.Body><Card.Title>{title}</Card.Title><Card.Text>{description}</Card.Text></Card.Body>
+            </Card>
+          ))}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <BootstrapButton disabled={!brutalStrikeSelection || brutalStrikeSubmittingRef.current} onClick={confirmBrutalStrikeChoice}>Confirm</BootstrapButton>
+      </Modal.Footer>
+    </Modal>
     {dockedModalElements}
       </div>
     </div>

--- a/client/src/components/Zombies/utils/attackResolution.js
+++ b/client/src/components/Zombies/utils/attackResolution.js
@@ -58,19 +58,23 @@ export async function resolveAttack({
   const hit = naturalRoll !== 1 && (critical || attackTotal >= armorClass);
   let rawDamage = 0;
   let damageApplied = 0;
+  let brutalStrikeDamage = 0;
   if (hit) {
-    rawDamage = Number(await rollDamage(attack, { critical, brutalStrike }));
+    const rolledDamage = await rollDamage(attack, { critical, brutalStrike });
+    rawDamage = Number(typeof rolledDamage === 'object' ? rolledDamage?.total : rolledDamage);
+    brutalStrikeDamage = Number(rolledDamage?.brutalStrikeDamage) || 0;
     if (!Number.isFinite(rawDamage)) throw new Error('The damage roll could not be completed.');
     damageApplied = Math.max(0, Number(calculateAppliedDamage({ rawDamage, damageType: attack.damageType, target })) || 0);
   }
   let hpAfter = Math.max(0, hpBefore - damageApplied);
   const result = {
-    type: 'attack-resolution', attackerId, targetId, attackId: attack.id,
+    type: 'attack-resolution', attackerId, targetId, attackId: attack.id, attackName: attack.name || '',
     naturalRoll, attackTotal, targetArmorClass: armorClass,
     outcome: critical && hit ? 'critical-hit' : hit ? 'hit' : 'miss',
-    damage: rawDamage, damageApplied, damageType: attack.damageType || '',
+    damage: rawDamage, damageApplied, damageType: attack.damageType || '', brutalStrikeDamage,
     hpBefore, hpAfter, rollMode: rollMode.mode, advantageSources: rollMode.advantageSources,
     disadvantageSources: rollMode.disadvantageSources, timestamp: Date.now(),
+    resolutionId: `${attackerId}:${targetId}:${attack.id}:${Date.now()}`,
   };
   if (hit) {
     // The HP writer owns the authoritative before/after values.  In particular,

--- a/client/src/components/Zombies/utils/attackResolution.test.js
+++ b/client/src/components/Zombies/utils/attackResolution.test.js
@@ -26,6 +26,16 @@ it('hits when total equals AC', async () => {
   expect(result.outcome).toBe('hit'); expect(result.damageApplied).toBe(7);
 });
 
+it('retains Brutal Strike damage and target resolution context after damage resolves', async () => {
+  const input = base(10, 15);
+  input.brutalStrike = true;
+  input.attack.name = 'Greataxe';
+  input.rollDamage.mockResolvedValue({ total: 13, brutalStrikeDamage: 6 });
+  const result = await resolveAttack(input);
+  expect(result).toMatchObject({ targetId: 'troll', attackName: 'Greataxe', brutalStrikeDamage: 6, damage: 13 });
+  expect(result.resolutionId).toEqual(expect.any(String));
+});
+
 it('logs HP returned by the canonical damage writer', async () => {
   const input = base(10, 15);
   input.applyDamage.mockResolvedValue({ previousHp: 12, currentHp: 4, appliedDamage: 8 });

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -695,6 +695,37 @@ export const consumeBrutalStrikeOnAttackResolution = (combatState, combatantId) 
   return pending ? removeActiveEffect(combatState, pending.id) : combatState;
 };
 
+export const createBrutalStrikeChoice = ({ resolutionId, sourceCombatantId, targetCombatantId, attackId, attackName, damageType, brutalStrikeDamage }) => ({
+  id: `brutal-strike-choice:${resolutionId}`,
+  definitionId: 'brutal-strike-choice-pending',
+  name: 'Brutal Strike choice pending',
+  resolutionId, sourceCombatantId, targetCombatantId, attackId, attackName, damageType,
+  brutalStrikeDamage: Number(brutalStrikeDamage) || 0,
+  expiration: { type: 'combatEnd' },
+  stackKey: `brutal-strike-choice:${resolutionId}`,
+  stackPolicy: 'ignore',
+});
+
+export const resolveBrutalStrikeAttack = (combatState, resolution) => {
+  const consumed = consumeBrutalStrikeOnAttackResolution(combatState, resolution.sourceCombatantId);
+  if (resolution.outcome === 'miss') return consumed;
+  return applyActiveEffect(consumed, createBrutalStrikeChoice(resolution));
+};
+
+export const getBrutalStrikeChoice = (combatState, sourceCombatantId) =>
+  (combatState?.activeEffects || []).find((effect) => effect.definitionId === 'brutal-strike-choice-pending' && effect.sourceCombatantId === sourceCombatantId);
+
+export const applyBrutalStrikeChoice = (combatState, { resolutionId, choice }) => {
+  const pending = (combatState?.activeEffects || []).find((effect) => effect.definitionId === 'brutal-strike-choice-pending' && effect.resolutionId === resolutionId);
+  if (!pending) return combatState;
+  let next = removeActiveEffect(combatState, pending.id);
+  if (choice === 'hamstring') next = applyHamstringBlow(next, pending);
+  return { ...next, eventLog: [...next.eventLog, {
+    type: 'brutalStrikeChoiceResolved', resolutionId, choice,
+    sourceCombatantId: pending.sourceCombatantId, targetCombatantId: pending.targetCombatantId,
+  }] };
+};
+
 export const createHamstringBlowEffect = ({ sourceCombatantId, targetCombatantId }) => ({
   id: `hamstring-blow:${targetCombatantId}:${Date.now()}`,
   definitionId: 'hamstring-blow',

--- a/client/src/components/Zombies/utils/barbarian.test.js
+++ b/client/src/components/Zombies/utils/barbarian.test.js
@@ -33,6 +33,8 @@ import {
   canActivateBrutalStrike,
   createRecklessAttackEffect,
   consumeBrutalStrikeOnAttackResolution,
+  applyBrutalStrikeChoice,
+  resolveBrutalStrikeAttack,
 } from "./barbarian";
 import { advanceTurn, applyActiveEffect, endCombat } from './combatTimeline';
 
@@ -90,6 +92,21 @@ describe('Brutal Strike rules', () => {
     const second = applyHamstringBlow(first, { sourceCombatantId: 'two', targetCombatantId: 'target' });
     expect(second.activeEffects).toHaveLength(1);
     expect(second.activeEffects[0]).toMatchObject({ sourceCombatantId: 'two', modifiers: [{ type: 'speed', value: -15 }] });
+  });
+
+  it('preserves a hit as an idempotent pending choice and applies Hamstring once', () => {
+    const pending = activateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian' });
+    const resolved = resolveBrutalStrikeAttack(pending, { resolutionId: 'roll-1', sourceCombatantId: 'barbarian', targetCombatantId: 'target', attackId: 'axe', attackName: 'Greataxe', damageType: 'slashing', brutalStrikeDamage: 8, outcome: 'hit' });
+    expect(resolved.activeEffects).toEqual(expect.arrayContaining([expect.objectContaining({ definitionId: 'brutal-strike-choice-pending', targetCombatantId: 'target', brutalStrikeDamage: 8 })]));
+    const chosen = applyBrutalStrikeChoice(resolved, { resolutionId: 'roll-1', choice: 'hamstring' });
+    expect(chosen.activeEffects.filter((effect) => effect.definitionId === 'hamstring-blow')).toHaveLength(1);
+    expect(applyBrutalStrikeChoice(chosen, { resolutionId: 'roll-1', choice: 'hamstring' })).toBe(chosen);
+  });
+
+  it('consumes a missed strike without creating a choice', () => {
+    const pending = activateBrutalStrike({ character: character(), combatState: combat, combatantId: 'barbarian' });
+    const missed = resolveBrutalStrikeAttack(pending, { resolutionId: 'miss-1', sourceCombatantId: 'barbarian', targetCombatantId: 'target', outcome: 'miss' });
+    expect(missed.activeEffects.some((effect) => /brutal-strike-(pending|choice-pending)/.test(effect.definitionId))).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Finish the Brutal Strike resolution lifecycle so a successful Brutal Strike hit opens a required choice modal after extra damage resolves and applies exactly one effect to the hit target.
- Preserve existing Reckless Attack interactions, the 1d10 extra damage roll, and single-consumption semantics while keeping the resolution context available for the modal.

### Description
- Record resolved attack context (including `attackName`, `damageType`, `brutalStrikeDamage`, and a unique `resolutionId`) from `resolveAttack` so downstream UI can reliably target the original hit. (`client/src/components/Zombies/utils/attackResolution.js`).
- Capture and expose the Brutal Strike die result from the damage pipeline by returning a richer object from the damage roll path and adding `brutalStrikeDamage` to the roll result object used by callers. (`client/src/components/Zombies/attributes/PlayerTurnActions.js`).
- Add a new pending-choice lifecycle: `brutal-strike-choice-pending` effects are created on a resolved hit while the original `brutal-strike-pending` activation is consumed, and are removed when a single choice is confirmed. (`client/src/components/Zombies/utils/barbarian.js`).
- Provide `applyBrutalStrikeChoice` which safely applies the selected effect once (Hamstring applies an existing `hamstring-blow` temporary effect; Forceful records the DM notification message) and prevents duplicate application via `resolutionId` idempotency. (`client/src/components/Zombies/utils/barbarian.js`).
- Wire the new lifecycle into the player's sheet so `onAttackResolved` converts a resolved Brutal Strike into the pending-choice state and persists it to shared combat state; the modal then reads that persisted pending choice (by stored source/target IDs) and requires an explicit confirm. (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Add a required, accessible modal using the project modal/card visuals that shows the two selectable effect cards, disables Confirm until one is chosen, and prevents backdrop/Escape from silently discarding the choice. (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Add unit tests covering retained resolution context, pending-choice creation on hit, missed-strike consumption, Hamstring application and replacement, and idempotent choice application. (`client/src/components/Zombies/utils/barbarian.test.js`, `client/src/components/Zombies/utils/attackResolution.test.js`).

### Testing
- Ran unit tests for the modified modules with: `npm test -- --watchAll=false --runInBand src/components/Zombies/utils/barbarian.test.js src/components/Zombies/utils/attackResolution.test.js` and they passed (all tests in those suites passed).
- Ran the character sheet test suite with: `npm test -- --watchAll=false --runInBand src/components/Zombies/pages/ZombiesCharacterSheet.test.js` and it passed (the suite emitted pre-existing React `act(...)` warnings but tests succeeded).
- Built production bundle with: `npm run build` which completed successfully (build emitted existing lint/Browserslist/autoprefixer warnings but produced a deployable `build` folder).
- New/updated tests added: `barbarian.test.js` additions verifying choice lifecycle and idempotency, and an `attackResolution.test.js` case verifying retained `brutalStrikeDamage` and `resolutionId` after damage resolves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62588e39408323ae040121cbe8f2ab)