### PR TITLE
Complete Hamstring Blow with shared combat conditions

### DIFF
--- a/client/src/components/Zombies/components/ActiveEnemyQuickList.js
+++ b/client/src/components/Zombies/components/ActiveEnemyQuickList.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Card, Button, Badge, Modal } from 'react-bootstrap';
 import { FiList, FiChevronDown, FiChevronUp } from 'react-icons/fi';
+import { Sparkles } from 'lucide-react';
+import CombatConditionsModal from './CombatConditionsModal';
 import { sanitizeIdentifierForTestId } from '../utils/sanitizeIdentifierForTestId';
 
 export function ActiveEnemyQuickCard({
@@ -8,6 +10,7 @@ export function ActiveEnemyQuickCard({
   challengeText,
   sizeDisplay,
   armorClassDisplay,
+  speedDisplay,
   maxHpValue,
   resolvedCurrentHp,
   healthSummary,
@@ -26,8 +29,10 @@ export function ActiveEnemyQuickCard({
   formatAttackBonus,
   getEnemyActionDamageString,
   latestEnemyRoll,
+  conditions = [],
 }) {
   const [showAttacksModal, setShowAttacksModal] = React.useState(false);
+  const [showConditionsModal, setShowConditionsModal] = React.useState(false);
 
   const rawEnemyId = typeof enemy?.enemyId === 'string' ? enemy.enemyId : '';
   const normalizedEnemyId = rawEnemyId.trim() !== '' ? rawEnemyId.trim() : null;
@@ -152,6 +157,8 @@ export function ActiveEnemyQuickCard({
         <div className="enemy-quick-card__meta-line">
           <span className="enemy-card__summary-label">Size:</span>
           <span aria-hidden="true">{sizeDisplay}</span>
+          <span className="enemy-card__summary-label">Speed:</span>
+          <span>{speedDisplay || '—'}</span>
         </div>
         <div className="enemy-card__health">
           <div
@@ -277,6 +284,22 @@ export function ActiveEnemyQuickCard({
           >
             Details
           </Button>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            className="d-inline-flex align-items-center gap-1"
+            onClick={() => setShowConditionsModal(true)}
+            disabled={conditions.length === 0}
+          >
+            <Sparkles size={16} aria-hidden="true" />
+            {conditions.length} {conditions.length === 1 ? 'Condition' : 'Conditions'}
+          </Button>
+          <CombatConditionsModal
+            show={showConditionsModal}
+            onHide={() => setShowConditionsModal(false)}
+            conditions={conditions}
+            combatantName={label}
+          />
         </div>
       </Card.Body>
     </Card>
@@ -414,6 +437,7 @@ export function ActiveEnemyQuickList({
   formatAttackBonus,
   getEnemyActionDamageString,
   latestEnemyRoll,
+  getConditionsForEnemy,
 }) {
   const [isCollapsed, setIsCollapsed] = React.useState(false);
 
@@ -541,6 +565,7 @@ export function ActiveEnemyQuickList({
             challengeText={summary.challengeText}
             sizeDisplay={summary.sizeDisplay}
             armorClassDisplay={summary.armorClassDisplay}
+            speedDisplay={summary.speedDisplay}
             maxHpValue={summary.maxHpValue}
             resolvedCurrentHp={summary.resolvedCurrentHp}
             healthSummary={summary.healthSummary}
@@ -559,6 +584,7 @@ export function ActiveEnemyQuickList({
             formatAttackBonus={formatAttackBonus}
             getEnemyActionDamageString={getEnemyActionDamageString}
             latestEnemyRoll={latestEnemyRoll}
+            conditions={getConditionsForEnemy ? getConditionsForEnemy(summary.enemy.enemyId || summary.enemy._id) : []}
           />
         ))}
       </div>

--- a/client/src/components/Zombies/components/CombatConditionsModal.js
+++ b/client/src/components/Zombies/components/CombatConditionsModal.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button, Card, Modal } from 'react-bootstrap';
+
+/** Shared presentation for every combatant's authoritative conditions. */
+export default function CombatConditionsModal({ show, onHide, conditions = [], combatantName }) {
+  return (
+    <Modal className="dnd-modal modern-modal" show={show} onHide={onHide} centered scrollable fullscreen="sm-down">
+      <Card className="modern-card active-conditions-modal">
+        <Card.Header className="modal-header">
+          <Card.Title className="modal-title">
+            {combatantName ? `${combatantName} Conditions` : 'Active Conditions'}
+          </Card.Title>
+        </Card.Header>
+        <Card.Body className="modal-body active-conditions-modal__body">
+          {conditions.length === 0 ? <p className="active-conditions-modal__empty">No conditions</p> : (
+            <ul className="active-conditions-modal__list">
+              {conditions.map((condition, index) => {
+                const name = condition?.name || condition?.label || condition?.id || 'Condition';
+                return (
+                  <li className="active-conditions-modal__item" key={condition?.id || `${name}-${index}`}>
+                    <span className="active-conditions-modal__icon" aria-hidden="true">{condition?.icon || '✦'}</span>
+                    <span className="active-conditions-modal__content">
+                      <strong>{name}</strong>
+                      {condition?.description && <small>{condition.description}</small>}
+                      {condition?.source && <small>{condition.source}</small>}
+                      {condition?.duration && <small>{condition.duration}</small>}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </Card.Body>
+        <Card.Footer className="modal-footer"><Button className="action-btn close-btn" onClick={onHide}>Close</Button></Card.Footer>
+      </Card>
+    </Modal>
+  );
+}

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { io } from "socket.io-client";
 import apiFetch from '../../../utils/apiFetch';
-import { createCombatState as normalizeTimelineState, advanceTurn } from '../utils/combatTimeline';
+import { createCombatState as normalizeTimelineState, advanceTurn, getActiveConditionsForCombatant, getEffectiveSpeed } from '../utils/combatTimeline';
 import { useParams } from "react-router-dom";
 import { Navbar, Container, Modal, Card, Button as BootstrapButton } from 'react-bootstrap';
 import '../../../App.scss';
@@ -78,6 +78,7 @@ import { notify } from '../../../utils/notification';
 import { bindCriticalRollTransport } from '../../../utils/criticalRolls';
 import { emitCriticalRollEvent } from '../../../utils/criticalRolls';
 import CombatTurnHeader, { HEADER_PADDING } from "../components/CombatTurnHeader";
+import CombatConditionsModal from '../components/CombatConditionsModal';
 
 const MIN_DOCKED_MODAL_WIDTH = 320;
 const DOCKED_MODAL_VIEWPORT_PADDING = 32;
@@ -610,7 +611,7 @@ export const getFooterConditionSummary = (conditions) => {
   };
 };
 
-export const buildFooterConditions = (character, normalizeCollection, combatState, combatantId) => {
+export const buildFooterConditions = (character, normalizeCollection, combatState, combatantId, resolveCombatantName) => {
   const normalize = typeof normalizeCollection === 'function' ? normalizeCollection : (value) => value || [];
   const conditions = normalize(character?.conditions || character?.statusConditions);
   const recklessActive = getRecklessAttackState(character).active;
@@ -620,6 +621,8 @@ export const buildFooterConditions = (character, normalizeCollection, combatStat
   if (getBrutalStrikePendingEffect(combatState, combatantId)) {
     withReckless = [{ id: 'brutal-strike-pending', icon: '👊', name: 'Brutal Strike', duration: 'Until end of turn', color: '#dc6047' }, ...withReckless];
   }
+  const combatConditions = getActiveConditionsForCombatant(combatantId, combatState, resolveCombatantName);
+  withReckless = [...combatConditions, ...withReckless];
   if (!getRageState(character).active) {
     return withReckless;
   }
@@ -631,54 +634,6 @@ export const buildFooterConditions = (character, normalizeCollection, combatStat
     : [{ id: 'rage-condition', icon: '🔥', name: 'Rage', color: '#f0733f' }, ...withReckless];
 };
 
-
-function ActiveConditionsModal({ show, onHide, conditions = [] }) {
-  return (
-    <Modal
-      className="dnd-modal modern-modal"
-      show={show}
-      onHide={onHide}
-      centered
-      scrollable
-      fullscreen="sm-down"
-    >
-      <Card className="modern-card active-conditions-modal">
-        <Card.Header className="modal-header">
-          <Card.Title className="modal-title">Active Conditions</Card.Title>
-        </Card.Header>
-        <Card.Body className="modal-body active-conditions-modal__body">
-          {conditions.length === 0 ? (
-            <p className="active-conditions-modal__empty">No conditions</p>
-          ) : (
-            <ul className="active-conditions-modal__list">
-              {conditions.map((condition, index) => {
-                const name = condition?.name || condition?.label || condition?.id || 'Condition';
-                const key = condition?.id || `${name}-${index}`;
-                const secondaryText = condition?.source || condition?.duration || condition?.description;
-                return (
-                  <li className="active-conditions-modal__item" key={key}>
-                    <span className="active-conditions-modal__icon" aria-hidden="true">
-                      {condition?.icon || '✦'}
-                    </span>
-                    <span className="active-conditions-modal__content">
-                      <strong>{name}</strong>
-                      {secondaryText && <small>{secondaryText}</small>}
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </Card.Body>
-        <Card.Footer className="modal-footer">
-          <BootstrapButton className="action-btn close-btn" onClick={onHide}>
-            Close
-          </BootstrapButton>
-        </Card.Footer>
-      </Card>
-    </Modal>
-  );
-}
 
 export default function ZombiesCharacterSheet() {
   const params = useParams();
@@ -5227,8 +5182,8 @@ export default function ZombiesCharacterSheet() {
     [form, totalLevel]
   );
   const footerMovementSpeed = useMemo(
-    () => calculateCharacterMovementSpeed(form),
-    [form]
+    () => getEffectiveSpeed(calculateCharacterMovementSpeed(form), combatState, resolvedCharacterId || characterId),
+    [characterId, combatState, form, resolvedCharacterId]
   );
   const footerInitiativeModifier = useMemo(
     () => calculateCharacterInitiative(form),
@@ -5552,8 +5507,9 @@ export default function ZombiesCharacterSheet() {
     [form?.activeBonuses, form?.bonuses, form?.activeEffects, normalizeFooterCollection]
   );
   const footerConditions = useMemo(
-    () => buildFooterConditions(form, normalizeFooterCollection, combatState, resolvedCharacterId || characterId),
-    [characterId, combatState, form, normalizeFooterCollection, resolvedCharacterId]
+    () => buildFooterConditions(form, normalizeFooterCollection, combatState, resolvedCharacterId || characterId,
+      (id) => id === (resolvedCharacterId || characterId) ? (form?.name || form?.characterName) : campaignCharacters?.[id]?.name || campaignCharacters?.[id]?.characterName),
+    [campaignCharacters, characterId, combatState, form, normalizeFooterCollection, resolvedCharacterId]
   );
   const footerConditionSummary = useMemo(
     () => getFooterConditionSummary(footerConditions),
@@ -6324,7 +6280,7 @@ export default function ZombiesCharacterSheet() {
               </Dock>
             </Container>
           </Navbar>
-          <ActiveConditionsModal
+          <CombatConditionsModal
             show={showActiveConditionsModal}
             onHide={handleCloseActiveConditionsModal}
             conditions={footerConditions}

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -24,7 +24,7 @@ import { SKILLS } from '../skillSchema';
 import { calculateCharacterInitiative, calculatePassivePerception } from '../utils/derivedStats';
 import { resolveInitiativeRollMode } from '../utils/barbarian';
 import { calculateCharacterHitPoints, calculateCharacterMovementSpeed, resolveCombatantArmorClass } from '../utils/characterMetrics';
-import { createCombatState as normalizeTimelineState, advanceTurn, undoTurn } from '../utils/combatTimeline';
+import { createCombatState as normalizeTimelineState, advanceTurn, undoTurn, getActiveConditionsForCombatant, getEffectiveMovement, getEffectiveSpeed } from '../utils/combatTimeline';
 import CampaignMapBoard from '../attributes/CampaignMapBoard';
 import MapModal from '../attributes/MapModal';
 import DamageDiceCanvas from '../attributes/DamageDiceCanvas';
@@ -348,17 +348,17 @@ export const getEntityMovementSpeed = (entity) => {
   return null;
 };
 
-export const getEntityMovementSpeedDisplay = (entity) => {
+export const getEntityMovementSpeedDisplay = (entity, combatState, combatantId = entity?.enemyId || entity?.characterId || entity?._id || entity?.id) => {
   if (!entity || typeof entity !== 'object') {
     return '—';
   }
 
   if (entity.entityType === 'enemy') {
-    return formatMovementSpeed(entity.speed);
+    return formatMovementSpeed(getEffectiveMovement(entity.speed, combatState, combatantId));
   }
 
   const movementSpeed = getEntityMovementSpeed(entity);
-  return movementSpeed !== null ? `${movementSpeed} ft` : '—';
+  return movementSpeed !== null ? `${getEffectiveSpeed(movementSpeed, combatState, combatantId)} ft` : '—';
 };
 
 const getEntityPassivePerception = (entity) => {
@@ -4364,7 +4364,7 @@ export default function ZombiesDM() {
             rowId,
             participantInfo,
             passivePerception: getEntityPassivePerception(entity),
-            movementSpeedDisplay: getEntityMovementSpeedDisplay(entity),
+            movementSpeedDisplay: getEntityMovementSpeedDisplay(entity, combatState, rowId),
             initiativeValue,
             sortInitiative: numericInitiative,
             recordIndex,
@@ -4391,7 +4391,7 @@ export default function ZombiesDM() {
 
           return a.recordIndex - b.recordIndex;
         });
-    }, [combinedRecords, participantLookup, characterInitiativeMap, getEntityId]);
+    }, [combinedRecords, participantLookup, characterInitiativeMap, getEntityId, combatState]);
 
     const formatArmorClass = useCallback((armorClass) => {
       if (!Array.isArray(armorClass) || armorClass.length === 0) {
@@ -7142,7 +7142,10 @@ const resolveIcon = (category, iconMap, fallback) => {
         )}
 
         <ActiveEnemyQuickList
-          summaries={activeMapEnemySummaries}
+          summaries={activeMapEnemySummaries.map((summary) => ({
+            ...summary,
+            speedDisplay: formatMovementSpeed(getEffectiveMovement(summary.enemy.speed, combatState, summary.enemy.enemyId || summary.enemy._id)),
+          }))}
           activeMapTitle={activeMapTitle}
           onManageEnemies={handleShowEnemiesTab}
           onResetInitiative={handleResetInitiative}
@@ -7162,6 +7165,10 @@ const resolveIcon = (category, iconMap, fallback) => {
           formatAttackBonus={formatAttackBonus}
           getEnemyActionDamageString={getEnemyActionDamageString}
           latestEnemyRoll={latestEnemyRoll}
+          getConditionsForEnemy={(enemyId) => getActiveConditionsForCombatant(enemyId, combatState, (sourceId) => {
+            const source = characterLookup.get(sourceId);
+            return source?.characterName || source?.name || sourceId;
+          })}
         />
       </div>
 
@@ -8312,7 +8319,7 @@ const resolveIcon = (category, iconMap, fallback) => {
                     ? enemy.actions.filter((action) => Boolean(getEnemyActionDamageString(action)))
                     : [];
                   const armorClassDisplay = formatArmorClass(enemy.armorClass);
-                  const speedDisplay = formatSpeed(enemy.speed);
+                  const speedDisplay = formatSpeed(getEffectiveMovement(enemy.speed, combatState, enemy.enemyId));
                   const alignmentDisplay = enemy.alignment || '—';
                   const savingThrowsDisplay = formatSavingThrowsDisplay(enemy.savingThrows);
                   const skillsDisplay = formatSkillsDisplay(enemy.skills);

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -730,6 +730,8 @@ export const createHamstringBlowEffect = ({ sourceCombatantId, targetCombatantId
   id: `hamstring-blow:${targetCombatantId}:${Date.now()}`,
   definitionId: 'hamstring-blow',
   name: 'Hamstring Blow',
+  icon: '🦵',
+  userVisible: true,
   sourceCombatantId,
   targetCombatantId,
   modifiers: [{ type: 'speed', operation: 'add', value: -15 }],

--- a/client/src/components/Zombies/utils/combatTimeline.js
+++ b/client/src/components/Zombies/utils/combatTimeline.js
@@ -152,5 +152,46 @@ export const endConcentration = (inputState, concentrationId) => {
 };
 
 export const getEffectiveSpeed = (baseSpeed, effects, targetCombatantId) => Math.max(0,
-  (Number(baseSpeed) || 0) + (effects || []).filter((effect) => effect.targetCombatantId === targetCombatantId).flatMap((effect) => effect.modifiers || []).filter((modifier) => modifier.type === 'speed' && modifier.operation === 'add').reduce((sum, modifier) => sum + (Number(modifier.value) || 0), 0)
+  (Number(baseSpeed) || 0) + (Array.isArray(effects) ? effects : effects?.activeEffects || []).filter((effect) => effect.targetCombatantId === targetCombatantId).flatMap((effect) => effect.modifiers || []).filter((modifier) => modifier.type === 'speed' && modifier.operation === 'add').reduce((sum, modifier) => sum + (Number(modifier.value) || 0), 0)
 );
+
+/** Apply the shared speed pipeline without changing the persisted movement block. */
+export const getEffectiveMovement = (baseMovement, combatState, targetCombatantId) => {
+  const apply = (value) => {
+    if (typeof value === 'number') return getEffectiveSpeed(value, combatState, targetCombatantId);
+    if (typeof value === 'string') {
+      const match = value.match(/-?\d+(?:\.\d+)?/);
+      if (!match) return value;
+      return value.replace(match[0], String(getEffectiveSpeed(Number(match[0]), combatState, targetCombatantId)));
+    }
+    return value;
+  };
+  if (Array.isArray(baseMovement)) return baseMovement.map((mode) => ({ ...mode, value: apply(mode?.value ?? mode?.speed ?? mode?.distance) }));
+  if (baseMovement && typeof baseMovement === 'object') {
+    return Object.fromEntries(Object.entries(baseMovement).map(([mode, value]) => [mode, apply(value)]));
+  }
+  return apply(baseMovement);
+};
+
+const INTERNAL_EFFECTS = new Set(['brutal-strike-pending', 'brutal-strike-choice-pending']);
+
+/** The single condition selector used by character and enemy UIs. */
+export const getActiveConditionsForCombatant = (combatantId, combatState, resolveCombatantName = () => null) =>
+  (combatState?.activeEffects || [])
+    .filter((effect) => effect?.targetCombatantId === combatantId && effect.userVisible !== false && !INTERNAL_EFFECTS.has(effect.definitionId))
+    .map((effect) => {
+      const sourceName = effect.sourceCombatantId ? resolveCombatantName(effect.sourceCombatantId) : null;
+      const expiration = effect.expiration || {};
+      const duration = expiration.type === 'sourceTurn' && expiration.boundary === 'start'
+        ? `Until the start of ${sourceName || 'the source'}'s next turn`
+        : effect.duration;
+      return {
+        ...effect,
+        icon: effect.icon || '✦',
+        source: sourceName ? `Source: ${sourceName}` : effect.source,
+        duration,
+        description: effect.description || (effect.definitionId === 'hamstring-blow'
+          ? `Speed reduced by 15 feet until the start of ${sourceName || 'the source'}'s next turn.`
+          : undefined),
+      };
+    });

--- a/client/src/components/Zombies/utils/combatTimeline.test.js
+++ b/client/src/components/Zombies/utils/combatTimeline.test.js
@@ -1,6 +1,6 @@
 import {
   advanceTurn, applyActiveEffect, createCombatState, durationToExpiration,
-  endCombat, endConcentration, getEffectiveSpeed, hasActiveEffect, removeCombatant, resolveCombatEvent, undoTurn,
+  endCombat, endConcentration, getActiveConditionsForCombatant, getEffectiveMovement, getEffectiveSpeed, hasActiveEffect, removeCombatant, resolveCombatEvent, undoTurn,
 } from './combatTimeline';
 
 const participants = ['source', 'other', 'target'].map((characterId, index) => ({ characterId, initiative: 20 - index }));
@@ -84,6 +84,18 @@ describe('combat timeline effects', () => {
     expect(base).toBe(30);
     state = { ...state, activeEffects: [] };
     expect(getEffectiveSpeed(base, state.activeEffects, 'target')).toBe(30);
+  });
+
+  test('shared movement and condition selectors support monsters with multiple modes', () => {
+    const base = { walk: 30, fly: '60 ft.' };
+    const state = applyActiveEffect(stateAtSource(), effect({
+      definitionId: 'hamstring-blow', name: 'Hamstring Blow', icon: '🦵', userVisible: true,
+    }));
+    expect(getEffectiveMovement(base, state, 'target')).toEqual({ walk: 15, fly: '45 ft.' });
+    expect(base).toEqual({ walk: 30, fly: '60 ft.' });
+    expect(getActiveConditionsForCombatant('target', state, (id) => id === 'source' ? 'Barb' : id)).toEqual([
+      expect.objectContaining({ name: 'Hamstring Blow', source: 'Source: Barb', description: expect.stringContaining("Barb's next turn") }),
+    ]);
   });
 
   test('skipped actions still process boundaries, while an extra action does not', () => {


### PR DESCRIPTION
### Motivation

- Represent Hamstring Blow as an authoritative, temporary combat effect so movement debuffs come from the shared combat state instead of UI flags.
- Centralize effective movement/speed calculation so all UIs (player HUD, DM tracker, enemy panels, details) use the same pipeline and no base movement values are mutated.
- Generalize the player Conditions UI so it can show any combatant's authoritative conditions and be reused for enemies in the DM views.

### Description

- Implemented Hamstring Blow as an active effect produced by `createHamstringBlowEffect` / `applyHamstringBlow` with a `-15` speed modifier, `sourceTurn`/`start` expiration and replace-by-target `stackKey` (file: `utils/barbarian.js`).
- Added a shared movement pipeline: `getEffectiveSpeed` (updated) and new `getEffectiveMovement` to apply modifiers across numeric, string, object, and multi-mode movement representations without mutating stored speed values (file: `utils/combatTimeline.js`).
- Added `getActiveConditionsForCombatant` to derive user-visible condition metadata (icon, source name, description, duration) from authoritative active effects for any combatant (file: `utils/combatTimeline.js`).
- Generalized conditions UI into `CombatConditionsModal` and wired it into the player footer and the DM enemy quick card so both players and monsters show authoritative conditions and counts (files: `components/CombatConditionsModal.js`, `pages/ZombiesCharacterSheet.js`, `components/ActiveEnemyQuickList.js`).
- Routed DM Combat Tracker, Active Map Enemy panel, and enemy Details to display movement derived via `getEffectiveMovement`/`getEffectiveSpeed` so monster movement reflects Hamstring and other active effects without altering base monster data (file: `pages/ZombiesDM.js`).
- Kept existing timeline semantics for replacement, start-of-turn expiration, combatant removal, and stacking semantics by using the existing `applyActiveEffect` lifecycle and `stackPolicy` (file: `utils/combatTimeline.js`).
- Added tests that cover multi-mode movement, non-mutating speed derivation, and condition metadata for Hamstring Blow (file: `utils/combatTimeline.test.js`).

### Testing

- Ran unit tests: `CI=true npm test -- --watchAll=false --runInBand src/components/Zombies/utils/combatTimeline.test.js src/components/Zombies/utils/barbarian.test.js src/components/Zombies/components/ActiveEnemyQuickList.test.js src/components/Zombies/pages/ZombiesCharacterSheet.test.js src/components/Zombies/pages/ZombiesDM.activeMapEnemySummaries.test.js` and all targeted suites passed (5 suites, 122 tests total).
- Ran `git diff --check` with no blocking issues from these changes.
- Attempted production build with `CI=true npm run build`; compilation reached lint/autoprefixer checks and failed because the CI environment treats many pre-existing repository-wide ESLint/Autoprefixer warnings as errors (these warnings are outside the scope of this PR and predate the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62629af9508323a67fd69c48431cd3)