### PR TITLE
Persist rest and potion healing through authoritative HP mutations

### DIFF
--- a/client/src/components/Items/ItemList.js
+++ b/client/src/components/Items/ItemList.js
@@ -400,6 +400,7 @@ const triggerHealingRoll = async (item, { diceColor } = {}) => {
   };
 
   window.dispatchEvent(new CustomEvent('damage-roll', { detail }));
+  return detail;
 };
 
 function ItemList({
@@ -415,6 +416,7 @@ function ItemList({
   cartCounts = null,
   diceColor,
   hiddenKeys = null,
+  onUseConsumable,
 }) {
   const [items, setItems] =
     useState/** @type {Record<string, Item & { owned?: boolean, ownedCount?: number, displayName?: string }> | null} */(null);
@@ -639,10 +641,28 @@ function ItemList({
       return;
     }
 
-    setOwnedEntries(nextEntries);
-
-    if (item?.healing) {
-      void triggerHealingRoll(item, { diceColor: normalizeDiceColor(diceColor) });
+    if (isConsumablePotion(item) && typeof onUseConsumable === 'function') {
+      void (async () => {
+       try {
+        const healingResult = item?.healing
+          ? await triggerHealingRoll(item, { diceColor: normalizeDiceColor(diceColor) })
+          : null;
+        const savedEntries = await onUseConsumable({
+          item,
+          itemKey: dataKey,
+          healingAmount: Number(healingResult?.value) || 0,
+        });
+        setOwnedEntries(Array.isArray(savedEntries) ? savedEntries : nextEntries);
+       } catch (useError) {
+        setError({ message: useError?.message || 'The healing could not be saved. No character resources were changed.' });
+       }
+      })();
+    } else {
+      if (item?.healing) {
+        void triggerHealingRoll(item, { diceColor: normalizeDiceColor(diceColor) });
+      }
+      setOwnedEntries(nextEntries);
+      if (typeof onChange === 'function') onChange(nextEntries);
     }
 
     if (isConsumablePotion(item)) {
@@ -652,9 +672,6 @@ function ItemList({
       }
     }
 
-    if (typeof onChange === 'function') {
-      onChange(nextEntries);
-    }
   };
 
   const handleRequestDelete = (dataKey, item) => () => {

--- a/client/src/components/Items/ItemList.test.js
+++ b/client/src/components/Items/ItemList.test.js
@@ -214,8 +214,8 @@ test('use button removes a consumable item copy and triggers onChange', async ()
   expect(screen.getAllByText('Potion of healing')).toHaveLength(1);
 
   await waitFor(() => expect(dispatchSpy).toHaveBeenCalled());
+  await waitFor(() => expect(dispatchSpy.mock.calls.some(([evt]) => evt?.type === 'damage-roll')).toBe(true));
   const events = dispatchSpy.mock.calls.map(([evt]) => evt);
-
   const healingEvent = events.find((evt) => evt?.type === 'damage-roll');
   expect(healingEvent).toBeInstanceOf(CustomEvent);
   expect(healingEvent?.detail?.source).toMatch(/potion of healing/i);

--- a/client/src/components/Zombies/attributes/InventoryModal.js
+++ b/client/src/components/Zombies/attributes/InventoryModal.js
@@ -29,6 +29,7 @@ export default function InventoryModal({
   onWeaponsChange,
   onArmorChange,
   onAccessoriesChange,
+  onUseConsumable,
 }) {
   const [activeTabState, setActiveTabState] = useState(
     activeTab || DEFAULT_TAB
@@ -151,6 +152,7 @@ export default function InventoryModal({
               onChange={onItemsChange}
               onClose={handleItemListClose}
               diceColor={form?.diceColor}
+              onUseConsumable={onUseConsumable}
             />
           ),
       },
@@ -185,6 +187,7 @@ export default function InventoryModal({
       onWeaponsChange,
       onArmorChange,
       onAccessoriesChange,
+      onUseConsumable,
       handleItemListClose,
     ]
   );

--- a/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
+++ b/client/src/components/Zombies/pages/ZombiesCharacterSheet.js
@@ -1725,15 +1725,7 @@ export default function ZombiesCharacterSheet() {
 
     // Clear effects on rest
     setActiveEffects([]);
-    if (didLongRestIncrement) {
-      const { maxHp } = calculateCharacterHitPoints(form);
-      const nextHealth = Number.isFinite(maxHp) ? maxHp : 0;
-      handleHealthChange(nextHealth);
-      return;
-    }
-
-    handleHealthChange(0);
-  }, [form, handleHealthChange, longRestCount, shortRestCount]);
+  }, [longRestCount, shortRestCount]);
 
   useEffect(() => {
     const hasteActive = activeEffects.some((e) => e.name === 'Haste');
@@ -3034,15 +3026,26 @@ export default function ZombiesCharacterSheet() {
     setForm((prev) => ({ ...prev, spells, spellPoints }));
   }, []);
 
-  const handleLongRest = useCallback(() => {
-    setLongRestCount((c) => c + 1);
-    setForm((prev) => applyRageRest(prev, 'long'));
-  }, []);
+  const completeRest = useCallback(async (type, healingAmount = 0) => {
+    const eventId = `${type}-rest-${characterId}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    try {
+      const response = await apiFetch(`/characters/rest/${encodeURIComponent(characterId)}`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type, healingAmount, eventId }),
+      });
+      if (!response.ok) throw new Error('The healing could not be saved. No character resources were changed.');
+      const saved = await response.json();
+      handleHealthChange(Number(saved.currentHp));
+      setForm((prev) => applyRageRest(prev, type));
+      if (type === 'long') setLongRestCount((count) => count + 1);
+      else setShortRestCount((count) => count + 1);
+    } catch (error) {
+      notify(error.message || 'The healing could not be saved. No character resources were changed.', 'danger');
+    }
+  }, [characterId, handleHealthChange]);
 
-  const handleShortRest = useCallback(() => {
-    setShortRestCount((c) => c + 1);
-    setForm((prev) => applyRageRest(prev, 'short'));
-  }, []);
+  const handleLongRest = useCallback(() => completeRest('long'), [completeRest]);
+  const handleShortRest = useCallback(() => completeRest('short'), [completeRest]);
 
   const handleActivateRage = useCallback(() => {
     setForm((prev) => activateRage(prev));
@@ -3522,6 +3525,26 @@ export default function ZombiesCharacterSheet() {
     },
     [characterId]
   );
+
+  const handleUseConsumable = useCallback(async ({ itemKey, healingAmount }) => {
+    const eventId = `potion-${characterId}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const response = await apiFetch(`/characters/use-healing-potion/${encodeURIComponent(characterId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ itemKey, healingAmount, eventId }),
+    });
+    if (!response.ok) {
+      throw new Error('The healing could not be saved. No character resources were changed.');
+    }
+    const saved = await response.json();
+    handleHealthChange(Number(saved.currentHp));
+    setForm((previous) => previous ? {
+      ...previous,
+      tempHealth: saved.currentHp,
+      item: saved.inventory,
+    } : previous);
+    return saved.inventory;
+  }, [characterId, handleHealthChange]);
 
   const handleAccessoriesChange = useCallback(
     async (accessories) => {
@@ -4178,6 +4201,7 @@ export default function ZombiesCharacterSheet() {
           ...prev,
           ...(update.tempHealth !== undefined ? { tempHealth: Number.isFinite(Number(update.tempHealth)) ? Number(update.tempHealth) : update.tempHealth } : {}),
           ...(update.health !== undefined ? { health: Number.isFinite(Number(update.health)) ? Number(update.health) : update.health } : {}),
+          ...(Array.isArray(update.item) ? { item: update.item } : {}),
           ...(update.deathState && typeof update.deathState === 'object' ? { deathState: update.deathState } : {}),
         } : prev);
         if (update.deathEvent?.message) notify(update.deathEvent.message, update.deathEvent.event === 'dead' ? 'danger' : 'success');
@@ -5774,6 +5798,7 @@ export default function ZombiesCharacterSheet() {
           onTabChange: setInventoryTab,
           characterId,
           onItemsChange: handleItemsChange,
+          onUseConsumable: handleUseConsumable,
           onWeaponsChange: handleWeaponsChange,
           onArmorChange: handleArmorChange,
           onAccessoriesChange: handleAccessoriesChange,
@@ -5844,6 +5869,7 @@ export default function ZombiesCharacterSheet() {
       handleDockChange,
       handleEquipmentChange,
       handleItemsChange,
+      handleUseConsumable,
       handleLongRest,
       handleRollResult,
       handleShortRest,
@@ -6481,6 +6507,7 @@ export default function ZombiesCharacterSheet() {
           dockedSide={getDockedSide('inventory')}
           onDockChange={(side) => handleDockChange('inventory', side)}
           onItemsChange={handleItemsChange}
+          onUseConsumable={handleUseConsumable}
           onWeaponsChange={handleWeaponsChange}
           onArmorChange={handleArmorChange}
           onAccessoriesChange={handleAccessoriesChange}

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -42,6 +42,43 @@ describe('Health routes validation', () => {
     );
   });
 
+  test('long rest atomically restores persisted current HP and is idempotent', async () => {
+    const character = { _id: '507f1f77bcf86cd799439011', campaign: 'Test', health: 20, tempHealth: 7, hpEventIds: [] };
+    const updateOne = jest.fn().mockImplementation(async (_filter, update) => {
+      character.tempHealth = update.$set.tempHealth;
+      character.hpEventIds.push('rest-1');
+      return { matchedCount: 1 };
+    });
+    dbo.mockResolvedValue({ collection: () => ({ findOne: async () => character, updateOne }) });
+
+    const first = await request(app).put('/characters/rest/507f1f77bcf86cd799439011')
+      .send({ type: 'long', eventId: 'rest-1' });
+    const duplicate = await request(app).put('/characters/rest/507f1f77bcf86cd799439011')
+      .send({ type: 'long', eventId: 'rest-1' });
+
+    expect(first.body).toMatchObject({ previousHp: 7, currentHp: 20, actualHealing: 13 });
+    expect(duplicate.body).toMatchObject({ duplicate: true, currentHp: 20, actualHealing: 0 });
+    expect(updateOne).toHaveBeenCalledTimes(1);
+  });
+
+  test('healing potion consumption and healing share one atomic update', async () => {
+    const character = {
+      _id: '507f1f77bcf86cd799439011', campaign: 'Test', health: 20, tempHealth: 10,
+      hpEventIds: [], item: [{ name: 'potion-healing', displayName: 'Potion of healing' }, { name: 'Torch' }],
+    };
+    const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });
+    dbo.mockResolvedValue({ collection: () => ({ findOne: async () => character, updateOne }) });
+
+    const res = await request(app).put('/characters/use-healing-potion/507f1f77bcf86cd799439011')
+      .send({ itemKey: 'potion-healing', healingAmount: 7, eventId: 'potion-1' });
+
+    expect(res.body).toMatchObject({ previousHp: 10, currentHp: 17, actualHealing: 7, inventory: [{ name: 'Torch' }] });
+    expect(updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ hpEventIds: { $ne: 'potion-1' } }),
+      expect.objectContaining({ $set: expect.objectContaining({ tempHealth: 17, item: [{ name: 'Torch' }] }) })
+    );
+  });
+
   test('update temphealth invalid id', async () => {
     dbo.mockResolvedValue({});
     const res = await request(app)

--- a/server/routes/characters/health.js
+++ b/server/routes/characters/health.js
@@ -5,7 +5,35 @@ const authenticateToken = require('../../middleware/auth');
 const handleValidationErrors = require('../../middleware/validation');
 const logger = require('../../utils/logger');
 const { emitCharacterHealthUpdate } = require('../../utils/socket');
+const { items: itemCatalog } = require('../../data/items');
 const { applyHealthChange, applyDeathSaveResult, normalizeDeathState, reviveCharacter, markCharacterDead, clearDeathState } = require('../../utils/deathState');
+
+const resolveCurrentHp = (character) => Number(character?.tempHealth ?? character?.health ?? 0);
+const resolveMaxHp = (character) => Number(character?.health ?? 0);
+
+/**
+ * Persist an HP delta against the latest character document.  Damage, rests and
+ * consumables all use tempHealth as the campaign character's authoritative
+ * current-HP field; health remains its maximum HP.
+ */
+const buildHealingOutcome = (character, requestedHealing) => {
+  const previousHp = resolveCurrentHp(character);
+  const maxHp = resolveMaxHp(character);
+  const healing = Math.max(0, Number(requestedHealing) || 0);
+  const currentHp = Math.max(0, Math.min(maxHp, previousHp + healing));
+  return { previousHp, currentHp, actualHealing: currentHp - previousHp, maxHp };
+};
+
+const normalizeItemKey = (value) => String(value || '').trim().toLowerCase();
+const findInventoryIndex = (inventory, itemKey) => inventory.findIndex((entry) => {
+  const names = [entry?.name, entry?.displayName, entry?.itemName].map(normalizeItemKey);
+  const definition = itemCatalog[itemKey];
+  return names.includes(itemKey) || (definition && names.includes(normalizeItemKey(definition.name)));
+});
+const healingMaximum = (expression) => {
+  const match = String(expression || '').match(/(\d+)d(\d+)\s*\+\s*(\d+)/i);
+  return match ? Number(match[1]) * Number(match[2]) + Number(match[3]) : 0;
+};
 
 const notifyCharacterHealthUpdate = async (db, characterObjectId, resolvedDamage) => {
   if (!db || !characterObjectId) {
@@ -22,6 +50,7 @@ const notifyCharacterHealthUpdate = async (db, characterObjectId, resolvedDamage
           health: 1,
           characterId: 1,
           deathState: 1,
+          item: 1,
         },
       }
     );
@@ -60,6 +89,7 @@ const notifyCharacterHealthUpdate = async (db, characterObjectId, resolvedDamage
       tempHealth: character.tempHealth,
       health: character.health,
       deathState: character.deathState,
+      item: character.item,
       ...(resolvedDamage ? { resolvedDamage } : {}),
     });
   } catch (error) {
@@ -78,6 +108,107 @@ module.exports = (router) => {
 
   // Apply authentication to all character routes
   characterRouter.use(authenticateToken);
+
+  characterRouter.route('/heal/:id').put(
+    [
+      body('amount').isInt({ min: 0 }).toInt(),
+      body('eventId').isString().trim().isLength({ min: 1, max: 160 }),
+      body('reason').optional().isString().trim().isLength({ min: 1, max: 100 }),
+    ],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Invalid ID' });
+      const id = { _id: ObjectId(req.params.id) };
+      const { amount, eventId } = matchedData(req, { locations: ['body'] });
+      try {
+        const collection = req.db.collection('Characters');
+        const character = await collection.findOne(id);
+        if (!character) return res.status(404).json({ message: 'Character not found' });
+        if (character.hpEventIds?.includes(eventId)) {
+          return res.json({ success: true, duplicate: true, previousHp: resolveCurrentHp(character), currentHp: resolveCurrentHp(character), actualHealing: 0, eventId });
+        }
+        const outcome = buildHealingOutcome(character, amount);
+        const result = await collection.updateOne(
+          { ...id, hpEventIds: { $ne: eventId }, tempHealth: character.tempHealth },
+          { $set: { tempHealth: outcome.currentHp, deathState: applyHealthChange(character, outcome.currentHp, character.tempHealth).character.deathState }, $push: { hpEventIds: { $each: [eventId], $slice: -100 } } }
+        );
+        if (!result?.matchedCount) return res.status(409).json({ message: 'HP changed concurrently; retry the update.' });
+        await notifyCharacterHealthUpdate(req.db, id._id);
+        res.json({ success: true, ...outcome, targetCombatantId: req.params.id, eventId });
+      } catch (err) { next(err); }
+    }
+  );
+
+  characterRouter.route('/rest/:id').put(
+    [
+      body('type').isIn(['long', 'short']),
+      body('healingAmount').optional().isInt({ min: 0 }).toInt(),
+      body('eventId').isString().trim().isLength({ min: 1, max: 160 }),
+    ],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Invalid ID' });
+      const id = { _id: ObjectId(req.params.id) };
+      const { type, healingAmount = 0, eventId } = matchedData(req, { locations: ['body'] });
+      try {
+        const collection = req.db.collection('Characters');
+        const character = await collection.findOne(id);
+        if (!character) return res.status(404).json({ message: 'Character not found' });
+        if (character.hpEventIds?.includes(eventId)) {
+          return res.json({ success: true, duplicate: true, previousHp: resolveCurrentHp(character), currentHp: resolveCurrentHp(character), actualHealing: 0, eventId });
+        }
+        const requested = type === 'long' ? resolveMaxHp(character) : healingAmount;
+        const outcome = buildHealingOutcome(character, requested);
+        const result = await collection.updateOne(
+          { ...id, hpEventIds: { $ne: eventId }, tempHealth: character.tempHealth },
+          { $set: { tempHealth: outcome.currentHp, deathState: applyHealthChange(character, outcome.currentHp, character.tempHealth).character.deathState }, $push: { hpEventIds: { $each: [eventId], $slice: -100 } } }
+        );
+        if (!result?.matchedCount) return res.status(409).json({ message: 'Rest state changed concurrently; retry the rest.' });
+        await notifyCharacterHealthUpdate(req.db, id._id);
+        res.json({ success: true, type, ...outcome, eventId });
+      } catch (err) { next(err); }
+    }
+  );
+
+  characterRouter.route('/use-healing-potion/:id').put(
+    [
+      body('itemKey').isString().trim().isLength({ min: 1, max: 100 }),
+      body('healingAmount').isInt({ min: 0 }).toInt(),
+      body('eventId').isString().trim().isLength({ min: 1, max: 160 }),
+    ],
+    handleValidationErrors,
+    async (req, res, next) => {
+      if (!ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Invalid ID' });
+      const id = { _id: ObjectId(req.params.id) };
+      const { itemKey: rawItemKey, healingAmount, eventId } = matchedData(req, { locations: ['body'] });
+      const itemKey = normalizeItemKey(rawItemKey);
+      const definition = itemCatalog[itemKey];
+      const maxRoll = healingMaximum(definition?.healing);
+      if (!definition || !definition.properties?.some((value) => normalizeItemKey(value) === 'consumable') || maxRoll < 1 || healingAmount > maxRoll) {
+        return res.status(400).json({ message: 'Invalid healing potion' });
+      }
+      try {
+        const collection = req.db.collection('Characters');
+        const character = await collection.findOne(id);
+        if (!character) return res.status(404).json({ message: 'Character not found' });
+        if (character.hpEventIds?.includes(eventId)) {
+          return res.json({ success: true, duplicate: true, previousHp: resolveCurrentHp(character), currentHp: resolveCurrentHp(character), actualHealing: 0, inventory: character.item || [], eventId });
+        }
+        const inventory = Array.isArray(character.item) ? character.item.slice() : [];
+        const inventoryIndex = findInventoryIndex(inventory, itemKey);
+        if (inventoryIndex < 0) return res.status(409).json({ message: 'The character does not own that potion.' });
+        inventory.splice(inventoryIndex, 1);
+        const outcome = buildHealingOutcome(character, healingAmount);
+        const result = await collection.updateOne(
+          { ...id, hpEventIds: { $ne: eventId }, tempHealth: character.tempHealth },
+          { $set: { tempHealth: outcome.currentHp, item: inventory, deathState: applyHealthChange(character, outcome.currentHp, character.tempHealth).character.deathState }, $push: { hpEventIds: { $each: [eventId], $slice: -100 } } }
+        );
+        if (!result?.matchedCount) return res.status(409).json({ message: 'Character state changed concurrently; the potion was not used.' });
+        await notifyCharacterHealthUpdate(req.db, id._id);
+        res.json({ success: true, ...outcome, inventory, itemKey, eventId });
+      } catch (err) { next(err); }
+    }
+  );
 
   // This section will update tempHealth.
   characterRouter.route('/update-temphealth/:id').put(

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -231,7 +231,7 @@ const emitEnemiesUpdate = (campaignId, enemies) => {
   io.to(getCampaignRoom(normalizedId)).emit('campaign:enemies:update', payload);
 };
 
-const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health, deathState, deathEvent, combatLogEntry, rollLogEntry, resolvedDamage }) => {
+const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health, item, deathState, deathEvent, combatLogEntry, rollLogEntry, resolvedDamage }) => {
   if (!io) {
     logger.warn('Socket.io server not initialized; cannot emit character health update');
     return;
@@ -257,6 +257,9 @@ const emitCharacterHealthUpdate = ({ campaignId, characterId, tempHealth, health
   }
   if (health !== undefined) {
     payload.health = health;
+  }
+  if (item !== undefined) {
+    payload.item = item;
   }
   if (deathState !== undefined) {
     payload.deathState = deathState;


### PR DESCRIPTION
### Motivation
- Long Rests, Short Rests, and healing potions were applying HP only to local UI state and not persisting to the authoritative character document, causing restored HP to be lost on refresh or reconnect.
- The fix routes all healing sources through the same server-authoritative HP persistence path (the same path used for damage) and preserves the existing architecture and realtime broadcast semantics.

### Description
- Added server-side, idempotent healing primitives that clamp to persisted max HP and persist via compare-and-swap updates: `/characters/heal/:id`, `/characters/rest/:id`, and `/characters/use-healing-potion/:id`, including `eventId` deduplication and atomic inventory + HP updates for potions (server changes in `server/routes/characters/health.js`).
- Implemented shared healing calculation utilities that treat `tempHealth` as the authoritative current HP and `health` as max HP, computing `previousHp`, `currentHp`, and `actualHealing` to return authoritative results for clients.
- Validated potion usage against the server item catalog, verified ownership, bounded requested healing to the item’s valid roll range, and removed exactly one inventory entry in the same database update as the HP change.
- Updated client UI to call the new authoritative endpoints instead of mutating local state directly: `ZombiesCharacterSheet` now completes rests via the `/rest/:id` endpoint and reconciles local HP only after server confirmation, and `ItemList`/`InventoryModal` route consumable potion use through a `onUseConsumable` handler that calls `/use-healing-potion/:id` (client changes in `client/src/components/Zombies/pages/ZombiesCharacterSheet.js`, `client/src/components/Items/ItemList.js`, and `client/src/components/Zombies/attributes/InventoryModal.js`).
- Extended the realtime health payload to include inventory state so connected clients receive authoritative HP and inventory updates together (changes in `server/utils/socket.js` and client reconciliation in character sheet code).
- Added server tests to cover long-rest idempotency and atomic potion consumption + healing, and adjusted client tests to exercise the consumable flow (tests in `server/__tests__/health.test.js` and `client/src/components/Items/ItemList.test.js`).

### Testing
- Ran `npm --prefix client test -- --watchAll=false --runInBand src/components/Items/ItemList.test.js` and the ItemList test suite passed (all tests for that file passed).
- Ran `npm --prefix server test -- --runInBand __tests__/health.test.js` and the server health tests passed (including long-rest idempotency and potion atomicity).
- Built the production client with `CI=true npm run build`; the build completed successfully (the repo had pre-existing lint warnings unrelated to these changes).
- Verified realtime payload inclusion and that `git diff --check` produced no blocking checks for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6299942d548323818b4f7e95d3f9be)