### PR TITLE
Fix Retaliation from authoritative damage events

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -645,6 +645,7 @@ export default function ZombiesCharacterSheet() {
   const [form, setForm] = useState(null);
   const [campaignId, setCampaignId] = useState(null);
   const [combatState, setCombatState] = useState(createEmptyCombatState());
+  const [resolvedDamageEvent, setResolvedDamageEvent] = useState(null);
   const [brutalStrikeSelection, setBrutalStrikeSelection] = useState('');
   const brutalStrikeSubmittingRef = useRef(false);
   const [campaignCharacters, setCampaignCharacters] = useState({});
@@ -4168,6 +4169,9 @@ export default function ZombiesCharacterSheet() {
         },
         notify,
       });
+      // Feed the exact authoritative event used by the incoming-damage toast
+      // into the shared Retaliation evaluator after this health update renders.
+      if (update.resolvedDamage) setResolvedDamageEvent(update.resolvedDamage);
 
       if (updateIdentifiers.includes(characterId)) {
         setForm((prev) => prev ? {
@@ -5589,6 +5593,13 @@ export default function ZombiesCharacterSheet() {
     });
     if (nextState !== combatState) await persistCombatState(nextState);
   }, [activeMapTokens, campaignCharacters, characterId, combatState, enemies, form, persistCombatState, resolvedCharacterId]);
+
+  useEffect(() => {
+    if (!resolvedDamageEvent) return;
+    handleResolvedCombatDamage(resolvedDamageEvent).catch((error) => {
+      notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
+    });
+  }, [handleResolvedCombatDamage, resolvedDamageEvent]);
 
   const retaliationDecision = (combatState.pendingDecisions || []).find((decision) =>
     decision.type === 'retaliation' &&

--- a/client/src/components/Zombies/utils/retaliation.js
+++ b/client/src/components/Zombies/utils/retaliation.js
@@ -22,7 +22,9 @@ export const getRetaliationAttacks = (attacks, targetValidator = () => true) =>
   (attacks || []).filter((attack) => isRetaliationAttack(attack) && attack.available !== false && targetValidator(attack));
 
 export const createRetaliationOpportunity = ({ combatState, character, damageEvent, sourceCombatant, targetCombatant, mapState }) => {
-  const eventId = damageEvent?.damageEventId || damageEvent?.resolutionId;
+  // Character health updates expose the authoritative damage identifier as
+  // `eventId`; locally resolved attacks use the two legacy aliases below.
+  const eventId = damageEvent?.eventId || damageEvent?.damageEventId || damageEvent?.resolutionId;
   const eventSourceId = idOf(damageEvent?.sourceCombatantId || damageEvent?.attackerId);
   const sourceId = eventSourceId && idOf(sourceCombatant || eventSourceId);
   const targetId = idOf(targetCombatant || damageEvent?.targetCombatantId || damageEvent?.targetId);

--- a/client/src/components/Zombies/utils/retaliation.test.js
+++ b/client/src/components/Zombies/utils/retaliation.test.js
@@ -1,6 +1,7 @@
 import { createRetaliationOpportunity, declineRetaliation, getRetaliationAttacks, hasRetaliation, processRetaliationDamageEvent, queueRetaliation, startReactionAttack } from './retaliation';
 import { advanceTurn, createCombatState, removeCombatant } from './combatTimeline';
 import { getGridDistanceFeet } from './gridSpatial';
+import { notifyIncomingDamage } from './incomingDamageNotification';
 
 const character = (level = 10, subclass = 'path-of-the-berserker') => ({
   occupation: [{ Name: 'Barbarian', Level: level }], classState: { barbarian: { subclass } },
@@ -41,6 +42,28 @@ it.each([
   expect(resolved.pendingDecisions[0]).toMatchObject({
     damageEventId: 'mega-hit', sourceCombatantId: 'mega-action', targetCombatantId: 'barbarian',
     ownerCombatantId: 'barbarian', status: 'pending', actualHpLost: 6,
+  });
+});
+
+it('evaluates the same authoritative eventId event used by the incoming-damage notification', () => {
+  const authoritativeEvent = {
+    eventId: 'socket-hit', sourceCombatantId: 'troll', targetCombatantId: 'barbarian', actualHpLost: 11,
+  };
+  const notify = jest.fn();
+  notifyIncomingDamage({
+    event: authoritativeEvent, controlledCombatantId: 'barbarian',
+    resolveCombatantName: () => 'Troll', notify, storage: null,
+  });
+  const resolved = processRetaliationDamageEvent({
+    combatState: baseState, character: character(), damageEvent: authoritativeEvent,
+    sourceCombatant: source, targetCombatant: target,
+  });
+
+  expect(notify).toHaveBeenCalledWith('Troll has dealt 11 damage to you.', 'danger');
+  expect(resolved.pendingDecisions).toHaveLength(1);
+  expect(resolved.pendingDecisions[0]).toMatchObject({
+    id: 'retaliation:socket-hit', damageEventId: 'socket-hit', ownerCombatantId: 'barbarian',
+    triggeringCombatantId: 'troll', status: 'pending',
   });
 });
 


### PR DESCRIPTION
### Motivation

- Retaliation did not create a prompt when the authoritative post-HP update damage event (the same event that shows the incoming-damage toast) arrived, so the feature was evaluating the wrong/legacy event fields and missing the canonical `eventId` used by the server.
- The change must use the same resolved-damage event already delivered to the client and create a single pending Retaliation decision without changing the overall architecture.

### Description

- Prefer the authoritative health update identifier by accepting `damageEvent?.eventId` in `createRetaliationOpportunity`, while preserving legacy aliases (`damageEventId` / `resolutionId`) for locally resolved attacks (`client/src/components/Zombies/utils/retaliation.js`).
- Feed the server-provided `resolvedDamage` payload used by the incoming-damage toast into the shared Retaliation evaluator by storing it (`resolvedDamageEvent`) and calling the existing `handleResolvedCombatDamage` path after render (`client/src/components/Zombies/pages/ZombiesCharacterSheet.js`).
- Add a focused regression test which asserts the same authoritative event both triggers the incoming-damage notification and creates exactly one Barb-owned pending Retaliation decision (`client/src/components/Zombies/utils/retaliation.test.js`).
- No additional damage subscriptions were added and the existing checks for feature, reaction availability, combat membership, and grid-distance remain unchanged.

### Testing

- Ran unit tests: `npm test -- --watchAll=false --runTestsByPath src/components/Zombies/utils/retaliation.test.js src/components/Zombies/utils/gridSpatial.test.js`, and both suites passed (2 suites, 22 tests passed).
- Ran `git diff --check` and validated the working-tree diff for introduced changes with no check errors.
- Attempted a production build (`CI=true npm run build`), but the environment terminated the build process while Create React App was producing the optimized bundle; no compilation errors were reported prior to termination.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6296012cc08323bd0f021ecae9dd4a)