### PR TITLE
Fix Retaliation modal render loop

### DIFF
--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -646,6 +646,9 @@ export default function ZombiesCharacterSheet() {
   const [campaignId, setCampaignId] = useState(null);
   const [combatState, setCombatState] = useState(createEmptyCombatState());
   const [resolvedDamageEvent, setResolvedDamageEvent] = useState(null);
+  const processedRetaliationDamageIdsRef = useRef(new Set());
+  const retaliationSubmittingRef = useRef(null);
+  const [retaliationSubmittingId, setRetaliationSubmittingId] = useState(null);
   const [brutalStrikeSelection, setBrutalStrikeSelection] = useState('');
   const brutalStrikeSubmittingRef = useRef(false);
   const [campaignCharacters, setCampaignCharacters] = useState({});
@@ -5596,7 +5599,15 @@ export default function ZombiesCharacterSheet() {
 
   useEffect(() => {
     if (!resolvedDamageEvent) return;
+    const damageEventId = resolvedDamageEvent.eventId || resolvedDamageEvent.damageEventId || resolvedDamageEvent.resolutionId;
+    if (!damageEventId || processedRetaliationDamageIdsRef.current.has(damageEventId)) return;
+    // A health notification is a one-shot event, not an enduring source of combat
+    // state. Claim it before starting the async write so Strict Mode and unrelated
+    // rerenders cannot enqueue the same decision concurrently.
+    processedRetaliationDamageIdsRef.current.add(damageEventId);
+    setResolvedDamageEvent(null);
     handleResolvedCombatDamage(resolvedDamageEvent).catch((error) => {
+      processedRetaliationDamageIdsRef.current.delete(damageEventId);
       notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
     });
   }, [handleResolvedCombatDamage, resolvedDamageEvent]);
@@ -5606,15 +5617,22 @@ export default function ZombiesCharacterSheet() {
     decision.status === 'pending' &&
     String(decision.ownerCombatantId || decision.targetCombatantId) === String(resolvedCharacterId || characterId));
   const declinePendingRetaliation = useCallback(async () => {
-    if (!retaliationDecision) return;
+    if (!retaliationDecision || retaliationSubmittingRef.current === retaliationDecision.id) return;
+    retaliationSubmittingRef.current = retaliationDecision.id;
+    setRetaliationSubmittingId(retaliationDecision.id);
     try {
       await persistCombatState(declineRetaliation(combatState, retaliationDecision.id));
     } catch (error) {
       notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
+    } finally {
+      retaliationSubmittingRef.current = null;
+      setRetaliationSubmittingId(null);
     }
   }, [combatState, persistCombatState, retaliationDecision]);
   const acceptPendingRetaliation = useCallback(async () => {
-    if (!retaliationDecision) return;
+    if (!retaliationDecision || retaliationSubmittingRef.current === retaliationDecision.id) return;
+    retaliationSubmittingRef.current = retaliationDecision.id;
+    setRetaliationSubmittingId(retaliationDecision.id);
     const combatants = Object.fromEntries((combatState.participants || []).map((participant) => [
       String(participant.characterId || participant.combatantId || participant.enemyId || participant._id || participant.id),
       targetingTokenLookupRef.current[String(participant.characterId || participant.combatantId || participant.enemyId || participant._id || participant.id)] || participant,
@@ -5628,7 +5646,14 @@ export default function ZombiesCharacterSheet() {
     });
     if (result.error) {
       notify(result.error, 'warning');
-      if (result.state !== combatState) await persistCombatState(result.state);
+      try {
+        if (result.state !== combatState) await persistCombatState(result.state);
+      } catch (error) {
+        notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
+      } finally {
+        retaliationSubmittingRef.current = null;
+        setRetaliationSubmittingId(null);
+      }
       return;
     }
     try {
@@ -5637,6 +5662,9 @@ export default function ZombiesCharacterSheet() {
       notify('Retaliation committed. Select the locked attacker with a melee weapon or Unarmed Strike.', 'info');
     } catch (error) {
       notify(error?.message || 'The Retaliation decision could not be saved.', 'danger');
+    } finally {
+      retaliationSubmittingRef.current = null;
+      setRetaliationSubmittingId(null);
     }
   }, [combatState, persistCombatState, retaliationDecision]);
 
@@ -6580,8 +6608,8 @@ export default function ZombiesCharacterSheet() {
         <p>You can use your Reaction to make one melee attack against it.</p>
       </Modal.Body>
       <Modal.Footer>
-        <BootstrapButton variant="secondary" onClick={declinePendingRetaliation}>No</BootstrapButton>
-        <BootstrapButton onClick={acceptPendingRetaliation}>Yes</BootstrapButton>
+        <BootstrapButton variant="secondary" disabled={retaliationSubmittingId === retaliationDecision?.id} onClick={declinePendingRetaliation}>No</BootstrapButton>
+        <BootstrapButton disabled={retaliationSubmittingId === retaliationDecision?.id} onClick={acceptPendingRetaliation}>Yes</BootstrapButton>
       </Modal.Footer>
     </Modal>
     {dockedModalElements}

--- a/client/src/components/Zombies/utils/retaliation.js
+++ b/client/src/components/Zombies/utils/retaliation.js
@@ -5,6 +5,8 @@ export const RETALIATION_DESCRIPTION = 'After you take damage from a creature wi
 const idOf = (value) => String(value?.characterId ?? value?.combatantId ?? value?.enemyId ?? value?._id ?? value?.id ?? value ?? '');
 const participants = (state) => state?.participants || [];
 const inCombat = (state, id) => participants(state).some((entry) => idOf(entry) === String(id));
+const retaliationResolutionKey = (damageEventId, targetCombatantId) =>
+  `retaliation:${damageEventId}:${targetCombatantId}`;
 
 export const hasRetaliation = (character) => isPathOfTheBerserker(character) &&
   getActiveBarbarianSubclassFeatures(character).some((feature) => feature.id === 'berserker-retaliation');
@@ -32,7 +34,11 @@ export const createRetaliationOpportunity = ({ combatState, character, damageEve
   if (!eventId || !eventSourceId || !sourceId || !targetId || sourceId !== eventSourceId || sourceId === targetId || actualHpLost <= 0) return null;
   if (!hasRetaliation(character) || !inCombat(combatState, sourceId) || !inCombat(combatState, targetId) || !isReactionAvailable(combatState, targetId)) return null;
   if (getGridDistanceFeet(sourceCombatant || sourceId, targetCombatant || targetId, mapState) > 5) return null;
-  if ((combatState?.resolvedDecisionIds || []).includes(eventId) || (combatState?.pendingDecisions || []).some((item) => item.damageEventId === eventId)) return null;
+  const resolutionKey = retaliationResolutionKey(eventId, targetId);
+  if ((combatState?.resolvedDecisionIds || []).some((id) => id === eventId || id === resolutionKey) ||
+      (combatState?.pendingDecisions || []).some((item) =>
+        item.type === 'retaliation' && item.damageEventId === eventId &&
+        String(item.ownerCombatantId || item.targetCombatantId) === targetId)) return null;
   return {
     id: `retaliation:${eventId}`, type: 'retaliation', status: 'pending', damageEventId: eventId,
     sourceCombatantId: sourceId, targetCombatantId: targetId, ownerCombatantId: targetId,
@@ -55,7 +61,10 @@ export const queueRetaliation = (state, opportunity) => opportunity ?
 const resolveDecision = (state, decision) => ({
   ...state,
   pendingDecisions: (state.pendingDecisions || []).filter((item) => item.id !== decision.id),
-  resolvedDecisionIds: [...new Set([...(state.resolvedDecisionIds || []), decision.damageEventId])],
+  resolvedDecisionIds: [...new Set([
+    ...(state.resolvedDecisionIds || []),
+    retaliationResolutionKey(decision.damageEventId, decision.ownerCombatantId || decision.targetCombatantId),
+  ])],
 });
 
 export const declineRetaliation = (state, decisionId) => {

--- a/client/src/components/Zombies/utils/retaliation.test.js
+++ b/client/src/components/Zombies/utils/retaliation.test.js
@@ -86,6 +86,18 @@ it('declining does not spend the Reaction', () => {
   const state = declineRetaliation(queueRetaliation(baseState, opportunity), opportunity.id);
   expect(state.reactions.barbarian).toBeUndefined();
   expect(state.pendingDecisions).toHaveLength(0);
+  expect(createRetaliationOpportunity({ combatState: state, character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target })).toBeNull();
+});
+
+it('deduplicates only the same Retaliation target and damage event', () => {
+  const unrelatedDecision = {
+    id: 'other', type: 'other-reaction', status: 'pending', damageEventId: event.resolutionId,
+    ownerCombatantId: 'barbarian',
+  };
+  expect(createRetaliationOpportunity({
+    combatState: { ...baseState, pendingDecisions: [unrelatedDecision] },
+    character: character(), damageEvent: event, sourceCombatant: source, targetCombatant: target,
+  })).not.toBeNull();
 });
 
 it('committing spends the Reaction, filters attacks, and locks the triggering target', () => {


### PR DESCRIPTION
### Motivation

- Stabilize the Retaliation modal so a single authoritative pending decision remains mounted until the player explicitly accepts or declines.
- Prevent duplicate Retaliation decisions and modal flicker caused by Strict Mode, repeated rerenders, and realtime/state subscription races when damage notifications are processed.

### Description

- Consume each resolved-damage notification once before starting asynchronous combat-state persistence by introducing `processedRetaliationDamageIdsRef` and clearing `resolvedDamageEvent` to stop duplicate enqueueing. 
- Deduplicate and persist a target-scoped resolution key via `retaliation:${damageEventId}:${targetCombatantId}` and refuse to create a new Retaliation decision if either the event or the resolution key is present in `resolvedDecisionIds` or `pendingDecisions`.
- Mark resolved decisions with the new resolution key in `resolvedDecisionIds` so the same damage event cannot recreate the decision after resolution. 
- Add submission locking scoped to the active decision using `retaliationSubmittingRef` and `retaliationSubmittingId`, and disable both modal buttons while persistence is in flight to prevent double submissions.
- Add a focused regression test that verifies a declined Retaliation cannot be recreated from the same damage event and that unrelated pending decisions do not suppress valid Retaliation opportunities.

### Testing

- Ran the focused Jest suite with `CI=true npm --prefix client test -- --watchAll=false --runTestsByPath src/components/Zombies/utils/retaliation.test.js` and all tests passed (15/15).
- Built the client with `npm --prefix client run build`, which completed successfully; only pre-existing lint, Browserslist, and autoprefixer warnings were reported.
- The new regression test confirms that declined decisions cannot be recreated from the same damage event and that unrelated decision types do not interfere with Retaliation creation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a629a10b83c8323b034dd6a4e5e07e6)