### PR TITLE
Fix Retaliation for player-originated damage

### DIFF
--- a/client/src/components/Zombies/attributes/PlayerTurnActions.js
+++ b/client/src/components/Zombies/attributes/PlayerTurnActions.js
@@ -472,6 +472,7 @@ const PlayerTurnActions = React.forwardRef(
       onCancelTargeting = () => {},
       combatState = null,
       onAttackResolved = async () => {},
+      onDamageResolved = async () => {},
     },
     ref
   ) => {
@@ -2622,7 +2623,7 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
         throw new Error('Brutal Strike requires a Strength-based attack that does not have Disadvantage.');
       }
       return resolveAttack({
-        attackerId: characterId, targetId, attack, target,
+        attackerId: characterId, sourceType: 'character', targetId, attack, target,
         combatState,
         rollAttack: (selected, targetRollMode) => selected.kind === 'weapon' || selected.kind === 'unarmed'
           ? handleWeaponAttackRoll(selected.slot, selected.weapon, targetRollMode)
@@ -2660,10 +2661,11 @@ const runDamageRoll = useCallback((item) => { if (!item) return; makeRecent(item
         },
         applyDamage: onApplyTargetDamage,
         writeLog: async (entry) => setDamageLog((previous) => [...previous, entry]),
+        onDamageResolved,
         onAttackResolved,
       });
     },
-  }), [abilityForWeapon, attackArsenalItems, characterId, combatState, form, getAbilityKeyForWeapon, getDamageStringForHandSelection, getSpellAttackDetails, handleShowAttack, isActiveTurn, onApplyTargetDamage, onAttackResolved, onCharacterChange, rollDamageExpression]);
+  }), [abilityForWeapon, attackArsenalItems, characterId, combatState, form, getAbilityKeyForWeapon, getDamageStringForHandSelection, getSpellAttackDetails, handleShowAttack, isActiveTurn, onApplyTargetDamage, onAttackResolved, onCharacterChange, onDamageResolved, rollDamageExpression]);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <div

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -68,7 +68,7 @@ import { normalizeEquipmentMap } from "../attributes/equipmentNormalization";
 import { sanitizeInventoryItemsForUpdate } from "../attributes/inventorySanitization";
 import MapModal from "../attributes/MapModal";
 import { INACTIVE_COMBAT_TARGETING } from '../utils/attackResolution';
-import { declineRetaliation, startReactionAttack } from '../utils/retaliation';
+import { declineRetaliation, processRetaliationDamageEvent, startReactionAttack } from '../utils/retaliation';
 import { ENEMY_FIGURINE_COLOR } from '../constants/tokenAppearance';
 import { mergeTokenPayload } from "./utils/mergeTokenPayload";
 import proficiencyBonus from '../../../utils/proficiencyBonus';
@@ -5543,10 +5543,36 @@ export default function ZombiesCharacterSheet() {
     setCombatState(normalizeCombatState(await response.json()));
   }, [encodedCampaignId]);
 
+  const handleResolvedCombatDamage = useCallback(async (damageEvent) => {
+    const sourceId = String(damageEvent?.sourceCombatantId || '');
+    const targetId = String(damageEvent?.targetCombatantId || '');
+    if (!sourceId || !targetId) return;
+    const defenderCharacter = targetId === String(resolvedCharacterId || characterId)
+      ? form
+      : campaignCharacters?.[targetId];
+    const sourceRecord = campaignCharacters?.[sourceId]
+      || enemies.find((enemy) => String(enemy?.enemyId || enemy?._id) === sourceId)
+      || {};
+    const targetRecord = campaignCharacters?.[targetId]
+      || enemies.find((enemy) => String(enemy?.enemyId || enemy?._id) === targetId)
+      || {};
+    const sourceCombatant = { ...sourceRecord, ...targetingTokenLookupRef.current[sourceId], characterId: sourceId };
+    const targetCombatant = { ...targetRecord, ...targetingTokenLookupRef.current[targetId], characterId: targetId };
+    const nextState = processRetaliationDamageEvent({
+      combatState,
+      character: defenderCharacter,
+      damageEvent,
+      sourceCombatant,
+      targetCombatant,
+      mapState: { tokens: activeMapTokens },
+    });
+    if (nextState !== combatState) await persistCombatState(nextState);
+  }, [activeMapTokens, campaignCharacters, characterId, combatState, enemies, form, persistCombatState, resolvedCharacterId]);
+
   const retaliationDecision = (combatState.pendingDecisions || []).find((decision) =>
     decision.type === 'retaliation' &&
     decision.status === 'pending' &&
-    String(decision.targetCombatantId) === String(resolvedCharacterId || characterId));
+    String(decision.ownerCombatantId || decision.targetCombatantId) === String(resolvedCharacterId || characterId));
   const declinePendingRetaliation = useCallback(async () => {
     if (!retaliationDecision) return;
     try {
@@ -6121,6 +6147,7 @@ export default function ZombiesCharacterSheet() {
                 shortRestCount={shortRestCount}
                 onBeginTargeting={(selection) => setCombatTargeting({ status: 'selecting-target', ...selection })}
                 onApplyTargetDamage={handleApplyTargetDamage}
+                onDamageResolved={handleResolvedCombatDamage}
                 onCancelTargeting={() => {
                   setCombatTargeting(INACTIVE_COMBAT_TARGETING);
                 }}

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -3807,6 +3807,7 @@ export default function ZombiesDM() {
         };
         const result = await resolveAttack({
           attackerId: combatTargeting.sourceCombatantId,
+          sourceType: attacker?.entityType === 'character' ? 'character' : 'monster',
           targetId,
           attack,
           target: { ...target, currentHp, armorClass },

--- a/client/src/components/Zombies/utils/attackResolution.js
+++ b/client/src/components/Zombies/utils/attackResolution.js
@@ -24,6 +24,7 @@ export const getAttackRollMode = ({ targetId, combatState, advantageSources = []
 // processing are deliberate extension points for range/cover and resistances later.
 export async function resolveAttack({
   attackerId,
+  sourceType = null,
   targetId,
   attack,
   target,
@@ -94,8 +95,10 @@ export async function resolveAttack({
       damageEventId: result.resolutionId,
       sourceCombatantId: attackerId,
       targetCombatantId: targetId,
+      sourceType,
       attackId: result.attackId,
       attackName: result.attackName,
+      damageType: result.damageType,
       actualHpLost,
       damageTaken: actualHpLost,
       sourcePosition: result.sourcePosition,

--- a/client/src/components/Zombies/utils/gridSpatial.js
+++ b/client/src/components/Zombies/utils/gridSpatial.js
@@ -16,8 +16,9 @@ const getGridDimensions = (mapState = {}) => ({
 
 const tokenFor = (combatant, mapState) => {
   const tokens = mapState?.tokens ?? mapState?.campaignMap?.tokens ?? [];
-  const values = Array.isArray(tokens) ? tokens : Object.values(tokens || {});
-  return values.find((token) => idOf(token) === idOf(combatant)) || combatant?.token || combatant;
+  const entries = Array.isArray(tokens) ? tokens.map((token) => ['', token]) : Object.entries(tokens || {});
+  const match = entries.find(([key, token]) => idOf(token) === idOf(combatant) || String(key) === idOf(combatant));
+  return match?.[1] || combatant?.token || combatant;
 };
 
 /** Logical grid footprint. Token coordinates are top-left normalized map coordinates. */

--- a/client/src/components/Zombies/utils/retaliation.js
+++ b/client/src/components/Zombies/utils/retaliation.js
@@ -33,7 +33,8 @@ export const createRetaliationOpportunity = ({ combatState, character, damageEve
   if ((combatState?.resolvedDecisionIds || []).includes(eventId) || (combatState?.pendingDecisions || []).some((item) => item.damageEventId === eventId)) return null;
   return {
     id: `retaliation:${eventId}`, type: 'retaliation', status: 'pending', damageEventId: eventId,
-    sourceCombatantId: sourceId, targetCombatantId: targetId, attackId: damageEvent.attackId,
+    sourceCombatantId: sourceId, targetCombatantId: targetId, ownerCombatantId: targetId,
+    triggeringCombatantId: sourceId, attackId: damageEvent.attackId,
     attackName: damageEvent.attackName || '', actualHpLost, damageTaken: actualHpLost,
     sourceName: sourceCombatant?.name || sourceCombatant?.characterName || '',
     sourcePosition: damageEvent.sourcePosition, targetPosition: damageEvent.targetPosition,

--- a/client/src/components/Zombies/utils/retaliation.test.js
+++ b/client/src/components/Zombies/utils/retaliation.test.js
@@ -1,5 +1,6 @@
-import { createRetaliationOpportunity, declineRetaliation, getRetaliationAttacks, hasRetaliation, queueRetaliation, startReactionAttack } from './retaliation';
+import { createRetaliationOpportunity, declineRetaliation, getRetaliationAttacks, hasRetaliation, processRetaliationDamageEvent, queueRetaliation, startReactionAttack } from './retaliation';
 import { advanceTurn, createCombatState, removeCombatant } from './combatTimeline';
+import { getGridDistanceFeet } from './gridSpatial';
 
 const character = (level = 10, subclass = 'path-of-the-berserker') => ({
   occupation: [{ Name: 'Barbarian', Level: level }], classState: { barbarian: { subclass } },
@@ -17,9 +18,35 @@ it('grants Retaliation only to a level 10 Path of the Berserker Barbarian', () =
 
 it('creates one post-damage opportunity for an adjacent creature', () => {
   const opportunity = createRetaliationOpportunity({ combatState: baseState, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target });
-  expect(opportunity).toMatchObject({ damageEventId: 'hit-1', sourceCombatantId: 'troll', targetCombatantId: 'barbarian', damageTaken: 7 });
+  expect(opportunity).toMatchObject({ damageEventId: 'hit-1', sourceCombatantId: 'troll', targetCombatantId: 'barbarian', ownerCombatantId: 'barbarian', triggeringCombatantId: 'troll', damageTaken: 7 });
   const queued = queueRetaliation(baseState, opportunity);
   expect(createRetaliationOpportunity({ combatState: queued, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target })).toBeNull();
+});
+
+it.each([
+  ['player character', { characterId: 'mega-action', gridX: 5, gridY: 5 }],
+  ['monster', { enemyId: 'mega-action', gridX: 5, gridY: 5 }],
+])('uses the same normalized post-damage path for a %s source', (_sourceType, attacker) => {
+  const defender = { characterId: 'barbarian', gridX: 4, gridY: 5 };
+  const state = createCombatState({ participants: [defender, attacker], activeTurn: 1 });
+  const damageEvent = {
+    damageEventId: 'mega-hit', sourceCombatantId: 'mega-action', targetCombatantId: 'barbarian',
+    actualHpLost: 6, attackId: 'sword', attackName: 'Sword', damageType: 'slashing',
+  };
+  const resolved = processRetaliationDamageEvent({
+    combatState: state, character: character(), damageEvent,
+    sourceCombatant: attacker, targetCombatant: defender,
+  });
+  expect(resolved.pendingDecisions).toHaveLength(1);
+  expect(resolved.pendingDecisions[0]).toMatchObject({
+    damageEventId: 'mega-hit', sourceCombatantId: 'mega-action', targetCombatantId: 'barbarian',
+    ownerCombatantId: 'barbarian', status: 'pending', actualHpLost: 6,
+  });
+});
+
+it('resolves adjacent dictionary-keyed map tokens in the shared grid coordinate space', () => {
+  const mapState = { tokens: { 'mega-action': { gridX: 5, gridY: 5 }, barbarian: { gridX: 4, gridY: 5 } } };
+  expect(getGridDistanceFeet({ characterId: 'mega-action' }, { characterId: 'barbarian' }, mapState)).toBe(5);
 });
 
 it.each([


### PR DESCRIPTION
### Motivation

- Retaliation did not appear when a player-controlled attacker (e.g. Mega Action) damaged another player because the player-to-player attack path did not emit the same normalized post-damage event used for monsters/DM attacks.
- The goal was to preserve the existing architecture while ensuring every damage path emits a source-aware, normalized post-HP-update event so Retaliation can be evaluated reliably on the damaged combatant.

### Description

- Route player attacks through the shared `resolveAttack` post-damage callback and add an `onDamageResolved` hook so the authoritative damage event is emitted only after HP is persisted.
- Extend the normalized damage payload with `sourceType`, `damageType`, `attackId`/`attackName`, and `actualHpLost` so downstream logic has full source/target context.
- Make Retaliation decisions ownable and explicit by adding `ownerCombatantId` and `triggeringCombatantId` fields and queueing decisions via `processRetaliationDamageEvent` so the damaged combatant’s client (not the attacker’s) receives the prompt.
- Normalize token lookup for maps whose `tokens` are dictionary-keyed so adjacency checks use the same grid coordinate utilities (e.g. `getGridDistanceFeet`) for player and monster tokens.
- Wire the new `onDamageResolved` callback from `PlayerTurnActions` into `ZombiesCharacterSheet` so player-originated damage produces the same queued retaliation decision as monster-originated damage, and update retaliation selection to filter by `ownerCombatantId`.
- Add unit tests to cover player and monster sources, dictionary-keyed token adjacency, decision ownership, duplicate prevention, and typical invalid cases.

### Testing

- Ran unit tests: `CI=true npm test -- --runInBand --watchAll=false src/components/Zombies/utils/attackResolution.test.js src/components/Zombies/utils/retaliation.test.js src/components/Zombies/utils/gridSpatial.test.js` and all 3 suites passed (27 tests total).
- Built the client with `npm run build`; production build completed successfully and reported only pre-existing lint/Browserslist/Autoprefixer warnings.
- Added/updated unit tests in `retaliation.test.js` to assert that player and monster damage follow the same normalized path and that the retaliation decision is owned by the damaged combatant.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6284e977348323befc8e1cf5d1f834)