### PR TITLE
Notify players when authoritative combat damage lands

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -80,6 +80,7 @@ import { bindCriticalRollTransport } from '../../../utils/criticalRolls';
 import { emitCriticalRollEvent } from '../../../utils/criticalRolls';
 import CombatTurnHeader, { HEADER_PADDING } from "../components/CombatTurnHeader";
 import CombatConditionsModal from '../components/CombatConditionsModal';
+import { notifyIncomingDamage } from '../utils/incomingDamageNotification';
 
 const MIN_DOCKED_MODAL_WIDTH = 320;
 const DOCKED_MODAL_VIEWPORT_PADDING = 32;
@@ -648,6 +649,10 @@ export default function ZombiesCharacterSheet() {
   const brutalStrikeSubmittingRef = useRef(false);
   const [campaignCharacters, setCampaignCharacters] = useState({});
   const [enemies, setEnemies] = useState([]);
+  const campaignCharactersRef = useRef(campaignCharacters);
+  const enemiesRef = useRef(enemies);
+  campaignCharactersRef.current = campaignCharacters;
+  enemiesRef.current = enemies;
   const [campaignMaps, setCampaignMaps] = useState([]);
   const [campaignActiveMapId, setCampaignActiveMapId] = useState(null);
   const [campaignMap, setCampaignMap] = useState(null);
@@ -1649,7 +1654,7 @@ export default function ZombiesCharacterSheet() {
     }
     const response = await apiFetch(`/characters/update-temphealth/${encodeURIComponent(targetId)}`, {
       method: 'PUT', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ delta: -Math.max(0, Number(damageApplied) || 0), eventId: result?.resolutionId }),
+      body: JSON.stringify({ delta: -Math.max(0, Number(damageApplied) || 0), eventId: result?.resolutionId, sourceCombatantId: result?.attackerId, rolledDamage: result?.damage }),
     });
     if (!response.ok) throw new Error('The HP update could not be saved. No combat state was changed.');
     const payload = await response.json();
@@ -4153,6 +4158,17 @@ export default function ZombiesCharacterSheet() {
         return;
       }
 
+      notifyIncomingDamage({
+        event: update.resolvedDamage,
+        controlledCombatantId: resolvedCharacterIdRef.current || characterId,
+        resolveCombatantName: (sourceId) => {
+          const source = campaignCharactersRef.current?.[sourceId]
+            || enemiesRef.current.find((enemy) => String(enemy?.enemyId || enemy?._id) === String(sourceId));
+          return source?.name || source?.characterName || source?.displayType || null;
+        },
+        notify,
+      });
+
       if (updateIdentifiers.includes(characterId)) {
         setForm((prev) => prev ? {
           ...prev,
@@ -4514,7 +4530,7 @@ export default function ZombiesCharacterSheet() {
       socket.disconnect();
       socketRef.current = null;
     };
-  }, [campaignId, applyMapPayload, updateLocalDiceColor, updateLocalFigurineImage]);
+  }, [campaignId, characterId, applyMapPayload, updateLocalDiceColor, updateLocalFigurineImage]);
 
   const handleDiceColorChange = useCallback(
     (nextColor, nextTheme = null) => {

--- a/client/src/components/Zombies/pages/ZombiesDM.js
+++ b/client/src/components/Zombies/pages/ZombiesDM.js
@@ -3830,7 +3830,7 @@ export default function ZombiesDM() {
               const response = await apiFetch(`/characters/update-temphealth/${encodeURIComponent(targetId)}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ delta: -damageApplied, eventId: result?.resolutionId }),
+                body: JSON.stringify({ delta: -damageApplied, eventId: result?.resolutionId, sourceCombatantId: result?.attackerId, rolledDamage: result?.damage }),
               });
               if (!response.ok) throw new Error('The HP update could not be saved. No combat state was changed.');
               resolved = await response.json();

--- a/client/src/components/Zombies/utils/incomingDamageNotification.js
+++ b/client/src/components/Zombies/utils/incomingDamageNotification.js
@@ -1,0 +1,19 @@
+const memoryHandled = new Set();
+
+const handledKey = (event) => `incomingDamage:${event.eventId}:${event.targetCombatantId}`;
+
+/** Present one authoritative, persisted damage event to its controlling player. */
+export const notifyIncomingDamage = ({ event, controlledCombatantId, resolveCombatantName, notify, storage = typeof window !== 'undefined' ? window.sessionStorage : null }) => {
+  const actualHpLost = Number(event?.actualHpLost);
+  if (!event?.eventId || !event?.targetCombatantId || actualHpLost <= 0
+    || String(controlledCombatantId || '') !== String(event.targetCombatantId)) return false;
+  const key = handledKey(event);
+  if (memoryHandled.has(key) || storage?.getItem(key) === '1') return false;
+  const attackerName = event.sourceCombatantId ? resolveCombatantName?.(event.sourceCombatantId) : event.sourceLabel;
+  notify(attackerName ? `${attackerName} has dealt ${actualHpLost} damage to you.` : `You took ${actualHpLost} damage.`, 'danger');
+  memoryHandled.add(key);
+  try { storage?.setItem(key, '1'); } catch (error) { /* In-memory deduplication remains available. */ }
+  return true;
+};
+
+export const resetIncomingDamageNotificationsForTest = () => memoryHandled.clear();

--- a/client/src/components/Zombies/utils/incomingDamageNotification.test.js
+++ b/client/src/components/Zombies/utils/incomingDamageNotification.test.js
@@ -1,0 +1,26 @@
+import { notifyIncomingDamage, resetIncomingDamageNotificationsForTest } from './incomingDamageNotification';
+
+const event = { eventId: 'hit-1', sourceCombatantId: 'troll', targetCombatantId: 'barb', rolledDamage: 20, actualHpLost: 13, previousHp: 30, currentHp: 17 };
+beforeEach(() => resetIncomingDamageNotificationsForTest());
+
+test('shows authoritative damage once to the target owner using danger styling', () => {
+  const notify = jest.fn();
+  const storage = { getItem: jest.fn(() => null), setItem: jest.fn() };
+  expect(notifyIncomingDamage({ event, controlledCombatantId: 'barb', resolveCombatantName: () => 'Troll', notify, storage })).toBe(true);
+  expect(notify).toHaveBeenCalledWith('Troll has dealt 13 damage to you.', 'danger');
+  expect(notifyIncomingDamage({ event, controlledCombatantId: 'barb', resolveCombatantName: () => 'Troll', notify, storage })).toBe(false);
+  expect(notify).toHaveBeenCalledTimes(1);
+});
+
+test('does not notify unrelated clients or zero-damage resolutions', () => {
+  const notify = jest.fn();
+  notifyIncomingDamage({ event, controlledCombatantId: 'attacker', notify, storage: null });
+  notifyIncomingDamage({ event: { ...event, eventId: 'zero', actualHpLost: 0 }, controlledCombatantId: 'barb', notify, storage: null });
+  expect(notify).not.toHaveBeenCalled();
+});
+
+test('uses another player character name and final applied damage', () => {
+  const notify = jest.fn();
+  notifyIncomingDamage({ event: { ...event, sourceCombatantId: 'fighter', actualHpLost: 4 }, controlledCombatantId: 'barb', resolveCombatantName: () => 'Aric', notify, storage: null });
+  expect(notify).toHaveBeenCalledWith('Aric has dealt 4 damage to you.', 'danger');
+});

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -7,7 +7,7 @@ const logger = require('../../utils/logger');
 const { emitCharacterHealthUpdate } = require('../../utils/socket');
 const { applyHealthChange, applyDeathSaveResult, normalizeDeathState, reviveCharacter, markCharacterDead, clearDeathState } = require('../../utils/deathState');
 
-const notifyCharacterHealthUpdate = async (db, characterObjectId) => {
+const notifyCharacterHealthUpdate = async (db, characterObjectId, resolvedDamage) => {
   if (!db || !characterObjectId) {
     return;
   }
@@ -60,6 +60,7 @@ const notifyCharacterHealthUpdate = async (db, characterObjectId) => {
       tempHealth: character.tempHealth,
       health: character.health,
       deathState: character.deathState,
+      ...(resolvedDamage ? { resolvedDamage } : {}),
     });
   } catch (error) {
     logger.warn('Failed to emit character health update', {
@@ -84,6 +85,9 @@ module.exports = (router) => {
       body('tempHealth').optional().isInt().withMessage('tempHealth must be an integer').toInt(),
       body('delta').optional().isInt().withMessage('delta must be an integer').toInt(),
       body('eventId').optional().isString().trim().isLength({ min: 1, max: 160 }),
+      body('sourceCombatantId').optional().isString().trim().isLength({ min: 1, max: 160 }),
+      body('sourceLabel').optional().isString().trim().isLength({ min: 1, max: 100 }),
+      body('rolledDamage').optional().isFloat().toFloat(),
       body().custom((value) => {
         if (Number.isInteger(value?.tempHealth) || Number.isInteger(value?.delta)) return true;
         throw new Error('tempHealth or delta is required');
@@ -96,7 +100,7 @@ module.exports = (router) => {
       }
       const id = { _id: ObjectId(req.params.id) };
       const db_connect = req.db;
-      const { tempHealth, delta, eventId } = matchedData(req, { locations: ['body'] });
+      const { tempHealth, delta, eventId, sourceCombatantId, sourceLabel, rolledDamage } = matchedData(req, { locations: ['body'] });
       try {
         const collection = db_connect.collection('Characters');
         const existing = await collection.findOne(id);
@@ -133,10 +137,21 @@ module.exports = (router) => {
           outcome.event = retryOutcome.event;
           outcome.previousHp = latest.tempHealth;
         }
-        await notifyCharacterHealthUpdate(db_connect, id._id);
-        logger.info('character tempHealth updated');
         const previousHp = Number(outcome.previousHp ?? authoritativePreviousHp);
-        res.json({ success: true, message: 'User updated successfully', previousHp, currentHp: outcome.character.tempHealth, actualHpLost: Math.max(0, previousHp - outcome.character.tempHealth), character: outcome.character, deathState: outcome.character.deathState, deathEvent: outcome.event, eventId });
+        const actualHpLost = Math.max(0, previousHp - outcome.character.tempHealth);
+        const resolvedDamage = eventId && actualHpLost > 0 ? {
+          eventId,
+          ...(sourceCombatantId ? { sourceCombatantId } : {}),
+          ...(sourceLabel ? { sourceLabel } : {}),
+          targetCombatantId: req.params.id,
+          ...(Number.isFinite(rolledDamage) ? { rolledDamage } : {}),
+          actualHpLost,
+          previousHp,
+          currentHp: outcome.character.tempHealth,
+        } : undefined;
+        await notifyCharacterHealthUpdate(db_connect, id._id, resolvedDamage);
+        logger.info('character tempHealth updated');
+        res.json({ success: true, message: 'User updated successfully', previousHp, currentHp: outcome.character.tempHealth, actualHpLost, character: outcome.character, deathState: outcome.character.deathState, deathEvent: outcome.event, eventId });
       } catch (err) {
         next(err);
       }

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -231,7 +231,7 @@ const emitEnemiesUpdate = (campaignId, enemies) => {
   io.to(getCampaignRoom(normalizedId)).emit('campaign:enemies:update', payload);
 };
 
-const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health, deathState, deathEvent, combatLogEntry, rollLogEntry }) => {
+const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health, deathState, deathEvent, combatLogEntry, rollLogEntry, resolvedDamage }) => {
   if (!io) {
     logger.warn('Socket.io server not initialized; cannot emit character health update');
     return;
@@ -269,6 +269,9 @@ const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health
   }
   if (rollLogEntry !== undefined) {
     payload.rollLogEntry = rollLogEntry;
+  }
+  if (resolvedDamage !== undefined) {
+    payload.resolvedDamage = resolvedDamage;
   }
 
   io.to(getCampaignRoom(normalizedCampaignId)).emit('character:health:update', payload);
@@ -329,4 +332,3 @@ module.exports = {
   emitCharacterHealthUpdate,
   emitCharacterMetadataUpdate,
 };
-


### PR DESCRIPTION
### Motivation
- Show a red/danger incoming-damage toast to the controlling player immediately after authoritative HP changes are persisted.  
- Reuse the existing authoritative resolved-damage delivery path and notification system while preventing duplicate toasts during replays/reconnects.

### Description
- Server: `update-temphealth` accepts optional `sourceCombatantId`, `sourceLabel`, and `rolledDamage` and builds a normalized `resolvedDamage` payload (eventId, source, target, rolledDamage, actualHpLost, previousHp, currentHp) only when persistence succeeds and HP actually decreased.  
- Server socket: `emitCharacterHealthUpdate` now includes an optional `resolvedDamage` field on the existing `character:health:update` channel.  
- Client: attack flows (player and DM paths) attach `sourceCombatantId` and `rolledDamage` to HP-update requests so the server can produce canonical resolved-damage metadata.  
- Client: new `notifyIncomingDamage` utility presents a single danger notification to the target owner using `actualHpLost` and a resolved attacker name (or fallback), deduplicates per `eventId+target` using session storage plus in-memory set, and is invoked from the character sheet socket handler when `resolvedDamage` arrives.  
- Tests: added focused unit tests for the incoming-damage notifier and integrated with existing attack/HP resolution tests.

### Testing
- Ran client unit tests for the new notifier and existing attack resolution tests with `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/utils/incomingDamageNotification.test.js src/components/Zombies/utils/attackResolution.test.js`, which passed.  
- Ran server health route tests with `npm --prefix server test -- --runInBand --runTestsByPath __tests__/health.test.js`, which passed.  
- Ran the character sheet test suite with `npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/pages/ZombiesCharacterSheet.test.js`, which passed.  
- Built the client with `npm --prefix client run build`; the production build completed (existing lint/autoprefixer/browserslist warnings remain unrelated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a629362e0ec83239bc9e6021458217a)