### PR TITLE
Add grid occupancy previews for token repositioning

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -5368,6 +5368,27 @@ h1 {
     cursor: grabbing;
   }
 
+  &__occupancy-preview {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  &__occupancy-cell {
+    position: absolute;
+    box-sizing: border-box;
+    background: rgba(66, 214, 164, 0.38);
+    border: 2px solid rgba(210, 255, 239, 0.95);
+    box-shadow: inset 0 0 0 1px rgba(10, 64, 49, 0.8), 0 0 8px rgba(45, 220, 158, 0.55);
+  }
+
+  &__occupancy-preview--invalid &__occupancy-cell {
+    background: rgba(220, 53, 69, 0.42);
+    border-color: rgba(255, 220, 224, 0.98);
+    box-shadow: inset 0 0 0 1px rgba(100, 10, 20, 0.85), 0 0 8px rgba(220, 53, 69, 0.65);
+  }
+
   &__stage--panning {
     .campaign-map-board__image,
     .campaign-map-board__grid-overlay,

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.js
@@ -7,6 +7,7 @@ import resolveMapImageSource from '../utils/mapImages';
 import clampMapZoom, { MAP_ZOOM_DEFAULT } from '../utils/mapZoom';
 import usePointerEventsSupported from '../../../hooks/usePointerEventsSupported';
 import { enhanceMouseEvent, enhanceTouchEvent } from '../../../utils/pointerEvents';
+import { getOccupiedGridCells, getOccupiedSquareSize } from '../utils/gridSpatial';
 
 const clamp01 = (value) => {
   const parsed = Number(value);
@@ -512,6 +513,7 @@ const CampaignMapBoard = ({
   onTokenRemove,
   onTokenClick,
   targeting,
+  repositionToken,
   disabled,
   className,
   children,
@@ -533,6 +535,7 @@ const CampaignMapBoard = ({
   const layerRef = useRef(null);
   const dragStateRef = useRef({ tokenId: null, pointerId: null });
   const [dragPositions, setDragPositions] = useState({});
+  const [occupancyPreview, setOccupancyPreview] = useState(null);
   const [activeLabelTokenId, setActiveLabelTokenId] = useState(null);
   const [lastDraggedTokenId, setLastDraggedTokenId] = useState(null);
   const [hoveredTokenId, setHoveredTokenId] = useState(null);
@@ -1159,6 +1162,7 @@ const CampaignMapBoard = ({
 
   const resetDragState = useCallback(() => {
     dragStateRef.current = { tokenId: null, pointerId: null };
+    setOccupancyPreview(null);
     setDragPositions((prev) => {
       if (Object.keys(prev).length === 0) {
         return prev;
@@ -1190,6 +1194,28 @@ const CampaignMapBoard = ({
 
     return { x, y };
   }, []);
+
+  const getSnappedPlacement = useCallback((clientX, clientY, token) => {
+    const normalized = getNormalizedCoordinates(clientX, clientY);
+    if (!normalized) return null;
+    const anchorCell = {
+      x: Math.min(gridColumns - 1, Math.max(0, Math.floor(normalized.x * gridColumns))),
+      y: Math.min(gridRows - 1, Math.max(0, Math.floor(normalized.y * gridRows))),
+    };
+    const size = getOccupiedSquareSize(token);
+    const cells = getOccupiedGridCells({ anchorCell, size });
+    return {
+      anchorCell,
+      cells,
+      valid: cells.every((cell) => cell.x < gridColumns && cell.y < gridRows),
+      // Stored normalized coordinates denote the center of the top-left anchor
+      // cell; gridSpatial floors them back to this exact logical anchor.
+      position: {
+        x: (anchorCell.x + 0.5) / gridColumns,
+        y: (anchorCell.y + 0.5) / gridRows,
+      },
+    };
+  }, [getNormalizedCoordinates, gridColumns, gridRows]);
 
   const handlePointerDown = useCallback(
     (event, token) => {
@@ -1267,18 +1293,22 @@ const CampaignMapBoard = ({
       event.preventDefault();
       event.stopPropagation();
 
-      const coords = getNormalizedCoordinates(event.clientX, event.clientY);
-      if (!coords) {
+      const token = tokenPositionsRef.current.find(({ characterId }) => characterId === dragState.tokenId);
+      const placement = getSnappedPlacement(event.clientX, event.clientY, token);
+      if (!placement) {
         return;
       }
 
+      const coords = placement.position;
+
       updateDragPosition(dragState.tokenId, coords);
+      setOccupancyPreview({ ...placement, characterId: dragState.tokenId });
 
       if (typeof onTokenDrag === 'function') {
         onTokenDrag({ characterId: dragState.tokenId, ...coords });
       }
     },
-    [getNormalizedCoordinates, onTokenDrag, updateDragPosition]
+    [getSnappedPlacement, onTokenDrag, updateDragPosition]
   );
 
   const finalizeDrag = useCallback(
@@ -1297,11 +1327,13 @@ const CampaignMapBoard = ({
         return;
       }
 
-      const coords = getNormalizedCoordinates(event.clientX, event.clientY);
-      if (!coords) {
+      const token = tokenPositionsRef.current.find(({ characterId }) => characterId === tokenId);
+      const placement = getSnappedPlacement(event.clientX, event.clientY, token);
+      if (!placement) {
         resetDragState();
         return;
       }
+      const coords = placement.position;
 
       updateDragPosition(tokenId, coords);
 
@@ -1316,8 +1348,21 @@ const CampaignMapBoard = ({
       resetDragState();
       setLastDraggedTokenId(cancelled ? null : tokenId);
     },
-    [getNormalizedCoordinates, onTokenDragEnd, onTokenPositionChange, resetDragState, updateDragPosition]
+    [getSnappedPlacement, onTokenDragEnd, onTokenPositionChange, resetDragState, updateDragPosition]
   );
+
+  useEffect(() => {
+    const cancelOnEscape = (event) => {
+      if (event.key !== 'Escape' || !dragStateRef.current?.tokenId) return;
+      event.preventDefault();
+      const tokenId = dragStateRef.current.tokenId;
+      onTokenDragEnd?.({ characterId: tokenId, cancelled: true });
+      resetDragState();
+      setLastDraggedTokenId(null);
+    };
+    window.addEventListener('keydown', cancelOnEscape);
+    return () => window.removeEventListener('keydown', cancelOnEscape);
+  }, [onTokenDragEnd, resetDragState]);
 
   const handlePointerUp = useCallback(
     (event) => {
@@ -1413,6 +1458,10 @@ const CampaignMapBoard = ({
   const handleLayerPointerMove = useCallback((event) => {
     const panState = mapPanStateRef.current;
     if (!panState) {
+      if (repositionToken) {
+        const placement = getSnappedPlacement(event.clientX, event.clientY, repositionToken);
+        setOccupancyPreview(placement ? { ...placement, characterId: repositionToken.characterId } : null);
+      }
       return;
     }
 
@@ -1470,7 +1519,11 @@ const CampaignMapBoard = ({
 
     mapPanOffsetRef.current = { x: nextX, y: nextY };
     setMapPanOffset({ x: nextX, y: nextY });
-  }, []);
+  }, [getSnappedPlacement, repositionToken]);
+
+  useEffect(() => {
+    if (!repositionToken && !dragStateRef.current?.tokenId) setOccupancyPreview(null);
+  }, [repositionToken]);
 
   const handleLayerPointerUp = useCallback(
     (event) => {
@@ -1515,9 +1568,11 @@ const CampaignMapBoard = ({
       const { x: upX, y: upY } = resolvePointerCoordinates(event);
       const resolvedClientX = Number.isFinite(upX) ? upX : panState.startClientX;
       const resolvedClientY = Number.isFinite(upY) ? upY : panState.startClientY;
-      const coords =
-        getNormalizedCoordinates(resolvedClientX, resolvedClientY) ||
-        panState.initialCoords;
+      const placement = repositionToken
+        ? getSnappedPlacement(resolvedClientX, resolvedClientY, repositionToken)
+        : null;
+      const coords = placement?.position ||
+        getNormalizedCoordinates(resolvedClientX, resolvedClientY) || panState.initialCoords;
       if (!coords) {
         return;
       }
@@ -1526,7 +1581,7 @@ const CampaignMapBoard = ({
       event.stopPropagation();
       onBackgroundClick(coords);
     },
-    [getNormalizedCoordinates, mapPanOffset, onBackgroundClick]
+    [getNormalizedCoordinates, getSnappedPlacement, mapPanOffset, onBackgroundClick, repositionToken]
   );
 
   const handleLayerPointerCancel = useCallback(
@@ -2232,6 +2287,30 @@ const CampaignMapBoard = ({
                 handleLayerPointerCancel(enhanceTouchEvent(event));
               }}
             >
+              {occupancyPreview && (
+                <div
+                  className={classNames(
+                    'campaign-map-board__occupancy-preview',
+                    !occupancyPreview.valid && 'campaign-map-board__occupancy-preview--invalid'
+                  )}
+                  data-testid="occupancy-preview"
+                  aria-hidden="true"
+                >
+                  {occupancyPreview.cells.map((cell) => (
+                    <span
+                      key={`${cell.x}:${cell.y}`}
+                      className="campaign-map-board__occupancy-cell"
+                      data-grid-cell={`${cell.x},${cell.y}`}
+                      style={{
+                        left: `${(cell.x / gridColumns) * 100}%`,
+                        top: `${(cell.y / gridRows) * 100}%`,
+                        width: `${100 / gridColumns}%`,
+                        height: `${100 / gridRows}%`,
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
               {tokenPositions.map((token, tokenIndex) => {
                 const {
                   characterId,
@@ -2821,6 +2900,7 @@ CampaignMapBoard.propTypes = {
   onTokenRemove: PropTypes.func,
   onTokenClick: PropTypes.func,
   targeting: PropTypes.bool,
+  repositionToken: PropTypes.shape({ characterId: PropTypes.string, size: PropTypes.string }),
   disabled: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
@@ -2838,6 +2918,7 @@ CampaignMapBoard.defaultProps = {
   onTokenRemove: null,
   onTokenClick: null,
   targeting: false,
+  repositionToken: null,
   disabled: false,
   className: '',
   children: null,

--- a/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
+++ b/client/src/components/Zombies/attributes/CampaignMapBoard.test.js
@@ -31,6 +31,7 @@ describe('CampaignMapBoard pointer interactions', () => {
         onTokenRemove={overrides.onTokenRemove}
         onTokenClick={overrides.onTokenClick}
         targeting={overrides.targeting}
+        repositionToken={overrides.repositionToken}
       />
     );
 
@@ -291,6 +292,65 @@ describe('CampaignMapBoard pointer interactions', () => {
     fireEvent(tokenElement, pointerUpEvent);
 
     expect(pointerUpEvent.defaultPrevented).toBe(true);
+  });
+
+  it('previews and commits the same snapped Large footprint, then clears it', () => {
+    const onTokenPositionChange = jest.fn();
+    const { container, queryByTestId } = renderBoard({
+      token: { size: 'large' },
+      onTokenPositionChange,
+    });
+    const layer = container.querySelector('.campaign-map-board__tokens-layer');
+    layer.getBoundingClientRect = () => ({ left: 100, top: 50, width: 480, height: 480 });
+    const token = container.querySelector('[data-token-id="char-1"]');
+
+    fireEvent.mouseDown(token, { button: 0, clientX: 200, clientY: 150 });
+    fireEvent.mouseMove(token, { clientX: 310, clientY: 260 });
+
+    const preview = queryByTestId('occupancy-preview');
+    expect(preview).not.toBeNull();
+    expect(Array.from(preview.querySelectorAll('[data-grid-cell]')).map((cell) =>
+      cell.getAttribute('data-grid-cell')
+    )).toEqual(['10,10', '11,10', '10,11', '11,11']);
+
+    fireEvent.mouseUp(token, { clientX: 310, clientY: 260 });
+    expect(onTokenPositionChange).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      x: 10.5 / 24,
+      y: 10.5 / 24,
+    });
+    expect(queryByTestId('occupancy-preview')).toBeNull();
+  });
+
+  it('clears a reposition preview on Escape without committing', () => {
+    const onTokenPositionChange = jest.fn();
+    const { container, queryByTestId } = renderBoard({ onTokenPositionChange });
+    const layer = container.querySelector('.campaign-map-board__tokens-layer');
+    layer.getBoundingClientRect = () => ({ left: 0, top: 0, width: 240, height: 240 });
+    const token = container.querySelector('[data-token-id="char-1"]');
+    fireEvent.mouseDown(token, { button: 0, clientX: 60, clientY: 60 });
+    fireEvent.mouseMove(token, { clientX: 120, clientY: 120 });
+    expect(queryByTestId('occupancy-preview')).not.toBeNull();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(queryByTestId('occupancy-preview')).toBeNull();
+    expect(onTokenPositionChange).not.toHaveBeenCalled();
+    expect(token.style.left).toBe('25%');
+    expect(token.style.top).toBe('25%');
+  });
+
+  it('shows a snapped hover footprint during click-to-reposition mode', () => {
+    const { container, getByTestId } = renderBoard({
+      repositionToken: { ...baseToken, size: 'huge' },
+    });
+    const layer = container.querySelector('.campaign-map-board__tokens-layer');
+    layer.getBoundingClientRect = () => ({ left: 0, top: 0, width: 240, height: 240 });
+
+    fireEvent.mouseMove(layer, { clientX: 45, clientY: 65 });
+
+    expect(getByTestId('occupancy-preview').querySelectorAll('[data-grid-cell]')).toHaveLength(9);
+    expect(getByTestId('occupancy-preview').querySelector('[data-grid-cell="4,6"]')).not.toBeNull();
   });
 
   it('keeps rotation controls visible after a token click until background or another token hover', async () => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -7013,6 +7013,11 @@ const resolveIcon = (category, iconMap, fallback) => {
             disabled={!shouldShowCampaignTokens || mapPlacementSaving}
             allowWheelZoom
             targeting={combatTargeting.status !== 'inactive'}
+            repositionToken={
+              mapPlacementState.show
+                ? boardTokens.find((token) => token.characterId === mapPlacementState.enemyId) || null
+                : null
+            }
             onTokenClick={handleEnemyTargetClick}
             onTokenPositionChange={
               shouldShowCampaignTokens && !mapPlacementSaving

--- a/client/src/components/Zombies/utils/gridSpatial.js
+++ b/client/src/components/Zombies/utils/gridSpatial.js
@@ -21,6 +21,27 @@ const tokenFor = (combatant, mapState) => {
   return match?.[1] || combatant?.token || combatant;
 };
 
+/**
+ * Returns every logical cell in a creature's square footprint. `anchorCell` is
+ * always the top-left occupied cell (token positions normalize to that cell).
+ */
+export const getOccupiedGridCells = ({ anchorCell, size, sizeCategory } = {}) => {
+  const x = number(anchorCell?.x ?? anchorCell?.gridX);
+  const y = number(anchorCell?.y ?? anchorCell?.gridY);
+  if (x === null || y === null) return [];
+  const footprintSize = getOccupiedSquareSize({
+    size: sizeCategory ?? size,
+    gridSize: typeof size === 'number' ? size : undefined,
+  });
+  const cells = [];
+  for (let row = 0; row < footprintSize; row += 1) {
+    for (let column = 0; column < footprintSize; column += 1) {
+      cells.push({ x: Math.floor(x) + column, y: Math.floor(y) + row });
+    }
+  }
+  return cells;
+};
+
 /** Logical grid footprint. Token coordinates are top-left normalized map coordinates. */
 export const getOccupiedGridSpace = (combatant, mapState = {}) => {
   if (!combatant) return null;
@@ -34,7 +55,15 @@ export const getOccupiedGridSpace = (combatant, mapState = {}) => {
   const y = row ?? (normalizedY === null ? null : Math.floor(normalizedY * rows));
   if (x === null || y === null) return null;
   const size = getOccupiedSquareSize(token?.size ? token : combatant);
-  return { left: x, top: y, right: x + size - 1, bottom: y + size - 1, size };
+  const cells = getOccupiedGridCells({ anchorCell: { x, y }, size });
+  return {
+    left: cells[0].x,
+    top: cells[0].y,
+    right: cells[cells.length - 1].x,
+    bottom: cells[cells.length - 1].y,
+    size,
+    cells,
+  };
 };
 
 /** Chebyshev edge-to-edge distance, matching the board's diagonal-adjacency rule. */

--- a/client/src/components/Zombies/utils/gridSpatial.test.js
+++ b/client/src/components/Zombies/utils/gridSpatial.test.js
@@ -1,6 +1,14 @@
-import { getGridDistanceFeet, getOccupiedGridSpace } from './gridSpatial';
+import { getGridDistanceFeet, getOccupiedGridCells, getOccupiedGridSpace } from './gridSpatial';
 
 const map = { gridColumns: 20, gridRows: 20 };
+
+it.each([
+  ['medium', 1], ['large', 4], ['huge', 9], ['gargantuan', 16],
+])('returns the shared %s footprint cells', (size, count) => {
+  const cells = getOccupiedGridCells({ anchorCell: { x: 3, y: 7 }, sizeCategory: size });
+  expect(cells).toHaveLength(count);
+  expect(cells[0]).toEqual({ x: 3, y: 7 });
+});
 
 it('measures Medium-to-Large adjacency from occupied square edges', () => {
   const barbarian = { characterId: 'barbarian', gridX: 4, gridY: 5, size: 'medium' };


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for logical token footprints so previews exactly match combat adjacency and range math. 
- Let users visually verify which grid squares a Small→Gargantuan token would occupy while dragging or using DM click-to-place, without changing existing placement or combat rules.

### Description
- Introduce `getOccupiedGridCells({ anchorCell, size, sizeCategory })` and use it from `getOccupiedGridSpace` so footprint cells are computed once and shared between preview and combat utilities (`client/src/components/Zombies/utils/gridSpatial.js`).
- Snap pointer coordinates through the existing map layer transform and convert to the documented top-left grid anchor before computing occupied cells using `getSnappedPlacement` and `getNormalizedCoordinates` in `CampaignMapBoard` so preview and commit use identical anchors (`client/src/components/Zombies/attributes/CampaignMapBoard.js`).
- Render a continuously-updating occupancy overlay of translucent cells with borders while repositioning, with distinct valid/invalid styling, and clear it on commit or cancel; styles and DOM use logical grid-cell dimensions rather than sprite bounds (`client/src/App.scss`, `CampaignMapBoard.js`).
- Add `repositionToken` prop to the campaign board and wire DM map placement to show hover previews for the selected enemy token (`client/src/components/Zombies/pages/ZombiesDM.js`).
- Add unit tests that assert shared footprint sizes and preview/commit parity and implement Escape-to-cancel behavior (`client/src/components/Zombies/utils/gridSpatial.test.js`, `client/src/components/Zombies/attributes/CampaignMapBoard.test.js`).

### Testing
- Ran unit tests: `CI=true npm test -- --runInBand --watch=false src/components/Zombies/utils/gridSpatial.test.js src/components/Zombies/attributes/CampaignMapBoard.test.js src/components/Zombies/utils/retaliation.test.js`, all tests passed (39 tests across these suites).
- Built the production bundle with `npm run build`, which completed successfully (with pre-existing lint/Browserslist warnings unrelated to this change).
- Verified `getGridDistanceFeet`/retaliation tests still pass and that preview cells match committed footprints via updated tests (all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6288e0e9e48323bb302db00500482c)