### PR TITLE
Add grid-aware Path of the Berserker Retaliation and post-damage hooks

### DIFF
--- a/client/src/components/Zombies/utils/attackResolution.js
+++ b/client/src/components/Zombies/utils/attackResolution.js
@@ -39,6 +39,7 @@ export async function resolveAttack({
   suppressedAdvantageSources,
   brutalStrike,
   onAttackResolved,
+  onDamageResolved,
 }) {
   if (!attackerId || !targetId || !attack?.id) throw new Error('Attack participants or attack are missing.');
   const armorClass = Number(target?.armorClass);
@@ -86,6 +87,19 @@ export async function resolveAttack({
       if (Number.isFinite(Number(applied.appliedDamage))) result.damageApplied = Number(applied.appliedDamage);
       hpAfter = result.hpAfter;
     }
+  }
+  if (result.damageApplied > 0) {
+    await onDamageResolved?.({
+      damageEventId: result.resolutionId,
+      sourceCombatantId: attackerId,
+      targetCombatantId: targetId,
+      attackId: result.attackId,
+      attackName: result.attackName,
+      damageTaken: Math.max(0, result.hpBefore - result.hpAfter),
+      sourcePosition: result.sourcePosition,
+      targetPosition: result.targetPosition,
+      result,
+    });
   }
   await writeLog(result);
   await onAttackResolved?.({ ...result, brutalStrike: Boolean(brutalStrike) });

--- a/client/src/components/Zombies/utils/attackResolution.test.js
+++ b/client/src/components/Zombies/utils/attackResolution.test.js
@@ -36,6 +36,15 @@ it('retains Brutal Strike damage and target resolution context after damage reso
   expect(result.resolutionId).toEqual(expect.any(String));
 });
 
+it('emits authoritative damage context after HP is applied and not for zero damage', async () => {
+  const input = base(10, 15);
+  input.onDamageResolved = jest.fn();
+  input.applyDamage.mockResolvedValue({ previousHp: 10, currentHp: 4, appliedDamage: 6 });
+  await resolveAttack(input);
+  expect(input.onDamageResolved).toHaveBeenCalledWith(expect.objectContaining({ sourceCombatantId: 'hero', targetCombatantId: 'troll', damageTaken: 6 }));
+  expect(input.applyDamage.mock.invocationCallOrder[0]).toBeLessThan(input.onDamageResolved.mock.invocationCallOrder[0]);
+});
+
 it('logs HP returned by the canonical damage writer', async () => {
   const input = base(10, 15);
   input.applyDamage.mockResolvedValue({ previousHp: 12, currentHp: 4, appliedDamage: 8 });

--- a/client/src/components/Zombies/utils/barbarian.js
+++ b/client/src/components/Zombies/utils/barbarian.js
@@ -176,7 +176,8 @@ export const BARBARIAN_SUBCLASSES = [
         description:
           "You have Immunity to the Charmed and Frightened conditions while your Rage is active. If you’re Charmed or Frightened when you enter your Rage, the condition ends on you.",
       },
-      { id: "berserker-retaliation", name: "Retaliation", level: 10 },
+      { id: "berserker-retaliation", name: "Retaliation", level: 10, type: "reaction", hideUseButton: true,
+        description: "After you take damage from a creature within 5 feet, you can use your Reaction to make one melee attack against it." },
       { id: "berserker-intimidating-presence", name: "Intimidating Presence", level: 14 },
     ],
   },

--- a/client/src/components/Zombies/utils/combatTimeline.js
+++ b/client/src/components/Zombies/utils/combatTimeline.js
@@ -9,6 +9,9 @@ export const createCombatState = (state = {}) => ({
   activeEffects: Array.isArray(state.activeEffects) ? state.activeEffects : [],
   eventLog: Array.isArray(state.eventLog) ? state.eventLog : [],
   undoStack: Array.isArray(state.undoStack) ? state.undoStack : [],
+  reactions: state.reactions && typeof state.reactions === 'object' ? state.reactions : {},
+  pendingDecisions: Array.isArray(state.pendingDecisions) ? state.pendingDecisions : [],
+  resolvedDecisionIds: Array.isArray(state.resolvedDecisionIds) ? state.resolvedDecisionIds : [],
 });
 
 const eventFor = (type, state, combatantId) => ({
@@ -102,7 +105,7 @@ export const removeCombatant = (inputState, combatantId) => {
   const activeId = state.participants[state.activeTurn]?.characterId;
   const participants = state.participants.filter((item) => item.characterId !== combatantId);
   const activeTurn = activeId === combatantId ? null : participants.findIndex((item) => item.characterId === activeId);
-  return { ...state, participants, activeTurn: activeTurn < 0 ? null : activeTurn, activeEffects: state.activeEffects.filter((effect) => effect.targetCombatantId !== combatantId && effect.sourceCombatantId !== combatantId && effect.expiration?.combatantId !== combatantId) };
+  return { ...state, participants, activeTurn: activeTurn < 0 ? null : activeTurn, activeEffects: state.activeEffects.filter((effect) => effect.targetCombatantId !== combatantId && effect.sourceCombatantId !== combatantId && effect.expiration?.combatantId !== combatantId), pendingDecisions: state.pendingDecisions.filter((item) => item.sourceCombatantId !== combatantId && item.targetCombatantId !== combatantId) };
 };
 
 export const advanceTurn = (inputState, { nextCombatantId } = {}) => {
@@ -122,6 +125,7 @@ export const advanceTurn = (inputState, { nextCombatantId } = {}) => {
     state = emit(state, eventFor('roundStarted', state));
   }
   state = { ...state, activeTurn: nextIndex, turnSequence: state.turnSequence + 1 };
+  state = { ...state, reactions: { ...state.reactions, [state.participants[nextIndex].characterId]: { used: false } } };
   return emit(state, eventFor('turnStarted', state, state.participants[nextIndex].characterId));
 };
 
@@ -139,6 +143,7 @@ export const endCombat = (inputState) => {
     ...state,
     activeTurn: null,
     activeEffects: state.activeEffects.filter((effect) => effect.definitionId !== 'brutal-strike-pending'),
+    pendingDecisions: [],
   };
 };
 

--- a/client/src/components/Zombies/utils/gridSpatial.js
+++ b/client/src/components/Zombies/utils/gridSpatial.js
@@ -1,0 +1,49 @@
+const SIZE_SQUARES = Object.freeze({ tiny: 1, small: 1, medium: 1, large: 2, huge: 3, gargantuan: 4 });
+
+const number = (value) => Number.isFinite(Number(value)) ? Number(value) : null;
+const idOf = (value) => String(value?.characterId ?? value?.combatantId ?? value?.enemyId ?? value?._id ?? value?.id ?? '');
+
+export const getOccupiedSquareSize = (combatant = {}) => {
+  const explicit = number(combatant.gridSize ?? combatant.occupiedSquares);
+  if (explicit !== null && explicit > 0) return Math.max(1, Math.floor(explicit));
+  return SIZE_SQUARES[String(combatant.size ?? combatant.creatureSize ?? 'medium').toLowerCase()] || 1;
+};
+
+const getGridDimensions = (mapState = {}) => ({
+  columns: Math.max(1, Math.floor(number(mapState.gridColumns ?? mapState.columns ?? mapState.gridWidth) || 24)),
+  rows: Math.max(1, Math.floor(number(mapState.gridRows ?? mapState.rows ?? mapState.gridHeight) || 24)),
+});
+
+const tokenFor = (combatant, mapState) => {
+  const tokens = mapState?.tokens ?? mapState?.campaignMap?.tokens ?? [];
+  const values = Array.isArray(tokens) ? tokens : Object.values(tokens || {});
+  return values.find((token) => idOf(token) === idOf(combatant)) || combatant?.token || combatant;
+};
+
+/** Logical grid footprint. Token coordinates are top-left normalized map coordinates. */
+export const getOccupiedGridSpace = (combatant, mapState = {}) => {
+  if (!combatant) return null;
+  const token = tokenFor(combatant, mapState);
+  const { columns, rows } = getGridDimensions(mapState?.campaignMap || mapState);
+  const column = number(token.gridX ?? token.column ?? token.col);
+  const row = number(token.gridY ?? token.row);
+  const normalizedX = number(token.x ?? token.position?.x);
+  const normalizedY = number(token.y ?? token.position?.y);
+  const x = column ?? (normalizedX === null ? null : Math.floor(normalizedX * columns));
+  const y = row ?? (normalizedY === null ? null : Math.floor(normalizedY * rows));
+  if (x === null || y === null) return null;
+  const size = getOccupiedSquareSize(token?.size ? token : combatant);
+  return { left: x, top: y, right: x + size - 1, bottom: y + size - 1, size };
+};
+
+/** Chebyshev edge-to-edge distance, matching the board's diagonal-adjacency rule. */
+export const getGridDistanceFeet = (sourceCombatant, targetCombatant, mapState = {}) => {
+  const source = getOccupiedGridSpace(sourceCombatant, mapState);
+  const target = getOccupiedGridSpace(targetCombatant, mapState);
+  if (!source || !target) return Infinity;
+  const horizontalGap = Math.max(0, target.left - source.right, source.left - target.right);
+  const verticalGap = Math.max(0, target.top - source.bottom, source.top - target.bottom);
+  return Math.max(horizontalGap, verticalGap) * 5;
+};
+
+export default getGridDistanceFeet;

--- a/client/src/components/Zombies/utils/gridSpatial.test.js
+++ b/client/src/components/Zombies/utils/gridSpatial.test.js
@@ -1,0 +1,28 @@
+import { getGridDistanceFeet, getOccupiedGridSpace } from './gridSpatial';
+
+const map = { gridColumns: 20, gridRows: 20 };
+
+it('measures Medium-to-Large adjacency from occupied square edges', () => {
+  const barbarian = { characterId: 'barbarian', gridX: 4, gridY: 5, size: 'medium' };
+  const troll = { characterId: 'troll', gridX: 5, gridY: 5, size: 'large' };
+  expect(getGridDistanceFeet(barbarian, troll, map)).toBe(5);
+  expect(getOccupiedGridSpace(troll, map)).toMatchObject({ left: 5, top: 5, right: 6, bottom: 6 });
+});
+
+it('counts diagonal adjacency as 5 feet and one empty square as 10 feet', () => {
+  const large = { gridX: 5, gridY: 5, size: 'large' };
+  expect(getGridDistanceFeet({ gridX: 4, gridY: 4, size: 'medium' }, large, map)).toBe(5);
+  expect(getGridDistanceFeet({ gridX: 3, gridY: 5, size: 'medium' }, large, map)).toBe(10);
+});
+
+it('never returns a negative distance for overlapping footprints', () => {
+  expect(getGridDistanceFeet({ gridX: 5, gridY: 5 }, { gridX: 4, gridY: 4, size: 'huge' }, map)).toBe(0);
+});
+
+it('resolves normalized map-token coordinates independently of sprite bounds', () => {
+  const state = { gridColumns: 20, gridRows: 20, tokens: [
+    { characterId: 'a', x: 0.2, y: 0.25, size: 'medium' },
+    { characterId: 'b', x: 0.25, y: 0.25, size: 'large' },
+  ] };
+  expect(getGridDistanceFeet({ characterId: 'a' }, { characterId: 'b' }, state)).toBe(5);
+});

--- a/client/src/components/Zombies/utils/retaliation.js
+++ b/client/src/components/Zombies/utils/retaliation.js
@@ -1,0 +1,73 @@
+import { getGridDistanceFeet } from './gridSpatial';
+import { getActiveBarbarianSubclassFeatures, isPathOfTheBerserker } from './barbarian';
+
+export const RETALIATION_DESCRIPTION = 'After you take damage from a creature within 5 feet, you can use your Reaction to make one melee attack against it.';
+const idOf = (value) => String(value?.characterId ?? value?.combatantId ?? value?.enemyId ?? value?._id ?? value?.id ?? value ?? '');
+const participants = (state) => state?.participants || [];
+const inCombat = (state, id) => participants(state).some((entry) => idOf(entry) === String(id));
+
+export const hasRetaliation = (character) => isPathOfTheBerserker(character) &&
+  getActiveBarbarianSubclassFeatures(character).some((feature) => feature.id === 'berserker-retaliation');
+
+export const isReactionAvailable = (combatState, combatantId) =>
+  !combatState?.reactions?.[combatantId]?.used;
+
+export const isRetaliationAttack = (attack) => {
+  if (!attack || attack.spell || ['spell', 'cantrip'].includes(attack.kind)) return false;
+  if (attack.kind === 'unarmed' || attack.isUnarmedStrike) return true;
+  return attack.kind === 'weapon' && !/ranged/i.test(`${attack.category || ''} ${attack.range || ''} ${(attack.tags || []).join(' ')}`);
+};
+
+export const getRetaliationAttacks = (attacks, targetValidator = () => true) =>
+  (attacks || []).filter((attack) => isRetaliationAttack(attack) && attack.available !== false && targetValidator(attack));
+
+export const createRetaliationOpportunity = ({ combatState, character, damageEvent, sourceCombatant, targetCombatant, mapState }) => {
+  const eventId = damageEvent?.damageEventId || damageEvent?.resolutionId;
+  const eventSourceId = idOf(damageEvent?.sourceCombatantId || damageEvent?.attackerId);
+  const sourceId = eventSourceId && idOf(sourceCombatant || eventSourceId);
+  const targetId = idOf(targetCombatant || damageEvent?.targetCombatantId || damageEvent?.targetId);
+  if (!eventId || !eventSourceId || !sourceId || !targetId || sourceId !== eventSourceId || sourceId === targetId || Number(damageEvent?.damageTaken ?? damageEvent?.damageApplied) <= 0) return null;
+  if (!hasRetaliation(character) || !inCombat(combatState, sourceId) || !inCombat(combatState, targetId) || !isReactionAvailable(combatState, targetId)) return null;
+  if (getGridDistanceFeet(sourceCombatant || sourceId, targetCombatant || targetId, mapState) > 5) return null;
+  if ((combatState?.resolvedDecisionIds || []).includes(eventId) || (combatState?.pendingDecisions || []).some((item) => item.damageEventId === eventId)) return null;
+  return {
+    id: `retaliation:${eventId}`, type: 'retaliation', status: 'pending', damageEventId: eventId,
+    sourceCombatantId: sourceId, targetCombatantId: targetId, attackId: damageEvent.attackId,
+    attackName: damageEvent.attackName || '', damageTaken: Number(damageEvent.damageTaken ?? damageEvent.damageApplied),
+    sourcePosition: damageEvent.sourcePosition, targetPosition: damageEvent.targetPosition,
+  };
+};
+
+export const queueRetaliation = (state, opportunity) => opportunity ?
+  { ...state, pendingDecisions: [...(state.pendingDecisions || []), opportunity] } : state;
+
+const resolveDecision = (state, decision) => ({
+  ...state,
+  pendingDecisions: (state.pendingDecisions || []).filter((item) => item.id !== decision.id),
+  resolvedDecisionIds: [...new Set([...(state.resolvedDecisionIds || []), decision.damageEventId])],
+});
+
+export const declineRetaliation = (state, decisionId) => {
+  const decision = (state?.pendingDecisions || []).find((item) => item.id === decisionId && item.type === 'retaliation');
+  return decision ? resolveDecision(state, decision) : state;
+};
+
+export const startReactionAttack = ({ combatState, decisionId, mapState, combatants, attacks }) => {
+  const decision = (combatState?.pendingDecisions || []).find((item) => item.id === decisionId && item.type === 'retaliation');
+  if (!decision) return { state: combatState, error: 'Retaliation is no longer available.' };
+  const source = combatants?.[decision.sourceCombatantId] || participants(combatState).find((item) => idOf(item) === decision.sourceCombatantId);
+  const attacker = combatants?.[decision.targetCombatantId] || participants(combatState).find((item) => idOf(item) === decision.targetCombatantId);
+  if (!source || !attacker || getGridDistanceFeet(source, attacker, mapState) > 5) return { state: resolveDecision(combatState, decision), error: 'Retaliation is no longer available because the attacker is not within 5 feet.' };
+  if (!isReactionAvailable(combatState, decision.targetCombatantId)) return { state: resolveDecision(combatState, decision), error: 'Your Reaction has already been used.' };
+  const eligibleAttacks = getRetaliationAttacks(attacks);
+  if (!eligibleAttacks.length) return { state: combatState, error: 'No eligible melee attack is currently available for Retaliation.' };
+  return {
+    state: { ...combatState, reactions: { ...(combatState.reactions || {}), [decision.targetCombatantId]: { used: true, usedBy: 'retaliation', usedAtRound: combatState.round } }, pendingDecisions: (combatState.pendingDecisions || []).map((item) => item.id === decisionId ? { ...item, status: 'selecting-attack' } : item) },
+    attackSelection: { reactionType: 'retaliation', attackerCombatantId: decision.targetCombatantId, targetCombatantId: decision.sourceCombatantId, lockedTargetCombatantId: decision.sourceCombatantId, attacks: eligibleAttacks },
+  };
+};
+
+export const completeRetaliation = (state, decisionId) => {
+  const decision = (state?.pendingDecisions || []).find((item) => item.id === decisionId);
+  return decision ? resolveDecision(state, decision) : state;
+};

--- a/client/src/components/Zombies/utils/retaliation.test.js
+++ b/client/src/components/Zombies/utils/retaliation.test.js
@@ -1,0 +1,66 @@
+import { createRetaliationOpportunity, declineRetaliation, getRetaliationAttacks, hasRetaliation, queueRetaliation, startReactionAttack } from './retaliation';
+import { advanceTurn, createCombatState, removeCombatant } from './combatTimeline';
+
+const character = (level = 10, subclass = 'path-of-the-berserker') => ({
+  occupation: [{ Name: 'Barbarian', Level: level }], classState: { barbarian: { subclass } },
+});
+const source = { characterId: 'troll', gridX: 5, gridY: 5, size: 'large' };
+const target = { characterId: 'barbarian', gridX: 4, gridY: 5, size: 'medium' };
+const baseState = createCombatState({ participants: [target, source], activeTurn: 1, round: 2 });
+const event = { resolutionId: 'hit-1', attackerId: 'troll', targetId: 'barbarian', attackId: 'claw', attackName: 'Claw', damageApplied: 7 };
+
+it('grants Retaliation only to a level 10 Path of the Berserker Barbarian', () => {
+  expect(hasRetaliation(character())).toBe(true);
+  expect(hasRetaliation(character(9))).toBe(false);
+  expect(hasRetaliation(character(10, 'other-path'))).toBe(false);
+});
+
+it('creates one post-damage opportunity for an adjacent creature', () => {
+  const opportunity = createRetaliationOpportunity({ combatState: baseState, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target });
+  expect(opportunity).toMatchObject({ damageEventId: 'hit-1', sourceCombatantId: 'troll', targetCombatantId: 'barbarian', damageTaken: 7 });
+  const queued = queueRetaliation(baseState, opportunity);
+  expect(createRetaliationOpportunity({ combatState: queued, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target })).toBeNull();
+});
+
+it.each([
+  ['zero damage', { ...event, damageApplied: 0 }, source],
+  ['environmental damage', { ...event, attackerId: null }, source],
+  ['self damage', { ...event, attackerId: 'barbarian' }, target],
+  ['distant damage', event, { ...source, gridX: 10 }],
+])('does not offer Retaliation for %s', (_name, damageEvent, attacker) => {
+  expect(createRetaliationOpportunity({ combatState: baseState, character: character(), damageEvent, sourceCombatant: attacker, targetCombatant: target })).toBeNull();
+});
+
+it('declining does not spend the Reaction', () => {
+  const opportunity = createRetaliationOpportunity({ combatState: baseState, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target });
+  const state = declineRetaliation(queueRetaliation(baseState, opportunity), opportunity.id);
+  expect(state.reactions.barbarian).toBeUndefined();
+  expect(state.pendingDecisions).toHaveLength(0);
+});
+
+it('committing spends the Reaction, filters attacks, and locks the triggering target', () => {
+  const opportunity = createRetaliationOpportunity({ combatState: baseState, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target });
+  const attacks = [
+    { id: 'axe', kind: 'weapon', category: 'martial melee' }, { id: 'fist', kind: 'unarmed' },
+    { id: 'bow', kind: 'weapon', category: 'martial ranged' }, { id: 'spell', kind: 'spell' },
+  ];
+  const result = startReactionAttack({ combatState: queueRetaliation(baseState, opportunity), decisionId: opportunity.id, combatants: { troll: source, barbarian: target }, attacks });
+  expect(result.state.reactions.barbarian.usedBy).toBe('retaliation');
+  expect(result.attackSelection).toMatchObject({ attackerCombatantId: 'barbarian', targetCombatantId: 'troll', lockedTargetCombatantId: 'troll' });
+  expect(result.attackSelection.attacks.map((attack) => attack.id)).toEqual(['axe', 'fist']);
+  expect(getRetaliationAttacks(attacks)).toHaveLength(2);
+});
+
+it('revalidates range before commit without spending the Reaction', () => {
+  const opportunity = createRetaliationOpportunity({ combatState: baseState, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target });
+  const result = startReactionAttack({ combatState: queueRetaliation(baseState, opportunity), decisionId: opportunity.id, combatants: { troll: { ...source, gridX: 10 }, barbarian: target }, attacks: [] });
+  expect(result.error).toMatch(/not within 5 feet/);
+  expect(result.state.reactions.barbarian).toBeUndefined();
+});
+
+it('cleans pending decisions on removal and refreshes Reaction at start of the combatant turn', () => {
+  const pending = { ...baseState, reactions: { barbarian: { used: true } }, pendingDecisions: [{ id: 'r', sourceCombatantId: 'troll', targetCombatantId: 'barbarian' }] };
+  expect(removeCombatant(pending, 'troll').pendingDecisions).toHaveLength(0);
+  const advanced = advanceTurn(pending, { nextCombatantId: 'barbarian' });
+  expect(advanced.reactions.barbarian.used).toBe(false);
+});


### PR DESCRIPTION
### Motivation

- Make map grid placement mechanically meaningful for melee-range rules so adjacency and creature size affect reach and adjacency-based features. 
- Provide a shared spatial helper that other systems (melee range, opportunity attacks, auras) can reuse without special-casing Retaliation. 
- Implement the Path of the Berserkerlevel 10 feature Retaliation and integrate it into the existing damage, reaction, and attack pipelines so the feature behaves like other combat reactions.

### Description

- Added a generic occupied-square spatial utility `getGridDistanceFeet` and helpers in `client/src/components/Zombies/utils/gridSpatial.js` that compute token footprints from size (Tiny→Gargantuan) and token/grid coordinates and return non-negative edge-to-edge distances using Chebyshev (diagonal adjacency) math. 
- Registered `berserker-retaliation` in the Barbarian subclass data and added a reaction-type feature entry in `client/src/components/Zombies/utils/barbarian.js`. 
- Implemented a Retaliation decision/opportunity flow in `client/src/components/Zombies/utils/retaliation.js` that validates eligibility (subclass/level, combat membership, non-zero damage from a creature source, reaction availability, grid distance), queues a single pending decision per damage event, declines without spending the Reaction, revalidates range before spending the Reaction, and locks the target for the reaction attack. 
- Extended the shared attack pipeline in `client/src/components/Zombies/utils/attackResolution.js` with an `onDamageResolved` post-HP-update callback that publishes authoritative damage context `{ damageEventId, sourceCombatantId, targetCombatantId, attackId, attackName, damageTaken, sourcePosition, targetPosition }` for features like Retaliation. 
- Extended combat state in `client/src/components/Zombies/utils/combatTimeline.js` to persist `reactions`, `pendingDecisions`, and `resolvedDecisionIds`, to clear pending decisions when combatants are removed or combat ends, and to refresh per-combatant Reaction availability at the start of that combatant’s turn. 
- Constrained reaction attack selection to eligible melee attacks and Unarmed Strike and returned a structured `attackSelection` payload from `startReactionAttack` so the existing melee attack flow can be reused with a locked target. 
- Added unit tests for spatial math and Retaliation flows under `client/src/components/Zombies/utils/` including `gridSpatial.test.js`, `retaliation.test.js`, and related updates to `attackResolution.test.js` to verify the post-damage hook and lifecycle behavior. 

### Testing

- Ran the focused test command `CI=true npm test -- --watchAll=false --runInBand src/components/Zombies/utils/gridSpatial.test.js src/components/Zombies/utils/retaliation.test.js src/components/Zombies/utils/attackResolution.test.js src/components/Zombies/utils/combatTimeline.test.js src/components/Zombies/utils/barbarian.test.js`, and all test suites passed (5 suites, 74 tests passed). 
- Exercised the attack resolution flow to verify `onDamageResolved` fires after HP application and that Retaliation opportunities are created only for valid creature-sourced, non-zero damage events and correctly deduplicated and cleaned up. 
- Verified range edge cases: adjacent Medium vs Large counts as 5 feet, one empty square counts as 10 feet, diagonal adjacency handled consistently, and overlapping footprints never produce negative distances via the new spatial tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a627281eae08323992387f7d10a6964)