### PR TITLE
Persist combat HP through authoritative atomic updates

### DIFF
--- a/client/src/components/Zombies/attributes/HealthDefense.js
+++ b/client/src/components/Zombies/attributes/HealthDefense.js
@@ -66,22 +66,27 @@ export default function HealthDefense({
   async function tempHealthUpdate(offset) {
     const updatedHealthValue = (Number.isFinite(health) ? health : 0) + offset;
     try {
-      await apiFetch(`/characters/update-temphealth/${params.id}`, {
+      const response = await apiFetch(`/characters/update-temphealth/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          tempHealth: updatedHealthValue,
+          delta: offset,
         }),
       });
+      if (!response.ok) throw new Error('The HP update could not be saved. No combat state was changed.');
+      const payload = await response.json();
+      const savedHealth = Number(payload.currentHp);
+      setHealth(savedHealth);
       setError(null);
       if (typeof onTempHealthChange === 'function') {
-        onTempHealthChange(updatedHealthValue);
+        onTempHealthChange(savedHealth);
       }
     } catch (error) {
       console.error(error);
-      setError("Failed to update health.");
+      setHealth(Number.isFinite(computedCurrentHp) ? computedCurrentHp : 0);
+      setError("The HP update could not be saved. No combat state was changed.");
     }
   }
 
@@ -345,4 +350,3 @@ export default function HealthDefense({
     </div>
   );
 }
-

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1628,15 +1628,14 @@ export default function ZombiesCharacterSheet() {
     [activeCharacterIds]
   );
 
-  const handleApplyTargetDamage = useCallback(async ({ targetId, hpBefore, damageApplied }) => {
+  const handleApplyTargetDamage = useCallback(async ({ targetId, hpBefore, damageApplied, result }) => {
     const enemy = enemies.find((candidate) => (candidate?.enemyId || candidate?._id) === targetId);
     if (enemy) {
       if (!encodedCampaignId) throw new Error('Campaign is unavailable; damage was not applied.');
       const previousHp = Number(enemy.currentHp ?? enemy.maxHp ?? enemy.hitPoints);
-      const requestedHp = Math.max(0, previousHp - Math.max(0, Number(damageApplied) || 0));
       const response = await apiFetch(`/campaigns/${encodedCampaignId}/enemies/${encodeURIComponent(targetId)}/health`, {
         method: 'PUT', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ currentHp: requestedHp }),
+        body: JSON.stringify({ delta: -Math.max(0, Number(damageApplied) || 0), eventId: result?.resolutionId }),
       });
       if (!response.ok) throw new Error(response.statusText || 'Failed to persist monster damage.');
       const payload = await response.json();
@@ -1648,13 +1647,19 @@ export default function ZombiesCharacterSheet() {
       const currentHp = Number(updatedEnemy.currentHp);
       return { previousHp, currentHp, appliedDamage: Math.max(0, previousHp - currentHp) };
     }
-    const hpAfter = Math.max(0, Number(hpBefore) - (Number(damageApplied) || 0));
+    const response = await apiFetch(`/characters/update-temphealth/${encodeURIComponent(targetId)}`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ delta: -Math.max(0, Number(damageApplied) || 0), eventId: result?.resolutionId }),
+    });
+    if (!response.ok) throw new Error('The HP update could not be saved. No combat state was changed.');
+    const payload = await response.json();
+    const hpAfter = Number(payload.currentHp);
     setCampaignCharacters((previous) => {
       if (!previous?.[targetId]) return previous;
       return { ...previous, [targetId]: { ...previous[targetId], currentHp: hpAfter, tempHealth: hpAfter } };
     });
     if (targetId === resolvedCharacterId) handleHealthChange(hpAfter);
-    return { previousHp: Number(hpBefore), currentHp: hpAfter, appliedDamage: Number(damageApplied) || 0 };
+    return { previousHp: Number(payload.previousHp), currentHp: hpAfter, appliedDamage: Number(payload.actualHpLost) || 0 };
   }, [encodedCampaignId, enemies, handleHealthChange, resolvedCharacterId]);
 
   const handleTargetTokenClick = useCallback(async (targetId) => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -2755,7 +2755,7 @@ export default function ZombiesDM() {
     }, []);
 
     const updateEnemyHealth = useCallback(
-      async (enemyId, nextHp) => {
+      async (enemyId, nextHp, options = {}) => {
         if (!enemyId || !encodedCampaign) {
           return;
         }
@@ -2769,7 +2769,9 @@ export default function ZombiesDM() {
             {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ currentHp: nextHp }),
+              body: JSON.stringify(options.delta !== undefined
+                ? { delta: options.delta, eventId: options.eventId }
+                : { currentHp: nextHp }),
             }
           );
 
@@ -2855,7 +2857,7 @@ export default function ZombiesDM() {
           }
         }
 
-        updateEnemyHealth(enemyId, nextValue);
+        updateEnemyHealth(enemyId, nextValue, { delta: direction * adjustment });
       },
       [enemyHealthAdjustments, enemies, updateEnemyHealth]
     );
@@ -3814,21 +3816,29 @@ export default function ZombiesDM() {
           combatState,
           rollAttack: (_selected, rollMode) => handleEnemyAttackRoll(attacker, action, rollMode),
           rollDamage: () => handleEnemyDamageRoll(attacker, action),
-          applyDamage: async ({ damageApplied }) => {
-            const nextHp = Math.max(0, currentHp - damageApplied);
+          applyDamage: async ({ damageApplied, result }) => {
+            let resolved;
             if (target.entityType === 'enemy') {
-              await updateEnemyHealth(targetId, nextHp);
+              const response = await apiFetch(`/campaigns/${encodedCampaign}/enemies/${encodeURIComponent(targetId)}/health`, {
+                method: 'PUT', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ delta: -damageApplied, eventId: result?.resolutionId }),
+              });
+              if (!response.ok) throw new Error('The HP update could not be saved. No combat state was changed.');
+              resolved = await response.json();
+              if (resolved.enemy) setEnemies((items) => items.map((item) => item.enemyId === targetId ? { ...item, ...resolved.enemy } : item));
             } else {
               const response = await apiFetch(`/characters/update-temphealth/${encodeURIComponent(targetId)}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ tempHealth: nextHp }),
+                body: JSON.stringify({ delta: -damageApplied, eventId: result?.resolutionId }),
               });
-              if (!response.ok) throw new Error(response.statusText || 'Failed to update character health.');
+              if (!response.ok) throw new Error('The HP update could not be saved. No combat state was changed.');
+              resolved = await response.json();
+              const nextHp = Number(resolved.currentHp);
               setRecords((previous) => previous.map((record) =>
                 getEntityId(record) === targetId ? { ...record, tempHealth: nextHp } : record));
             }
-            return { previousHp: currentHp, currentHp: nextHp, appliedDamage: damageApplied };
+            return { previousHp: Number(resolved.previousHp), currentHp: Number(resolved.currentHp), appliedDamage: Number(resolved.actualHpLost) };
           },
           onDamageResolved: async (damageEvent) => {
             // Damage has been persisted at this point. Queue the reaction in the
@@ -3868,7 +3878,7 @@ export default function ZombiesDM() {
         targetingLockRef.current = false;
         setCombatTargeting(INACTIVE_COMBAT_TARGETING);
       }
-    }, [activeMapTokens, characterLookup, combatState, combatTargeting, getEntityId, handleEnemyAttackRoll, handleEnemyDamageRoll, persistCombatState, updateEnemyHealth]);
+    }, [activeMapTokens, characterLookup, combatState, combatTargeting, encodedCampaign, getEntityId, handleEnemyAttackRoll, handleEnemyDamageRoll, persistCombatState, setEnemies]);
 
     useEffect(() => {
       if (combatTargeting.status === 'inactive') return undefined;

--- a/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
+++ b/client/src/components/Zombies/pages/components/FooterCharacterSlot.js
@@ -215,7 +215,7 @@ const FooterCharacterSlot = ({
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            tempHealth: next,
+            delta: next - resolvedCurrent,
           }),
         });
 
@@ -223,13 +223,14 @@ const FooterCharacterSlot = ({
           throw new Error(response.statusText || 'Failed to update health.');
         }
 
+        const payload = await response.json();
         if (typeof onHealthChange === 'function') {
-          onHealthChange(next);
+          onHealthChange(Number(payload.currentHp));
         }
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error(err);
-        setError('Failed to update health.');
+        setError('The HP update could not be saved. No combat state was changed.');
         setPendingHealth(null);
       } finally {
         setIsUpdating(false);

--- a/server/__tests__/campaigns.test.js
+++ b/server/__tests__/campaigns.test.js
@@ -1980,6 +1980,34 @@ describe('Campaign routes', () => {
     });
   });
 
+  test('atomically applies an idempotent enemy HP delta to the deployed instance', async () => {
+    const campaign = {
+      campaignName: 'Test', hpEventIds: [],
+      enemies: [{ enemyId: 'enemy-1', name: 'Goblin', hitPoints: 30, currentHp: 30 }],
+      combat: { participants: [{ characterId: 'enemy-1', initiative: 15 }], activeTurn: 0 },
+    };
+    const updateOne = jest.fn().mockImplementation(async (_filter, update) => {
+      if (update.$set?.['enemies.$[target].currentHp'] !== undefined) {
+        campaign.enemies[0].currentHp = update.$set['enemies.$[target].currentHp'];
+        campaign.hpEventIds.push('attack-1');
+      }
+      return { matchedCount: 1 };
+    });
+    dbo.mockResolvedValue({ collection: () => ({ findOne: async () => campaign, updateOne }) });
+
+    const res = await request(app)
+      .put('/campaigns/Test/enemies/enemy-1/health')
+      .send({ delta: -7, eventId: 'attack-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ previousHp: 30, currentHp: 23, actualHpLost: 7, eventId: 'attack-1' });
+    expect(updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ hpEventIds: { $ne: 'attack-1' } }),
+      expect.objectContaining({ $set: { 'enemies.$[target].currentHp': 23 } }),
+      { arrayFilters: [{ 'target.enemyId': 'enemy-1' }] }
+    );
+  });
+
   test('update enemy health validation failure', async () => {
     dbo.mockResolvedValue({
       collection: () => ({

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -20,6 +20,28 @@ app.use((err, req, res, next) => {
 });
 
 describe('Health routes validation', () => {
+  test('applies character HP deltas and returns the authoritative value', async () => {
+    const character = { _id: '507f1f77bcf86cd799439011', campaign: 'Test', health: 20, tempHealth: 15, characterId: 'hero-1' };
+    const updateOne = jest.fn().mockImplementation(async (_filter, update) => {
+      character.tempHealth = update.$set.tempHealth;
+      character.deathState = update.$set.deathState;
+      character.hpEventIds = ['damage-1'];
+      return { matchedCount: 1 };
+    });
+    dbo.mockResolvedValue({ collection: () => ({ findOne: async () => character, updateOne }) });
+
+    const res = await request(app)
+      .put('/characters/update-temphealth/507f1f77bcf86cd799439011')
+      .send({ delta: -6, eventId: 'damage-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ previousHp: 15, currentHp: 9, actualHpLost: 6, eventId: 'damage-1' });
+    expect(updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ tempHealth: 15 }),
+      expect.objectContaining({ $set: expect.objectContaining({ tempHealth: 9 }) })
+    );
+  });
+
   test('update temphealth invalid id', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)

--- a/server/routes/campaigns.js
+++ b/server/routes/campaigns.js
@@ -1861,6 +1861,12 @@ module.exports = (router) => {
 
             return true;
           }),
+        body('delta').optional().isFloat().toFloat(),
+        body('eventId').optional().isString().trim().isLength({ min: 1, max: 160 }),
+        body().custom((value) => {
+          if (value?.currentHp !== undefined || Number.isFinite(Number(value?.delta))) return true;
+          throw new Error('currentHp or delta is required');
+        }),
       ],
       handleValidationErrors,
       async (req, res, next) => {
@@ -1869,10 +1875,49 @@ module.exports = (router) => {
           const { enemyId } = req.params;
           const db_connect = req.db;
           const collection = db_connect.collection('Campaigns');
-          const campaign = await collection.findOne({ campaignName });
+          let campaign = await collection.findOne({ campaignName });
 
           if (!campaign) {
             return res.status(404).json({ message: 'Campaign not found' });
+          }
+
+          const requestedDelta = Number(req.body.delta);
+          const eventId = typeof req.body.eventId === 'string' ? req.body.eventId.trim() : '';
+          if (Number.isFinite(requestedDelta)) {
+            let previousHp;
+            let nextHp;
+            let duplicate = false;
+            for (let attempt = 0; attempt < 3; attempt += 1) {
+              if (eventId && campaign.hpEventIds?.includes(eventId)) {
+                duplicate = true;
+                break;
+              }
+              const enemy = (campaign.enemies || []).find((entry) => entry?.enemyId === enemyId);
+              if (!enemy) return res.status(404).json({ message: 'Enemy not found' });
+              const maxHp = toFiniteNumberOrNull(enemy.maxHp ?? enemy.hitPoints);
+              previousHp = toFiniteNumberOrNull(enemy.currentHp) ?? maxHp ?? 0;
+              nextHp = Math.max(0, maxHp === null ? previousHp + requestedDelta : Math.min(previousHp + requestedDelta, maxHp));
+              const filter = { campaignName, enemies: { $elemMatch: { enemyId, currentHp: enemy.currentHp } } };
+              if (eventId) filter.hpEventIds = { $ne: eventId };
+              const update = { $set: { 'enemies.$[target].currentHp': nextHp } };
+              if (eventId) update.$push = { hpEventIds: { $each: [eventId], $slice: -200 } };
+              const write = await collection.updateOne(filter, update, { arrayFilters: [{ 'target.enemyId': enemyId }] });
+              if (write?.matchedCount) break;
+              campaign = await collection.findOne({ campaignName });
+              if (!campaign) return res.status(404).json({ message: 'Campaign not found' });
+              if (attempt === 2) return res.status(409).json({ message: 'HP changed concurrently; retry the update.' });
+            }
+            campaign = await collection.findOne({ campaignName });
+            const updatedEnemy = (campaign.enemies || []).find((entry) => entry?.enemyId === enemyId);
+            if (!updatedEnemy) return res.status(404).json({ message: 'Enemy not found' });
+            const enemyLookup = createEnemyLookup(campaign.enemies);
+            const participants = sanitizeParticipants(campaign.combat?.participants, enemyLookup);
+            const combatState = { participants, activeTurn: parseTurnIndex(campaign.combat?.activeTurn), ...timelineMetadata(campaign.combat) };
+            await collection.updateOne({ campaignName }, { $set: { combat: combatState } });
+            emitEnemiesUpdate(campaignName, campaign.enemies);
+            emitCombatUpdate(campaignName, combatState);
+            const resolvedHp = toFiniteNumberOrNull(updatedEnemy.currentHp) ?? 0;
+            return res.json({ success: true, duplicate, enemy: updatedEnemy, combat: combatState, previousHp: duplicate ? resolvedHp : previousHp, currentHp: resolvedHp, actualHpLost: duplicate ? 0 : Math.max(0, previousHp - resolvedHp), eventId: eventId || undefined });
           }
 
           const existingEnemies = Array.isArray(campaign.enemies) ? campaign.enemies : [];

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -80,7 +80,15 @@ module.exports = (router) => {
 
   // This section will update tempHealth.
   characterRouter.route('/update-temphealth/:id').put(
-    [body('tempHealth').isInt().withMessage('tempHealth must be an integer').toInt()],
+    [
+      body('tempHealth').optional().isInt().withMessage('tempHealth must be an integer').toInt(),
+      body('delta').optional().isInt().withMessage('delta must be an integer').toInt(),
+      body('eventId').optional().isString().trim().isLength({ min: 1, max: 160 }),
+      body().custom((value) => {
+        if (Number.isInteger(value?.tempHealth) || Number.isInteger(value?.delta)) return true;
+        throw new Error('tempHealth or delta is required');
+      }),
+    ],
     handleValidationErrors,
     async (req, res, next) => {
       if (!ObjectId.isValid(req.params.id)) {
@@ -88,19 +96,47 @@ module.exports = (router) => {
       }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
-      const { tempHealth } = matchedData(req, { locations: ['body'] });
+      const { tempHealth, delta, eventId } = matchedData(req, { locations: ['body'] });
       try {
-        const existing = await db_connect.collection('Characters').findOne(id);
+        const collection = db_connect.collection('Characters');
+        const existing = await collection.findOne(id);
         if (!existing) {
           return res.status(404).json({ message: 'Character not found' });
         }
-        const outcome = applyHealthChange(existing, tempHealth, existing.tempHealth);
-        await db_connect.collection('Characters').updateOne(id, {
-          $set: { tempHealth: outcome.character.tempHealth, deathState: outcome.character.deathState },
-        });
+        if (eventId && Array.isArray(existing.hpEventIds) && existing.hpEventIds.includes(eventId)) {
+          return res.json({ success: true, duplicate: true, previousHp: existing.tempHealth, currentHp: existing.tempHealth, actualHpLost: 0, character: existing });
+        }
+        const authoritativePreviousHp = Number(existing.tempHealth ?? existing.health ?? 0);
+        const requested = Number.isInteger(delta)
+          ? Number(existing.tempHealth ?? existing.health ?? 0) + delta
+          : tempHealth;
+        const maxHp = Number.isFinite(Number(existing.health)) ? Number(existing.health) : requested;
+        const nextHp = Math.max(0, Math.min(requested, maxHp));
+        const outcome = applyHealthChange(existing, nextHp, existing.tempHealth);
+        const update = { $set: { tempHealth: outcome.character.tempHealth, deathState: outcome.character.deathState } };
+        if (eventId) update.$push = { hpEventIds: { $each: [eventId], $slice: -100 } };
+        // The current value is part of the filter, making this an optimistic atomic
+        // compare-and-swap. A racing delta is retried against the latest document.
+        let result = await collection.updateOne({ ...id, tempHealth: existing.tempHealth }, update);
+        if (!result?.matchedCount && Number.isInteger(delta)) {
+          const latest = await collection.findOne(id);
+          if (!latest) return res.status(404).json({ message: 'Character not found' });
+          if (eventId && latest.hpEventIds?.includes(eventId)) {
+            return res.json({ success: true, duplicate: true, previousHp: latest.tempHealth, currentHp: latest.tempHealth, actualHpLost: 0, character: latest });
+          }
+          const retryHp = Math.max(0, Math.min(Number(latest.tempHealth ?? latest.health ?? 0) + delta, Number(latest.health ?? Infinity)));
+          const retryOutcome = applyHealthChange(latest, retryHp, latest.tempHealth);
+          update.$set = { tempHealth: retryOutcome.character.tempHealth, deathState: retryOutcome.character.deathState };
+          result = await collection.updateOne({ ...id, tempHealth: latest.tempHealth }, update);
+          if (!result?.matchedCount) return res.status(409).json({ message: 'HP changed concurrently; retry the update.' });
+          outcome.character = retryOutcome.character;
+          outcome.event = retryOutcome.event;
+          outcome.previousHp = latest.tempHealth;
+        }
         await notifyCharacterHealthUpdate(db_connect, id._id);
         logger.info('character tempHealth updated');
-        res.json({ message: 'User updated successfully', deathState: outcome.character.deathState, deathEvent: outcome.event });
+        const previousHp = Number(outcome.previousHp ?? authoritativePreviousHp);
+        res.json({ success: true, message: 'User updated successfully', previousHp, currentHp: outcome.character.tempHealth, actualHpLost: Math.max(0, previousHp - outcome.character.tempHealth), character: outcome.character, deathState: outcome.character.deathState, deathEvent: outcome.event, eventId });
       } catch (err) {
         next(err);
       }
@@ -183,4 +219,3 @@ module.exports = (router) => {
 
   router.use('/characters', characterRouter);
 };
-


### PR DESCRIPTION
### Motivation

- Combat HP changes were sometimes only applied to local/client state causing stale or divergent HP across players and failures to persist after reloads.
- Ensure the server / database is the single source of truth for all HP mutations and prevent lost updates from concurrent damage/healing.

### Description

- Extended the character temp-HP endpoint to accept `delta` and `eventId`, add server-side clamping, apply the shared `applyHealthChange` logic, and perform an optimistic compare-and-swap with a retry path for concurrent deltas to persist authoritative HP atomically (`server/routes/characters/health.js`).
- Extended the campaign enemy health endpoint to accept `delta` and `eventId`, perform array-filtered atomic updates against deployed enemy instances (not monster templates), record bounded event IDs for idempotency, recompute & persist combat state, and broadcast using existing Socket.IO emits (`server/routes/campaigns.js`).
- Updated client HP mutation flows to send `delta` + `eventId` rather than trusting absolute client-side calculations, and to reconcile optimistic UI with the authoritative server response or roll back on failure; changes touch `HealthDefense`, `FooterCharacterSlot`, `ZombiesCharacterSheet`, and `ZombiesDM` components to route attacks, DM/manual adjustments, and player HP controls through the server path.
- Added regression tests that exercise character HP deltas and idempotent enemy HP delta persistence (`server/__tests__/health.test.js` and `server/__tests__/campaigns.test.js`).

### Testing

- Ran server unit tests with `npm --prefix server test -- --runInBand health.test.js campaigns.test.js`, and the suites passed (all tests successful).
- Built the client with `npm run build` to verify the UI compiles and the updated client/server integration code bundles; the production build completed successfully (only pre-existing lint/browserslist/autoprefixer warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a628ffd85048323b17a65ad99c903e4)