### PR TITLE
Fix Retaliation trigger after monster damage

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -68,6 +68,7 @@ import { normalizeEquipmentMap } from "../attributes/equipmentNormalization";
 import { sanitizeInventoryItemsForUpdate } from "../attributes/inventorySanitization";
 import MapModal from "../attributes/MapModal";
 import { INACTIVE_COMBAT_TARGETING } from '../utils/attackResolution';
+import { declineRetaliation, startReactionAttack } from '../utils/retaliation';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -1659,6 +1660,7 @@ export default function ZombiesCharacterSheet() {
   const handleTargetTokenClick = useCallback(async (targetId) => {
     if (combatTargeting.status !== 'selecting-target' || targetingLockRef.current) return;
     if (!targetId || targetId === combatTargeting.sourceCombatantId) return;
+    if (combatTargeting.lockedTargetCombatantId && targetId !== combatTargeting.lockedTargetCombatantId) return;
     const target = targetingTokenLookupRef.current[targetId];
     if (!target || Number(target.currentHp) <= 0) return;
     targetingLockRef.current = true;
@@ -5541,6 +5543,45 @@ export default function ZombiesCharacterSheet() {
     setCombatState(normalizeCombatState(await response.json()));
   }, [encodedCampaignId]);
 
+  const retaliationDecision = (combatState.pendingDecisions || []).find((decision) =>
+    decision.type === 'retaliation' &&
+    decision.status === 'pending' &&
+    String(decision.targetCombatantId) === String(resolvedCharacterId || characterId));
+  const declinePendingRetaliation = useCallback(async () => {
+    if (!retaliationDecision) return;
+    try {
+      await persistCombatState(declineRetaliation(combatState, retaliationDecision.id));
+    } catch (error) {
+      notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
+    }
+  }, [combatState, persistCombatState, retaliationDecision]);
+  const acceptPendingRetaliation = useCallback(async () => {
+    if (!retaliationDecision) return;
+    const combatants = Object.fromEntries((combatState.participants || []).map((participant) => [
+      String(participant.characterId || participant.combatantId || participant.enemyId || participant._id || participant.id),
+      targetingTokenLookupRef.current[String(participant.characterId || participant.combatantId || participant.enemyId || participant._id || participant.id)] || participant,
+    ]));
+    const result = startReactionAttack({
+      combatState,
+      decisionId: retaliationDecision.id,
+      combatants,
+      mapState: { tokens: targetingTokenLookupRef.current },
+      attacks: [{ id: 'unarmed-strike', name: 'Unarmed Strike', kind: 'unarmed', isUnarmedStrike: true }],
+    });
+    if (result.error) {
+      notify(result.error, 'warning');
+      if (result.state !== combatState) await persistCombatState(result.state);
+      return;
+    }
+    try {
+      await persistCombatState(result.state);
+      setCombatTargeting({ status: 'selecting-target', attackId: 'unarmed-strike', ...result.attackSelection });
+      notify('Retaliation committed. Select the locked attacker with a melee weapon or Unarmed Strike.', 'info');
+    } catch (error) {
+      notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
+    }
+  }, [combatState, persistCombatState, retaliationDecision]);
+
   const confirmBrutalStrikeChoice = useCallback(async () => {
     if (!brutalStrikeChoice || !brutalStrikeSelection || brutalStrikeSubmittingRef.current) return;
     brutalStrikeSubmittingRef.current = true;
@@ -6471,6 +6512,17 @@ export default function ZombiesCharacterSheet() {
       </Modal.Body>
       <Modal.Footer>
         <BootstrapButton disabled={!brutalStrikeSelection || brutalStrikeSubmittingRef.current} onClick={confirmBrutalStrikeChoice}>Confirm</BootstrapButton>
+      </Modal.Footer>
+    </Modal>
+    <Modal className="dnd-modal" centered show={Boolean(retaliationDecision)} onHide={() => {}} backdrop="static" keyboard={false}>
+      <Modal.Header><Modal.Title>Use Retaliation?</Modal.Title></Modal.Header>
+      <Modal.Body>
+        <p>{retaliationDecision?.sourceName || 'The attacking creature'} damaged you while within 5 feet.</p>
+        <p>You can use your Reaction to make one melee attack against it.</p>
+      </Modal.Body>
+      <Modal.Footer>
+        <BootstrapButton variant="secondary" onClick={declinePendingRetaliation}>No</BootstrapButton>
+        <BootstrapButton onClick={acceptPendingRetaliation}>Yes</BootstrapButton>
       </Modal.Footer>
     </Modal>
     {dockedModalElements}

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -30,6 +30,7 @@ import MapModal from '../attributes/MapModal';
 import DamageDiceCanvas from '../attributes/DamageDiceCanvas';
 import { calculateDamage, createCriticalDamageFormula, isCriticalAttackRoll } from '../attributes/PlayerTurnActions';
 import { INACTIVE_COMBAT_TARGETING, resolveAttack } from '../utils/attackResolution';
+import { processRetaliationDamageEvent } from '../utils/retaliation';
 import { rollSkillWithDiceBox } from '../attributes/Skills';
 import { rollDiceWithBox, setDiceBoxThemeColor } from '../../../utils/diceBoxManager';
 import { bindCriticalRollTransport } from '../../../utils/criticalRolls';
@@ -3828,6 +3829,20 @@ export default function ZombiesDM() {
             }
             return { previousHp: currentHp, currentHp: nextHp, appliedDamage: damageApplied };
           },
+          onDamageResolved: async (damageEvent) => {
+            // Damage has been persisted at this point. Queue the reaction in the
+            // campaign combat document so the character's client, not just the DM,
+            // receives the decision.
+            const nextState = processRetaliationDamageEvent({
+              combatState,
+              character: target,
+              damageEvent,
+              sourceCombatant: attacker,
+              targetCombatant: target,
+              mapState: { tokens: activeMapTokens },
+            });
+            if (nextState !== combatState) await persistCombatState(nextState);
+          },
           writeLog: async () => {},
         });
         const targetName = target.characterName || target.name || targetId;
@@ -3852,7 +3867,7 @@ export default function ZombiesDM() {
         targetingLockRef.current = false;
         setCombatTargeting(INACTIVE_COMBAT_TARGETING);
       }
-    }, [characterLookup, combatTargeting, getEntityId, handleEnemyAttackRoll, handleEnemyDamageRoll, updateEnemyHealth]);
+    }, [activeMapTokens, characterLookup, combatState, combatTargeting, getEntityId, handleEnemyAttackRoll, handleEnemyDamageRoll, persistCombatState, updateEnemyHealth]);
 
     useEffect(() => {
       if (combatTargeting.status === 'inactive') return undefined;

--- a/client/src/components/Zombies/utils/attackResolution.js
+++ b/client/src/components/Zombies/utils/attackResolution.js
@@ -89,13 +89,15 @@ export async function resolveAttack({
     }
   }
   if (result.damageApplied > 0) {
+    const actualHpLost = Math.max(0, result.hpBefore - result.hpAfter);
     await onDamageResolved?.({
       damageEventId: result.resolutionId,
       sourceCombatantId: attackerId,
       targetCombatantId: targetId,
       attackId: result.attackId,
       attackName: result.attackName,
-      damageTaken: Math.max(0, result.hpBefore - result.hpAfter),
+      actualHpLost,
+      damageTaken: actualHpLost,
       sourcePosition: result.sourcePosition,
       targetPosition: result.targetPosition,
       result,

--- a/client/src/components/Zombies/utils/retaliation.js
+++ b/client/src/components/Zombies/utils/retaliation.js
@@ -26,17 +26,25 @@ export const createRetaliationOpportunity = ({ combatState, character, damageEve
   const eventSourceId = idOf(damageEvent?.sourceCombatantId || damageEvent?.attackerId);
   const sourceId = eventSourceId && idOf(sourceCombatant || eventSourceId);
   const targetId = idOf(targetCombatant || damageEvent?.targetCombatantId || damageEvent?.targetId);
-  if (!eventId || !eventSourceId || !sourceId || !targetId || sourceId !== eventSourceId || sourceId === targetId || Number(damageEvent?.damageTaken ?? damageEvent?.damageApplied) <= 0) return null;
+  const actualHpLost = Number(damageEvent?.actualHpLost ?? damageEvent?.damageTaken ?? damageEvent?.damageApplied);
+  if (!eventId || !eventSourceId || !sourceId || !targetId || sourceId !== eventSourceId || sourceId === targetId || actualHpLost <= 0) return null;
   if (!hasRetaliation(character) || !inCombat(combatState, sourceId) || !inCombat(combatState, targetId) || !isReactionAvailable(combatState, targetId)) return null;
   if (getGridDistanceFeet(sourceCombatant || sourceId, targetCombatant || targetId, mapState) > 5) return null;
   if ((combatState?.resolvedDecisionIds || []).includes(eventId) || (combatState?.pendingDecisions || []).some((item) => item.damageEventId === eventId)) return null;
   return {
     id: `retaliation:${eventId}`, type: 'retaliation', status: 'pending', damageEventId: eventId,
     sourceCombatantId: sourceId, targetCombatantId: targetId, attackId: damageEvent.attackId,
-    attackName: damageEvent.attackName || '', damageTaken: Number(damageEvent.damageTaken ?? damageEvent.damageApplied),
+    attackName: damageEvent.attackName || '', actualHpLost, damageTaken: actualHpLost,
+    sourceName: sourceCombatant?.name || sourceCombatant?.characterName || '',
     sourcePosition: damageEvent.sourcePosition, targetPosition: damageEvent.targetPosition,
   };
 };
+
+/** Converts the authoritative post-HP-update event into shared combat state. */
+export const processRetaliationDamageEvent = ({ combatState, character, damageEvent, sourceCombatant, targetCombatant, mapState }) =>
+  queueRetaliation(combatState, createRetaliationOpportunity({
+    combatState, character, damageEvent, sourceCombatant, targetCombatant, mapState,
+  }));
 
 export const queueRetaliation = (state, opportunity) => opportunity ?
   { ...state, pendingDecisions: [...(state.pendingDecisions || []), opportunity] } : state;


### PR DESCRIPTION
### Motivation
- Retaliation was not being offered when a DM-controlled monster damaged a Barbarian because the authoritative HP-loss context and attacker identity were not propagated into the shared post-damage pipeline. 
- The feature must be evaluated only after HP is persisted, use the authoritative HP lost, and deliver a pending decision into shared combat state so the player owning the damaged character sees the prompt.

### Description
- Emit authoritative HP loss after the HP writer confirms persisted values by adding `actualHpLost` to the centralized post-damage callback in `client/src/components/Zombies/utils/attackResolution.js` and pass it through `onDamageResolved`. 
- Evaluate Retaliation using the authoritative field and stronger identity checks in `client/src/components/Zombies/utils/retaliation.js`, include attacker display name, prevent duplicate decisions, and expose `processRetaliationDamageEvent` to queue the pending decision into combat state. 
- Wire DM monster damage into the Retaliation flow by invoking `processRetaliationDamageEvent` from the DM damage application path in `client/src/components/Zombies/pages/ZombiesDM.js` so the decision is persisted to the shared combat document after HP update. 
- Add the player-side prompt and decision lifecycle in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js` to show the “Use Retaliation?” modal to the damaged character’s client, handle decline (do not spend Reaction), handle accept (revalidate, spend Reaction, lock attacker, and open attack selection), and prevent selecting targets other than the locked attacker. 
- Preserve existing spatial logic and only rely on `getGridDistanceFeet` (logical occupied squares) to evaluate the within-5-feet requirement; no changes to grid utilities were required. 

### Testing
- Ran focused unit tests: `CI=true npm test -- --watchAll=false --runInBand src/components/Zombies/utils/attackResolution.test.js src/components/Zombies/utils/retaliation.test.js src/components/Zombies/utils/gridSpatial.test.js`, and all suites passed. 
- Triggered larger page test runs and a production build attempt in CI; those processes were started in the environment but did not complete within the session timeout (no failing test output was produced before termination).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6281dd8ca88323a7447bf090a49774)